### PR TITLE
feat: improve tag autocomplete responsiveness and ranking

### DIFF
--- a/src/lorairo/gui/widgets/filter_search_panel.py
+++ b/src/lorairo/gui/widgets/filter_search_panel.py
@@ -4,7 +4,7 @@ from datetime import datetime
 from enum import Enum
 from typing import TYPE_CHECKING, Any
 
-from PySide6.QtCore import QStringListModel, Qt, QTimer, Signal
+from PySide6.QtCore import QObject, QRunnable, QStringListModel, Qt, QThreadPool, QTimer, Signal
 from PySide6.QtWidgets import QCompleter, QScrollArea
 
 from ...gui.designer.FilterSearchPanel_ui import Ui_FilterSearchPanel
@@ -12,9 +12,9 @@ from ...utils.log import logger
 from .custom_range_slider import CustomRangeSlider
 
 if TYPE_CHECKING:
+    from ...services.search_models import SearchConditions
     from ...services.tag_suggestion_service import TagSuggestionService
     from ..services.search_filter_service import SearchFilterService
-    from ...services.search_models import SearchConditions
     from ..services.worker_service import WorkerService
 
 
@@ -27,6 +27,37 @@ class PipelineState(Enum):
     DISPLAYING = "displaying"  # 結果表示中
     ERROR = "error"  # エラー状態
     CANCELED = "canceled"  # キャンセル状態
+
+
+class _TagSuggestionTaskSignals(QObject):
+    """タグサジェスト非同期タスク用シグナル。"""
+
+    finished = Signal(int, str, list)  # request_id, token, suggestions
+    failed = Signal(int, str, str)  # request_id, token, error_message
+
+
+class _TagSuggestionTask(QRunnable):
+    """TagSuggestionService.get_suggestions() をワーカースレッドで実行する。"""
+
+    def __init__(
+        self,
+        request_id: int,
+        token: str,
+        service: "TagSuggestionService",
+        signals: _TagSuggestionTaskSignals,
+    ) -> None:
+        super().__init__()
+        self._request_id = request_id
+        self._token = token
+        self._service = service
+        self.signals = signals
+
+    def run(self) -> None:
+        try:
+            suggestions = self._service.get_suggestions(self._token)
+            self.signals.finished.emit(self._request_id, self._token, suggestions)
+        except Exception as e:  # pragma: no cover - 例外経路はログ確認のみ
+            self.signals.failed.emit(self._request_id, self._token, str(e))
 
 
 class FilterSearchPanel(QScrollArea):
@@ -67,6 +98,10 @@ class FilterSearchPanel(QScrollArea):
         self._tag_suggestion_timer = QTimer(self)
         self._tag_suggestion_timer.setSingleShot(True)
         self._tag_suggestion_timer.setInterval(300)
+        self._tag_suggestion_pool = QThreadPool(self)
+        self._tag_suggestion_pool.setMaxThreadCount(1)
+        self._tag_suggestion_request_seq = 0
+        self._active_tag_suggestion_request_id = 0
 
         # 現在のSearchWorkerのID
         self._current_search_worker_id: str | None = None
@@ -235,18 +270,49 @@ class FilterSearchPanel(QScrollArea):
             return
 
         token = self._extract_last_token(self.ui.lineEditSearch.text())
-        suggestions = self.tag_suggestion_service.get_suggestions(token)
-        self._tag_completer_model.setStringList(suggestions)
+        if len(token) < self.tag_suggestion_service.min_chars:
+            self._clear_tag_suggestions()
+            return
 
+        self._tag_suggestion_request_seq += 1
+        request_id = self._tag_suggestion_request_seq
+        self._active_tag_suggestion_request_id = request_id
+        signals = _TagSuggestionTaskSignals(self)
+        signals.finished.connect(self._on_tag_suggestions_ready)
+        signals.failed.connect(self._on_tag_suggestions_failed)
+        self._tag_suggestion_pool.start(
+            _TagSuggestionTask(request_id, token, self.tag_suggestion_service, signals),
+        )
+
+    def _on_tag_suggestions_ready(self, request_id: int, token: str, suggestions: list[str]) -> None:
+        """非同期タスク完了時に最新リクエストの候補のみをUIに反映する。"""
+        current_token = self._extract_last_token(self.ui.lineEditSearch.text())
+        if request_id != self._active_tag_suggestion_request_id:
+            return
+        if current_token.casefold() != token.casefold():
+            return
+
+        self._tag_completer_model.setStringList(suggestions)
         if suggestions and self.ui.lineEditSearch.hasFocus():
-            # P2 修正: QCompleter のプレフィックスをトークンに合わせる
-            # これにより "1girl, bl" 入力時も "bl" を prefix として候補をフィルタリングできる
             self._tag_completer.setCompletionPrefix(token)
             self._tag_completer.complete()
+
+    def _on_tag_suggestions_failed(self, request_id: int, token: str, error_message: str) -> None:
+        """非同期タグ取得エラーをログに記録する。"""
+        if request_id != self._active_tag_suggestion_request_id:
+            return
+        logger.warning(
+            "タグ候補の非同期取得に失敗: request_id={}, token='{}', error={}",
+            request_id,
+            token,
+            error_message,
+        )
+        self._clear_tag_suggestions()
 
     def _clear_tag_suggestions(self) -> None:
         """タグ候補をクリアしてデバウンスタイマーを停止する。"""
         self._tag_suggestion_timer.stop()
+        self._active_tag_suggestion_request_id = self._tag_suggestion_request_seq
         self._tag_completer_model.setStringList([])
 
     def _on_tag_completion_activated(self, selected_tag: str) -> None:

--- a/src/lorairo/services/tag_suggestion_service.py
+++ b/src/lorairo/services/tag_suggestion_service.py
@@ -6,6 +6,8 @@
 from __future__ import annotations
 
 from collections import OrderedDict
+from inspect import Parameter, signature
+from threading import RLock
 from time import monotonic
 from typing import TYPE_CHECKING, Any
 
@@ -49,6 +51,7 @@ class TagSuggestionService:
         self._cache_ttl = cache_ttl_seconds
         # OrderedDict で LRU + TTL キャッシュを実装: key -> (timestamp, list[str])
         self._cache: OrderedDict[str, tuple[float, list[str]]] = OrderedDict()
+        self._cache_lock = RLock()
 
     def get_suggestions(self, query: str) -> list[str]:
         """入力文字列からタグ候補一覧を取得する。
@@ -77,7 +80,8 @@ class TagSuggestionService:
 
     def clear_cache(self) -> None:
         """キャッシュをクリアする。"""
-        self._cache.clear()
+        with self._cache_lock:
+            self._cache.clear()
 
     def _search_tags(self, query: str) -> list[str]:
         """genai-tag-db-tools で タグ検索を実行する。"""
@@ -85,13 +89,7 @@ class TagSuggestionService:
             from genai_tag_db_tools import search_tags
             from genai_tag_db_tools.models import TagSearchRequest
 
-            request = TagSearchRequest(
-                query=query,
-                partial=True,
-                resolve_preferred=False,
-                include_aliases=True,
-                include_deprecated=False,
-            )
+            request = self._build_search_request(TagSearchRequest, query)
             result = search_tags(self._merged_reader, request)
 
             # TagSearchResult.items は list[TagRecordPublic]、各 item.tag がタグ文字列
@@ -109,7 +107,7 @@ class TagSuggestionService:
                 if len(candidates) >= self.max_results:
                     break
 
-            return candidates
+            return self._sort_candidates(candidates, query)
 
         except Exception as e:
             logger.warning("タグ候補取得に失敗: query='{}', error={}", query, e)
@@ -138,23 +136,73 @@ class TagSuggestionService:
 
     def _get_cache(self, key: str) -> list[str] | None:
         """キャッシュからエントリを取得する（TTL チェック込み）。"""
-        if key not in self._cache:
-            return None
+        with self._cache_lock:
+            if key not in self._cache:
+                return None
 
-        created_at, data = self._cache[key]
-        if monotonic() - created_at > self._cache_ttl:
-            del self._cache[key]
-            return None
+            created_at, data = self._cache[key]
+            if monotonic() - created_at > self._cache_ttl:
+                del self._cache[key]
+                return None
 
-        # LRU: 最近アクセスしたエントリを末尾へ移動
-        self._cache.move_to_end(key)
-        return data
+            # LRU: 最近アクセスしたエントリを末尾へ移動
+            self._cache.move_to_end(key)
+            return data
 
     def _set_cache(self, key: str, suggestions: list[str]) -> None:
         """キャッシュにエントリを追加する（LRU サイズ制限付き）。"""
-        self._cache[key] = (monotonic(), suggestions)
-        self._cache.move_to_end(key)
+        with self._cache_lock:
+            self._cache[key] = (monotonic(), suggestions)
+            self._cache.move_to_end(key)
 
-        # LRU: サイズ超過時は最古のエントリを削除
-        while len(self._cache) > self._cache_size:
-            self._cache.popitem(last=False)
+            # LRU: サイズ超過時は最古のエントリを削除
+            while len(self._cache) > self._cache_size:
+                self._cache.popitem(last=False)
+
+    def _build_search_request(self, request_cls: Any, query: str) -> Any:
+        """TagSearchRequest を互換性を保ちながら組み立てる。"""
+        kwargs: dict[str, Any] = {
+            "query": query,
+            "partial": True,
+            "resolve_preferred": False,
+            "include_aliases": True,
+            "include_deprecated": False,
+        }
+        if self._supports_request_field(request_cls, "limit"):
+            kwargs["limit"] = self.max_results
+        return request_cls(**kwargs)
+
+    @staticmethod
+    def _supports_request_field(request_cls: Any, field_name: str) -> bool:
+        """TagSearchRequest が指定フィールドを受け付けるかを判定する。"""
+        model_fields = getattr(request_cls, "model_fields", None)
+        if isinstance(model_fields, dict):
+            return field_name in model_fields
+
+        try:
+            sig = signature(request_cls)
+        except (TypeError, ValueError):
+            return False
+
+        if field_name in sig.parameters:
+            return True
+
+        return any(param.kind == Parameter.VAR_KEYWORD for param in sig.parameters.values())
+
+    @staticmethod
+    def _sort_candidates(candidates: list[str], query: str) -> list[str]:
+        """前方一致を優先しつつ候補を安定ソートする。"""
+        lowered_query = query.casefold()
+
+        def sort_key(tag: str) -> tuple[int, int, str]:
+            lowered_tag = tag.casefold()
+            if lowered_tag == lowered_query:
+                return (0, 0, lowered_tag)
+            if lowered_tag.startswith(lowered_query):
+                return (0, 1, lowered_tag)
+            contains_index = lowered_tag.find(lowered_query)
+            if contains_index >= 0:
+                return (1, contains_index, lowered_tag)
+            return (2, 9999, lowered_tag)
+
+        return sorted(candidates, key=sort_key)

--- a/tests/unit/gui/widgets/test_filter_search_panel_autocomplete.py
+++ b/tests/unit/gui/widgets/test_filter_search_panel_autocomplete.py
@@ -118,3 +118,42 @@ class TestClearTagSuggestions:
 
         panel._clear_tag_suggestions()
         assert not panel._tag_suggestion_timer.isActive()
+
+
+class _AsyncFakeTagService:
+    def __init__(self, response_map: dict[str, tuple[float, list[str]]], min_chars: int = 2) -> None:
+        self.min_chars = min_chars
+        self._response_map = response_map
+
+    def get_suggestions(self, query: str) -> list[str]:
+        import time
+
+        delay, response = self._response_map[query]
+        if delay > 0:
+            time.sleep(delay)
+        return response
+
+
+class TestAsyncTagSuggestion:
+    """タグ候補取得が非同期で行われ、古い結果が無視されることを検証。"""
+
+    def test_updates_model_asynchronously(self, panel, qtbot):
+        panel.ui.lineEditSearch.setFocus()
+        panel.ui.lineEditSearch.setText("bl")
+        panel.set_tag_suggestion_service(_AsyncFakeTagService({"bl": (0.01, ["blue_hair"])}))
+
+        panel._update_tag_completions()
+        qtbot.waitUntil(lambda: panel._tag_completer_model.stringList() == ["blue_hair"], timeout=1000)
+
+    def test_ignores_stale_results(self, panel, qtbot):
+        panel.ui.lineEditSearch.setFocus()
+        panel.set_tag_suggestion_service(
+            _AsyncFakeTagService({"bl": (0.05, ["blue_hair"]), "blu": (0.0, ["blush"])}),
+        )
+
+        panel.ui.lineEditSearch.setText("bl")
+        panel._update_tag_completions()
+        panel.ui.lineEditSearch.setText("blu")
+        panel._update_tag_completions()
+
+        qtbot.waitUntil(lambda: panel._tag_completer_model.stringList() == ["blush"], timeout=1500)

--- a/tests/unit/services/test_tag_suggestion_service.py
+++ b/tests/unit/services/test_tag_suggestion_service.py
@@ -143,6 +143,35 @@ class TestTagSuggestionServiceMaxResults:
 
         assert result.count("1girl") == 1
 
+    def test_limit_is_included_when_request_accepts_kwargs(self, monkeypatch):
+        """TagSearchRequest が可変キーワードを受ける場合は limit が付与される。"""
+        captured_request: dict = {}
+
+        def fake_search_tags(_reader, request):
+            captured_request.update(request)
+            return _FakeResult([_FakeItem("blue_hair")])
+
+        fake_models = types.SimpleNamespace(TagSearchRequest=lambda **kwargs: kwargs)
+        fake_module = types.SimpleNamespace(search_tags=fake_search_tags)
+        monkeypatch.setitem(sys.modules, "genai_tag_db_tools", fake_module)
+        monkeypatch.setitem(sys.modules, "genai_tag_db_tools.models", fake_models)
+
+        service = TagSuggestionService(object(), max_results=7)
+        service.get_suggestions("bl")
+
+        assert captured_request["limit"] == 7
+
+
+class TestTagSuggestionServiceSorting:
+    """候補ソート優先度テスト（前方一致優先）。"""
+
+    def test_prefix_matches_are_prioritized(self, patch_genai):
+        patch_genai([_FakeItem("table"), _FakeItem("blue_hair"), _FakeItem("black_hair")])
+        service = TagSuggestionService(object())
+
+        result = service.get_suggestions("bl")
+        assert result[:2] == ["black_hair", "blue_hair"]
+
 
 class TestExtractTagName:
     """_extract_tag_name の各フォーマット対応テスト。"""


### PR DESCRIPTION
### Motivation
- Resolve UI freezes and poor UX from synchronous tag DB lookups by moving suggestion retrieval off the GUI thread. 
- Prevent stale suggestion responses from overwriting newer input during rapid typing. 
- Improve suggestion relevance by prioritizing exact/prefix matches and reduce traffic when upstream supports a `limit` parameter. 
- Make cache usage safe for concurrent access when suggestions are fetched from worker threads. 

### Description
- Offloaded tag suggestion lookup in `FilterSearchPanel` to a single-thread `QThreadPool`/`QRunnable` task and added request sequencing to ignore stale results. 
- Hardened `TagSuggestionService` with an `RLock`-protected TTL+LRU cache and added `_build_search_request` that feature-detects whether `TagSearchRequest` accepts a `limit` kwarg. 
- Added `_sort_candidates` to the service to prefer exact matches then prefix matches, then contains matches, and kept deduplication and `max_results` semantics. 
- Added unit tests and GUI tests: async autocomplete behavior and stale-result suppression (`tests/unit/gui/widgets/test_filter_search_panel_autocomplete.py`) and request `limit` inclusion plus prefix-priority sorting (`tests/unit/services/test_tag_suggestion_service.py`). 

### Testing
- Compiled updated modules with `python -m compileall ...` which succeeded for the modified files. 
- Ran `ruff format` on modified files which completed successfully. 
- Ran `ruff check` on the modified files and observed a remaining preexisting complexity warning in an unrelated function (`_on_search_requested`) that is outside this change. 
- Attempted to run `pytest -q` for the relevant test files but the run failed early due to missing environment dependency `sqlalchemy` (import error in `tests/conftest.py`), so unit tests could not be fully executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69babfade2e88329a329171a4af23476)