### PR TITLE
feat: リアルタイム検索件数プレビュー（Issue #10）

### DIFF
--- a/src/lorairo/database/db_manager.py
+++ b/src/lorairo/database/db_manager.py
@@ -151,13 +151,10 @@ class ImageDatabaseManager:
 
             # 4. 512px サムネイル画像の自動生成
             try:
-                self._generate_thumbnail_512px(
-                    image_id, db_stored_original_path, original_metadata, fsm
-                )
+                self._generate_thumbnail_512px(image_id, db_stored_original_path, original_metadata, fsm)
             except Exception as e:
                 logger.warning(
-                    f"512px サムネイル生成に失敗しましたが、処理を続行します: "
-                    f"{image_path}, Error: {e}",
+                    f"512px サムネイル生成に失敗しましたが、処理を続行します: {image_path}, Error: {e}",
                 )
 
             return image_id, original_metadata
@@ -665,6 +662,19 @@ class ImageDatabaseManager:
                 session.commit()
             logger.debug(f"MANUAL_EDITモデルIDをキャッシュ: {self._manual_edit_model_id}")
         return self._manual_edit_model_id
+
+    def get_images_count_only(
+        self,
+        criteria: ImageFilterCriteria | None = None,
+        **kwargs: Any,
+    ) -> int:
+        """指定された条件に基づいて画像件数のみを返します。"""
+        try:
+            filter_criteria = criteria if criteria else ImageFilterCriteria.from_kwargs(**kwargs)
+            return self.repository.get_images_count_only(filter_criteria)
+        except Exception as e:
+            logger.error(f"画像件数取得中にエラーが発生しました: {e}", exc_info=True)
+            return 0
 
     def get_images_by_filter(
         self,

--- a/src/lorairo/database/db_repository.py
+++ b/src/lorairo/database/db_repository.py
@@ -2551,6 +2551,41 @@ class ImageRepository:
                 logger.error(f"画像フィルタリング検索中にエラーが発生しました: {e}", exc_info=True)
                 raise
 
+    def get_images_count_only(
+        self,
+        criteria: ImageFilterCriteria | None = None,
+        **kwargs: Any,
+    ) -> int:
+        """指定された条件に基づいて、画像件数のみを軽量に取得する。"""
+        filter_criteria = criteria if criteria else ImageFilterCriteria.from_kwargs(**kwargs)
+
+        with self.session_factory() as session:
+            try:
+                query = self._build_image_filter_query(
+                    session=session,
+                    tags=filter_criteria.tags,
+                    caption=filter_criteria.caption,
+                    use_and=filter_criteria.use_and,
+                    start_date=filter_criteria.start_date,
+                    end_date=filter_criteria.end_date,
+                    include_untagged=filter_criteria.include_untagged,
+                    include_nsfw=filter_criteria.include_nsfw,
+                    include_unrated=filter_criteria.include_unrated,
+                    manual_rating_filter=filter_criteria.manual_rating_filter,
+                    ai_rating_filter=filter_criteria.ai_rating_filter,
+                    manual_edit_filter=filter_criteria.manual_edit_filter,
+                    score_min=filter_criteria.score_min,
+                    score_max=filter_criteria.score_max,
+                )
+                count_stmt = select(func.count()).select_from(query.subquery())
+                count = session.execute(count_stmt).scalar_one()
+                logger.debug(f"画像件数のみ取得: {count}件")
+                return count
+
+            except SQLAlchemyError as e:
+                logger.error(f"画像件数取得中にエラーが発生しました: {e}", exc_info=True)
+                raise
+
     # --- Model Information Retrieval ---
 
     def get_models(self) -> list[dict[str, Any]]:

--- a/src/lorairo/gui/services/search_filter_service.py
+++ b/src/lorairo/gui/services/search_filter_service.py
@@ -302,6 +302,15 @@ class SearchFilterService:
         """後方互換性ラッパー:SearchCriteriaProcessorに委譲"""
         return self.criteria_processor.execute_search_with_filters(conditions)
 
+    def get_estimated_count(self, conditions: SearchConditions) -> int:
+        """現在の検索条件に対する推定件数を取得する。"""
+        try:
+            filter_criteria = conditions.to_filter_criteria()
+            return self.db_manager.get_images_count_only(criteria=filter_criteria)
+        except Exception as e:
+            logger.error(f"推定件数取得エラー: {e}", exc_info=True)
+            return 0
+
     def get_annotation_models_list(self) -> list[dict[str, Any]]:
         """後方互換性ラッパー:ModelFilterServiceに委譲"""
         return self.model_filter_service.get_annotation_models_list()

--- a/src/lorairo/gui/widgets/filter_search_panel.py
+++ b/src/lorairo/gui/widgets/filter_search_panel.py
@@ -4,7 +4,7 @@ from datetime import datetime
 from enum import Enum
 from typing import TYPE_CHECKING, Any
 
-from PySide6.QtCore import Signal
+from PySide6.QtCore import QTimer, Signal
 from PySide6.QtWidgets import QScrollArea
 
 from ...gui.designer.FilterSearchPanel_ui import Ui_FilterSearchPanel
@@ -57,6 +57,12 @@ class FilterSearchPanel(QScrollArea):
 
         # 現在のSearchWorkerのID
         self._current_search_worker_id: str | None = None
+
+        # リアルタイム件数表示用（Issue #10）
+        self._estimated_count_timer = QTimer(self)
+        self._estimated_count_timer.setSingleShot(True)
+        self._estimated_count_timer.setInterval(500)
+        self._estimated_count_timer.timeout.connect(self._update_estimated_count)
 
         # Phase 3: Pipeline State Management
         self._current_state: PipelineState = PipelineState.IDLE
@@ -140,10 +146,12 @@ class FilterSearchPanel(QScrollArea):
         self.progress_layout.addWidget(self.progress_bar)
         self.progress_layout.addWidget(self._status_label)
 
-        # 検索グループの最後に進捗UIを追加
-        # プレビューエリア削除後は、lineEditSearchの下に追加
+        # 検索グループにリアルタイム件数ラベルと進捗UIを追加
         main_layout = self.ui.searchGroup.layout()
         if main_layout:
+            self.estimated_count_label = QLabel("該当件数: -")
+            self.estimated_count_label.setStyleSheet("color: #666; font-size: 11px;")
+            main_layout.addWidget(self.estimated_count_label)
             main_layout.addLayout(self.progress_layout)
 
         # 重複除外トグルは廃止: 登録時のpHash重複防止により検索UI上では不要
@@ -384,18 +392,35 @@ class FilterSearchPanel(QScrollArea):
         """Qt DesignerのUIコンポーネントにシグナルを接続"""
         # 検索関連（チェックボックスに更新）
         self.ui.lineEditSearch.returnPressed.connect(self._on_search_requested)
+        self.ui.lineEditSearch.textChanged.connect(self._schedule_estimated_count_update)
         self.ui.checkboxTags.toggled.connect(self._on_search_type_changed)
+        self.ui.checkboxTags.toggled.connect(self._schedule_estimated_count_update)
         self.ui.checkboxCaption.toggled.connect(self._on_search_type_changed)
+        self.ui.checkboxCaption.toggled.connect(self._schedule_estimated_count_update)
 
-        # 解像度フィルター
+        # 解像度・比率フィルター
         self.ui.comboResolution.currentTextChanged.connect(self._on_resolution_changed)
+        self.ui.comboResolution.currentTextChanged.connect(self._schedule_estimated_count_update)
+        self.ui.comboAspectRatio.currentTextChanged.connect(self._schedule_estimated_count_update)
 
         # 日付フィルター
         self.ui.checkboxDateFilter.toggled.connect(self._on_date_filter_toggled)
+        self.ui.checkboxDateFilter.toggled.connect(self._schedule_estimated_count_update)
         self.date_range_slider.valueChanged.connect(self._on_date_range_changed)
+        self.date_range_slider.valueChanged.connect(lambda *_: self._schedule_estimated_count_update())
 
         # Ratingフィルター
         self.ui.comboRating.currentTextChanged.connect(self._on_rating_changed)
+        self.ui.comboRating.currentTextChanged.connect(self._schedule_estimated_count_update)
+        self.ui.comboAIRating.currentTextChanged.connect(self._schedule_estimated_count_update)
+        self.ui.checkboxIncludeUnrated.toggled.connect(self._schedule_estimated_count_update)
+
+        # 追加フィルター
+        self.ui.checkboxOnlyUntagged.toggled.connect(self._on_only_untagged_toggled)
+        self.ui.checkboxOnlyUntagged.toggled.connect(self._schedule_estimated_count_update)
+        self.ui.checkboxOnlyUncaptioned.toggled.connect(self._on_only_uncaptioned_toggled)
+        self.ui.checkboxOnlyUncaptioned.toggled.connect(self._schedule_estimated_count_update)
+        self.score_range_slider.valueChanged.connect(lambda *_: self._schedule_estimated_count_update())
 
         # アクションボタン
         self.ui.buttonApply.clicked.connect(self._on_apply_clicked)
@@ -813,6 +838,77 @@ class FilterSearchPanel(QScrollArea):
         )
         self.ui.lineEditSearch.setEnabled(not disabled)
 
+    def _schedule_estimated_count_update(self, *_: Any) -> None:
+        """条件変更時に推定件数更新をデバウンス実行する。"""
+        if not self.search_filter_service:
+            return
+        self._estimated_count_timer.start()
+
+    def _update_estimated_count(self) -> None:
+        """現在条件に基づく推定件数を表示する。"""
+        if not self.search_filter_service:
+            return
+
+        conditions = self._build_conditions_for_estimate()
+        if conditions is None:
+            self.estimated_count_label.setText("該当件数: -")
+            return
+
+        count = self.search_filter_service.get_estimated_count(conditions)
+        self.estimated_count_label.setText(f"該当件数: {count}件")
+
+    def _build_conditions_for_estimate(self) -> Any | None:
+        """UI状態から推定件数取得用の検索条件を構築する。"""
+        search_text = self.ui.lineEditSearch.text().strip()
+        keywords = self.search_filter_service.parse_search_input(search_text) if search_text else []
+
+        score_min_internal, score_max_internal = self.score_range_slider.get_range()
+        has_score_filter = score_min_internal != 0 or score_max_internal != 1000
+
+        has_any_condition = keywords or any(
+            [
+                self.ui.checkboxOnlyUntagged.isChecked(),
+                self.ui.checkboxOnlyUncaptioned.isChecked(),
+                self.ui.checkboxDateFilter.isChecked(),
+                self.ui.comboResolution.currentText() != "全て",
+                self.ui.comboRating.currentText() != "全て",
+                self.ui.comboAIRating.currentText() != "全て",
+                not self.ui.checkboxIncludeUnrated.isChecked(),
+                has_score_filter,
+            ],
+        )
+        if not has_any_condition:
+            return None
+
+        date_range_start, date_range_end = self.get_date_range_from_slider()
+        if self.ui.checkboxDateFilter.isChecked() and (date_range_start is None or date_range_end is None):
+            return None
+
+        rating_filter = self._get_rating_filter_value()
+        ai_rating_filter = self._get_ai_rating_filter_value()
+        include_nsfw = self._resolve_include_nsfw(rating_filter, ai_rating_filter)
+        score_min, score_max = self._get_score_filter_values()
+
+        return self.search_filter_service.create_search_conditions(
+            search_type=self._get_primary_search_type(),
+            keywords=keywords,
+            tag_logic="and" if self.ui.radioAnd.isChecked() else "or",
+            resolution_filter=self.ui.comboResolution.currentText(),
+            aspect_ratio_filter=self.ui.comboAspectRatio.currentText(),
+            date_filter_enabled=self.ui.checkboxDateFilter.isChecked(),
+            date_range_start=date_range_start,
+            date_range_end=date_range_end,
+            only_untagged=self.ui.checkboxOnlyUntagged.isChecked(),
+            only_uncaptioned=self.ui.checkboxOnlyUncaptioned.isChecked(),
+            exclude_duplicates=False,
+            include_nsfw=include_nsfw,
+            rating_filter=rating_filter,
+            ai_rating_filter=ai_rating_filter,
+            include_unrated=self.ui.checkboxIncludeUnrated.isChecked(),
+            score_min=score_min,
+            score_max=score_max,
+        )
+
     def _on_search_requested(self) -> None:
         """検索要求処理 - WorkerService経由で非同期実行（Qt Designer Phase 2レスポンシブレイアウト対応強化版）"""
         if not self.search_filter_service:
@@ -1088,6 +1184,8 @@ class FilterSearchPanel(QScrollArea):
 
     def _clear_all_inputs(self) -> None:
         """全入力をクリア"""
+        self._estimated_count_timer.stop()
+        self.estimated_count_label.setText("該当件数: -")
         self.ui.lineEditSearch.clear()
         self.ui.checkboxTags.setChecked(True)
         self.ui.checkboxCaption.setChecked(False)

--- a/tests/unit/database/test_db_manager_search_count.py
+++ b/tests/unit/database/test_db_manager_search_count.py
@@ -1,0 +1,30 @@
+from unittest.mock import Mock
+
+from lorairo.database.db_manager import ImageDatabaseManager
+from lorairo.database.filter_criteria import ImageFilterCriteria
+
+
+def test_get_images_count_only_calls_repository() -> None:
+    repository = Mock()
+    config_service = Mock()
+    manager = ImageDatabaseManager(repository=repository, config_service=config_service)
+
+    criteria = ImageFilterCriteria(tags=["cat"], use_and=True)
+    repository.get_images_count_only.return_value = 42
+
+    count = manager.get_images_count_only(criteria=criteria)
+
+    assert count == 42
+    repository.get_images_count_only.assert_called_once_with(criteria)
+
+
+def test_get_images_count_only_returns_zero_on_error() -> None:
+    repository = Mock()
+    config_service = Mock()
+    manager = ImageDatabaseManager(repository=repository, config_service=config_service)
+
+    repository.get_images_count_only.side_effect = RuntimeError("db down")
+
+    count = manager.get_images_count_only(criteria=ImageFilterCriteria())
+
+    assert count == 0

--- a/tests/unit/gui/services/test_search_filter_service.py
+++ b/tests/unit/gui/services/test_search_filter_service.py
@@ -342,6 +342,16 @@ class TestSearchFilterServiceDatabase:
         # データベースマネージャーが正しく呼ばれたことを確認
         mock_db_manager.get_images_by_filter.assert_called_once()
 
+    def test_get_estimated_count(self, service_with_db, mock_db_manager):
+        """推定件数取得テスト"""
+        conditions = SearchConditions(search_type="tags", keywords=["cat"], tag_logic="and")
+        mock_db_manager.get_images_count_only.return_value = 7
+
+        count = service_with_db.get_estimated_count(conditions)
+
+        assert count == 7
+        mock_db_manager.get_images_count_only.assert_called_once()
+
 
 class TestSearchFilterServiceAnnotation:
     """SearchFilterService のアノテーション系機能テスト（Phase 2拡張）"""


### PR DESCRIPTION
### Motivation
- 検索フィルターを変更した際に、実際に検索を実行する前に該当件数をリアルタイム表示してUXを改善するため。 
- 軽量に実装するため、既存のフィルター構築ロジックを流用した `COUNT` クエリを用いる方針（デバウンス 500ms）。

### Description
- 追加: リポジトリに件数取得専用メソッド `get_images_count_only()` を実装し、既存の `_build_image_filter_query()` を再利用して軽量な件数取得を行う（`src/lorairo/database/db_repository.py`）。
- 追加: 上記経路を呼び出す `ImageDatabaseManager.get_images_count_only()` を追加してマネージャ経由で利用可能にした（`src/lorairo/database/db_manager.py`）。
- 追加: UI側から条件を受け取って推定件数を返す `SearchFilterService.get_estimated_count()` を実装（`src/lorairo/gui/services/search_filter_service.py`）。
- 追加: `FilterSearchPanel` に 500ms デバウンスの `QTimer` とインラインの件数ラベル（「該当件数」）を追加し、検索テキストや主要フィルターの変更で推定件数を更新する処理を配線（`src/lorairo/gui/widgets/filter_search_panel.py`）。
- テスト: `tests/unit/database/test_db_manager_search_count.py` を追加し、`ImageDatabaseManager` のパススルーとエラーハンドリングを検証、既存の `tests/unit/gui/services/test_search_filter_service.py` に `get_estimated_count` のユニットテストを追加。

### Testing
- 実行: `ruff format` によるフォーマットは成功し、対象ファイルを整形しました。 
- 実行: `python -m py_compile` で変更対象ファイルおよび追加テストの構文チェックは成功しました。 
- 実行: `pytest -q tests/unit/database/test_db_manager_search_count.py tests/unit/gui/services/test_search_filter_service.py` は、テスト環境に `sqlalchemy` が無いため `tests/conftest.py` のロード時に失敗しテストは実行できませんでした。 
- 静的チェック: `ruff check` は既存の複雑度警告（C901）を報告しましたが、今回追加分の大きな静的エラーは発生していません。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b629601390832984f1f95dfdc20a94)