### PR TITLE
feat: support excluded tags (-tag) in search (NOT search)

### DIFF
--- a/src/lorairo/database/db_repository.py
+++ b/src/lorairo/database/db_repository.py
@@ -1868,6 +1868,7 @@ class ImageRepository:
         self,
         query: Select,
         tags: list[str] | None,
+        excluded_tags: list[str] | None,
         use_and: bool,
         include_untagged: bool,
     ) -> Select:
@@ -1909,6 +1910,22 @@ class ImageRepository:
                 if tag_criteria:
                     query = query.join(Tag, Image.id == Tag.image_id).where(or_(*tag_criteria))
                     # logger.debug(f"Query after OR tag join: {query}") # クエリ確認用
+
+        if excluded_tags:
+            logger.debug(f"Applying exclusion tag filter (NOT EXISTS) for tags: {excluded_tags}")
+            for excluded_tag_term in excluded_tags:
+                pattern, is_exact = self._prepare_like_pattern(excluded_tag_term)
+                excluded_condition = (Tag.tag == pattern) if is_exact else Tag.tag.like(pattern)
+                excluded_exists_subquery = (
+                    select(Tag.id)
+                    .where(
+                        Tag.image_id == Image.id,
+                        excluded_condition,
+                    )
+                    .correlate(Image)
+                    .exists()
+                )
+                query = query.where(not_(excluded_exists_subquery))
 
         return query
 
@@ -2406,6 +2423,7 @@ class ImageRepository:
         self,
         session: Session,
         tags: list[str] | None,
+        excluded_tags: list[str] | None,
         caption: str | None,
         use_and: bool,
         start_date: str | None,
@@ -2424,6 +2442,7 @@ class ImageRepository:
         Args:
             session: SQLAlchemyセッション。
             tags: 検索タグリスト。
+            excluded_tags: 除外するタグリスト。
             caption: 検索キャプション文字列。
             use_and: 複数タグのAND/OR指定。
             start_date: 検索開始日時(ISO 8601)。
@@ -2450,7 +2469,7 @@ class ImageRepository:
         if include_untagged and (tags or caption):
             logger.warning("検索語句と include_untagged が同時に指定されたため、検索語句は無視されます。")
 
-        query = self._apply_tag_filter(query, tags, use_and, include_untagged)
+        query = self._apply_tag_filter(query, tags, excluded_tags, use_and, include_untagged)
         query = self._apply_caption_filter(query, caption)
 
         # Rating Filters (Priority-based: manual > AI)
@@ -2517,6 +2536,7 @@ class ImageRepository:
                 query = self._build_image_filter_query(
                     session=session,
                     tags=filter_criteria.tags,
+                    excluded_tags=filter_criteria.excluded_tags,
                     caption=filter_criteria.caption,
                     use_and=filter_criteria.use_and,
                     start_date=filter_criteria.start_date,

--- a/src/lorairo/database/filter_criteria.py
+++ b/src/lorairo/database/filter_criteria.py
@@ -32,9 +32,11 @@ class ImageFilterCriteria:
         manual_edit_filter: アノテーションが手動編集されたかでフィルタするか
         score_min: 最小スコア値（0.0-10.0）
         score_max: 最大スコア値（0.0-10.0）
+        excluded_tags: 除外するタグのリスト
     """
 
     tags: list[str] | None = None
+    excluded_tags: list[str] | None = None
     caption: str | None = None
     resolution: int = 0
     use_and: bool = True
@@ -86,6 +88,7 @@ class ImageFilterCriteria:
         return {
             "tags": self.tags,
             "caption": self.caption,
+            "excluded_tags": self.excluded_tags,
             "resolution": self.resolution,
             "use_and": self.use_and,
             "start_date": self.start_date,

--- a/src/lorairo/gui/services/search_filter_service.py
+++ b/src/lorairo/gui/services/search_filter_service.py
@@ -71,28 +71,33 @@ class SearchFilterService:
 
         logger.info("SearchFilterService (純化版) initialized with new service layer integration")
 
-    def parse_search_input(self, input_text: str) -> list[str]:
+    def parse_search_input(self, input_text: str) -> tuple[list[str], list[str]]:
         """UI入力テキストの解析とキーワード抽出
 
         Args:
             input_text: ユーザー入力テキスト
 
         Returns:
-            list: 抽出されたキーワードリスト
+            tuple[list[str], list[str]]: (通常キーワード, 除外キーワード)
 
         """
         if not input_text:
-            return []
+            return [], []
 
         # 基本的なキーワード分割(カンマ区切り、タグ内スペース保持)
-        keywords = [keyword.strip() for keyword in input_text.split(",") if keyword.strip()]
-        logger.debug(f"入力解析完了: '{input_text}' -> {keywords}")
-        return keywords
+        raw_keywords = [keyword.strip() for keyword in input_text.split(",") if keyword.strip()]
+        keywords = [keyword for keyword in raw_keywords if not keyword.startswith("-")]
+        excluded_keywords = [keyword[1:].strip() for keyword in raw_keywords if keyword.startswith("-") and keyword[1:].strip()]
+        logger.debug(
+            f"入力解析完了: '{input_text}' -> include={keywords}, exclude={excluded_keywords}",
+        )
+        return keywords, excluded_keywords
 
     def create_search_conditions(
         self,
         search_type: str,
         keywords: list[str],
+        excluded_keywords: list[str] | None = None,
         tag_logic: str = "and",
         resolution_filter: str | None = None,
         aspect_ratio_filter: str | None = None,
@@ -124,6 +129,7 @@ class SearchFilterService:
         conditions = SearchConditions(
             search_type=search_type,
             keywords=keywords,
+            excluded_keywords=excluded_keywords,
             tag_logic=tag_logic,
             resolution_filter=resolution_filter,
             aspect_ratio_filter=aspect_ratio_filter,
@@ -164,6 +170,9 @@ class SearchFilterService:
         if conditions.keywords:
             keyword_text = f" {conditions.tag_logic.upper()} ".join(conditions.keywords)
             preview_parts.append(f"キーワード: {keyword_text} ({conditions.search_type})")
+        if conditions.excluded_keywords:
+            exclude_text = ", ".join(conditions.excluded_keywords)
+            preview_parts.append(f"除外キーワード: {exclude_text}")
 
         # フィルター条件
         if conditions.resolution_filter:

--- a/src/lorairo/gui/widgets/filter_search_panel.py
+++ b/src/lorairo/gui/widgets/filter_search_panel.py
@@ -899,7 +899,9 @@ class FilterSearchPanel(QScrollArea):
         try:
             # 検索テキストをキーワードリストに変換
             search_text = self.ui.lineEditSearch.text().strip()
-            keywords = self.search_filter_service.parse_search_input(search_text) if search_text else []
+            keywords, excluded_keywords = (
+                self.search_filter_service.parse_search_input(search_text) if search_text else ([], [])
+            )
 
             # スコア範囲を取得して検索条件に含めるか判定
             score_min_internal, score_max_internal = self.score_range_slider.get_range()
@@ -944,6 +946,7 @@ class FilterSearchPanel(QScrollArea):
             conditions = self.search_filter_service.create_search_conditions(
                 search_type=self._get_primary_search_type(),
                 keywords=keywords,
+                excluded_keywords=excluded_keywords,
                 tag_logic="and" if self.ui.radioAnd.isChecked() else "or",
                 resolution_filter=self.ui.comboResolution.currentText(),
                 aspect_ratio_filter=self.ui.comboAspectRatio.currentText(),
@@ -997,7 +1000,9 @@ class FilterSearchPanel(QScrollArea):
         try:
             # 検索テキストをキーワードリストに変換
             search_text = self.ui.lineEditSearch.text().strip()
-            keywords = self.search_filter_service.parse_search_input(search_text) if search_text else []
+            keywords, excluded_keywords = (
+                self.search_filter_service.parse_search_input(search_text) if search_text else ([], [])
+            )
 
             # 日付範囲を取得
             date_range_start, date_range_end = self.get_date_range_from_slider()
@@ -1013,6 +1018,7 @@ class FilterSearchPanel(QScrollArea):
             conditions = self.search_filter_service.create_search_conditions(
                 search_type=self._get_primary_search_type(),
                 keywords=keywords,
+                excluded_keywords=excluded_keywords,
                 tag_logic="and" if self.ui.radioAnd.isChecked() else "or",
                 resolution_filter=self.ui.comboResolution.currentText(),
                 aspect_ratio_filter=self.ui.comboAspectRatio.currentText(),

--- a/src/lorairo/services/search_models.py
+++ b/src/lorairo/services/search_models.py
@@ -23,6 +23,7 @@ class SearchConditions:
     search_type: str  # "tags" or "caption"
     keywords: list[str]
     tag_logic: str  # "and" or "or"
+    excluded_keywords: list[str] | None = None
     resolution_filter: str | None = None
     aspect_ratio_filter: str | None = None
     date_filter_enabled: bool = False
@@ -57,6 +58,7 @@ class SearchConditions:
 
         return ImageFilterCriteria(
             tags=self.keywords if self.search_type == "tags" else None,
+            excluded_tags=self.excluded_keywords if self.search_type == "tags" else None,
             caption=self.keywords[0] if self.search_type == "caption" and self.keywords else None,
             resolution=self._resolve_resolution(),
             use_and=self.tag_logic == "and",

--- a/tests/integration/gui/test_filter_search_integration.py
+++ b/tests/integration/gui/test_filter_search_integration.py
@@ -170,13 +170,15 @@ class TestFilterSearchIntegration:
         service = filter_panel.search_filter_service
 
         # parse_search_inputをテスト（カンマ区切りで分割、スペースは保持）
-        keywords = service.parse_search_input("test, keyword")
+        keywords, excluded_keywords = service.parse_search_input("test, keyword")
         assert keywords == ["test", "keyword"]
+        assert excluded_keywords == []
 
         # create_search_conditionsをテスト
         conditions = service.create_search_conditions(
             search_type="caption",
             keywords=keywords,
+            excluded_keywords=excluded_keywords,
             tag_logic="or",
             resolution_filter="1024x1024",
             only_untagged=True,

--- a/tests/unit/gui/services/test_search_filter_service.py
+++ b/tests/unit/gui/services/test_search_filter_service.py
@@ -110,39 +110,54 @@ class TestSearchFilterService:
     def test_parse_search_input_tags(self, service):
         """タグ検索入力解析テスト"""
         # 基本的なカンマ区切り
-        keywords = service.parse_search_input("tag1, tag2, tag3")
+        keywords, excluded = service.parse_search_input("tag1, tag2, tag3")
         assert keywords == ["tag1", "tag2", "tag3"]
+        assert excluded == []
 
         # スペース込みタグ
-        keywords = service.parse_search_input("1girl, long hair, blue eyes")
+        keywords, excluded = service.parse_search_input("1girl, long hair, blue eyes")
         assert keywords == ["1girl", "long hair", "blue eyes"]
+        assert excluded == []
 
         # 空のタグ除去
-        keywords = service.parse_search_input("tag1, , tag3, ")
+        keywords, excluded = service.parse_search_input("tag1, , tag3, ")
         assert keywords == ["tag1", "tag3"]
+        assert excluded == []
 
     def test_parse_search_input_caption(self, service):
         """キャプション検索入力解析テスト"""
         # カンマ区切りキャプション
-        keywords = service.parse_search_input("beautiful scene, landscape view, mountain scenery")
+        keywords, excluded = service.parse_search_input("beautiful scene, landscape view, mountain scenery")
         assert keywords == ["beautiful scene", "landscape view", "mountain scenery"]
+        assert excluded == []
 
         # 余分なスペース処理（単一キーワード）
-        keywords = service.parse_search_input("  single keyword  ")
+        keywords, excluded = service.parse_search_input("  single keyword  ")
         assert keywords == ["single keyword"]
+        assert excluded == []
+
+    def test_parse_search_input_with_excluded_keywords(self, service):
+        """除外キーワードを含む検索入力解析テスト"""
+        keywords, excluded = service.parse_search_input("1girl, -1boy, blue_eyes, -lowres")
+
+        assert keywords == ["1girl", "blue_eyes"]
+        assert excluded == ["1boy", "lowres"]
 
     def test_parse_search_input_empty(self, service):
         """空の検索入力テスト"""
-        keywords = service.parse_search_input("")
+        keywords, excluded = service.parse_search_input("")
         assert keywords == []
+        assert excluded == []
 
-        keywords = service.parse_search_input("   ")
+        keywords, excluded = service.parse_search_input("   ")
         assert keywords == []
+        assert excluded == []
 
     def test_create_search_conditions_basic(self, service):
         """基本的な検索条件作成テスト"""
-        keywords = service.parse_search_input("tag1, tag2")
+        keywords, excluded = service.parse_search_input("tag1, tag2")
         conditions = service.create_search_conditions(
+            excluded_keywords=excluded,
             search_type="tags",
             keywords=keywords,
             tag_logic="and",
@@ -168,9 +183,10 @@ class TestSearchFilterService:
         """日付付き検索条件作成テスト"""
         start_date = datetime(2023, 1, 1)
         end_date = datetime(2023, 12, 31)
-        keywords = service.parse_search_input("test")
+        keywords, excluded = service.parse_search_input("test")
 
         conditions = service.create_search_conditions(
+            excluded_keywords=excluded,
             search_type="caption",
             keywords=keywords,
             tag_logic="or",


### PR DESCRIPTION
### Motivation
- Add support for user-facing exclude keywords (prefix `-tag`) so searches can specify tags to exclude (NOT search), as requested in Issue #11. 
- Propagate exclude semantics from UI input to DB query layer so exclusion is applied efficiently at SQL level.

### Description
- Added `excluded_keywords: list[str] | None` to `SearchConditions` and map it to `excluded_tags` in the DB criteria conversion in `src/lorairo/services/search_models.py`.
- Extended `ImageFilterCriteria` with `excluded_tags` and its `to_dict()` output in `src/lorairo/database/filter_criteria.py`.
- Updated `ImageRepository._apply_tag_filter()` to accept `excluded_tags` and apply a `NOT EXISTS` subquery per excluded tag (SQL-level exclusion) in `src/lorairo/database/db_repository.py`.
- Modified `SearchFilterService.parse_search_input()` to return `(keywords, excluded_keywords)`, updated `create_search_conditions()` to accept `excluded_keywords`, and added exclude text to the search preview in `src/lorairo/gui/services/search_filter_service.py`.
- Updated `FilterSearchPanel` to unpack `parse_search_input()` as `(keywords, excluded_keywords)` and pass `excluded_keywords` into `create_search_conditions()` for both async and sync search paths in `src/lorairo/gui/widgets/filter_search_panel.py`.
- Adjusted unit/integration tests to the new parsing contract and added a new test for exclude-keyword parsing in `tests/unit/gui/services/test_search_filter_service.py` and adapted `tests/integration/gui/test_filter_search_integration.py`.

### Testing
- Ran `python -m compileall` as a basic sanity compile check; it failed in this environment due to an existing f-string/backslash expression and other preexisting syntax issues unrelated to the changes, so full compile success could not be validated here.
- Attempted unit tests with `PYTHONPATH=src python -m pytest tests/unit/gui/services/test_search_filter_service.py -q`; test execution failed due to missing runtime dependencies (`sqlalchemy` not installed in this environment), so tests could not be run to completion.
- Attempted full test run via the project's `uv` workflow but venv creation failed because a local editable package (`local_packages/genai-tag-db-tools`) lacks packaging metadata in this environment, preventing `uv` test execution.
- Updated and committed test expectations to match the new API (parse returns include/exclude tuple and `create_search_conditions()` accepts `excluded_keywords`), but automated CI/test runs were blocked by the environment constraints above.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b68f7e27708329adaad56c1a4f0831)