### PR TITLE
feat: add tag autocomplete suggestions in search panel

### DIFF
--- a/src/lorairo/gui/widgets/filter_search_panel.py
+++ b/src/lorairo/gui/widgets/filter_search_panel.py
@@ -4,10 +4,11 @@ from datetime import datetime
 from enum import Enum
 from typing import TYPE_CHECKING, Any
 
-from PySide6.QtCore import Signal
-from PySide6.QtWidgets import QScrollArea
+from PySide6.QtCore import QTimer, Qt, Signal, QStringListModel
+from PySide6.QtWidgets import QCompleter, QScrollArea
 
 from ...gui.designer.FilterSearchPanel_ui import Ui_FilterSearchPanel
+from ...services.tag_suggestion_service import TagSuggestionService
 from ...utils.log import logger
 from .custom_range_slider import CustomRangeSlider
 
@@ -54,6 +55,17 @@ class FilterSearchPanel(QScrollArea):
 
         # FavoriteFiltersService（依存注入） - Phase 4
         self.favorite_filters_service: Any = None  # type: ignore[assignment]
+
+        # タグオートコンプリート
+        self._tag_suggestion_service = TagSuggestionService()
+        self._tag_suggestion_timer = QTimer(self)
+        self._tag_suggestion_timer.setSingleShot(True)
+        self._tag_suggestion_timer.setInterval(300)
+        self._tag_suggestion_timer.timeout.connect(self._update_tag_completions)
+        self._tag_completer_model = QStringListModel(self)
+        self._tag_completer = QCompleter(self._tag_completer_model, self)
+        self._tag_completer.setCaseSensitivity(Qt.CaseSensitivity.CaseInsensitive)
+        self._tag_completer.setCompletionMode(QCompleter.CompletionMode.PopupCompletion)
 
         # 現在のSearchWorkerのID
         self._current_search_worker_id: str | None = None
@@ -384,6 +396,9 @@ class FilterSearchPanel(QScrollArea):
         """Qt DesignerのUIコンポーネントにシグナルを接続"""
         # 検索関連（チェックボックスに更新）
         self.ui.lineEditSearch.returnPressed.connect(self._on_search_requested)
+        self.ui.lineEditSearch.textEdited.connect(self._on_search_text_edited)
+        self.ui.lineEditSearch.setCompleter(self._tag_completer)
+        self._tag_completer.activated.connect(self._on_tag_completion_activated)
         self.ui.checkboxTags.toggled.connect(self._on_search_type_changed)
         self.ui.checkboxCaption.toggled.connect(self._on_search_type_changed)
 
@@ -690,6 +705,55 @@ class FilterSearchPanel(QScrollArea):
         self._update_search_input_state()
         self._on_search_type_changed()
 
+    @staticmethod
+    def _extract_last_token(text: str) -> str:
+        """カンマ区切り入力の最後のトークンを返す。"""
+        return text.rsplit(",", 1)[-1].strip()
+
+    @staticmethod
+    def _merge_completion_into_text(current_text: str, completion: str) -> str:
+        """カンマ区切り入力の最後のトークンを補完候補で置換する。"""
+        if "," not in current_text:
+            return completion
+
+        parts = current_text.rsplit(",", 1)
+        prefix = parts[0].strip()
+        if not prefix:
+            return completion
+        return f"{prefix}, {completion}"
+
+    def _on_search_text_edited(self, text: str) -> None:
+        """タグ検索入力時にデバウンスして候補取得を開始する。"""
+        if "tags" not in self._get_selected_search_types() or not self.ui.lineEditSearch.isEnabled():
+            self._tag_suggestion_timer.stop()
+            self._tag_completer_model.setStringList([])
+            return
+
+        token = self._extract_last_token(text)
+        if len(token) < 2:
+            self._tag_suggestion_timer.stop()
+            self._tag_completer_model.setStringList([])
+            return
+
+        self._tag_suggestion_timer.start()
+
+    def _update_tag_completions(self) -> None:
+        """現在入力中のタグトークンに対応する候補を更新する。"""
+        token = self._extract_last_token(self.ui.lineEditSearch.text())
+        if len(token) < 2:
+            self._tag_completer_model.setStringList([])
+            return
+
+        suggestions = self._tag_suggestion_service.get_suggestions(token)
+        self._tag_completer_model.setStringList(suggestions)
+        if suggestions:
+            self._tag_completer.complete()
+
+    def _on_tag_completion_activated(self, completion: str) -> None:
+        """候補選択時に最後のトークンを補完して反映する。"""
+        updated_text = self._merge_completion_into_text(self.ui.lineEditSearch.text(), completion)
+        self.ui.lineEditSearch.setText(updated_text)
+
     def _get_selected_search_types(self) -> list[str]:
         """選択された検索タイプのリストを取得"""
         types = []
@@ -804,6 +868,10 @@ class FilterSearchPanel(QScrollArea):
         else:
             # 複数タイプ選択時
             self.ui.lineEditSearch.setPlaceholderText("タグ・キャプション検索キーワードを入力...")
+
+        if "tags" not in selected_types:
+            self._tag_suggestion_timer.stop()
+            self._tag_completer_model.setStringList([])
 
     def _update_search_input_state(self) -> None:
         """検索入力フィールドの有効/無効状態を更新（チェックボックス対応）"""

--- a/src/lorairo/services/tag_suggestion_service.py
+++ b/src/lorairo/services/tag_suggestion_service.py
@@ -1,0 +1,60 @@
+"""Tag suggestion service for search auto-complete."""
+
+from __future__ import annotations
+
+from time import monotonic
+
+from genai_tag_db_tools import search_tags
+from genai_tag_db_tools.db.repository import MergedTagReader, get_default_reader
+from genai_tag_db_tools.models import TagSearchRequest
+
+from ..utils.log import logger
+
+
+class TagSuggestionService:
+    """タグ候補のサジェストを提供するサービス。"""
+
+    def __init__(
+        self,
+        reader: MergedTagReader | None = None,
+        *,
+        min_query_length: int = 2,
+        max_results: int = 20,
+        cache_ttl_seconds: int = 300,
+    ) -> None:
+        self.reader = reader if reader is not None else get_default_reader()
+        self.min_query_length = min_query_length
+        self.max_results = max_results
+        self.cache_ttl_seconds = cache_ttl_seconds
+        self._cache: dict[str, tuple[float, list[str]]] = {}
+
+    def get_suggestions(self, query: str) -> list[str]:
+        """queryに対するタグ候補を返す。"""
+        normalized_query = query.strip()
+        if len(normalized_query) < self.min_query_length:
+            return []
+
+        cache_key = normalized_query.casefold()
+        now = monotonic()
+        cached = self._cache.get(cache_key)
+        if cached and (now - cached[0]) < self.cache_ttl_seconds:
+            return cached[1]
+
+        request = TagSearchRequest(
+            query=normalized_query,
+            partial=True,
+            resolve_preferred=True,
+            include_aliases=False,
+            include_deprecated=False,
+        )
+
+        try:
+            result = search_tags(self.reader, request)
+            suggestions = [item.tag for item in result.items[: self.max_results]]
+        except Exception as e:
+            logger.warning("Failed to fetch tag suggestions for '{}': {}", normalized_query, e)
+            return []
+
+        self._cache[cache_key] = (now, suggestions)
+        return suggestions
+

--- a/tests/unit/gui/widgets/test_custom_range_slider.py
+++ b/tests/unit/gui/widgets/test_custom_range_slider.py
@@ -637,6 +637,17 @@ class TestFilterSearchPanel:
         primary_type = filter_panel._get_primary_search_type()
         assert primary_type == "tags"
 
+
+    def test_extract_last_token_for_comma_separated_input(self, filter_panel):
+        """カンマ区切り入力の末尾トークン抽出テスト"""
+        token = filter_panel._extract_last_token("1girl, blue_hair")
+        assert token == "blue_hair"
+
+    def test_merge_completion_into_text_for_comma_separated_input(self, filter_panel):
+        """補完候補を末尾トークンへマージするテスト"""
+        merged = filter_panel._merge_completion_into_text("1girl, blue", "blue_hair")
+        assert merged == "1girl, blue_hair"
+
     def test_qbuttongroup_logic_operators_new_functionality(self, filter_panel):
         """QButtonGroup論理演算子テスト（新機能）"""
         # QButtonGroupが正しく設定されているかテスト

--- a/tests/unit/services/test_tag_suggestion_service.py
+++ b/tests/unit/services/test_tag_suggestion_service.py
@@ -1,0 +1,28 @@
+from types import SimpleNamespace
+
+from lorairo.services import tag_suggestion_service
+from lorairo.services.tag_suggestion_service import TagSuggestionService
+
+
+class TestTagSuggestionService:
+    def test_returns_empty_for_short_query(self):
+        service = TagSuggestionService(reader=object(), min_query_length=2)
+        assert service.get_suggestions("a") == []
+
+    def test_uses_cache_for_same_query(self, monkeypatch):
+        calls = {"count": 0}
+
+        def mock_search_tags(reader, request):
+            calls["count"] += 1
+            item = SimpleNamespace(tag="blue_hair")
+            return SimpleNamespace(items=[item])
+
+        monkeypatch.setattr(tag_suggestion_service, "search_tags", mock_search_tags)
+
+        service = TagSuggestionService(reader=object(), cache_ttl_seconds=300)
+        first = service.get_suggestions("blue")
+        second = service.get_suggestions("blue")
+
+        assert first == ["blue_hair"]
+        assert second == ["blue_hair"]
+        assert calls["count"] == 1


### PR DESCRIPTION
### Motivation
- Improve search UX by providing real-time tag suggestions when typing in the tag search field, supporting comma-separated tag input and minimizing unnecessary queries.

### Description
- Added a new service `src/lorairo/services/tag_suggestion_service.py` that calls `search_tags()` and provides normalization, a minimal query length guard, result limiting, and an in-memory TTL cache.
- Integrated a `QCompleter` into `FilterSearchPanel` (`src/lorairo/gui/widgets/filter_search_panel.py`) with a 300ms debounce on `textEdited`, plus helper methods to extract/replace the last token in comma-separated inputs and to clear suggestions when tag search is not selected.
- Added unit tests: `tests/unit/services/test_tag_suggestion_service.py` for caching/short-query behavior and small helper tests inserted into `tests/unit/gui/widgets/test_custom_range_slider.py` to validate token extraction/merging logic.

### Testing
- Ran `python -m compileall` to verify source files compile, which succeeded for the changed files (`tag_suggestion_service.py`, `filter_search_panel.py`, and new/updated tests`).
- Attempted targeted pytest run: `PYTHONPATH=src python -m pytest tests/unit/services/test_tag_suggestion_service.py tests/unit/gui/widgets/test_custom_range_slider.py -k "tag_suggestion_service or extract_last_token or merge_completion"`, which failed during `tests/conftest.py` import due to missing system dependency `sqlalchemy` in the environment (not a failure of the added unit tests themselves).
- Basic static checks (module import/compile) passed; runtime unit tests require the repository dev dependencies to be installed (e.g., via `make install-dev`) to run in CI or a dev environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b62944f5d0832998006e200fda35ed)