### PR TITLE
feat: フィルター変更時にリアルタイム件数表示を追加

### DIFF
--- a/src/lorairo/database/db_manager.py
+++ b/src/lorairo/database/db_manager.py
@@ -688,6 +688,19 @@ class ImageDatabaseManager:
             logger.error(f"画像フィルタリング検索中にエラーが発生しました: {e}", exc_info=True)
             raise
 
+    def get_images_count_only(
+        self,
+        criteria: ImageFilterCriteria | None = None,
+        **kwargs: Any,
+    ) -> int:
+        """指定条件に一致する画像件数のみを取得します。"""
+        try:
+            filter_criteria = criteria if criteria else ImageFilterCriteria.from_kwargs(**kwargs)
+            return self.repository.get_images_count_only(filter_criteria)
+        except Exception as e:
+            logger.error(f"画像件数取得中にエラーが発生しました: {e}", exc_info=True)
+            raise
+
     def detect_duplicate_image(self, image_path: Path) -> int | None:
         """画像の重複を検出し、重複する場合はその画像のIDを返す。
         pHashベースの視覚的重複検出を使用します。

--- a/src/lorairo/database/db_repository.py
+++ b/src/lorairo/database/db_repository.py
@@ -2551,6 +2551,42 @@ class ImageRepository:
                 logger.error(f"画像フィルタリング検索中にエラーが発生しました: {e}", exc_info=True)
                 raise
 
+    def get_images_count_only(
+        self,
+        criteria: ImageFilterCriteria | None = None,
+        **kwargs: Any,
+    ) -> int:
+        """指定条件に一致する画像件数のみを取得する。"""
+        filter_criteria = criteria if criteria else ImageFilterCriteria.from_kwargs(**kwargs)
+
+        with self.session_factory() as session:
+            try:
+                base_query = self._build_image_filter_query(
+                    session=session,
+                    tags=filter_criteria.tags,
+                    caption=filter_criteria.caption,
+                    use_and=filter_criteria.use_and,
+                    start_date=filter_criteria.start_date,
+                    end_date=filter_criteria.end_date,
+                    include_untagged=filter_criteria.include_untagged,
+                    include_nsfw=filter_criteria.include_nsfw,
+                    include_unrated=filter_criteria.include_unrated,
+                    manual_rating_filter=filter_criteria.manual_rating_filter,
+                    ai_rating_filter=filter_criteria.ai_rating_filter,
+                    manual_edit_filter=filter_criteria.manual_edit_filter,
+                    score_min=filter_criteria.score_min,
+                    score_max=filter_criteria.score_max,
+                )
+
+                count_query = select(func.count(func.distinct(base_query.subquery().c.id)))
+                count = session.execute(count_query).scalar_one()
+                logger.debug(f"条件一致件数のみ取得: {count} 件")
+                return count
+
+            except SQLAlchemyError as e:
+                logger.error(f"件数取得専用クエリ実行中にエラーが発生しました: {e}", exc_info=True)
+                raise
+
     # --- Model Information Retrieval ---
 
     def get_models(self) -> list[dict[str, Any]]:

--- a/src/lorairo/gui/services/search_filter_service.py
+++ b/src/lorairo/gui/services/search_filter_service.py
@@ -302,6 +302,16 @@ class SearchFilterService:
         """後方互換性ラッパー:SearchCriteriaProcessorに委譲"""
         return self.criteria_processor.execute_search_with_filters(conditions)
 
+
+    def get_estimated_count(self, conditions: SearchConditions) -> int:
+        """現在条件に一致する推定件数を軽量クエリで取得する。"""
+        try:
+            filter_criteria = conditions.to_filter_criteria()
+            return self.db_manager.get_images_count_only(criteria=filter_criteria)
+        except Exception as e:
+            logger.error(f"推定件数取得エラー: {e}", exc_info=True)
+            return 0
+
     def get_annotation_models_list(self) -> list[dict[str, Any]]:
         """後方互換性ラッパー:ModelFilterServiceに委譲"""
         return self.model_filter_service.get_annotation_models_list()

--- a/src/lorairo/gui/widgets/filter_search_panel.py
+++ b/src/lorairo/gui/widgets/filter_search_panel.py
@@ -4,7 +4,7 @@ from datetime import datetime
 from enum import Enum
 from typing import TYPE_CHECKING, Any
 
-from PySide6.QtCore import Signal
+from PySide6.QtCore import QTimer, Signal
 from PySide6.QtWidgets import QScrollArea
 
 from ...gui.designer.FilterSearchPanel_ui import Ui_FilterSearchPanel
@@ -68,6 +68,12 @@ class FilterSearchPanel(QScrollArea):
             PipelineState.ERROR: "エラーが発生しました",
             PipelineState.CANCELED: "キャンセルされました",
         }
+
+        # リアルタイム件数表示（Issue #10）
+        self._realtime_count_debounce_ms = 500
+        self._realtime_count_timer = QTimer(self)
+        self._realtime_count_timer.setSingleShot(True)
+        self._realtime_count_timer.timeout.connect(self._update_realtime_count)
 
         # UI設定
         self.ui = Ui_FilterSearchPanel()
@@ -145,6 +151,10 @@ class FilterSearchPanel(QScrollArea):
         main_layout = self.ui.searchGroup.layout()
         if main_layout:
             main_layout.addLayout(self.progress_layout)
+
+            self.realtime_count_label = QLabel("該当件数: -")
+            self.realtime_count_label.setStyleSheet("color: #666; font-size: 11px;")
+            main_layout.addWidget(self.realtime_count_label)
 
         # 重複除外トグルは廃止: 登録時のpHash重複防止により検索UI上では不要
         self.ui.checkboxExcludeDuplicates.setChecked(False)
@@ -389,6 +399,7 @@ class FilterSearchPanel(QScrollArea):
 
         # 解像度フィルター
         self.ui.comboResolution.currentTextChanged.connect(self._on_resolution_changed)
+        self.ui.comboAspectRatio.currentTextChanged.connect(self._on_realtime_count_trigger)
 
         # 日付フィルター
         self.ui.checkboxDateFilter.toggled.connect(self._on_date_filter_toggled)
@@ -396,6 +407,16 @@ class FilterSearchPanel(QScrollArea):
 
         # Ratingフィルター
         self.ui.comboRating.currentTextChanged.connect(self._on_rating_changed)
+        self.ui.comboAIRating.currentTextChanged.connect(self._on_realtime_count_trigger)
+        self.ui.checkboxIncludeUnrated.toggled.connect(self._on_realtime_count_trigger)
+
+        # その他フィルター
+        self.ui.checkboxOnlyUntagged.toggled.connect(self._on_only_untagged_toggled)
+        self.ui.checkboxOnlyUncaptioned.toggled.connect(self._on_only_uncaptioned_toggled)
+        self.ui.radioAnd.toggled.connect(self._on_realtime_count_trigger)
+        self.ui.radioOr.toggled.connect(self._on_realtime_count_trigger)
+        self.score_range_slider.valueChanged.connect(self._on_realtime_count_trigger)
+        self.ui.lineEditSearch.textChanged.connect(self._on_realtime_count_trigger)
 
         # アクションボタン
         self.ui.buttonApply.clicked.connect(self._on_apply_clicked)
@@ -616,21 +637,73 @@ class FilterSearchPanel(QScrollArea):
 
     def _on_resolution_changed(self, text: str) -> None:
         """解像度選択変更処理"""
-        # 固定解像度選択肢のみのため処理不要
+        logger.debug(f"Resolution changed: {text}")
+        self._on_realtime_count_trigger()
 
     def _on_rating_changed(self, text: str) -> None:
         """Rating選択変更処理"""
-        # Rating選択肢変更時の処理（必要に応じて実装）
         logger.debug(f"Rating changed: {text}")
+        self._on_realtime_count_trigger()
 
     def _on_date_filter_toggled(self, checked: bool) -> None:
         """日付フィルター有効化切り替え処理"""
         self.ui.frameDateRange.setVisible(checked)
+        self._on_realtime_count_trigger()
 
     def _on_date_range_changed(self, min_timestamp: int, max_timestamp: int) -> None:
         """日付範囲変更処理"""
         logger.debug(f"日付範囲変更: {min_timestamp} - {max_timestamp}")
-        # 自動検索は行わず、ユーザーが検索ボタンを押すまで待つ
+        self._on_realtime_count_trigger()
+
+    def _on_realtime_count_trigger(self, *args: Any) -> None:
+        """フィルター変更時に件数再計算をデバウンスで予約する。"""
+        del args
+        if hasattr(self, "realtime_count_label"):
+            self.realtime_count_label.setText("該当件数: 計算中...")
+        self._realtime_count_timer.start(self._realtime_count_debounce_ms)
+
+    def _update_realtime_count(self) -> None:
+        """現在のフィルター条件で件数のみを取得して表示する。"""
+        if not self.search_filter_service:
+            return
+
+        try:
+            search_text = self.ui.lineEditSearch.text().strip()
+            keywords = self.search_filter_service.parse_search_input(search_text) if search_text else []
+            date_range_start, date_range_end = self.get_date_range_from_slider()
+            rating_filter = self._get_rating_filter_value()
+            ai_rating_filter = self._get_ai_rating_filter_value()
+            include_nsfw = self._resolve_include_nsfw(rating_filter, ai_rating_filter)
+            score_min, score_max = self._get_score_filter_values()
+
+            conditions = self.search_filter_service.create_search_conditions(
+                search_type=self._get_primary_search_type(),
+                keywords=keywords,
+                tag_logic="and" if self.ui.radioAnd.isChecked() else "or",
+                resolution_filter=self.ui.comboResolution.currentText(),
+                aspect_ratio_filter=self.ui.comboAspectRatio.currentText(),
+                date_filter_enabled=self.ui.checkboxDateFilter.isChecked(),
+                date_range_start=date_range_start,
+                date_range_end=date_range_end,
+                only_untagged=self.ui.checkboxOnlyUntagged.isChecked(),
+                only_uncaptioned=self.ui.checkboxOnlyUncaptioned.isChecked(),
+                exclude_duplicates=False,
+                include_nsfw=include_nsfw,
+                rating_filter=rating_filter,
+                ai_rating_filter=ai_rating_filter,
+                include_unrated=self.ui.checkboxIncludeUnrated.isChecked(),
+                score_min=score_min,
+                score_max=score_max,
+            )
+
+            count = self.search_filter_service.get_estimated_count(conditions)
+            if hasattr(self, "realtime_count_label"):
+                self.realtime_count_label.setText(f"該当件数: {count:,} 件")
+
+        except Exception as e:
+            logger.error(f"リアルタイム件数更新エラー: {e}", exc_info=True)
+            if hasattr(self, "realtime_count_label"):
+                self.realtime_count_label.setText("該当件数: エラー")
 
     def get_date_range_from_slider(self) -> tuple[datetime | None, datetime | None]:
         """CustomRangeSliderから日付範囲を取得してdatetimeオブジェクトに変換
@@ -684,11 +757,13 @@ class FilterSearchPanel(QScrollArea):
         """未タグ画像のみ検索トグル処理"""
         self._update_search_input_state()
         self._on_search_type_changed()
+        self._on_realtime_count_trigger()
 
     def _on_only_uncaptioned_toggled(self, checked: bool) -> None:
         """未キャプション画像のみ検索トグル処理"""
         self._update_search_input_state()
         self._on_search_type_changed()
+        self._on_realtime_count_trigger()
 
     def _get_selected_search_types(self) -> list[str]:
         """選択された検索タイプのリストを取得"""
@@ -1181,6 +1256,8 @@ class FilterSearchPanel(QScrollArea):
     def _on_clear_clicked(self) -> None:
         """クリアボタンクリック処理"""
         self._on_clear_requested()
+        if hasattr(self, "realtime_count_label"):
+            self.realtime_count_label.setText("該当件数: -")
 
     def update_pipeline_progress(self, message: str, current_progress: float, end_progress: float) -> None:
         """Pipeline進捗表示の更新 - ModernProgressManagerに移行済みため無効化"""

--- a/tests/unit/gui/services/test_search_filter_service.py
+++ b/tests/unit/gui/services/test_search_filter_service.py
@@ -343,6 +343,18 @@ class TestSearchFilterServiceDatabase:
         mock_db_manager.get_images_by_filter.assert_called_once()
 
 
+
+    def test_get_estimated_count_success(self, service_with_db, mock_db_manager):
+        """推定件数取得テスト"""
+        mock_db_manager.get_images_count_only.return_value = 42
+
+        conditions = SearchConditions(search_type="tags", keywords=["test"], tag_logic="and")
+
+        count = service_with_db.get_estimated_count(conditions)
+
+        assert count == 42
+        mock_db_manager.get_images_count_only.assert_called_once()
+
 class TestSearchFilterServiceAnnotation:
     """SearchFilterService のアノテーション系機能テスト（Phase 2拡張）"""
 


### PR DESCRIPTION
### Motivation
- 検索フィルター変更時に、検索実行前に該当件数を軽量に表示してUXを改善するため（Issue #10 の要件）。

### Description
- `ImageRepository` に `get_images_count_only()` を追加し既存の `_build_image_filter_query()` を再利用して `COUNT(DISTINCT image.id)` 相当の軽量件数クエリを実行するようにしました。 
- `ImageDatabaseManager` に `get_images_count_only()` ラッパーを追加してサービス層から呼べるようにしました。 
- `SearchFilterService` に `get_estimated_count(conditions: SearchConditions)` を追加し、`SearchConditions` を `ImageFilterCriteria` に変換して件数専用APIへ委譲するようにしました。 
- `FilterSearchPanel` に 500ms のデバウンスを行う `QTimer` と `該当件数` ラベルを追加し、解像度・アスペクト比・日付・レーティング・スコア・検索テキスト等の変更でデバウンスされた件数再計算を行うようにしました。 
- ユニットテストに `get_estimated_count()` の呼び出しを検証するテストを追加しました (`tests/unit/gui/services/test_search_filter_service.py`)。 

### Testing
- `python -m py_compile src/lorairo/gui/services/search_filter_service.py src/lorairo/gui/widgets/filter_search_panel.py tests/unit/gui/services/test_search_filter_service.py` は成功しました。 
- `python -m py_compile src/lorairo/database/db_manager.py` は成功しました。 
- `pytest -q tests/unit/gui/services/test_search_filter_service.py -k estimated_count` を試行しましたが、環境に `sqlalchemy` が存在しないため `ModuleNotFoundError` により実行できませんでした。 
- `ruff check` を実行したところ既存コードの複雑度違反 (`C901`) が検出されて失敗しましたが、該当の警告は既存の関数に起因しており今回の差分で新たに導入された問題ではありません。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b629601390832984f1f95dfdc20a94)