### PR TITLE
feat: フィルター変更時のリアルタイム件数表示を追加

### DIFF
--- a/src/lorairo/database/db_manager.py
+++ b/src/lorairo/database/db_manager.py
@@ -723,6 +723,19 @@ class ImageDatabaseManager:
             )
             return None
 
+    def get_images_count_only(
+        self,
+        criteria: ImageFilterCriteria | None = None,
+        **kwargs: Any,
+    ) -> int:
+        """指定条件に一致する画像件数を取得します（メタデータ取得なし）。"""
+        try:
+            filter_criteria = criteria if criteria else ImageFilterCriteria.from_kwargs(**kwargs)
+            return self.repository.get_images_count_only(filter_criteria)
+        except Exception as e:
+            logger.error(f"画像件数取得中にエラーが発生しました: {e}", exc_info=True)
+            return 0
+
     def get_total_image_count(self) -> int:
         """データベース内に登録されたオリジナル画像の総数を取得します。"""
         try:

--- a/src/lorairo/database/db_repository.py
+++ b/src/lorairo/database/db_repository.py
@@ -2551,6 +2551,46 @@ class ImageRepository:
                 logger.error(f"画像フィルタリング検索中にエラーが発生しました: {e}", exc_info=True)
                 raise
 
+    def get_images_count_only(
+        self,
+        criteria: ImageFilterCriteria | None = None,
+        **kwargs: Any,
+    ) -> int:
+        """指定条件に一致する画像件数を軽量クエリで取得する。"""
+        filter_criteria = criteria if criteria else ImageFilterCriteria.from_kwargs(**kwargs)
+
+        if isinstance(filter_criteria.resolution, str):
+            try:
+                filter_criteria.resolution = int(filter_criteria.resolution)
+            except ValueError:
+                logger.error(f"無効な解像度形式です: '{filter_criteria.resolution}'")
+                return 0
+
+        with self.session_factory() as session:
+            try:
+                filtered_ids_query = self._build_image_filter_query(
+                    session=session,
+                    tags=filter_criteria.tags,
+                    caption=filter_criteria.caption,
+                    use_and=filter_criteria.use_and,
+                    start_date=filter_criteria.start_date,
+                    end_date=filter_criteria.end_date,
+                    include_untagged=filter_criteria.include_untagged,
+                    include_nsfw=filter_criteria.include_nsfw,
+                    include_unrated=filter_criteria.include_unrated,
+                    manual_rating_filter=filter_criteria.manual_rating_filter,
+                    ai_rating_filter=filter_criteria.ai_rating_filter,
+                    manual_edit_filter=filter_criteria.manual_edit_filter,
+                    score_min=filter_criteria.score_min,
+                    score_max=filter_criteria.score_max,
+                )
+                count_stmt = select(func.count()).select_from(filtered_ids_query.subquery())
+                count = session.execute(count_stmt).scalar_one()
+                return int(count)
+            except SQLAlchemyError as e:
+                logger.error(f"画像件数取得中にエラーが発生しました: {e}", exc_info=True)
+                raise
+
     # --- Model Information Retrieval ---
 
     def get_models(self) -> list[dict[str, Any]]:

--- a/src/lorairo/gui/services/search_filter_service.py
+++ b/src/lorairo/gui/services/search_filter_service.py
@@ -298,6 +298,15 @@ class SearchFilterService:
 
     # === 後方互換性ラッパーメソッド(段階的移行用) ===
 
+    def get_estimated_count(self, conditions: SearchConditions) -> int:
+        """現在の検索条件に一致する推定件数を取得する。"""
+        try:
+            filter_criteria = conditions.to_filter_criteria()
+            return self.db_manager.get_images_count_only(criteria=filter_criteria)
+        except Exception as e:
+            logger.error(f"推定件数取得エラー: {e}", exc_info=True)
+            return 0
+
     def execute_search_with_filters(self, conditions: SearchConditions) -> tuple[list[dict[str, Any]], int]:
         """後方互換性ラッパー:SearchCriteriaProcessorに委譲"""
         return self.criteria_processor.execute_search_with_filters(conditions)

--- a/src/lorairo/gui/widgets/filter_search_panel.py
+++ b/src/lorairo/gui/widgets/filter_search_panel.py
@@ -4,7 +4,7 @@ from datetime import datetime
 from enum import Enum
 from typing import TYPE_CHECKING, Any
 
-from PySide6.QtCore import Signal
+from PySide6.QtCore import QTimer, Signal
 from PySide6.QtWidgets import QScrollArea
 
 from ...gui.designer.FilterSearchPanel_ui import Ui_FilterSearchPanel
@@ -68,6 +68,12 @@ class FilterSearchPanel(QScrollArea):
             PipelineState.ERROR: "エラーが発生しました",
             PipelineState.CANCELED: "キャンセルされました",
         }
+
+        # リアルタイム件数表示（500msデバウンス）
+        self._count_debounce_timer = QTimer(self)
+        self._count_debounce_timer.setSingleShot(True)
+        self._count_debounce_timer.setInterval(500)
+        self._count_debounce_timer.timeout.connect(self._update_estimated_count)
 
         # UI設定
         self.ui = Ui_FilterSearchPanel()
@@ -140,10 +146,15 @@ class FilterSearchPanel(QScrollArea):
         self.progress_layout.addWidget(self.progress_bar)
         self.progress_layout.addWidget(self._status_label)
 
+        # リアルタイム件数ラベル
+        self._estimated_count_label = QLabel("該当件数: -")
+        self._estimated_count_label.setStyleSheet("color: #95a5a6; font-size: 11px;")
+
         # 検索グループの最後に進捗UIを追加
         # プレビューエリア削除後は、lineEditSearchの下に追加
         main_layout = self.ui.searchGroup.layout()
         if main_layout:
+            main_layout.addWidget(self._estimated_count_label)
             main_layout.addLayout(self.progress_layout)
 
         # 重複除外トグルは廃止: 登録時のpHash重複防止により検索UI上では不要
@@ -384,18 +395,33 @@ class FilterSearchPanel(QScrollArea):
         """Qt DesignerのUIコンポーネントにシグナルを接続"""
         # 検索関連（チェックボックスに更新）
         self.ui.lineEditSearch.returnPressed.connect(self._on_search_requested)
+        self.ui.lineEditSearch.textChanged.connect(self._schedule_estimated_count_update)
         self.ui.checkboxTags.toggled.connect(self._on_search_type_changed)
+        self.ui.checkboxTags.toggled.connect(self._schedule_estimated_count_update)
         self.ui.checkboxCaption.toggled.connect(self._on_search_type_changed)
+        self.ui.checkboxCaption.toggled.connect(self._schedule_estimated_count_update)
+        self.ui.radioAnd.toggled.connect(self._schedule_estimated_count_update)
+        self.ui.radioOr.toggled.connect(self._schedule_estimated_count_update)
 
         # 解像度フィルター
         self.ui.comboResolution.currentTextChanged.connect(self._on_resolution_changed)
+        self.ui.comboResolution.currentTextChanged.connect(self._schedule_estimated_count_update)
+        self.ui.comboAspectRatio.currentTextChanged.connect(self._schedule_estimated_count_update)
 
         # 日付フィルター
         self.ui.checkboxDateFilter.toggled.connect(self._on_date_filter_toggled)
+        self.ui.checkboxDateFilter.toggled.connect(self._schedule_estimated_count_update)
         self.date_range_slider.valueChanged.connect(self._on_date_range_changed)
+        self.date_range_slider.valueChanged.connect(self._schedule_estimated_count_update)
 
         # Ratingフィルター
         self.ui.comboRating.currentTextChanged.connect(self._on_rating_changed)
+        self.ui.comboRating.currentTextChanged.connect(self._schedule_estimated_count_update)
+        self.ui.comboAIRating.currentTextChanged.connect(self._schedule_estimated_count_update)
+        self.ui.checkboxIncludeUnrated.toggled.connect(self._schedule_estimated_count_update)
+        self.ui.checkboxOnlyUntagged.toggled.connect(self._schedule_estimated_count_update)
+        self.ui.checkboxOnlyUncaptioned.toggled.connect(self._schedule_estimated_count_update)
+        self.score_range_slider.valueChanged.connect(self._schedule_estimated_count_update)
 
         # アクションボタン
         self.ui.buttonApply.clicked.connect(self._on_apply_clicked)
@@ -418,6 +444,7 @@ class FilterSearchPanel(QScrollArea):
 
         self.search_filter_service = service
         logger.info(f"SearchFilterService set for FilterSearchPanel: {type(service)}")
+        self._schedule_estimated_count_update()
 
         # サービス機能確認（デバッグ用）
         try:
@@ -813,6 +840,81 @@ class FilterSearchPanel(QScrollArea):
         )
         self.ui.lineEditSearch.setEnabled(not disabled)
 
+    def _schedule_estimated_count_update(self, *args: Any) -> None:
+        """フィルター変更時に件数更新をデバウンス実行する。"""
+        del args
+        self._count_debounce_timer.start()
+
+    def _build_search_conditions_for_estimate(self):
+        """現在UI状態から件数取得用の検索条件を組み立てる。"""
+        if not self.search_filter_service:
+            return None
+
+        search_text = self.ui.lineEditSearch.text().strip()
+        keywords = self.search_filter_service.parse_search_input(search_text) if search_text else []
+
+        score_min, score_max = self._get_score_filter_values()
+        date_range_start, date_range_end = self.get_date_range_from_slider()
+        rating_filter = self._get_rating_filter_value()
+        ai_rating_filter = self._get_ai_rating_filter_value()
+        include_nsfw = self._resolve_include_nsfw(rating_filter, ai_rating_filter)
+
+        return self.search_filter_service.create_search_conditions(
+            search_type=self._get_primary_search_type(),
+            keywords=keywords,
+            tag_logic="and" if self.ui.radioAnd.isChecked() else "or",
+            resolution_filter=self.ui.comboResolution.currentText(),
+            aspect_ratio_filter=self.ui.comboAspectRatio.currentText(),
+            date_filter_enabled=self.ui.checkboxDateFilter.isChecked(),
+            date_range_start=date_range_start,
+            date_range_end=date_range_end,
+            only_untagged=self.ui.checkboxOnlyUntagged.isChecked(),
+            only_uncaptioned=self.ui.checkboxOnlyUncaptioned.isChecked(),
+            exclude_duplicates=False,
+            include_nsfw=include_nsfw,
+            rating_filter=rating_filter,
+            ai_rating_filter=ai_rating_filter,
+            include_unrated=self.ui.checkboxIncludeUnrated.isChecked(),
+            score_min=score_min,
+            score_max=score_max,
+        )
+
+    def _update_estimated_count(self) -> None:
+        """件数表示ラベルをリアルタイム更新する。"""
+        if not self.search_filter_service:
+            return
+
+        conditions = self._build_search_conditions_for_estimate()
+        if not conditions:
+            self._estimated_count_label.setText("該当件数: -")
+            return
+
+        has_condition = bool(conditions.keywords) or any(
+            [
+                conditions.only_untagged,
+                conditions.only_uncaptioned,
+                conditions.date_filter_enabled,
+                conditions.resolution_filter not in (None, "全て"),
+                conditions.aspect_ratio_filter not in (None, "全て"),
+                conditions.rating_filter is not None,
+                conditions.ai_rating_filter is not None,
+                not conditions.include_unrated,
+                conditions.score_min is not None,
+                conditions.score_max is not None,
+            ],
+        )
+
+        if not has_condition:
+            self._estimated_count_label.setText("該当件数: -")
+            return
+
+        try:
+            count = self.search_filter_service.get_estimated_count(conditions)
+            self._estimated_count_label.setText(f"該当件数: {count:,}件")
+        except Exception as e:
+            logger.error(f"リアルタイム件数更新エラー: {e}", exc_info=True)
+            self._estimated_count_label.setText("該当件数: 取得失敗")
+
     def _on_search_requested(self) -> None:
         """検索要求処理 - WorkerService経由で非同期実行（Qt Designer Phase 2レスポンシブレイアウト対応強化版）"""
         if not self.search_filter_service:
@@ -1088,6 +1190,8 @@ class FilterSearchPanel(QScrollArea):
 
     def _clear_all_inputs(self) -> None:
         """全入力をクリア"""
+        self._count_debounce_timer.stop()
+        self._estimated_count_label.setText("該当件数: -")
         self.ui.lineEditSearch.clear()
         self.ui.checkboxTags.setChecked(True)
         self.ui.checkboxCaption.setChecked(False)

--- a/tests/unit/gui/services/test_search_filter_service.py
+++ b/tests/unit/gui/services/test_search_filter_service.py
@@ -270,6 +270,16 @@ class TestSearchFilterService:
 
         assert ratios == expected
 
+    def test_get_estimated_count(self, service):
+        """推定件数取得テスト"""
+        conditions = SearchConditions(search_type="tags", keywords=["test"], tag_logic="and")
+        service.db_manager.get_images_count_only.return_value = 42
+
+        count = service.get_estimated_count(conditions)
+
+        assert count == 42
+        service.db_manager.get_images_count_only.assert_called_once()
+
     def test_clear_conditions(self, service):
         """検索条件クリアテスト"""
         # 条件を設定


### PR DESCRIPTION
### Motivation
- 検索実行前にフィルター変更で該当件数をリアルタイムに表示し、ユーザーが結果規模を事前に把握できるようにするため。 
- 件数取得は軽量化された `COUNT` クエリで行い、検索全体の負荷を抑える設計とするため。 

### Description
- `ImageRepository` に軽量件数取得メソッド `get_images_count_only()` を追加し既存の `_build_image_filter_query()` を再利用して `COUNT` のみを実行するようにしました (`src/lorairo/database/db_repository.py`).
- `ImageDatabaseManager` に `get_images_count_only()` のラッパーを追加しサービス層から呼び出しやすくしました (`src/lorairo/database/db_manager.py`).
- GUI 側の `SearchFilterService` に `get_estimated_count()` を追加して `SearchConditions` を `ImageFilterCriteria` に変換し件数を取得する経路を実装しました (`src/lorairo/gui/services/search_filter_service.py`).
- `FilterSearchPanel` に件数表示ラベル `該当件数: -` と 500ms のデバウンスタイマーを導入し、各種フィルター変更シグナルからデバウンス更新をスケジュールしてリアルタイムに件数を表示するロジックを追加しました (`src/lorairo/gui/widgets/filter_search_panel.py`).
- GUI の変更に伴いユニットテストに `get_estimated_count()` の検証を追加しました (`tests/unit/gui/services/test_search_filter_service.py`).

### Testing
- `python -m py_compile` を使った静的コンパイルチェックは対象ファイルに対して成功しました。 
- `uv run pytest tests/unit/gui/services/test_search_filter_service.py -q` はローカルの editable パッケージ `local_packages/image-annotator-lib` に `pyproject.toml`/`setup.py` が無いため環境依存で失敗しました。 
- `pytest tests/unit/gui/services/test_search_filter_service.py -q` は実行環境に `sqlalchemy` が未インストールのため実行できず（環境依存で失敗）という結果でした。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b629601390832984f1f95dfdc20a94)