### PR TITLE
perf: improve tag autocomplete responsiveness with async lookups

### DIFF
--- a/src/lorairo/gui/widgets/filter_search_panel.py
+++ b/src/lorairo/gui/widgets/filter_search_panel.py
@@ -4,7 +4,7 @@ from datetime import datetime
 from enum import Enum
 from typing import TYPE_CHECKING, Any
 
-from PySide6.QtCore import QStringListModel, Qt, QTimer, Signal
+from PySide6.QtCore import QObject, QRunnable, QStringListModel, Qt, QThreadPool, QTimer, Signal
 from PySide6.QtWidgets import QCompleter, QScrollArea
 
 from ...gui.designer.FilterSearchPanel_ui import Ui_FilterSearchPanel
@@ -27,6 +27,31 @@ class PipelineState(Enum):
     DISPLAYING = "displaying"  # 結果表示中
     ERROR = "error"  # エラー状態
     CANCELED = "canceled"  # キャンセル状態
+
+
+class _TagSuggestionTaskSignals(QObject):
+    """Tag suggestion background task signals."""
+
+    completed = Signal(int, str, list)  # request_id, token, suggestions
+    failed = Signal(int, str, str)  # request_id, token, error
+
+
+class _TagSuggestionTask(QRunnable):
+    """Run tag suggestion lookup in a background thread."""
+
+    def __init__(self, request_id: int, token: str, service: "TagSuggestionService") -> None:
+        super().__init__()
+        self.request_id = request_id
+        self.token = token
+        self.service = service
+        self.signals = _TagSuggestionTaskSignals()
+
+    def run(self) -> None:
+        try:
+            suggestions = self.service.get_suggestions(self.token)
+            self.signals.completed.emit(self.request_id, self.token, suggestions)
+        except Exception as e:
+            self.signals.failed.emit(self.request_id, self.token, str(e))
 
 
 class FilterSearchPanel(QScrollArea):
@@ -67,6 +92,9 @@ class FilterSearchPanel(QScrollArea):
         self._tag_suggestion_timer = QTimer(self)
         self._tag_suggestion_timer.setSingleShot(True)
         self._tag_suggestion_timer.setInterval(300)
+        self._tag_suggestion_pool = QThreadPool(self)
+        self._tag_suggestion_pool.setMaxThreadCount(1)
+        self._tag_request_id = 0
 
         # 現在のSearchWorkerのID
         self._current_search_worker_id: str | None = None
@@ -235,7 +263,45 @@ class FilterSearchPanel(QScrollArea):
             return
 
         token = self._extract_last_token(self.ui.lineEditSearch.text())
-        suggestions = self.tag_suggestion_service.get_suggestions(token)
+        if len(token) < self.tag_suggestion_service.min_chars:
+            self._clear_tag_suggestions()
+            return
+
+        cached = self.tag_suggestion_service.get_cached_suggestions(token)
+        if cached is not None:
+            self._apply_tag_suggestions(token, cached)
+            return
+
+        # 古い未実行タスクをキューから除去し、最新リクエストを優先
+        self._tag_suggestion_pool.clear()
+        self._tag_request_id += 1
+        request_id = self._tag_request_id
+        task = _TagSuggestionTask(request_id, token, self.tag_suggestion_service)
+        task.signals.completed.connect(self._on_tag_suggestions_completed)
+        task.signals.failed.connect(self._on_tag_suggestions_failed)
+        self._tag_suggestion_pool.start(task)
+
+    def _on_tag_suggestions_completed(self, request_id: int, token: str, suggestions: list[str]) -> None:
+        """バックグラウンド検索完了時に候補を反映する。"""
+        # 最新リクエスト以外は破棄（入力遅延で古い結果が上書きしないようにする）
+        if request_id != self._tag_request_id:
+            return
+
+        current_token = self._extract_last_token(self.ui.lineEditSearch.text())
+        if current_token.casefold() != token.casefold():
+            return
+
+        self._apply_tag_suggestions(token, suggestions)
+
+    def _on_tag_suggestions_failed(self, request_id: int, token: str, error: str) -> None:
+        """バックグラウンド検索エラーをログ出力する。"""
+        if request_id != self._tag_request_id:
+            return
+        logger.warning("タグ候補の非同期取得に失敗: token='{}', error={}", token, error)
+        self._clear_tag_suggestions()
+
+    def _apply_tag_suggestions(self, token: str, suggestions: list[str]) -> None:
+        """候補リストを completer に反映する。"""
         self._tag_completer_model.setStringList(suggestions)
 
         if suggestions and self.ui.lineEditSearch.hasFocus():
@@ -247,6 +313,9 @@ class FilterSearchPanel(QScrollArea):
     def _clear_tag_suggestions(self) -> None:
         """タグ候補をクリアしてデバウンスタイマーを停止する。"""
         self._tag_suggestion_timer.stop()
+        # 進行中/待機中タスクを無効化
+        self._tag_request_id += 1
+        self._tag_suggestion_pool.clear()
         self._tag_completer_model.setStringList([])
 
     def _on_tag_completion_activated(self, selected_tag: str) -> None:

--- a/src/lorairo/services/tag_suggestion_service.py
+++ b/src/lorairo/services/tag_suggestion_service.py
@@ -49,6 +49,7 @@ class TagSuggestionService:
         self._cache_ttl = cache_ttl_seconds
         # OrderedDict で LRU + TTL キャッシュを実装: key -> (timestamp, list[str])
         self._cache: OrderedDict[str, tuple[float, list[str]]] = OrderedDict()
+        self._request_supports_limit: bool | None = None
 
     def get_suggestions(self, query: str) -> list[str]:
         """入力文字列からタグ候補一覧を取得する。
@@ -79,19 +80,40 @@ class TagSuggestionService:
         """キャッシュをクリアする。"""
         self._cache.clear()
 
+    def get_cached_suggestions(self, query: str) -> list[str] | None:
+        """有効なキャッシュが存在する場合のみ候補を返す。"""
+        normalized = query.strip()
+        if len(normalized) < self.min_chars:
+            return []
+        cache_key = normalized.casefold()
+        return self._get_cache(cache_key)
+
     def _search_tags(self, query: str) -> list[str]:
         """genai-tag-db-tools で タグ検索を実行する。"""
         try:
             from genai_tag_db_tools import search_tags
             from genai_tag_db_tools.models import TagSearchRequest
 
-            request = TagSearchRequest(
-                query=query,
-                partial=True,
-                resolve_preferred=False,
-                include_aliases=True,
-                include_deprecated=False,
-            )
+            request_kwargs: dict[str, Any] = {
+                "query": query,
+                "partial": True,
+                "resolve_preferred": False,
+                "include_aliases": True,
+                "include_deprecated": False,
+            }
+            if self._request_supports_limit is not False:
+                request_kwargs["limit"] = self.max_results
+
+            try:
+                request = TagSearchRequest(**request_kwargs)
+                self._request_supports_limit = "limit" in request_kwargs
+            except Exception:
+                if "limit" not in request_kwargs:
+                    raise
+                request_kwargs.pop("limit", None)
+                request = TagSearchRequest(**request_kwargs)
+                self._request_supports_limit = False
+
             result = search_tags(self._merged_reader, request)
 
             # TagSearchResult.items は list[TagRecordPublic]、各 item.tag がタグ文字列
@@ -109,11 +131,25 @@ class TagSuggestionService:
                 if len(candidates) >= self.max_results:
                     break
 
-            return candidates
+            return self._sort_candidates(candidates, query)
 
         except Exception as e:
             logger.warning("タグ候補取得に失敗: query='{}', error={}", query, e)
             return []
+
+    @staticmethod
+    def _sort_candidates(candidates: list[str], query: str) -> list[str]:
+        """候補を exact/prefix 優先で並び替える。"""
+        folded_query = query.casefold()
+        return sorted(
+            candidates,
+            key=lambda tag: (
+                0 if tag.casefold() == folded_query else 1,
+                0 if tag.casefold().startswith(folded_query) else 1,
+                len(tag),
+                tag.casefold(),
+            ),
+        )
 
     @staticmethod
     def _extract_tag_name(item: Any) -> str | None:

--- a/tests/unit/services/test_tag_suggestion_service.py
+++ b/tests/unit/services/test_tag_suggestion_service.py
@@ -92,6 +92,19 @@ class TestTagSuggestionServiceCache:
         assert "bb" in service._cache
         assert "cc" in service._cache
 
+    def test_get_cached_suggestions_returns_none_when_missing(self, patch_genai):
+        patch_genai([_FakeItem("tag")])
+        service = TagSuggestionService(object(), cache_ttl_seconds=60)
+
+        assert service.get_cached_suggestions("ta") is None
+
+    def test_get_cached_suggestions_returns_data_when_present(self, patch_genai):
+        patch_genai([_FakeItem("tag")])
+        service = TagSuggestionService(object(), cache_ttl_seconds=60)
+        service.get_suggestions("ta")
+
+        assert service.get_cached_suggestions("ta") == ["tag"]
+
 
 class TestTagSuggestionServiceMinChars:
     """最小文字数チェックのテスト。"""
@@ -142,6 +155,45 @@ class TestTagSuggestionServiceMaxResults:
         result = service.get_suggestions("gi")
 
         assert result.count("1girl") == 1
+
+    def test_prefix_match_is_prioritized(self, patch_genai):
+        patch_genai([_FakeItem("zzz_bl"), _FakeItem("blue_hair"), _FakeItem("blush")])
+        service = TagSuggestionService(object())
+
+        result = service.get_suggestions("bl")
+
+        assert result[:2] == ["blush", "blue_hair"]
+
+
+class TestTagSearchRequestLimitFallback:
+    """TagSearchRequest が limit 非対応でも動作継続できることを検証。"""
+
+    def test_limit_fallback_when_request_rejects_limit(self, monkeypatch):
+        calls: list[dict] = []
+
+        class _StrictRequest:
+            def __init__(self, **kwargs):
+                if "limit" in kwargs:
+                    raise TypeError("unexpected keyword argument: limit")
+                self.kwargs = kwargs
+
+        def fake_search_tags(_reader, request):
+            calls.append(request.kwargs)
+            return _FakeResult([_FakeItem("blue_hair")])
+
+        monkeypatch.setitem(sys.modules, "genai_tag_db_tools", types.SimpleNamespace(search_tags=fake_search_tags))
+        monkeypatch.setitem(
+            sys.modules,
+            "genai_tag_db_tools.models",
+            types.SimpleNamespace(TagSearchRequest=_StrictRequest),
+        )
+
+        service = TagSuggestionService(object())
+        result = service.get_suggestions("bl")
+
+        assert result == ["blue_hair"]
+        assert calls, "search_tags should be called"
+        assert "limit" not in calls[0]
 
 
 class TestExtractTagName:


### PR DESCRIPTION
### Motivation

- Fix slow / blocking tag autocomplete (issue #36) by removing synchronous DB work from the GUI thread. 
- Reduce unnecessary data transfer and improve perceived quality of suggestions by applying server-side `limit` when available and improving ranking.

### Description

- Move tag suggestion lookups out of the GUI thread using a `QRunnable` task run on a `QThreadPool` in `FilterSearchPanel` and add a `request_id` stale-response guard to prevent old results from overwriting newer input. 
- Use cache-first UI updates by exposing `TagSuggestionService.get_cached_suggestions()` so cached suggestions are applied immediately and background work is avoided when possible. 
- Enhance `TagSuggestionService` to attempt adding a `limit` to `TagSearchRequest` (with transparent fallback for older `genai_tag_db_tools` that reject `limit`) and to prioritize exact/prefix matches when sorting returned candidates. 
- Add/update unit tests covering cache reads, prefix prioritization, and `TagSearchRequest` `limit` fallback behavior.

### Testing

- Successfully type-checked/compiled modified files with `python -m compileall` for `src/lorairo/services/tag_suggestion_service.py`, `src/lorairo/gui/widgets/filter_search_panel.py`, and updated tests. 
- Attempted to run the focused pytest commands for the modified tests but the environment test run failed due to repository-local dependency issues (missing metadata in `local_packages/image-annotator-lib`) and missing runtime dependencies (e.g. `sqlalchemy`) in this execution environment. 
- Added unit tests that should pass in CI/maintainer environment once project editable local packages and dependencies are installed; CI is expected to run the updated test suite with the normal project environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69babfade2e88329a329171a4af23476)