### PR TITLE
feat: add tag autocomplete to FilterSearchPanel

### DIFF
--- a/src/lorairo/gui/widgets/filter_search_panel.py
+++ b/src/lorairo/gui/widgets/filter_search_panel.py
@@ -4,10 +4,11 @@ from datetime import datetime
 from enum import Enum
 from typing import TYPE_CHECKING, Any
 
-from PySide6.QtCore import Signal
-from PySide6.QtWidgets import QScrollArea
+from PySide6.QtCore import QStringListModel, QTimer, Qt, Signal
+from PySide6.QtWidgets import QCompleter, QScrollArea
 
 from ...gui.designer.FilterSearchPanel_ui import Ui_FilterSearchPanel
+from ...services.tag_suggestion_service import TagSuggestionService
 from ...utils.log import logger
 from .custom_range_slider import CustomRangeSlider
 
@@ -72,6 +73,7 @@ class FilterSearchPanel(QScrollArea):
         # UI設定
         self.ui = Ui_FilterSearchPanel()
         self.ui.setupUi(self)
+        self._setup_tag_autocomplete()
         self.setup_custom_widgets()
         self.setup_favorite_filters_ui()  # Phase 4
         self.connect_signals()
@@ -153,6 +155,25 @@ class FilterSearchPanel(QScrollArea):
         # NSFWトグルは廃止: レーティング選択から自動判定する
         self.ui.checkboxIncludeNSFW.setChecked(False)
         self.ui.checkboxIncludeNSFW.setVisible(False)
+
+    def _setup_tag_autocomplete(self) -> None:
+        """タグ検索入力にオートコンプリートを設定する。"""
+        self.tag_suggestion_service = TagSuggestionService()
+
+        self._tag_completer_model = QStringListModel(self)
+        self._tag_completer = QCompleter(self._tag_completer_model, self)
+        self._tag_completer.setCaseSensitivity(False)
+        self._tag_completer.setCompletionMode(QCompleter.CompletionMode.PopupCompletion)
+        self._tag_completer.setFilterMode(Qt.MatchFlag.MatchContains)
+
+        self._tag_suggestion_timer = QTimer(self)
+        self._tag_suggestion_timer.setSingleShot(True)
+        self._tag_suggestion_timer.setInterval(self.tag_suggestion_service.debounce_ms)
+        self._tag_suggestion_timer.timeout.connect(self._update_tag_suggestions)
+
+        self.ui.lineEditSearch.setCompleter(self._tag_completer)
+        self.ui.lineEditSearch.textEdited.connect(self._on_search_text_edited)
+        self._tag_completer.activated[str].connect(self._on_tag_suggestion_selected)
 
     def setup_favorite_filters_ui(self) -> None:
         """お気に入りフィルターUIを作成してメインレイアウトに追加 (Phase 4)"""
@@ -400,6 +421,55 @@ class FilterSearchPanel(QScrollArea):
         # アクションボタン
         self.ui.buttonApply.clicked.connect(self._on_apply_clicked)
         self.ui.buttonClear.clicked.connect(self._on_clear_clicked)
+
+    @staticmethod
+    def _extract_current_tag_token(text: str) -> str:
+        """カンマ区切り入力の最後のトークンを取得する。"""
+        return text.split(",")[-1].strip()
+
+    def _on_search_text_edited(self, text: str) -> None:
+        """検索入力編集中にタグ候補取得をデバウンス実行する。"""
+        if not self.ui.checkboxTags.isChecked() or not self.ui.lineEditSearch.isEnabled():
+            self._clear_tag_suggestions()
+            return
+
+        token = self._extract_current_tag_token(text)
+        if len(token) < self.tag_suggestion_service.min_chars:
+            self._clear_tag_suggestions()
+            return
+
+        self._tag_suggestion_timer.start()
+
+    def _update_tag_suggestions(self) -> None:
+        """現在入力中のトークンに基づいて候補を更新する。"""
+        token = self._extract_current_tag_token(self.ui.lineEditSearch.text())
+        suggestions = self.tag_suggestion_service.get_suggestions(token)
+        self._tag_completer_model.setStringList(suggestions)
+
+        if suggestions and self.ui.lineEditSearch.hasFocus():
+            self._tag_completer.complete()
+
+    def _clear_tag_suggestions(self) -> None:
+        self._tag_suggestion_timer.stop()
+        self._tag_completer_model.setStringList([])
+
+    def _on_tag_suggestion_selected(self, selected_tag: str) -> None:
+        """補完候補選択時に最後のトークンだけを置き換える。"""
+        current_text = self.ui.lineEditSearch.text()
+        segments = current_text.split(",")
+        if not segments:
+            self.ui.lineEditSearch.setText(selected_tag)
+            return
+
+        segments[-1] = f" {selected_tag}" if len(segments) > 1 else selected_tag
+        updated = ",".join(segment.rstrip() for segment in segments[:-1])
+        if updated:
+            new_text = f"{updated},{segments[-1]}"
+        else:
+            new_text = segments[-1].lstrip()
+
+        self.ui.lineEditSearch.setText(new_text)
+        self.ui.lineEditSearch.setCursorPosition(len(new_text))
 
     def set_search_filter_service(self, service: "SearchFilterService") -> None:
         """SearchFilterServiceを設定（拡張版：バリデーションとログ強化）"""
@@ -805,6 +875,9 @@ class FilterSearchPanel(QScrollArea):
             # 複数タイプ選択時
             self.ui.lineEditSearch.setPlaceholderText("タグ・キャプション検索キーワードを入力...")
 
+        if not self.ui.checkboxTags.isChecked():
+            self._clear_tag_suggestions()
+
     def _update_search_input_state(self) -> None:
         """検索入力フィールドの有効/無効状態を更新（チェックボックス対応）"""
         # タグ検索で未タグ検索が有効、またはキャプション検索で未キャプション検索が有効の場合は無効化
@@ -812,6 +885,8 @@ class FilterSearchPanel(QScrollArea):
             self.ui.checkboxCaption.isChecked() and self.ui.checkboxOnlyUncaptioned.isChecked()
         )
         self.ui.lineEditSearch.setEnabled(not disabled)
+        if disabled:
+            self._clear_tag_suggestions()
 
     def _on_search_requested(self) -> None:
         """検索要求処理 - WorkerService経由で非同期実行（Qt Designer Phase 2レスポンシブレイアウト対応強化版）"""

--- a/src/lorairo/services/tag_suggestion_service.py
+++ b/src/lorairo/services/tag_suggestion_service.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+from collections import OrderedDict
+from time import monotonic
+from typing import Any
+
+from ..utils.log import logger
+
+
+class TagSuggestionService:
+    """タグ入力オートコンプリート用サジェストサービス。"""
+
+    def __init__(
+        self,
+        *,
+        min_chars: int = 2,
+        debounce_ms: int = 300,
+        max_suggestions: int = 20,
+        cache_size: int = 256,
+        cache_ttl_seconds: float = 300.0,
+    ) -> None:
+        self.min_chars = min_chars
+        self.debounce_ms = debounce_ms
+        self.max_suggestions = max_suggestions
+        self.cache_size = cache_size
+        self.cache_ttl_seconds = cache_ttl_seconds
+        self._cache: OrderedDict[str, tuple[float, list[str]]] = OrderedDict()
+
+    def get_suggestions(self, raw_query: str) -> list[str]:
+        """入力文字列からタグ候補一覧を取得する。"""
+        query = raw_query.strip()
+        if len(query) < self.min_chars:
+            return []
+
+        cache_key = query.casefold()
+        cached = self._get_cache(cache_key)
+        if cached is not None:
+            return cached
+
+        suggestions = self._search_tags(query)
+        self._set_cache(cache_key, suggestions)
+        return suggestions
+
+    def _search_tags(self, query: str) -> list[str]:
+        try:
+            from genai_tag_db_tools import search_tags
+
+            try:
+                records = search_tags(query=query, limit=self.max_suggestions)
+            except TypeError:
+                records = search_tags(query)
+        except Exception as e:
+            logger.warning("タグ候補取得に失敗: query='{}', error={}", query, e)
+            return []
+
+        return self._normalize_results(records)
+
+    def _normalize_results(self, records: Any) -> list[str]:
+        suggestions: list[str] = []
+        seen: set[str] = set()
+
+        if not isinstance(records, list):
+            return []
+
+        for record in records:
+            tag_name = self._extract_tag_name(record)
+            if not tag_name:
+                continue
+
+            normalized = tag_name.strip()
+            key = normalized.casefold()
+            if key in seen:
+                continue
+
+            seen.add(key)
+            suggestions.append(normalized)
+
+            if len(suggestions) >= self.max_suggestions:
+                break
+
+        return suggestions
+
+    @staticmethod
+    def _extract_tag_name(record: Any) -> str | None:
+        if isinstance(record, str):
+            return record
+
+        if isinstance(record, dict):
+            for key in ("tag", "name", "tag_name"):
+                value = record.get(key)
+                if isinstance(value, str):
+                    return value
+            return None
+
+        for attr in ("tag", "name", "tag_name"):
+            value = getattr(record, attr, None)
+            if isinstance(value, str):
+                return value
+
+        return None
+
+    def _get_cache(self, key: str) -> list[str] | None:
+        if key not in self._cache:
+            return None
+
+        created_at, data = self._cache[key]
+        now = monotonic()
+        if now - created_at > self.cache_ttl_seconds:
+            del self._cache[key]
+            return None
+
+        self._cache.move_to_end(key)
+        return data
+
+    def _set_cache(self, key: str, suggestions: list[str]) -> None:
+        self._cache[key] = (monotonic(), suggestions)
+        self._cache.move_to_end(key)
+
+        while len(self._cache) > self.cache_size:
+            self._cache.popitem(last=False)

--- a/tests/unit/services/test_tag_suggestion_service.py
+++ b/tests/unit/services/test_tag_suggestion_service.py
@@ -1,0 +1,68 @@
+import sys
+import time
+import types
+
+from lorairo.services.tag_suggestion_service import TagSuggestionService
+
+
+class TestTagSuggestionService:
+    def test_get_suggestions_returns_empty_when_too_short(self):
+        service = TagSuggestionService(min_chars=2)
+
+        assert service.get_suggestions("a") == []
+
+    def test_get_suggestions_normalizes_and_deduplicates_results(self, monkeypatch):
+        fake_module = types.ModuleType("genai_tag_db_tools")
+        fake_module.search_tags = lambda query, limit=None: [
+            {"tag": "blue_hair"},
+            {"name": "Blue_Hair"},
+            {"tag_name": "1girl"},
+            "solo",
+            {"unknown": "skip"},
+        ]
+        monkeypatch.setitem(sys.modules, "genai_tag_db_tools", fake_module)
+
+        service = TagSuggestionService(max_suggestions=10)
+        result = service.get_suggestions("blue")
+
+        assert result == ["blue_hair", "1girl", "solo"]
+
+    def test_get_suggestions_uses_cache(self, monkeypatch):
+        calls = {"count": 0}
+
+        fake_module = types.ModuleType("genai_tag_db_tools")
+
+        def fake_search_tags(query, limit=None):
+            calls["count"] += 1
+            return ["cached_tag"]
+
+        fake_module.search_tags = fake_search_tags
+        monkeypatch.setitem(sys.modules, "genai_tag_db_tools", fake_module)
+
+        service = TagSuggestionService(cache_ttl_seconds=60)
+
+        assert service.get_suggestions("cache") == ["cached_tag"]
+        assert service.get_suggestions("cache") == ["cached_tag"]
+        assert calls["count"] == 1
+
+    def test_get_suggestions_cache_expires(self, monkeypatch):
+        calls = {"count": 0}
+
+        fake_module = types.ModuleType("genai_tag_db_tools")
+
+        def fake_search_tags(query, limit=None):
+            calls["count"] += 1
+            return [f"tag_{calls['count']}"]
+
+        fake_module.search_tags = fake_search_tags
+        monkeypatch.setitem(sys.modules, "genai_tag_db_tools", fake_module)
+
+        service = TagSuggestionService(cache_ttl_seconds=0.01)
+
+        first = service.get_suggestions("expire")
+        time.sleep(0.02)
+        second = service.get_suggestions("expire")
+
+        assert first == ["tag_1"]
+        assert second == ["tag_2"]
+        assert calls["count"] == 2


### PR DESCRIPTION
### Motivation
- Improve search UX by providing tag autocompletion in the search input to match Issue #9 requirements.  
- Provide a reusable service that wraps `genai-tag-db-tools.search_tags()` and tolerates its return-type variations.  

### Description
- Add `TagSuggestionService` (`src/lorairo/services/tag_suggestion_service.py`) which wraps `search_tags()`, enforces `min_chars` (default 2), normalizes results (handles `str` / `dict` / object shapes), and implements an LRU+TTL cache.  
- Integrate a `QCompleter` into `FilterSearchPanel` (`src/lorairo/gui/widgets/filter_search_panel.py`) and wire it to `lineEditSearch` with a 300ms debounce and `MatchContains` filtering.  
- Support comma-separated input by completing only the last token and replacing that token when a suggestion is selected.  
- Clear suggestions when tag search is disabled or input is invalid.  
- Add unit tests (`tests/unit/services/test_tag_suggestion_service.py`) covering minimum-length behavior, normalization/deduplication, cache hits, and TTL expiry.  

### Testing
- Compiled modified modules with `python -m compileall src/lorairo/services/tag_suggestion_service.py src/lorairo/gui/widgets/filter_search_panel.py` and compilation succeeded.  
- Attempted to run unit tests with `pytest -q tests/unit/services/test_tag_suggestion_service.py`, but the run aborted due to environment dependency missing: `ModuleNotFoundError: No module named 'sqlalchemy'` raised while importing `tests/conftest.py`; this prevented executing the test file in the current environment.  
- The new unit tests are included and should pass in a properly provisioned dev environment with project dependencies installed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b62944f5d0832998006e200fda35ed)