### PR TITLE
feat: support excluded tag search via `-tag` syntax

### DIFF
--- a/src/lorairo/database/db_repository.py
+++ b/src/lorairo/database/db_repository.py
@@ -1868,6 +1868,7 @@ class ImageRepository:
         self,
         query: Select,
         tags: list[str] | None,
+        excluded_tags: list[str] | None,
         use_and: bool,
         include_untagged: bool,
     ) -> Select:
@@ -1909,6 +1910,22 @@ class ImageRepository:
                 if tag_criteria:
                     query = query.join(Tag, Image.id == Tag.image_id).where(or_(*tag_criteria))
                     # logger.debug(f"Query after OR tag join: {query}") # クエリ確認用
+
+        if excluded_tags:
+            logger.debug(f"Applying NOT tag filter (NOT EXISTS) for tags: {excluded_tags}")
+            for excluded_tag in excluded_tags:
+                pattern, is_exact = self._prepare_like_pattern(excluded_tag)
+                excluded_condition = (Tag.tag == pattern) if is_exact else Tag.tag.like(pattern)
+                excluded_exists_subquery = (
+                    select(Tag.id)
+                    .where(
+                        Tag.image_id == Image.id,
+                        excluded_condition,
+                    )
+                    .correlate(Image)
+                    .exists()
+                )
+                query = query.where(not_(excluded_exists_subquery))
 
         return query
 
@@ -2408,6 +2425,7 @@ class ImageRepository:
         tags: list[str] | None,
         caption: str | None,
         use_and: bool,
+        excluded_tags: list[str] | None,
         start_date: str | None,
         end_date: str | None,
         include_untagged: bool,
@@ -2426,6 +2444,7 @@ class ImageRepository:
             tags: 検索タグリスト。
             caption: 検索キャプション文字列。
             use_and: 複数タグのAND/OR指定。
+            excluded_tags: 除外対象のタグリスト。
             start_date: 検索開始日時(ISO 8601)。
             end_date: 検索終了日時(ISO 8601)。
             include_untagged: タグなし画像のみ対象とするか。
@@ -2450,7 +2469,7 @@ class ImageRepository:
         if include_untagged and (tags or caption):
             logger.warning("検索語句と include_untagged が同時に指定されたため、検索語句は無視されます。")
 
-        query = self._apply_tag_filter(query, tags, use_and, include_untagged)
+        query = self._apply_tag_filter(query, tags, excluded_tags, use_and, include_untagged)
         query = self._apply_caption_filter(query, caption)
 
         # Rating Filters (Priority-based: manual > AI)
@@ -2519,6 +2538,7 @@ class ImageRepository:
                     tags=filter_criteria.tags,
                     caption=filter_criteria.caption,
                     use_and=filter_criteria.use_and,
+                    excluded_tags=filter_criteria.excluded_tags,
                     start_date=filter_criteria.start_date,
                     end_date=filter_criteria.end_date,
                     include_untagged=filter_criteria.include_untagged,

--- a/src/lorairo/database/filter_criteria.py
+++ b/src/lorairo/database/filter_criteria.py
@@ -36,6 +36,7 @@ class ImageFilterCriteria:
 
     tags: list[str] | None = None
     caption: str | None = None
+    excluded_tags: list[str] | None = None
     resolution: int = 0
     use_and: bool = True
     start_date: str | None = None
@@ -86,6 +87,7 @@ class ImageFilterCriteria:
         return {
             "tags": self.tags,
             "caption": self.caption,
+            "excluded_tags": self.excluded_tags,
             "resolution": self.resolution,
             "use_and": self.use_and,
             "start_date": self.start_date,

--- a/src/lorairo/gui/services/search_filter_service.py
+++ b/src/lorairo/gui/services/search_filter_service.py
@@ -71,28 +71,42 @@ class SearchFilterService:
 
         logger.info("SearchFilterService (純化版) initialized with new service layer integration")
 
-    def parse_search_input(self, input_text: str) -> list[str]:
+    def parse_search_input(self, input_text: str) -> tuple[list[str], list[str]]:
         """UI入力テキストの解析とキーワード抽出
 
         Args:
             input_text: ユーザー入力テキスト
 
         Returns:
-            list: 抽出されたキーワードリスト
+            tuple[list[str], list[str]]: (通常キーワード, 除外キーワード) のタプル
 
         """
         if not input_text:
-            return []
+            return [], []
+
+        keywords: list[str] = []
+        excluded_keywords: list[str] = []
 
         # 基本的なキーワード分割(カンマ区切り、タグ内スペース保持)
-        keywords = [keyword.strip() for keyword in input_text.split(",") if keyword.strip()]
-        logger.debug(f"入力解析完了: '{input_text}' -> {keywords}")
-        return keywords
+        for keyword in [part.strip() for part in input_text.split(",") if part.strip()]:
+            if keyword.startswith("-") and len(keyword) > 1:
+                excluded_keywords.append(keyword[1:].strip())
+            else:
+                keywords.append(keyword)
+
+        logger.debug(
+            "入力解析完了: '%s' -> include=%s, exclude=%s",
+            input_text,
+            keywords,
+            excluded_keywords,
+        )
+        return keywords, excluded_keywords
 
     def create_search_conditions(
         self,
         search_type: str,
         keywords: list[str],
+        excluded_keywords: list[str] | None = None,
         tag_logic: str = "and",
         resolution_filter: str | None = None,
         aspect_ratio_filter: str | None = None,
@@ -124,6 +138,7 @@ class SearchFilterService:
         conditions = SearchConditions(
             search_type=search_type,
             keywords=keywords,
+            excluded_keywords=excluded_keywords,
             tag_logic=tag_logic,
             resolution_filter=resolution_filter,
             aspect_ratio_filter=aspect_ratio_filter,
@@ -164,6 +179,10 @@ class SearchFilterService:
         if conditions.keywords:
             keyword_text = f" {conditions.tag_logic.upper()} ".join(conditions.keywords)
             preview_parts.append(f"キーワード: {keyword_text} ({conditions.search_type})")
+
+        if conditions.excluded_keywords:
+            excluded_text = " NOT ".join(conditions.excluded_keywords)
+            preview_parts.append(f"除外キーワード: {excluded_text}")
 
         # フィルター条件
         if conditions.resolution_filter:

--- a/src/lorairo/gui/widgets/filter_search_panel.py
+++ b/src/lorairo/gui/widgets/filter_search_panel.py
@@ -899,7 +899,9 @@ class FilterSearchPanel(QScrollArea):
         try:
             # 検索テキストをキーワードリストに変換
             search_text = self.ui.lineEditSearch.text().strip()
-            keywords = self.search_filter_service.parse_search_input(search_text) if search_text else []
+            keywords, excluded_keywords = (
+                self.search_filter_service.parse_search_input(search_text) if search_text else ([], [])
+            )
 
             # スコア範囲を取得して検索条件に含めるか判定
             score_min_internal, score_max_internal = self.score_range_slider.get_range()
@@ -944,6 +946,7 @@ class FilterSearchPanel(QScrollArea):
             conditions = self.search_filter_service.create_search_conditions(
                 search_type=self._get_primary_search_type(),
                 keywords=keywords,
+                excluded_keywords=excluded_keywords,
                 tag_logic="and" if self.ui.radioAnd.isChecked() else "or",
                 resolution_filter=self.ui.comboResolution.currentText(),
                 aspect_ratio_filter=self.ui.comboAspectRatio.currentText(),
@@ -997,7 +1000,9 @@ class FilterSearchPanel(QScrollArea):
         try:
             # 検索テキストをキーワードリストに変換
             search_text = self.ui.lineEditSearch.text().strip()
-            keywords = self.search_filter_service.parse_search_input(search_text) if search_text else []
+            keywords, excluded_keywords = (
+                self.search_filter_service.parse_search_input(search_text) if search_text else ([], [])
+            )
 
             # 日付範囲を取得
             date_range_start, date_range_end = self.get_date_range_from_slider()
@@ -1013,6 +1018,7 @@ class FilterSearchPanel(QScrollArea):
             conditions = self.search_filter_service.create_search_conditions(
                 search_type=self._get_primary_search_type(),
                 keywords=keywords,
+                excluded_keywords=excluded_keywords,
                 tag_logic="and" if self.ui.radioAnd.isChecked() else "or",
                 resolution_filter=self.ui.comboResolution.currentText(),
                 aspect_ratio_filter=self.ui.comboAspectRatio.currentText(),

--- a/src/lorairo/services/search_models.py
+++ b/src/lorairo/services/search_models.py
@@ -23,6 +23,7 @@ class SearchConditions:
     search_type: str  # "tags" or "caption"
     keywords: list[str]
     tag_logic: str  # "and" or "or"
+    excluded_keywords: list[str] | None = None
     resolution_filter: str | None = None
     aspect_ratio_filter: str | None = None
     date_filter_enabled: bool = False
@@ -57,6 +58,7 @@ class SearchConditions:
 
         return ImageFilterCriteria(
             tags=self.keywords if self.search_type == "tags" else None,
+            excluded_tags=self.excluded_keywords if self.search_type == "tags" else None,
             caption=self.keywords[0] if self.search_type == "caption" and self.keywords else None,
             resolution=self._resolve_resolution(),
             use_and=self.tag_logic == "and",

--- a/tests/integration/gui/test_filter_search_integration.py
+++ b/tests/integration/gui/test_filter_search_integration.py
@@ -170,8 +170,9 @@ class TestFilterSearchIntegration:
         service = filter_panel.search_filter_service
 
         # parse_search_inputをテスト（カンマ区切りで分割、スペースは保持）
-        keywords = service.parse_search_input("test, keyword")
+        keywords, excluded = service.parse_search_input("test, keyword")
         assert keywords == ["test", "keyword"]
+        assert excluded == []
 
         # create_search_conditionsをテスト
         conditions = service.create_search_conditions(

--- a/tests/unit/database/test_db_repository_score_filter.py
+++ b/tests/unit/database/test_db_repository_score_filter.py
@@ -157,6 +157,21 @@ class TestSearchConditionsIntegration:
         assert "score_max" in db_args
         assert db_args["score_max"] == 7.5
 
+    def test_search_conditions_to_db_filter_args_includes_excluded_tags(self):
+        """SearchConditions.to_db_filter_args() が excluded_tags を含むことを確認"""
+        from lorairo.services.search_models import SearchConditions
+
+        conditions = SearchConditions(
+            search_type="tags",
+            keywords=["1girl"],
+            tag_logic="and",
+            excluded_keywords=["1boy"],
+        )
+
+        db_args = conditions.to_db_filter_args()
+
+        assert db_args["excluded_tags"] == ["1boy"]
+
 
 class TestSearchFilterServiceIntegration:
     """SearchFilterService の統合テスト"""
@@ -185,3 +200,42 @@ class TestSearchFilterServiceIntegration:
 
         assert conditions.score_min == 3.0
         assert conditions.score_max == 7.5
+
+
+class TestApplyTagFilterExcludeIntegration:
+    """_apply_tag_filter() の除外タグ統合テスト"""
+
+    @pytest.fixture
+    def repository(self):
+        mock_session_factory = Mock()
+        return ImageRepository(session_factory=mock_session_factory)
+
+    def test_apply_tag_filter_with_excluded_tags(self, repository):
+        """除外タグ指定時にクエリが更新されることを確認"""
+        base_query = select(Image.id)
+
+        result_query = repository._apply_tag_filter(
+            base_query,
+            tags=["1girl"],
+            excluded_tags=["1boy"],
+            use_and=True,
+            include_untagged=False,
+        )
+
+        assert result_query is not None
+        assert result_query != base_query
+
+    def test_apply_tag_filter_only_excluded_tags(self, repository):
+        """除外タグのみ指定時もクエリが更新されることを確認"""
+        base_query = select(Image.id)
+
+        result_query = repository._apply_tag_filter(
+            base_query,
+            tags=None,
+            excluded_tags=["nsfw"],
+            use_and=True,
+            include_untagged=False,
+        )
+
+        assert result_query is not None
+        assert result_query != base_query

--- a/tests/unit/gui/services/test_search_filter_service.py
+++ b/tests/unit/gui/services/test_search_filter_service.py
@@ -110,41 +110,56 @@ class TestSearchFilterService:
     def test_parse_search_input_tags(self, service):
         """タグ検索入力解析テスト"""
         # 基本的なカンマ区切り
-        keywords = service.parse_search_input("tag1, tag2, tag3")
+        keywords, excluded = service.parse_search_input("tag1, tag2, tag3")
         assert keywords == ["tag1", "tag2", "tag3"]
+        assert excluded == []
 
         # スペース込みタグ
-        keywords = service.parse_search_input("1girl, long hair, blue eyes")
+        keywords, excluded = service.parse_search_input("1girl, long hair, blue eyes")
         assert keywords == ["1girl", "long hair", "blue eyes"]
+        assert excluded == []
 
         # 空のタグ除去
-        keywords = service.parse_search_input("tag1, , tag3, ")
+        keywords, excluded = service.parse_search_input("tag1, , tag3, ")
         assert keywords == ["tag1", "tag3"]
+        assert excluded == []
+
+    def test_parse_search_input_excluded_tags(self, service):
+        """除外タグ入力解析テスト"""
+        keywords, excluded = service.parse_search_input("1girl, -1boy, blue_eyes")
+
+        assert keywords == ["1girl", "blue_eyes"]
+        assert excluded == ["1boy"]
 
     def test_parse_search_input_caption(self, service):
         """キャプション検索入力解析テスト"""
         # カンマ区切りキャプション
-        keywords = service.parse_search_input("beautiful scene, landscape view, mountain scenery")
+        keywords, excluded = service.parse_search_input("beautiful scene, landscape view, mountain scenery")
         assert keywords == ["beautiful scene", "landscape view", "mountain scenery"]
+        assert excluded == []
 
         # 余分なスペース処理（単一キーワード）
-        keywords = service.parse_search_input("  single keyword  ")
+        keywords, excluded = service.parse_search_input("  single keyword  ")
         assert keywords == ["single keyword"]
+        assert excluded == []
 
     def test_parse_search_input_empty(self, service):
         """空の検索入力テスト"""
-        keywords = service.parse_search_input("")
+        keywords, excluded = service.parse_search_input("")
         assert keywords == []
+        assert excluded == []
 
-        keywords = service.parse_search_input("   ")
+        keywords, excluded = service.parse_search_input("   ")
         assert keywords == []
+        assert excluded == []
 
     def test_create_search_conditions_basic(self, service):
         """基本的な検索条件作成テスト"""
-        keywords = service.parse_search_input("tag1, tag2")
+        keywords, excluded = service.parse_search_input("tag1, tag2")
         conditions = service.create_search_conditions(
             search_type="tags",
             keywords=keywords,
+            excluded_keywords=excluded,
             tag_logic="and",
             resolution_filter="1024x1024",
             aspect_ratio_filter="1:1 (正方形)",
@@ -168,11 +183,12 @@ class TestSearchFilterService:
         """日付付き検索条件作成テスト"""
         start_date = datetime(2023, 1, 1)
         end_date = datetime(2023, 12, 31)
-        keywords = service.parse_search_input("test")
+        keywords, excluded = service.parse_search_input("test")
 
         conditions = service.create_search_conditions(
             search_type="caption",
             keywords=keywords,
+            excluded_keywords=excluded,
             tag_logic="or",
             resolution_filter="1024x1024",
             aspect_ratio_filter="正方形 (1:1)",


### PR DESCRIPTION
### Motivation
- Provide user-facing NOT-tag (exclude) search support so inputs like `1girl, -1boy, blue_eyes` return images that include `1girl` and `blue_eyes` but exclude `1boy` as requested in Issue #11.
- Propagate the exclude intent through the GUI parsing, service layer, and DB query so exclusions are applied efficiently at the repository level.

### Description
- Added `excluded_keywords: list[str] | None` to `SearchConditions` and map it into DB criteria as `excluded_tags` in `ImageFilterCriteria` via `to_filter_criteria()`; updated `to_db_filter_args()` path accordingly. (`src/lorairo/services/search_models.py`, `src/lorairo/database/filter_criteria.py`)
- Extended the UI search input parser to split include/exclude keywords and return `(include_keywords, excluded_keywords)` when parsing `-prefix` exclusions. (`src/lorairo/gui/services/search_filter_service.py`)
- Updated `create_search_conditions()` and the human-readable preview to accept/display excluded keywords. (`src/lorairo/gui/services/search_filter_service.py`)
- Updated the filter panel to extract excluded keywords and pass them into created `SearchConditions` for both async and sync search flows. (`src/lorairo/gui/widgets/filter_search_panel.py`)
- Implemented NOT filtering in repository queries by accepting `excluded_tags` in `_apply_tag_filter()` and adding `NOT EXISTS` subqueries per excluded tag to exclude images that have those tags. Integrated `excluded_tags` into the main query builder (`_build_image_filter_query`). (`src/lorairo/database/db_repository.py`)
- Updated and added unit/integration tests to cover parsing of excluded tags, propagation into DB args, and that `_apply_tag_filter()` changes the query when exclusions are present. (`tests/unit/gui/services/test_search_filter_service.py`, `tests/unit/database/test_db_repository_score_filter.py`, `tests/integration/gui/test_filter_search_integration.py`)

### Testing
- Updated tests were added and targeted commands were run: `uv run pytest tests/unit/gui/services/test_search_filter_service.py tests/unit/database/test_db_repository_score_filter.py tests/integration/gui/test_filter_search_integration.py`, but the run failed due to local environment dependency packaging issues (`local_packages/genai-tag-db-tools` lacks Python project metadata), so full pytest could not complete.
- Running `pytest` directly for the same test files failed because `sqlalchemy` is not installed in the execution environment, preventing test execution.
- Performed a bytecode/compile check with `python -m compileall ...` which partially failed due to a pre-existing syntax issue in `src/lorairo/database/db_repository.py` unrelated to the recently added exclusion logic; other modified modules compiled as expected.
- Note: all exclusion-related code paths and tests have been added and committed, but full automated test execution could not be completed in this environment because of missing external/local dependencies and an unrelated syntax problem detected by `compileall`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b68f7e27708329adaad56c1a4f0831)