### PR TITLE
feat: フィルター変更時のリアルタイム推定件数表示を追加

### DIFF
--- a/src/lorairo/database/db_manager.py
+++ b/src/lorairo/database/db_manager.py
@@ -151,13 +151,10 @@ class ImageDatabaseManager:
 
             # 4. 512px サムネイル画像の自動生成
             try:
-                self._generate_thumbnail_512px(
-                    image_id, db_stored_original_path, original_metadata, fsm
-                )
+                self._generate_thumbnail_512px(image_id, db_stored_original_path, original_metadata, fsm)
             except Exception as e:
                 logger.warning(
-                    f"512px サムネイル生成に失敗しましたが、処理を続行します: "
-                    f"{image_path}, Error: {e}",
+                    f"512px サムネイル生成に失敗しましたが、処理を続行します: {image_path}, Error: {e}",
                 )
 
             return image_id, original_metadata
@@ -722,6 +719,19 @@ class ImageDatabaseManager:
                 exc_info=True,
             )
             return None
+
+    def get_images_count_only(
+        self,
+        criteria: ImageFilterCriteria | None = None,
+        **kwargs: Any,
+    ) -> int:
+        """指定条件に一致する画像件数のみを取得します。"""
+        try:
+            filter_criteria = criteria if criteria else ImageFilterCriteria.from_kwargs(**kwargs)
+            return self.repository.get_images_count_only(filter_criteria)
+        except Exception as e:
+            logger.error(f"画像件数の取得中にエラーが発生しました: {e}", exc_info=True)
+            return 0
 
     def get_total_image_count(self) -> int:
         """データベース内に登録されたオリジナル画像の総数を取得します。"""

--- a/src/lorairo/database/db_repository.py
+++ b/src/lorairo/database/db_repository.py
@@ -2551,6 +2551,54 @@ class ImageRepository:
                 logger.error(f"画像フィルタリング検索中にエラーが発生しました: {e}", exc_info=True)
                 raise
 
+    def get_images_count_only(
+        self,
+        criteria: ImageFilterCriteria | None = None,
+        **kwargs: Any,
+    ) -> int:
+        """指定された条件に基づいて画像件数のみを取得する。
+
+        フィルター式は ``get_images_by_filter`` と同一ロジックを使用し、
+        メタデータ取得を行わない軽量な件数集計を実行する。
+
+        Args:
+            criteria: ImageFilterCriteria形式のフィルター条件（推奨）
+            **kwargs: レガシー形式のキーワード引数（後方互換性用）
+
+        Returns:
+            条件に一致した画像件数。
+
+        """
+        filter_criteria = criteria if criteria else ImageFilterCriteria.from_kwargs(**kwargs)
+
+        with self.session_factory() as session:
+            try:
+                filtered_query = self._build_image_filter_query(
+                    session=session,
+                    tags=filter_criteria.tags,
+                    caption=filter_criteria.caption,
+                    use_and=filter_criteria.use_and,
+                    start_date=filter_criteria.start_date,
+                    end_date=filter_criteria.end_date,
+                    include_untagged=filter_criteria.include_untagged,
+                    include_nsfw=filter_criteria.include_nsfw,
+                    include_unrated=filter_criteria.include_unrated,
+                    manual_rating_filter=filter_criteria.manual_rating_filter,
+                    ai_rating_filter=filter_criteria.ai_rating_filter,
+                    manual_edit_filter=filter_criteria.manual_edit_filter,
+                    score_min=filter_criteria.score_min,
+                    score_max=filter_criteria.score_max,
+                )
+
+                count_query = select(func.count()).select_from(filtered_query.subquery())
+                count = session.execute(count_query).scalar_one()
+                logger.debug(f"フィルター件数のみ取得: {count} 件")
+                return count
+
+            except SQLAlchemyError as e:
+                logger.error(f"画像件数取得中にエラーが発生しました: {e}", exc_info=True)
+                raise
+
     # --- Model Information Retrieval ---
 
     def get_models(self) -> list[dict[str, Any]]:

--- a/src/lorairo/gui/services/search_filter_service.py
+++ b/src/lorairo/gui/services/search_filter_service.py
@@ -298,6 +298,14 @@ class SearchFilterService:
 
     # === 後方互換性ラッパーメソッド(段階的移行用) ===
 
+    def get_estimated_count(self, conditions: SearchConditions) -> int:
+        """現在の検索条件に対する概算件数を取得する。"""
+        try:
+            return self.db_manager.get_images_count_only(criteria=conditions.to_filter_criteria())
+        except Exception as e:
+            logger.error(f"概算件数の取得中にエラーが発生しました: {e}", exc_info=True)
+            return 0
+
     def execute_search_with_filters(self, conditions: SearchConditions) -> tuple[list[dict[str, Any]], int]:
         """後方互換性ラッパー:SearchCriteriaProcessorに委譲"""
         return self.criteria_processor.execute_search_with_filters(conditions)

--- a/src/lorairo/gui/widgets/filter_search_panel.py
+++ b/src/lorairo/gui/widgets/filter_search_panel.py
@@ -4,7 +4,7 @@ from datetime import datetime
 from enum import Enum
 from typing import TYPE_CHECKING, Any
 
-from PySide6.QtCore import Signal
+from PySide6.QtCore import QTimer, Signal
 from PySide6.QtWidgets import QScrollArea
 
 from ...gui.designer.FilterSearchPanel_ui import Ui_FilterSearchPanel
@@ -57,6 +57,12 @@ class FilterSearchPanel(QScrollArea):
 
         # 現在のSearchWorkerのID
         self._current_search_worker_id: str | None = None
+
+        # フィルター変更時の件数見積もり（デバウンス）
+        self._realtime_count_timer = QTimer(self)
+        self._realtime_count_timer.setSingleShot(True)
+        self._realtime_count_timer.setInterval(500)
+        self._realtime_count_timer.timeout.connect(self._update_realtime_count)
 
         # Phase 3: Pipeline State Management
         self._current_state: PipelineState = PipelineState.IDLE
@@ -135,6 +141,10 @@ class FilterSearchPanel(QScrollArea):
         self._status_label.setStyleSheet("color: #e74c3c; font-size: 11px;")
         self._status_label.setVisible(False)
 
+        # リアルタイム件数ラベル（フィルター変更時の見積もり表示）
+        self._estimated_count_label = QLabel("推定件数: -")
+        self._estimated_count_label.setStyleSheet("color: #3498db; font-size: 11px;")
+
         # 進捗表示レイアウト作成（キャンセルボタンなし）
         self.progress_layout = QHBoxLayout()
         self.progress_layout.addWidget(self.progress_bar)
@@ -144,6 +154,7 @@ class FilterSearchPanel(QScrollArea):
         # プレビューエリア削除後は、lineEditSearchの下に追加
         main_layout = self.ui.searchGroup.layout()
         if main_layout:
+            main_layout.addWidget(self._estimated_count_label)
             main_layout.addLayout(self.progress_layout)
 
         # 重複除外トグルは廃止: 登録時のpHash重複防止により検索UI上では不要
@@ -401,6 +412,21 @@ class FilterSearchPanel(QScrollArea):
         self.ui.buttonApply.clicked.connect(self._on_apply_clicked)
         self.ui.buttonClear.clicked.connect(self._on_clear_clicked)
 
+        # リアルタイム件数更新トリガー
+        self.ui.lineEditSearch.textChanged.connect(self._on_filter_value_changed)
+        self.ui.radioAnd.toggled.connect(self._on_filter_value_changed)
+        self.ui.radioOr.toggled.connect(self._on_filter_value_changed)
+        self.ui.comboResolution.currentTextChanged.connect(self._on_filter_value_changed)
+        self.ui.comboAspectRatio.currentTextChanged.connect(self._on_filter_value_changed)
+        self.ui.checkboxDateFilter.toggled.connect(self._on_filter_value_changed)
+        self.ui.comboRating.currentTextChanged.connect(self._on_filter_value_changed)
+        self.ui.comboAIRating.currentTextChanged.connect(self._on_filter_value_changed)
+        self.ui.checkboxIncludeUnrated.toggled.connect(self._on_filter_value_changed)
+        self.ui.checkboxOnlyUntagged.toggled.connect(self._on_filter_value_changed)
+        self.ui.checkboxOnlyUncaptioned.toggled.connect(self._on_filter_value_changed)
+        self.date_range_slider.valueChanged.connect(self._on_filter_value_changed)
+        self.score_range_slider.valueChanged.connect(self._on_filter_value_changed)
+
     def set_search_filter_service(self, service: "SearchFilterService") -> None:
         """SearchFilterServiceを設定（拡張版：バリデーションとログ強化）"""
         if service is None:
@@ -631,6 +657,56 @@ class FilterSearchPanel(QScrollArea):
         """日付範囲変更処理"""
         logger.debug(f"日付範囲変更: {min_timestamp} - {max_timestamp}")
         # 自動検索は行わず、ユーザーが検索ボタンを押すまで待つ
+
+    def _on_filter_value_changed(self, *args: Any) -> None:
+        """フィルター変更時にデバウンス付きで推定件数更新を予約する。"""
+        del args
+        if not self.search_filter_service:
+            return
+        self._realtime_count_timer.start()
+
+    def _build_current_search_conditions(self):
+        """現在のUI状態からSearchConditionsを組み立てる。"""
+        search_text = self.ui.lineEditSearch.text().strip()
+        keywords = self.search_filter_service.parse_search_input(search_text) if search_text else []
+        date_range_start, date_range_end = self.get_date_range_from_slider()
+        rating_filter = self._get_rating_filter_value()
+        ai_rating_filter = self._get_ai_rating_filter_value()
+        include_nsfw = self._resolve_include_nsfw(rating_filter, ai_rating_filter)
+        score_min, score_max = self._get_score_filter_values()
+
+        return self.search_filter_service.create_search_conditions(
+            search_type=self._get_primary_search_type(),
+            keywords=keywords,
+            tag_logic="and" if self.ui.radioAnd.isChecked() else "or",
+            resolution_filter=self.ui.comboResolution.currentText(),
+            aspect_ratio_filter=self.ui.comboAspectRatio.currentText(),
+            date_filter_enabled=self.ui.checkboxDateFilter.isChecked(),
+            date_range_start=date_range_start,
+            date_range_end=date_range_end,
+            only_untagged=self.ui.checkboxOnlyUntagged.isChecked(),
+            only_uncaptioned=self.ui.checkboxOnlyUncaptioned.isChecked(),
+            exclude_duplicates=False,
+            include_nsfw=include_nsfw,
+            rating_filter=rating_filter,
+            ai_rating_filter=ai_rating_filter,
+            include_unrated=self.ui.checkboxIncludeUnrated.isChecked(),
+            score_min=score_min,
+            score_max=score_max,
+        )
+
+    def _update_realtime_count(self) -> None:
+        """現在のフィルター条件に対する推定件数を更新する。"""
+        if not self.search_filter_service:
+            return
+
+        try:
+            conditions = self._build_current_search_conditions()
+            estimated_count = self.search_filter_service.get_estimated_count(conditions)
+            self._estimated_count_label.setText(f"推定件数: {estimated_count:,} 件")
+        except Exception as e:
+            logger.debug(f"推定件数更新に失敗: {e}")
+            self._estimated_count_label.setText("推定件数: -")
 
     def get_date_range_from_slider(self) -> tuple[datetime | None, datetime | None]:
         """CustomRangeSliderから日付範囲を取得してdatetimeオブジェクトに変換

--- a/tests/unit/database/test_db_repository_score_filter.py
+++ b/tests/unit/database/test_db_repository_score_filter.py
@@ -185,3 +185,56 @@ class TestSearchFilterServiceIntegration:
 
         assert conditions.score_min == 3.0
         assert conditions.score_max == 7.5
+
+
+class TestGetImagesCountOnly:
+    """get_images_count_only() メソッドのテスト"""
+
+    @pytest.fixture
+    def mock_session_and_repository(self):
+        from sqlalchemy.orm import Session
+
+        mock_session = Mock(spec=Session)
+        mock_session_factory = Mock(return_value=mock_session)
+
+        mock_session.__enter__ = Mock(return_value=mock_session)
+        mock_session.__exit__ = Mock(return_value=None)
+
+        count_result = Mock()
+        count_result.scalar_one = Mock(return_value=3)
+        mock_session.execute = Mock(return_value=count_result)
+
+        repository = ImageRepository(session_factory=mock_session_factory)
+        return repository
+
+    def test_get_images_count_only_returns_count(self, mock_session_and_repository):
+        repository = mock_session_and_repository
+
+        count = repository.get_images_count_only(score_min=3.0, score_max=7.5)
+
+        assert count == 3
+
+
+class TestSearchFilterServiceEstimatedCount:
+    """SearchFilterService.get_estimated_count() のテスト"""
+
+    def test_get_estimated_count_delegates_to_db_manager(self):
+        from lorairo.gui.services.search_filter_service import SearchFilterService
+
+        mock_db_manager = Mock()
+        mock_db_manager.get_images_count_only.return_value = 42
+        mock_model_selection_service = Mock()
+
+        service = SearchFilterService(
+            db_manager=mock_db_manager,
+            model_selection_service=mock_model_selection_service,
+        )
+
+        conditions = service.create_search_conditions(
+            search_type="tags",
+            keywords=["test"],
+            tag_logic="and",
+        )
+
+        assert service.get_estimated_count(conditions) == 42
+        mock_db_manager.get_images_count_only.assert_called_once()


### PR DESCRIPTION
### Motivation

- 検索フィルターを変更した際、検索実行前に該当件数を即時に把握できるようにし、UXを改善するため（Issue #10 の要望）。

### Description

- `ImageRepository.get_images_count_only()` を追加して、既存の `_build_image_filter_query()` を再利用した軽量な `COUNT` クエリを実装した。 
- `ImageDatabaseManager.get_images_count_only()` を追加してリポジトリへ委譲する API を用意した。 
- `SearchFilterService.get_estimated_count()` を追加して `SearchConditions` から `ImageFilterCriteria` に変換し件数を取得する機能を公開した。 
- `FilterSearchPanel` に UI 要素（「推定件数」ラベル）と 500ms の `QTimer` によるデバウンスを実装し、検索文字列や論理演算子・解像度・日付・レーティング・スコア等の変更をトリガーに推定件数を自動更新する処理を追加した。 
- 関連ユニットテストを `tests/unit/database/test_db_repository_score_filter.py` に追加し、件数取得とサービス委譲の基本動作を検証するテストを追加した。 

### Testing

- コード整形は `ruff format` を実行して対象ファイルを整形し成功した。 
- 変更ファイルの構文チェックは `python -m py_compile ...` にて確認し成功した。 
- ユニットテスト実行を `pytest -q tests/unit/database/test_db_repository_score_filter.py` で試行したが、実行環境に `sqlalchemy` が存在しなかったため `ModuleNotFoundError` によりテスト実行は失敗した（環境依存）。 
- 追加したテストはローカル CI 環境で `ImageRepository.get_images_count_only()` の返り値と `SearchFilterService.get_estimated_count()` の DB デリゲーションを検証する内容で実装済み。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b629601390832984f1f95dfdc20a94)