### PR TITLE
feat: add NOT tag search support using `-` prefix (excluded keywords)

### DIFF
--- a/src/lorairo/database/db_repository.py
+++ b/src/lorairo/database/db_repository.py
@@ -1868,6 +1868,7 @@ class ImageRepository:
         self,
         query: Select,
         tags: list[str] | None,
+        excluded_tags: list[str] | None,
         use_and: bool,
         include_untagged: bool,
     ) -> Select:
@@ -1909,6 +1910,22 @@ class ImageRepository:
                 if tag_criteria:
                     query = query.join(Tag, Image.id == Tag.image_id).where(or_(*tag_criteria))
                     # logger.debug(f"Query after OR tag join: {query}") # クエリ確認用
+
+        if excluded_tags and not include_untagged:
+            logger.debug(f"Applying excluded tag filter (NOT EXISTS) for tags: {excluded_tags}")
+            for excluded_tag in excluded_tags:
+                pattern, is_exact = self._prepare_like_pattern(excluded_tag)
+                subquery_condition = (Tag.tag == pattern) if is_exact else Tag.tag.like(pattern)
+                excluded_exists_subquery = (
+                    select(Tag.id)
+                    .where(
+                        Tag.image_id == Image.id,
+                        subquery_condition,
+                    )
+                    .correlate(Image)
+                    .exists()
+                )
+                query = query.where(~excluded_exists_subquery)
 
         return query
 
@@ -2406,6 +2423,7 @@ class ImageRepository:
         self,
         session: Session,
         tags: list[str] | None,
+        excluded_tags: list[str] | None,
         caption: str | None,
         use_and: bool,
         start_date: str | None,
@@ -2424,6 +2442,7 @@ class ImageRepository:
         Args:
             session: SQLAlchemyセッション。
             tags: 検索タグリスト。
+            excluded_tags: 除外タグリスト。
             caption: 検索キャプション文字列。
             use_and: 複数タグのAND/OR指定。
             start_date: 検索開始日時(ISO 8601)。
@@ -2450,7 +2469,7 @@ class ImageRepository:
         if include_untagged and (tags or caption):
             logger.warning("検索語句と include_untagged が同時に指定されたため、検索語句は無視されます。")
 
-        query = self._apply_tag_filter(query, tags, use_and, include_untagged)
+        query = self._apply_tag_filter(query, tags, excluded_tags, use_and, include_untagged)
         query = self._apply_caption_filter(query, caption)
 
         # Rating Filters (Priority-based: manual > AI)
@@ -2517,6 +2536,7 @@ class ImageRepository:
                 query = self._build_image_filter_query(
                     session=session,
                     tags=filter_criteria.tags,
+                    excluded_tags=filter_criteria.excluded_tags,
                     caption=filter_criteria.caption,
                     use_and=filter_criteria.use_and,
                     start_date=filter_criteria.start_date,

--- a/src/lorairo/database/filter_criteria.py
+++ b/src/lorairo/database/filter_criteria.py
@@ -20,6 +20,7 @@ class ImageFilterCriteria:
     Attributes:
         tags: 検索するタグのリスト
         caption: 検索するキャプション文字列
+        excluded_tags: 検索結果から除外するタグのリスト
         resolution: 検索対象の解像度(長辺)、0の場合はオリジナル画像
         use_and: 複数タグ指定時の検索方法 (True: AND, False: OR)
         start_date: 検索開始日時 (ISO 8601形式)
@@ -36,6 +37,7 @@ class ImageFilterCriteria:
 
     tags: list[str] | None = None
     caption: str | None = None
+    excluded_tags: list[str] | None = None
     resolution: int = 0
     use_and: bool = True
     start_date: str | None = None
@@ -86,6 +88,7 @@ class ImageFilterCriteria:
         return {
             "tags": self.tags,
             "caption": self.caption,
+            "excluded_tags": self.excluded_tags,
             "resolution": self.resolution,
             "use_and": self.use_and,
             "start_date": self.start_date,

--- a/src/lorairo/gui/services/search_filter_service.py
+++ b/src/lorairo/gui/services/search_filter_service.py
@@ -71,28 +71,46 @@ class SearchFilterService:
 
         logger.info("SearchFilterService (純化版) initialized with new service layer integration")
 
-    def parse_search_input(self, input_text: str) -> list[str]:
+    def parse_search_input(self, input_text: str) -> tuple[list[str], list[str]]:
         """UI入力テキストの解析とキーワード抽出
 
         Args:
             input_text: ユーザー入力テキスト
 
         Returns:
-            list: 抽出されたキーワードリスト
+            tuple[list[str], list[str]]: (通常キーワード, 除外キーワード)
 
         """
         if not input_text:
-            return []
+            return [], []
+
+        keywords: list[str] = []
+        excluded_keywords: list[str] = []
 
         # 基本的なキーワード分割(カンマ区切り、タグ内スペース保持)
-        keywords = [keyword.strip() for keyword in input_text.split(",") if keyword.strip()]
-        logger.debug(f"入力解析完了: '{input_text}' -> {keywords}")
-        return keywords
+        for raw_keyword in input_text.split(","):
+            keyword = raw_keyword.strip()
+            if not keyword:
+                continue
+
+            if keyword.startswith("-") and len(keyword) > 1:
+                excluded_keyword = keyword[1:].strip()
+                if excluded_keyword:
+                    excluded_keywords.append(excluded_keyword)
+                continue
+
+            keywords.append(keyword)
+
+        logger.debug(
+            f"入力解析完了: '{input_text}' -> keywords={keywords}, excluded_keywords={excluded_keywords}"
+        )
+        return keywords, excluded_keywords
 
     def create_search_conditions(
         self,
         search_type: str,
         keywords: list[str],
+        excluded_keywords: list[str] | None = None,
         tag_logic: str = "and",
         resolution_filter: str | None = None,
         aspect_ratio_filter: str | None = None,
@@ -125,6 +143,7 @@ class SearchFilterService:
             search_type=search_type,
             keywords=keywords,
             tag_logic=tag_logic,
+            excluded_keywords=excluded_keywords,
             resolution_filter=resolution_filter,
             aspect_ratio_filter=aspect_ratio_filter,
             date_filter_enabled=date_filter_enabled,
@@ -164,6 +183,10 @@ class SearchFilterService:
         if conditions.keywords:
             keyword_text = f" {conditions.tag_logic.upper()} ".join(conditions.keywords)
             preview_parts.append(f"キーワード: {keyword_text} ({conditions.search_type})")
+
+        if conditions.excluded_keywords:
+            excluded_text = f" {conditions.tag_logic.upper()} ".join(conditions.excluded_keywords)
+            preview_parts.append(f"除外: {excluded_text}")
 
         # フィルター条件
         if conditions.resolution_filter:

--- a/src/lorairo/gui/widgets/filter_search_panel.py
+++ b/src/lorairo/gui/widgets/filter_search_panel.py
@@ -899,7 +899,9 @@ class FilterSearchPanel(QScrollArea):
         try:
             # 検索テキストをキーワードリストに変換
             search_text = self.ui.lineEditSearch.text().strip()
-            keywords = self.search_filter_service.parse_search_input(search_text) if search_text else []
+            keywords, excluded_keywords = (
+                self.search_filter_service.parse_search_input(search_text) if search_text else ([], [])
+            )
 
             # スコア範囲を取得して検索条件に含めるか判定
             score_min_internal, score_max_internal = self.score_range_slider.get_range()
@@ -944,6 +946,7 @@ class FilterSearchPanel(QScrollArea):
             conditions = self.search_filter_service.create_search_conditions(
                 search_type=self._get_primary_search_type(),
                 keywords=keywords,
+                excluded_keywords=excluded_keywords,
                 tag_logic="and" if self.ui.radioAnd.isChecked() else "or",
                 resolution_filter=self.ui.comboResolution.currentText(),
                 aspect_ratio_filter=self.ui.comboAspectRatio.currentText(),
@@ -997,7 +1000,9 @@ class FilterSearchPanel(QScrollArea):
         try:
             # 検索テキストをキーワードリストに変換
             search_text = self.ui.lineEditSearch.text().strip()
-            keywords = self.search_filter_service.parse_search_input(search_text) if search_text else []
+            keywords, excluded_keywords = (
+                self.search_filter_service.parse_search_input(search_text) if search_text else ([], [])
+            )
 
             # 日付範囲を取得
             date_range_start, date_range_end = self.get_date_range_from_slider()
@@ -1013,6 +1018,7 @@ class FilterSearchPanel(QScrollArea):
             conditions = self.search_filter_service.create_search_conditions(
                 search_type=self._get_primary_search_type(),
                 keywords=keywords,
+                excluded_keywords=excluded_keywords,
                 tag_logic="and" if self.ui.radioAnd.isChecked() else "or",
                 resolution_filter=self.ui.comboResolution.currentText(),
                 aspect_ratio_filter=self.ui.comboAspectRatio.currentText(),
@@ -1129,6 +1135,7 @@ class FilterSearchPanel(QScrollArea):
             return {
                 "search_type": current.search_type,
                 "keywords": current.keywords,
+                "excluded_keywords": current.excluded_keywords,
                 "tag_logic": current.tag_logic,
                 "resolution_filter": current.resolution_filter,
                 "aspect_ratio_filter": current.aspect_ratio_filter,

--- a/src/lorairo/services/search_models.py
+++ b/src/lorairo/services/search_models.py
@@ -23,6 +23,7 @@ class SearchConditions:
     search_type: str  # "tags" or "caption"
     keywords: list[str]
     tag_logic: str  # "and" or "or"
+    excluded_keywords: list[str] | None = None
     resolution_filter: str | None = None
     aspect_ratio_filter: str | None = None
     date_filter_enabled: bool = False
@@ -57,6 +58,7 @@ class SearchConditions:
 
         return ImageFilterCriteria(
             tags=self.keywords if self.search_type == "tags" else None,
+            excluded_tags=self.excluded_keywords if self.search_type == "tags" else None,
             caption=self.keywords[0] if self.search_type == "caption" and self.keywords else None,
             resolution=self._resolve_resolution(),
             use_and=self.tag_logic == "and",

--- a/tests/integration/gui/test_filter_search_integration.py
+++ b/tests/integration/gui/test_filter_search_integration.py
@@ -170,8 +170,9 @@ class TestFilterSearchIntegration:
         service = filter_panel.search_filter_service
 
         # parse_search_inputをテスト（カンマ区切りで分割、スペースは保持）
-        keywords = service.parse_search_input("test, keyword")
+        keywords, excluded_keywords = service.parse_search_input("test, keyword")
         assert keywords == ["test", "keyword"]
+        assert excluded_keywords == []
 
         # create_search_conditionsをテスト
         conditions = service.create_search_conditions(

--- a/tests/unit/gui/services/test_search_filter_service.py
+++ b/tests/unit/gui/services/test_search_filter_service.py
@@ -71,6 +71,20 @@ class TestSearchConditions:
         assert conditions.rating_filter == "PG"
         assert conditions.include_unrated is False
 
+    def test_to_db_filter_args_with_excluded_keywords(self):
+        """to_db_filter_args() の除外キーワード変換テスト"""
+        conditions = SearchConditions(
+            search_type="tags",
+            keywords=["1girl", "blue_eyes"],
+            excluded_keywords=["1boy"],
+            tag_logic="and",
+        )
+
+        db_args = conditions.to_db_filter_args()
+
+        assert db_args["tags"] == ["1girl", "blue_eyes"]
+        assert db_args["excluded_tags"] == ["1boy"]
+
     def test_to_db_filter_args_with_rating(self):
         """to_db_filter_args() のRatingフィルター変換テスト"""
         conditions = SearchConditions(
@@ -110,41 +124,57 @@ class TestSearchFilterService:
     def test_parse_search_input_tags(self, service):
         """タグ検索入力解析テスト"""
         # 基本的なカンマ区切り
-        keywords = service.parse_search_input("tag1, tag2, tag3")
+        keywords, excluded = service.parse_search_input("tag1, tag2, tag3")
         assert keywords == ["tag1", "tag2", "tag3"]
+        assert excluded == []
 
         # スペース込みタグ
-        keywords = service.parse_search_input("1girl, long hair, blue eyes")
+        keywords, excluded = service.parse_search_input("1girl, long hair, blue eyes")
         assert keywords == ["1girl", "long hair", "blue eyes"]
+        assert excluded == []
 
         # 空のタグ除去
-        keywords = service.parse_search_input("tag1, , tag3, ")
+        keywords, excluded = service.parse_search_input("tag1, , tag3, ")
         assert keywords == ["tag1", "tag3"]
+        assert excluded == []
+
+
+    def test_parse_search_input_with_excluded_tags(self, service):
+        """除外タグ付き入力解析テスト"""
+        keywords, excluded = service.parse_search_input("1girl, -1boy, blue_eyes")
+
+        assert keywords == ["1girl", "blue_eyes"]
+        assert excluded == ["1boy"]
 
     def test_parse_search_input_caption(self, service):
         """キャプション検索入力解析テスト"""
         # カンマ区切りキャプション
-        keywords = service.parse_search_input("beautiful scene, landscape view, mountain scenery")
+        keywords, excluded = service.parse_search_input("beautiful scene, landscape view, mountain scenery")
         assert keywords == ["beautiful scene", "landscape view", "mountain scenery"]
+        assert excluded == []
 
         # 余分なスペース処理（単一キーワード）
-        keywords = service.parse_search_input("  single keyword  ")
+        keywords, excluded = service.parse_search_input("  single keyword  ")
         assert keywords == ["single keyword"]
+        assert excluded == []
 
     def test_parse_search_input_empty(self, service):
         """空の検索入力テスト"""
-        keywords = service.parse_search_input("")
+        keywords, excluded = service.parse_search_input("")
         assert keywords == []
+        assert excluded == []
 
-        keywords = service.parse_search_input("   ")
+        keywords, excluded = service.parse_search_input("   ")
         assert keywords == []
+        assert excluded == []
 
     def test_create_search_conditions_basic(self, service):
         """基本的な検索条件作成テスト"""
-        keywords = service.parse_search_input("tag1, tag2")
+        keywords, excluded_keywords = service.parse_search_input("tag1, tag2")
         conditions = service.create_search_conditions(
             search_type="tags",
             keywords=keywords,
+            excluded_keywords=excluded_keywords,
             tag_logic="and",
             resolution_filter="1024x1024",
             aspect_ratio_filter="1:1 (正方形)",
@@ -168,11 +198,12 @@ class TestSearchFilterService:
         """日付付き検索条件作成テスト"""
         start_date = datetime(2023, 1, 1)
         end_date = datetime(2023, 12, 31)
-        keywords = service.parse_search_input("test")
+        keywords, excluded_keywords = service.parse_search_input("test")
 
         conditions = service.create_search_conditions(
             search_type="caption",
             keywords=keywords,
+            excluded_keywords=excluded_keywords,
             tag_logic="or",
             resolution_filter="1024x1024",
             aspect_ratio_filter="正方形 (1:1)",
@@ -215,6 +246,20 @@ class TestSearchFilterService:
         assert "日付範囲: 開始: 2023-01-01, 終了: 2023-12-31" in preview
         assert "未タグ付きのみ" in preview
         assert "重複除外" in preview
+
+    def test_create_search_preview_with_excluded_keywords(self, service):
+        """除外キーワード付き検索プレビュー作成テスト"""
+        conditions = SearchConditions(
+            search_type="tags",
+            keywords=["1girl", "blue_eyes"],
+            excluded_keywords=["1boy"],
+            tag_logic="and",
+        )
+
+        preview = service.create_search_preview(conditions)
+
+        assert "キーワード: 1girl AND blue_eyes (tags)" in preview
+        assert "除外: 1boy" in preview
 
     def test_create_search_preview_with_rating_filter(self, service):
         """Ratingフィルター付き検索プレビュー作成テスト"""


### PR DESCRIPTION
### Motivation

- Implement Issue #11: allow users to exclude tags from searches using a `-` prefix (e.g. `1girl, -1boy, blue_eyes`) so searches can express NOT semantics.
- Propagate exclusion information through the UI -> service -> DB stack so excluded terms affect actual query results instead of only being cosmetic.

### Description

- Added `excluded_keywords: list[str] | None` to `SearchConditions` and mapped it to DB criteria as `excluded_tags` via `to_filter_criteria()` in `src/lorairo/services/search_models.py` and `src/lorairo/database/filter_criteria.py`.
- Extended the UI input parser `SearchFilterService.parse_search_input()` to return `(keywords, excluded_keywords)` and updated `create_search_conditions()` and preview generation to include an "除外: ..." entry in `src/lorairo/gui/services/search_filter_service.py`.
- Updated `FilterSearchPanel` to unpack parser output and pass `excluded_keywords` into both asynchronous and synchronous search flows and to include it in `get_current_conditions()` in `src/lorairo/gui/widgets/filter_search_panel.py`.
- Implemented exclusion filtering in the repository by adding an `excluded_tags` parameter and applying a `NOT EXISTS` subquery per excluded tag in `_apply_tag_filter()` and threading `excluded_tags` through `_build_image_filter_query()` in `src/lorairo/database/db_repository.py`.
- Updated unit/integration tests to validate parsing, `to_db_filter_args()` mapping, and preview rendering, under `tests/unit/gui/services/test_search_filter_service.py` and `tests/integration/gui/test_filter_search_integration.py`.

### Testing

- `python -m py_compile ...` on the modified files and updated tests succeeded for basic syntax checks.
- Attempted `pytest -q tests/unit/gui/services/test_search_filter_service.py` but the test run failed in this environment during test bootstrap due to a missing runtime test dependency (`sqlalchemy`) reported by `tests/conftest.py`.
- Ran `ruff check` in this environment but it reported repository/environment issues (missing packaging metadata for a local editable package and existing complexity/lint warnings unrelated to the change); these prevented a clean lint pass here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b68f7e27708329adaad56c1a4f0831)