### PR TITLE
feat: 検索UXに除外検索（-tag）を追加

### DIFF
--- a/src/lorairo/database/db_repository.py
+++ b/src/lorairo/database/db_repository.py
@@ -1868,6 +1868,7 @@ class ImageRepository:
         self,
         query: Select,
         tags: list[str] | None,
+        excluded_tags: list[str] | None,
         use_and: bool,
         include_untagged: bool,
     ) -> Select:
@@ -1909,6 +1910,22 @@ class ImageRepository:
                 if tag_criteria:
                     query = query.join(Tag, Image.id == Tag.image_id).where(or_(*tag_criteria))
                     # logger.debug(f"Query after OR tag join: {query}") # クエリ確認用
+
+        if excluded_tags:
+            logger.debug(f"Applying excluded tag filter (NOT EXISTS) for tags: {excluded_tags}")
+            for excluded_tag in excluded_tags:
+                pattern, is_exact = self._prepare_like_pattern(excluded_tag)
+                excluded_condition = (Tag.tag == pattern) if is_exact else Tag.tag.like(pattern)
+                not_exists_subquery = (
+                    select(Tag.id)
+                    .where(
+                        Tag.image_id == Image.id,
+                        excluded_condition,
+                    )
+                    .correlate(Image)
+                    .exists()
+                )
+                query = query.where(~not_exists_subquery)
 
         return query
 
@@ -2406,6 +2423,7 @@ class ImageRepository:
         self,
         session: Session,
         tags: list[str] | None,
+        excluded_tags: list[str] | None,
         caption: str | None,
         use_and: bool,
         start_date: str | None,
@@ -2424,6 +2442,7 @@ class ImageRepository:
         Args:
             session: SQLAlchemyセッション。
             tags: 検索タグリスト。
+            excluded_tags: 除外検索タグリスト。
             caption: 検索キャプション文字列。
             use_and: 複数タグのAND/OR指定。
             start_date: 検索開始日時(ISO 8601)。
@@ -2450,7 +2469,7 @@ class ImageRepository:
         if include_untagged and (tags or caption):
             logger.warning("検索語句と include_untagged が同時に指定されたため、検索語句は無視されます。")
 
-        query = self._apply_tag_filter(query, tags, use_and, include_untagged)
+        query = self._apply_tag_filter(query, tags, excluded_tags, use_and, include_untagged)
         query = self._apply_caption_filter(query, caption)
 
         # Rating Filters (Priority-based: manual > AI)
@@ -2517,6 +2536,7 @@ class ImageRepository:
                 query = self._build_image_filter_query(
                     session=session,
                     tags=filter_criteria.tags,
+                    excluded_tags=filter_criteria.excluded_tags,
                     caption=filter_criteria.caption,
                     use_and=filter_criteria.use_and,
                     start_date=filter_criteria.start_date,

--- a/src/lorairo/database/filter_criteria.py
+++ b/src/lorairo/database/filter_criteria.py
@@ -20,6 +20,7 @@ class ImageFilterCriteria:
     Attributes:
         tags: 検索するタグのリスト
         caption: 検索するキャプション文字列
+        excluded_tags: 除外するタグのリスト（NOT検索）
         resolution: 検索対象の解像度(長辺)、0の場合はオリジナル画像
         use_and: 複数タグ指定時の検索方法 (True: AND, False: OR)
         start_date: 検索開始日時 (ISO 8601形式)
@@ -36,6 +37,7 @@ class ImageFilterCriteria:
 
     tags: list[str] | None = None
     caption: str | None = None
+    excluded_tags: list[str] | None = None
     resolution: int = 0
     use_and: bool = True
     start_date: str | None = None
@@ -86,6 +88,7 @@ class ImageFilterCriteria:
         return {
             "tags": self.tags,
             "caption": self.caption,
+            "excluded_tags": self.excluded_tags,
             "resolution": self.resolution,
             "use_and": self.use_and,
             "start_date": self.start_date,

--- a/src/lorairo/gui/services/search_filter_service.py
+++ b/src/lorairo/gui/services/search_filter_service.py
@@ -71,28 +71,39 @@ class SearchFilterService:
 
         logger.info("SearchFilterService (純化版) initialized with new service layer integration")
 
-    def parse_search_input(self, input_text: str) -> list[str]:
+    def parse_search_input(self, input_text: str) -> tuple[list[str], list[str]]:
         """UI入力テキストの解析とキーワード抽出
 
         Args:
             input_text: ユーザー入力テキスト
 
         Returns:
-            list: 抽出されたキーワードリスト
+            tuple[list[str], list[str]]: (通常キーワード, 除外キーワード)
 
         """
         if not input_text:
-            return []
+            return [], []
 
         # 基本的なキーワード分割(カンマ区切り、タグ内スペース保持)
-        keywords = [keyword.strip() for keyword in input_text.split(",") if keyword.strip()]
-        logger.debug(f"入力解析完了: '{input_text}' -> {keywords}")
-        return keywords
+        keywords: list[str] = []
+        excluded_keywords: list[str] = []
+        for raw_keyword in input_text.split(","):
+            keyword = raw_keyword.strip()
+            if not keyword:
+                continue
+            if keyword.startswith("-") and len(keyword) > 1:
+                excluded_keywords.append(keyword[1:].strip())
+            else:
+                keywords.append(keyword)
+
+        logger.debug(f"入力解析完了: '{input_text}' -> keywords={keywords}, excluded={excluded_keywords}")
+        return keywords, excluded_keywords
 
     def create_search_conditions(
         self,
         search_type: str,
         keywords: list[str],
+        excluded_keywords: list[str] | None = None,
         tag_logic: str = "and",
         resolution_filter: str | None = None,
         aspect_ratio_filter: str | None = None,
@@ -124,6 +135,7 @@ class SearchFilterService:
         conditions = SearchConditions(
             search_type=search_type,
             keywords=keywords,
+            excluded_keywords=excluded_keywords,
             tag_logic=tag_logic,
             resolution_filter=resolution_filter,
             aspect_ratio_filter=aspect_ratio_filter,
@@ -164,6 +176,10 @@ class SearchFilterService:
         if conditions.keywords:
             keyword_text = f" {conditions.tag_logic.upper()} ".join(conditions.keywords)
             preview_parts.append(f"キーワード: {keyword_text} ({conditions.search_type})")
+
+        if conditions.excluded_keywords:
+            excluded_text = ", ".join(conditions.excluded_keywords)
+            preview_parts.append(f"除外キーワード: {excluded_text}")
 
         # フィルター条件
         if conditions.resolution_filter:

--- a/src/lorairo/gui/widgets/filter_search_panel.py
+++ b/src/lorairo/gui/widgets/filter_search_panel.py
@@ -899,7 +899,9 @@ class FilterSearchPanel(QScrollArea):
         try:
             # 検索テキストをキーワードリストに変換
             search_text = self.ui.lineEditSearch.text().strip()
-            keywords = self.search_filter_service.parse_search_input(search_text) if search_text else []
+            keywords, excluded_keywords = (
+                self.search_filter_service.parse_search_input(search_text) if search_text else ([], [])
+            )
 
             # スコア範囲を取得して検索条件に含めるか判定
             score_min_internal, score_max_internal = self.score_range_slider.get_range()
@@ -944,6 +946,7 @@ class FilterSearchPanel(QScrollArea):
             conditions = self.search_filter_service.create_search_conditions(
                 search_type=self._get_primary_search_type(),
                 keywords=keywords,
+                excluded_keywords=excluded_keywords,
                 tag_logic="and" if self.ui.radioAnd.isChecked() else "or",
                 resolution_filter=self.ui.comboResolution.currentText(),
                 aspect_ratio_filter=self.ui.comboAspectRatio.currentText(),
@@ -997,7 +1000,9 @@ class FilterSearchPanel(QScrollArea):
         try:
             # 検索テキストをキーワードリストに変換
             search_text = self.ui.lineEditSearch.text().strip()
-            keywords = self.search_filter_service.parse_search_input(search_text) if search_text else []
+            keywords, excluded_keywords = (
+                self.search_filter_service.parse_search_input(search_text) if search_text else ([], [])
+            )
 
             # 日付範囲を取得
             date_range_start, date_range_end = self.get_date_range_from_slider()
@@ -1013,6 +1018,7 @@ class FilterSearchPanel(QScrollArea):
             conditions = self.search_filter_service.create_search_conditions(
                 search_type=self._get_primary_search_type(),
                 keywords=keywords,
+                excluded_keywords=excluded_keywords,
                 tag_logic="and" if self.ui.radioAnd.isChecked() else "or",
                 resolution_filter=self.ui.comboResolution.currentText(),
                 aspect_ratio_filter=self.ui.comboAspectRatio.currentText(),
@@ -1129,6 +1135,7 @@ class FilterSearchPanel(QScrollArea):
             return {
                 "search_type": current.search_type,
                 "keywords": current.keywords,
+                "excluded_keywords": current.excluded_keywords or [],
                 "tag_logic": current.tag_logic,
                 "resolution_filter": current.resolution_filter,
                 "aspect_ratio_filter": current.aspect_ratio_filter,

--- a/src/lorairo/services/search_models.py
+++ b/src/lorairo/services/search_models.py
@@ -23,6 +23,7 @@ class SearchConditions:
     search_type: str  # "tags" or "caption"
     keywords: list[str]
     tag_logic: str  # "and" or "or"
+    excluded_keywords: list[str] | None = None
     resolution_filter: str | None = None
     aspect_ratio_filter: str | None = None
     date_filter_enabled: bool = False
@@ -57,6 +58,7 @@ class SearchConditions:
 
         return ImageFilterCriteria(
             tags=self.keywords if self.search_type == "tags" else None,
+            excluded_tags=self.excluded_keywords if self.search_type == "tags" else None,
             caption=self.keywords[0] if self.search_type == "caption" and self.keywords else None,
             resolution=self._resolve_resolution(),
             use_and=self.tag_logic == "and",

--- a/tests/integration/gui/test_filter_search_integration.py
+++ b/tests/integration/gui/test_filter_search_integration.py
@@ -170,13 +170,15 @@ class TestFilterSearchIntegration:
         service = filter_panel.search_filter_service
 
         # parse_search_inputをテスト（カンマ区切りで分割、スペースは保持）
-        keywords = service.parse_search_input("test, keyword")
+        keywords, excluded_keywords = service.parse_search_input("test, keyword")
         assert keywords == ["test", "keyword"]
+        assert excluded_keywords == []
 
         # create_search_conditionsをテスト
         conditions = service.create_search_conditions(
             search_type="caption",
             keywords=keywords,
+            excluded_keywords=excluded_keywords,
             tag_logic="or",
             resolution_filter="1024x1024",
             only_untagged=True,

--- a/tests/unit/gui/services/test_search_filter_service.py
+++ b/tests/unit/gui/services/test_search_filter_service.py
@@ -18,6 +18,7 @@ class TestSearchConditions:
             search_type="tags",
             keywords=["tag1", "tag2"],
             tag_logic="and",
+            excluded_keywords=["tag3"],
             resolution_filter="1024x1024",
             aspect_ratio_filter="正方形 (1:1)",
             date_filter_enabled=True,
@@ -77,6 +78,7 @@ class TestSearchConditions:
             search_type="tags",
             keywords=["tag1", "tag2"],
             tag_logic="and",
+            excluded_keywords=["tag3"],
             include_nsfw=False,
             rating_filter="PG-13",
         )
@@ -86,6 +88,7 @@ class TestSearchConditions:
         assert db_args["include_nsfw"] is False
         assert db_args["manual_rating_filter"] == "PG-13"
         assert db_args["tags"] == ["tag1", "tag2"]
+        assert db_args["excluded_tags"] == ["tag3"]
         assert db_args["use_and"] is True
 
 
@@ -110,41 +113,57 @@ class TestSearchFilterService:
     def test_parse_search_input_tags(self, service):
         """タグ検索入力解析テスト"""
         # 基本的なカンマ区切り
-        keywords = service.parse_search_input("tag1, tag2, tag3")
+        keywords, excluded_keywords = service.parse_search_input("tag1, tag2, tag3")
         assert keywords == ["tag1", "tag2", "tag3"]
+        assert excluded_keywords == []
 
         # スペース込みタグ
-        keywords = service.parse_search_input("1girl, long hair, blue eyes")
+        keywords, excluded_keywords = service.parse_search_input("1girl, long hair, blue eyes")
         assert keywords == ["1girl", "long hair", "blue eyes"]
+        assert excluded_keywords == []
 
         # 空のタグ除去
-        keywords = service.parse_search_input("tag1, , tag3, ")
+        keywords, excluded_keywords = service.parse_search_input("tag1, , tag3, ")
         assert keywords == ["tag1", "tag3"]
+        assert excluded_keywords == []
 
     def test_parse_search_input_caption(self, service):
         """キャプション検索入力解析テスト"""
         # カンマ区切りキャプション
-        keywords = service.parse_search_input("beautiful scene, landscape view, mountain scenery")
+        keywords, excluded_keywords = service.parse_search_input("beautiful scene, landscape view, mountain scenery")
         assert keywords == ["beautiful scene", "landscape view", "mountain scenery"]
+        assert excluded_keywords == []
 
         # 余分なスペース処理（単一キーワード）
-        keywords = service.parse_search_input("  single keyword  ")
+        keywords, excluded_keywords = service.parse_search_input("  single keyword  ")
         assert keywords == ["single keyword"]
+        assert excluded_keywords == []
 
     def test_parse_search_input_empty(self, service):
         """空の検索入力テスト"""
-        keywords = service.parse_search_input("")
+        keywords, excluded_keywords = service.parse_search_input("")
         assert keywords == []
+        assert excluded_keywords == []
 
-        keywords = service.parse_search_input("   ")
+        keywords, excluded_keywords = service.parse_search_input("   ")
         assert keywords == []
+        assert excluded_keywords == []
+
+
+    def test_parse_search_input_with_exclusion(self, service):
+        """除外検索入力解析テスト"""
+        keywords, excluded_keywords = service.parse_search_input("1girl, -1boy, blue_eyes, -smile")
+
+        assert keywords == ["1girl", "blue_eyes"]
+        assert excluded_keywords == ["1boy", "smile"]
 
     def test_create_search_conditions_basic(self, service):
         """基本的な検索条件作成テスト"""
-        keywords = service.parse_search_input("tag1, tag2")
+        keywords, excluded_keywords = service.parse_search_input("tag1, tag2")
         conditions = service.create_search_conditions(
             search_type="tags",
             keywords=keywords,
+            excluded_keywords=excluded_keywords,
             tag_logic="and",
             resolution_filter="1024x1024",
             aspect_ratio_filter="1:1 (正方形)",
@@ -168,11 +187,12 @@ class TestSearchFilterService:
         """日付付き検索条件作成テスト"""
         start_date = datetime(2023, 1, 1)
         end_date = datetime(2023, 12, 31)
-        keywords = service.parse_search_input("test")
+        keywords, excluded_keywords = service.parse_search_input("test")
 
         conditions = service.create_search_conditions(
             search_type="caption",
             keywords=keywords,
+            excluded_keywords=excluded_keywords,
             tag_logic="or",
             resolution_filter="1024x1024",
             aspect_ratio_filter="正方形 (1:1)",
@@ -196,6 +216,7 @@ class TestSearchFilterService:
         conditions = SearchConditions(
             search_type="tags",
             keywords=["1girl", "long hair"],
+            excluded_keywords=["1boy"],
             tag_logic="and",
             resolution_filter="1024x1024",
             aspect_ratio_filter="1:1 (正方形)",
@@ -210,6 +231,7 @@ class TestSearchFilterService:
         preview = service.create_search_preview(conditions)
 
         assert "キーワード: 1girl AND long hair (tags)" in preview
+        assert "除外キーワード: 1boy" in preview
         assert "解像度: 1024x1024" in preview
         assert "アスペクト比: 1:1 (正方形)" in preview
         assert "日付範囲: 開始: 2023-01-01, 終了: 2023-12-31" in preview


### PR DESCRIPTION
### Motivation

- 検索入力で `-tag` プレフィックスによる除外検索（NOT検索）をサポートし、タグベースの検索表現力を高めるため。  
- 例: `1girl, -1boy, blue_eyes` が「`1girl` AND `blue_eyes` を含み `1boy` を含まない」結果を得られるようにするため。

### Description

- `SearchConditions` に `excluded_keywords` フィールドを追加し、DB側へは `excluded_tags` として渡すようにした（`to_filter_criteria()` 経路を含む）。
- `ImageFilterCriteria` に `excluded_tags` を追加し、`to_dict()` にも反映してレガシー経路でも除外タグを保持するようにした。
- UI側の `SearchFilterService.parse_search_input()` を拡張して戻り値を `(keywords, excluded_keywords)` に変更し、`-` プレフィックスを除外語として分離するように実装した。`create_search_preview()` では除外キーワードを表示するように更新した。
- `FilterSearchPanel` の同期/非同期検索経路で新しいパース結果を受け取り `create_search_conditions()` に `excluded_keywords` を渡すように更新し、`get_current_conditions()` の辞書化にも `excluded_keywords` を含めた。
- リポジトリ層の `ImageRepository._apply_tag_filter()` に `excluded_tags` 用の `NOT EXISTS` サブクエリを追加し、除外タグを実際の SQL 条件として適用するようにした（`_build_image_filter_query()` 呼び出しにも `excluded_tags` を伝播）。
- 関連する unit/integration テストを `parse_search_input()` の新仕様と除外語表示を検証するように更新した（テストコードの期待値と入力パターンを修正／追加）。

### Testing

- 実行した自動テストコマンド: `uv run pytest tests/unit/gui/services/test_search_filter_service.py tests/integration/gui/test_filter_search_integration.py tests/unit/database/test_db_repository_score_filter.py -q`, しかし環境セットアップ段階で `local_packages/image-annotator-lib` に `pyproject.toml`/`setup.py` が存在せず仮想環境構築に失敗して実行できなかった。
- 単体実行を試みた `python -m pytest tests/unit/gui/services/test_search_filter_service.py -q` は依存ライブラリ `sqlalchemy` が未インストールのため実行不能で失敗した。
- 静的チェックとして `python -m compileall ...` を実行したが、`src/lorairo/database/db_repository.py` に既存の f-string エスケープに起因する構文エラーがあり（今回の変更範囲外）、コンパイルが失敗したため変更の完全な検証は実行環境の整備後に行う必要がある。

（注）テストコードは今回の API 変更に合わせて更新済みだが、実行環境依存の問題および既存の構文エラーのため CI 上での実行と通過確認は未完了です。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b68f7e27708329adaad56c1a4f0831)