### PR TITLE
feat: add tag autocomplete to search panel (QCompleter + TagSuggestionService)

### DIFF
--- a/src/lorairo/gui/widgets/filter_search_panel.py
+++ b/src/lorairo/gui/widgets/filter_search_panel.py
@@ -4,10 +4,11 @@ from datetime import datetime
 from enum import Enum
 from typing import TYPE_CHECKING, Any
 
-from PySide6.QtCore import Signal
-from PySide6.QtWidgets import QScrollArea
+from PySide6.QtCore import QTimer, Qt, Signal, QStringListModel
+from PySide6.QtWidgets import QCompleter, QScrollArea
 
 from ...gui.designer.FilterSearchPanel_ui import Ui_FilterSearchPanel
+from ...services.tag_suggestion_service import TagSuggestionService
 from ...utils.log import logger
 from .custom_range_slider import CustomRangeSlider
 
@@ -68,6 +69,12 @@ class FilterSearchPanel(QScrollArea):
             PipelineState.ERROR: "エラーが発生しました",
             PipelineState.CANCELED: "キャンセルされました",
         }
+
+        # タグサジェスト関連
+        self.tag_suggestion_service: TagSuggestionService | None = None
+        self._suggestion_timer = QTimer(self)
+        self._suggestion_timer.setSingleShot(True)
+        self._suggestion_timer.setInterval(300)
 
         # UI設定
         self.ui = Ui_FilterSearchPanel()
@@ -384,6 +391,8 @@ class FilterSearchPanel(QScrollArea):
         """Qt DesignerのUIコンポーネントにシグナルを接続"""
         # 検索関連（チェックボックスに更新）
         self.ui.lineEditSearch.returnPressed.connect(self._on_search_requested)
+        self.ui.lineEditSearch.textChanged.connect(self._on_search_text_changed)
+        self._suggestion_timer.timeout.connect(self._fetch_tag_suggestions)
         self.ui.checkboxTags.toggled.connect(self._on_search_type_changed)
         self.ui.checkboxCaption.toggled.connect(self._on_search_type_changed)
 
@@ -400,6 +409,20 @@ class FilterSearchPanel(QScrollArea):
         # アクションボタン
         self.ui.buttonApply.clicked.connect(self._on_apply_clicked)
         self.ui.buttonClear.clicked.connect(self._on_clear_clicked)
+
+    def set_tag_suggestion_service(self, service: TagSuggestionService) -> None:
+        """TagSuggestionServiceを設定してQCompleterを初期化する。"""
+        self.tag_suggestion_service = service
+
+        model = QStringListModel([], self)
+        completer = QCompleter(model, self.ui.lineEditSearch)
+        completer.setCaseSensitivity(Qt.CaseSensitivity.CaseInsensitive)
+        completer.setFilterMode(Qt.MatchFlag.MatchContains)
+        completer.setCompletionMode(QCompleter.CompletionMode.PopupCompletion)
+        completer.activated[str].connect(self._on_tag_completer_activated)
+        self.ui.lineEditSearch.setCompleter(completer)
+
+        logger.debug("TagSuggestionService set for FilterSearchPanel")
 
     def set_search_filter_service(self, service: "SearchFilterService") -> None:
         """SearchFilterServiceを設定（拡張版：バリデーションとログ強化）"""
@@ -773,6 +796,69 @@ class FilterSearchPanel(QScrollArea):
             f"ai={ai_rating_filter}, include_nsfw={include_nsfw}",
         )
         return include_nsfw
+
+    @staticmethod
+    def _extract_last_token(text: str) -> str:
+        """カンマ区切り入力の最後のトークンを取得する。"""
+        if not text:
+            return ""
+        return text.split(",")[-1].strip()
+
+    def _on_search_text_changed(self, _text: str) -> None:
+        """検索入力変更時のタグサジェスト処理（300msデバウンス）。"""
+        if not self.ui.checkboxTags.isChecked():
+            return
+
+        if self.tag_suggestion_service is None:
+            return
+
+        token = self._extract_last_token(self.ui.lineEditSearch.text())
+        if len(token) < 2:
+            self._update_completer_items([])
+            return
+
+        self._suggestion_timer.start()
+
+    def _fetch_tag_suggestions(self) -> None:
+        if self.tag_suggestion_service is None:
+            return
+
+        token = self._extract_last_token(self.ui.lineEditSearch.text())
+        if len(token) < 2:
+            self._update_completer_items([])
+            return
+
+        suggestions = self.tag_suggestion_service.get_suggestions(token)
+        self._update_completer_items(suggestions)
+
+    def _update_completer_items(self, items: list[str]) -> None:
+        completer = self.ui.lineEditSearch.completer()
+        if not completer:
+            return
+        model = completer.model()
+        if not isinstance(model, QStringListModel):
+            return
+        model.setStringList(items)
+
+        popup = completer.popup()
+        if items and popup is not None and self.ui.lineEditSearch.hasFocus():
+            completer.complete()
+
+    def _on_tag_completer_activated(self, selected: str) -> None:
+        """補完選択時に最後のトークンを置換する。"""
+        full_text = self.ui.lineEditSearch.text()
+        tokens = [segment.strip() for segment in full_text.split(",")]
+
+        if tokens:
+            tokens[-1] = selected
+        else:
+            tokens = [selected]
+
+        updated = ", ".join(token for token in tokens if token)
+        if updated and not updated.endswith(","):
+            updated = f"{updated}, "
+
+        self.ui.lineEditSearch.setText(updated)
 
     def _on_search_type_changed(self) -> None:
         """検索タイプ変更時の処理（チェックボックス対応）"""

--- a/src/lorairo/gui/window/main_window.py
+++ b/src/lorairo/gui/window/main_window.py
@@ -23,6 +23,7 @@ from ...services.configuration_service import ConfigurationService
 from ...services.model_selection_service import ModelSelectionService
 from ...services.selection_state_service import SelectionStateService
 from ...services.service_container import ServiceContainer
+from ...services.tag_suggestion_service import TagSuggestionService
 from ...storage.file_system import FileSystemManager
 from ...utils.log import logger
 from ..controllers.annotation_workflow_controller import AnnotationWorkflowController
@@ -1319,6 +1320,9 @@ class MainWindow(QMainWindow, Ui_MainWindow):
         try:
             search_filter_service = self._create_search_filter_service()
             self.filterSearchPanel.set_search_filter_service(search_filter_service)
+
+            tag_suggestion_service = TagSuggestionService(self.db_manager.repository.merged_reader)
+            self.filterSearchPanel.set_tag_suggestion_service(tag_suggestion_service)
 
             if self.worker_service:
                 self.filterSearchPanel.set_worker_service(self.worker_service)

--- a/src/lorairo/services/tag_suggestion_service.py
+++ b/src/lorairo/services/tag_suggestion_service.py
@@ -1,0 +1,75 @@
+"""Tag suggestion service for search autocomplete."""
+
+from collections.abc import Sequence
+
+from genai_tag_db_tools import search_tags
+from genai_tag_db_tools.db.repository import MergedTagReader
+from genai_tag_db_tools.models import TagSearchRequest
+
+from ..utils.log import logger
+
+
+class TagSuggestionService:
+    """Provide cached tag suggestions via genai-tag-db-tools search API."""
+
+    def __init__(self, merged_reader: MergedTagReader | None, max_cache_size: int = 512) -> None:
+        self.merged_reader = merged_reader
+        self.max_cache_size = max_cache_size
+        self._cache: dict[str, list[str]] = {}
+
+    def get_suggestions(self, query: str, limit: int = 20) -> list[str]:
+        """Fetch tag suggestions with in-memory cache.
+
+        Args:
+            query: Current token text.
+            limit: Max number of candidates.
+
+        Returns:
+            List of suggested tags.
+        """
+        normalized_query = query.strip()
+        if len(normalized_query) < 2:
+            return []
+
+        cache_key = normalized_query.lower()
+        if cache_key in self._cache:
+            return self._cache[cache_key]
+
+        if self.merged_reader is None:
+            logger.debug("TagSuggestionService skipped: merged_reader unavailable")
+            return []
+
+        try:
+            request = TagSearchRequest(
+                query=normalized_query,
+                partial=True,
+                resolve_preferred=False,
+                include_aliases=True,
+                include_deprecated=False,
+                limit=limit,
+            )
+            result = search_tags(self.merged_reader, request)
+            suggestions = self._extract_tag_names(result.items)
+            self._put_cache(cache_key, suggestions)
+            return suggestions
+        except Exception as e:
+            logger.warning("Failed to fetch tag suggestions for '{}': {}", normalized_query, e)
+            return []
+
+    def clear_cache(self) -> None:
+        self._cache.clear()
+
+    def _put_cache(self, key: str, value: list[str]) -> None:
+        if len(self._cache) >= self.max_cache_size:
+            self._cache.pop(next(iter(self._cache)))
+        self._cache[key] = value
+
+    @staticmethod
+    def _extract_tag_names(items: Sequence[object]) -> list[str]:
+        names: list[str] = []
+        for item in items:
+            name = getattr(item, "tag", None) or getattr(item, "name", None)
+            if isinstance(name, str) and name and name not in names:
+                names.append(name)
+        return names
+

--- a/tests/unit/gui/widgets/test_filter_search_panel_autocomplete.py
+++ b/tests/unit/gui/widgets/test_filter_search_panel_autocomplete.py
@@ -1,0 +1,16 @@
+from lorairo.gui.widgets.filter_search_panel import FilterSearchPanel
+
+
+class TestFilterSearchPanelAutocomplete:
+    def test_extract_last_token(self):
+        assert FilterSearchPanel._extract_last_token("cat, dog") == "dog"
+        assert FilterSearchPanel._extract_last_token("single") == "single"
+
+    def test_on_tag_completer_activated_replaces_last_token(self, qtbot):
+        panel = FilterSearchPanel()
+        qtbot.addWidget(panel)
+
+        panel.ui.lineEditSearch.setText("cat, do")
+        panel._on_tag_completer_activated("dog")
+
+        assert panel.ui.lineEditSearch.text() == "cat, dog, "

--- a/tests/unit/services/test_tag_suggestion_service.py
+++ b/tests/unit/services/test_tag_suggestion_service.py
@@ -1,0 +1,29 @@
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+from lorairo.services.tag_suggestion_service import TagSuggestionService
+
+
+class TestTagSuggestionService:
+    def test_get_suggestions_returns_empty_when_short_query(self):
+        service = TagSuggestionService(merged_reader=Mock())
+
+        assert service.get_suggestions("a") == []
+
+    def test_get_suggestions_uses_cache(self):
+        reader = Mock()
+        service = TagSuggestionService(merged_reader=reader)
+
+        result_obj = SimpleNamespace(items=[SimpleNamespace(tag="cat"), SimpleNamespace(tag="catgirl")])
+        with patch("lorairo.services.tag_suggestion_service.search_tags", return_value=result_obj) as mock_search:
+            first = service.get_suggestions("cat")
+            second = service.get_suggestions("cat")
+
+        assert first == ["cat", "catgirl"]
+        assert second == ["cat", "catgirl"]
+        assert mock_search.call_count == 1
+
+    def test_get_suggestions_returns_empty_when_reader_unavailable(self):
+        service = TagSuggestionService(merged_reader=None)
+
+        assert service.get_suggestions("cat") == []


### PR DESCRIPTION
### Motivation
- 検索入力時にタグ候補をサジェストしてUXを向上させるため、外部タグDBの `search_tags()` を利用したオートコンプリート機能を実装する。
- カンマ区切り入力で最後のトークンのみ補完し、誤操作を減らすために2文字以上・300msのデバウンスを採用する。

### Description
- 追加: `src/lorairo/services/tag_suggestion_service.py` を新規作成し、`genai_tag_db_tools.search_tags()` を用いた候補取得・メモリキャッシュ・縮退動作を実装した（`TagSearchRequest(partial=True)` を使用）。
- 変更: `FilterSearchPanel` に `QCompleter` と `QStringListModel` を統合し、300msデバウンスの `QTimer` と以下の補助メソッドを追加して最後のトークン補完を行う：`_extract_last_token`, `_on_search_text_changed`, `_fetch_tag_suggestions`, `_update_completer_items`, `_on_tag_completer_activated`, および `set_tag_suggestion_service`。
- 変更: `MainWindow` の検索パネル統合処理で `TagSuggestionService` を生成し `FilterSearchPanel` に注入するようにした。
- 追加: ユニットテストを追加して、`TagSuggestionService` のキャッシュ動作と `FilterSearchPanel` のカンマ区切りトークン置換挙動を検証するテストを追加した（`tests/unit/services/test_tag_suggestion_service.py` と `tests/unit/gui/widgets/test_filter_search_panel_autocomplete.py`）。

### Testing
- 実施: `python -m py_compile` による静的コンパイルチェックは `src/lorairo/services/tag_suggestion_service.py`、`src/lorairo/gui/widgets/filter_search_panel.py`、`src/lorairo/gui/window/main_window.py` と追加テストファイルで成功した。 
- 実施: `pytest -q tests/unit/services/test_tag_suggestion_service.py tests/unit/gui/widgets/test_filter_search_panel_autocomplete.py` を試行したが、テスト実行は `tests/conftest.py` の読み込み時に環境側で `sqlalchemy` が見つからず失敗したため実行できなかった（テスト自体は追加済みで CI 環境での実行を想定）。
- 結果: コードはコンパイルされ正常で、単体テストは依存環境が整った CI/ローカルでの実行を想定している。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b62944f5d0832998006e200fda35ed)