### PR TITLE
feat: 検索欄にタグオートコンプリートを追加

### DIFF
--- a/src/lorairo/gui/widgets/filter_search_panel.py
+++ b/src/lorairo/gui/widgets/filter_search_panel.py
@@ -4,14 +4,16 @@ from datetime import datetime
 from enum import Enum
 from typing import TYPE_CHECKING, Any
 
-from PySide6.QtCore import Signal
-from PySide6.QtWidgets import QScrollArea
+from PySide6.QtCore import QTimer, Qt, Signal
+from PySide6.QtGui import QStringListModel
+from PySide6.QtWidgets import QCompleter, QScrollArea
 
 from ...gui.designer.FilterSearchPanel_ui import Ui_FilterSearchPanel
 from ...utils.log import logger
 from .custom_range_slider import CustomRangeSlider
 
 if TYPE_CHECKING:
+    from ...services.tag_suggestion_service import TagSuggestionService
     from ..services.search_filter_service import SearchFilterService
     from ..services.worker_service import WorkerService
 
@@ -55,6 +57,16 @@ class FilterSearchPanel(QScrollArea):
         # FavoriteFiltersService（依存注入） - Phase 4
         self.favorite_filters_service: Any = None  # type: ignore[assignment]
 
+        # タグ候補サジェストサービス
+        self.tag_suggestion_service: TagSuggestionService | None = None
+        self._tag_suggestion_timer = QTimer(self)
+        self._tag_suggestion_timer.setSingleShot(True)
+        self._tag_suggestion_timer.setInterval(300)
+        self._tag_suggestion_model = QStringListModel(self)
+        self._tag_completer = QCompleter(self._tag_suggestion_model, self)
+        self._tag_completer.setCaseSensitivity(False)
+        self._tag_completer.setFilterMode(Qt.MatchFlag.MatchContains)
+
         # 現在のSearchWorkerのID
         self._current_search_worker_id: str | None = None
 
@@ -74,6 +86,7 @@ class FilterSearchPanel(QScrollArea):
         self.ui.setupUi(self)
         self.setup_custom_widgets()
         self.setup_favorite_filters_ui()  # Phase 4
+        self.setup_tag_autocomplete()
         self.connect_signals()
 
         logger.debug("FilterSearchPanel initialized")
@@ -380,10 +393,59 @@ class FilterSearchPanel(QScrollArea):
             logger.error("Failed to delete filter '{}': {}", filter_name, e, exc_info=True)
             QMessageBox.critical(self, "エラー", f"フィルターの削除中にエラーが発生しました:\n{e}")
 
+    def setup_tag_autocomplete(self) -> None:
+        """検索入力欄にタグオートコンプリートを設定"""
+        self.ui.lineEditSearch.setCompleter(self._tag_completer)
+        self._tag_suggestion_timer.timeout.connect(self._update_tag_suggestions)
+        self._tag_completer.activated.connect(self._on_tag_completion_activated)
+
+    def set_tag_suggestion_service(self, service: "TagSuggestionService" | None) -> None:
+        """タグ候補サジェストサービスを設定"""
+        self.tag_suggestion_service = service
+
+    def _on_search_text_changed(self, _text: str) -> None:
+        if not self.ui.checkboxTags.isChecked():
+            return
+        self._tag_suggestion_timer.start()
+
+    def _update_tag_suggestions(self) -> None:
+        if not self.tag_suggestion_service or not self.ui.checkboxTags.isChecked():
+            self._tag_suggestion_model.setStringList([])
+            return
+
+        current_token = self._extract_current_tag_token(self.ui.lineEditSearch.text())
+        suggestions = self.tag_suggestion_service.suggest_tags(current_token)
+        self._tag_suggestion_model.setStringList(suggestions)
+
+    @staticmethod
+    def _extract_current_tag_token(text: str) -> str:
+        return text.rsplit(",", 1)[-1].strip()
+
+    def _on_tag_completion_activated(self, completion: str) -> None:
+        if not completion:
+            return
+        self._apply_completion_for_current_token(completion)
+
+    def _apply_completion_for_current_token(self, completion: str) -> None:
+        text = self.ui.lineEditSearch.text()
+        segments = text.split(",")
+        if len(segments) == 1:
+            new_text = completion
+        else:
+            segments[-1] = f" {completion}"
+            new_text = ",".join(segments)
+
+        if not new_text.endswith(", "):
+            new_text = f"{new_text}, "
+
+        self.ui.lineEditSearch.setText(new_text)
+        self.ui.lineEditSearch.setCursorPosition(len(new_text))
+
     def connect_signals(self) -> None:
         """Qt DesignerのUIコンポーネントにシグナルを接続"""
         # 検索関連（チェックボックスに更新）
         self.ui.lineEditSearch.returnPressed.connect(self._on_search_requested)
+        self.ui.lineEditSearch.textChanged.connect(self._on_search_text_changed)
         self.ui.checkboxTags.toggled.connect(self._on_search_type_changed)
         self.ui.checkboxCaption.toggled.connect(self._on_search_type_changed)
 
@@ -418,6 +480,15 @@ class FilterSearchPanel(QScrollArea):
 
         self.search_filter_service = service
         logger.info(f"SearchFilterService set for FilterSearchPanel: {type(service)}")
+
+        repository = getattr(getattr(service, "db_manager", None), "repository", None)
+        merged_reader = getattr(repository, "merged_reader", None)
+        if merged_reader is not None:
+            from ...services.tag_suggestion_service import TagSuggestionService
+
+            self.set_tag_suggestion_service(TagSuggestionService(merged_reader))
+        else:
+            self.set_tag_suggestion_service(None)
 
         # サービス機能確認（デバッグ用）
         try:

--- a/src/lorairo/services/tag_suggestion_service.py
+++ b/src/lorairo/services/tag_suggestion_service.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from time import monotonic
+from typing import Any
+
+from ..utils.log import logger
+
+
+@dataclass
+class _CacheEntry:
+    suggestions: list[str]
+    expires_at: float
+
+
+class TagSuggestionService:
+    """タグ補完候補を取得するサービス。
+
+    - genai-tag-db-tools の search_tags() を利用
+    - クエリ単位でTTLキャッシュ
+    """
+
+    def __init__(
+        self, merged_reader: Any, *, cache_ttl_seconds: float = 300.0, max_results: int = 20
+    ) -> None:
+        self._merged_reader = merged_reader
+        self._cache_ttl_seconds = cache_ttl_seconds
+        self._max_results = max_results
+        self._cache: dict[str, _CacheEntry] = {}
+
+    def suggest_tags(self, query: str, *, min_length: int = 2) -> list[str]:
+        normalized_query = query.strip().lower()
+        if len(normalized_query) < min_length:
+            return []
+
+        now = monotonic()
+        cached = self._cache.get(normalized_query)
+        if cached and cached.expires_at > now:
+            return cached.suggestions
+
+        suggestions = self._query_tags(normalized_query)
+        self._cache[normalized_query] = _CacheEntry(
+            suggestions=suggestions,
+            expires_at=now + self._cache_ttl_seconds,
+        )
+        return suggestions
+
+    def clear_cache(self) -> None:
+        self._cache.clear()
+
+    def _query_tags(self, query: str) -> list[str]:
+        if self._merged_reader is None:
+            return []
+
+        try:
+            from genai_tag_db_tools import search_tags
+            from genai_tag_db_tools.models import TagSearchRequest
+
+            request = TagSearchRequest(
+                query=query,
+                partial=True,
+                resolve_preferred=False,
+                include_aliases=True,
+                include_deprecated=False,
+            )
+            result = search_tags(self._merged_reader, request)
+
+            candidates: list[str] = []
+            for item in getattr(result, "items", []):
+                tag_name = self._extract_tag_name(item)
+                if tag_name:
+                    candidates.append(tag_name)
+
+            unique_candidates = list(dict.fromkeys(candidates))
+            return unique_candidates[: self._max_results]
+        except Exception as e:
+            logger.warning("Failed to fetch tag suggestions for '{}': {}", query, e)
+            return []
+
+    @staticmethod
+    def _extract_tag_name(item: Any) -> str | None:
+        if item is None:
+            return None
+
+        for key in ("tag", "source_tag", "name"):
+            value = getattr(item, key, None)
+            if isinstance(value, str) and value.strip():
+                return value.strip()
+
+        if isinstance(item, dict):
+            for key in ("tag", "source_tag", "name"):
+                value = item.get(key)
+                if isinstance(value, str) and value.strip():
+                    return value.strip()
+
+        return None

--- a/tests/unit/gui/widgets/test_filter_search_panel_autocomplete.py
+++ b/tests/unit/gui/widgets/test_filter_search_panel_autocomplete.py
@@ -1,0 +1,16 @@
+from lorairo.gui.widgets.filter_search_panel import FilterSearchPanel
+
+
+def test_extract_current_tag_token():
+    assert FilterSearchPanel._extract_current_tag_token("1girl, long") == "long"
+    assert FilterSearchPanel._extract_current_tag_token("solo") == "solo"
+
+
+def test_apply_completion_for_current_token(qtbot):
+    panel = FilterSearchPanel()
+    qtbot.addWidget(panel)
+
+    panel.ui.lineEditSearch.setText("1girl, lon")
+    panel._apply_completion_for_current_token("long_hair")
+
+    assert panel.ui.lineEditSearch.text() == "1girl, long_hair, "

--- a/tests/unit/services/test_tag_suggestion_service.py
+++ b/tests/unit/services/test_tag_suggestion_service.py
@@ -1,0 +1,42 @@
+import sys
+import types
+
+from lorairo.services.tag_suggestion_service import TagSuggestionService
+
+
+class _Item:
+    def __init__(self, tag: str):
+        self.tag = tag
+
+
+class _Result:
+    def __init__(self, items):
+        self.items = items
+
+
+def test_suggest_tags_uses_cache(monkeypatch):
+    calls = {"count": 0}
+
+    def fake_search_tags(_reader, _request):
+        calls["count"] += 1
+        return _Result([_Item("1girl"), _Item("solo")])
+
+    fake_models = types.SimpleNamespace(TagSearchRequest=lambda **kwargs: kwargs)
+    fake_module = types.SimpleNamespace(search_tags=fake_search_tags, models=fake_models)
+
+    monkeypatch.setitem(sys.modules, "genai_tag_db_tools", fake_module)
+    monkeypatch.setitem(sys.modules, "genai_tag_db_tools.models", fake_models)
+
+    service = TagSuggestionService(object(), cache_ttl_seconds=60)
+
+    first = service.suggest_tags("gi")
+    second = service.suggest_tags("gi")
+
+    assert first == ["1girl", "solo"]
+    assert second == ["1girl", "solo"]
+    assert calls["count"] == 1
+
+
+def test_suggest_tags_returns_empty_when_query_short():
+    service = TagSuggestionService(object())
+    assert service.suggest_tags("a") == []


### PR DESCRIPTION
### Motivation
- 検索入力時にタグ候補をサジェストしてUXを向上させるため、外部タグDBを利用したオートコンプリートを実装しました。
- 候補取得処理を UI から分離してテスト可能にするためにサービス層を導入しました。

### Description
- 新規サービス `TagSuggestionService` を追加し、`genai-tag-db-tools.search_tags()` を使った候補取得とクエリ単位の TTL キャッシュを実装しました (`src/lorairo/services/tag_suggestion_service.py`).
- `FilterSearchPanel` に `QCompleter` を統合し、`QTimer` で 300ms デバウンスして候補を取得する仕組みと、カンマ区切り入力で最後のトークンのみを補完するロジックを追加しました (`src/lorairo/gui/widgets/filter_search_panel.py`).
- `SearchFilterService` が設定された際に `db_manager.repository.merged_reader` から自動的に `TagSuggestionService` を生成して接続するよう DI を組み込みました。
- ユニットテストを追加してキャッシュ動作とトークン置換の基本的な振る舞いを検証するテストを追加しました (`tests/unit/services/test_tag_suggestion_service.py`, `tests/unit/gui/widgets/test_filter_search_panel_autocomplete.py`).

### Testing
- `python -m compileall -q ...` による静的コンパイルチェックは成功しました. 
- 追加ユニットテストの実行を試みましたが、`PYTHONPATH=src pytest -q tests/unit/services/test_tag_suggestion_service.py tests/unit/gui/widgets/test_filter_search_panel_autocomplete.py` は環境に `sqlalchemy` が無いため `tests/conftest.py` の読み込みで失敗しました（依存環境が未整備のため）。
- 単体レベルでのロジック検証として `TagSuggestionService` のキャッシュ挙動と `FilterSearchPanel` のトークン抽出・補完適用をカバーするテストファイルを追加しました。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b62944f5d0832998006e200fda35ed)