### PR TITLE
Define rating and score connections in UI

### DIFF
--- a/src/lorairo/gui/designer/SelectedImageDetailsWidget.ui
+++ b/src/lorairo/gui/designer/SelectedImageDetailsWidget.ui
@@ -379,5 +379,75 @@
   </customwidget>
  </customwidgets>
  <resources />
- <connections />
+ <connections>
+  <connection>
+   <sender>comboBoxRating</sender>
+   <signal>currentTextChanged(QString)</signal>
+   <receiver>SelectedImageDetailsWidget</receiver>
+   <slot>_on_rating_changed(QString)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>149</x>
+     <y>272</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>124</x>
+     <y>200</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>sliderScore</sender>
+   <signal>valueChanged(int)</signal>
+   <receiver>SelectedImageDetailsWidget</receiver>
+   <slot>_on_score_changed(int)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>147</x>
+     <y>299</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>124</x>
+     <y>200</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>pushButtonSaveRating</sender>
+   <signal>clicked()</signal>
+   <receiver>SelectedImageDetailsWidget</receiver>
+   <slot>_on_save_clicked()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>223</x>
+     <y>241</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>124</x>
+     <y>200</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>pushButtonSaveScore</sender>
+   <signal>clicked()</signal>
+   <receiver>SelectedImageDetailsWidget</receiver>
+   <slot>_on_save_clicked()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>223</x>
+     <y>299</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>124</x>
+     <y>200</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+ <slots>
+  <slot>_on_rating_changed(QString)</slot>
+  <slot>_on_score_changed(int)</slot>
+  <slot>_on_save_clicked()</slot>
+ </slots>
 </ui>

--- a/src/lorairo/gui/designer/SelectedImageDetailsWidget_ui.py
+++ b/src/lorairo/gui/designer/SelectedImageDetailsWidget_ui.py
@@ -227,7 +227,10 @@ class Ui_SelectedImageDetailsWidget(object):
 
 
         self.retranslateUi(SelectedImageDetailsWidget)
-
+        self.comboBoxRating.currentTextChanged.connect(SelectedImageDetailsWidget._on_rating_changed)
+        self.sliderScore.valueChanged.connect(SelectedImageDetailsWidget._on_score_changed)
+        self.pushButtonSaveRating.clicked.connect(SelectedImageDetailsWidget._on_save_clicked)
+        self.pushButtonSaveScore.clicked.connect(SelectedImageDetailsWidget._on_save_clicked)
         QMetaObject.connectSlotsByName(SelectedImageDetailsWidget)
     # setupUi
 

--- a/src/lorairo/gui/widgets/selected_image_details_widget.py
+++ b/src/lorairo/gui/widgets/selected_image_details_widget.py
@@ -110,15 +110,8 @@ class SelectedImageDetailsWidget(QScrollArea):
         UIコンポーネントのシグナル接続設定
 
         Qt Designerで設定されていないシグナルを追加接続。
-        - Rating/Scoreの変更監視
-        - 保存ボタンのクリック処理
+        Rating/Score関連のハンドラは .ui 側の接続定義を使用。
         """
-        # 自動接続されるシグナル（Qt Designerで設定済み）:
-        # - comboBoxRating.currentTextChanged -> _on_rating_changed
-        # - sliderScore.valueChanged -> _on_score_changed
-        # - pushButtonSaveRating.clicked -> _on_save_clicked
-        # - pushButtonSaveScore.clicked -> _on_save_clicked
-
         # AnnotationDataDisplayWidgetからのシグナル接続
         self.annotation_display.data_loaded.connect(self._on_annotation_data_loaded)
 


### PR DESCRIPTION
## Summary
- connect rating, score, and save signals in the .ui definition so their slots fire consistently
- simplify widget setup to rely on designer connections while keeping annotation data signal hookup

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693c377e35b8832984fdac3f22623ba8)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Connect rating, score, and save signals in the `.ui` and generated UI, simplifying the widget to rely on Designer-defined connections while keeping annotation display signal hookup.
> 
> - **UI Wiring**
>   - Add signal-slot connections in `designer/SelectedImageDetailsWidget.ui` for `comboBoxRating.currentTextChanged -> _on_rating_changed`, `sliderScore.valueChanged -> _on_score_changed`, and both save buttons' `clicked -> _on_save_clicked`.
>   - Declare corresponding slots in the `.ui`.
> - **Generated UI Code** (`designer/SelectedImageDetailsWidget_ui.py`)
>   - Connect the same signals to `SelectedImageDetailsWidget` slots in `setupUi`.
> - **Widget Cleanup** (`widgets/selected_image_details_widget.py`)
>   - Remove manual connection comments and rely on `.ui`-defined connections; keep `annotation_display.data_loaded -> _on_annotation_data_loaded` hookup.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 289c9d01c061ac133030dc62c7795fd588966eb2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->