### PR TITLE
feat: improve tag autocomplete responsiveness and query efficiency

### DIFF
--- a/src/lorairo/gui/widgets/filter_search_panel.py
+++ b/src/lorairo/gui/widgets/filter_search_panel.py
@@ -1,10 +1,12 @@
 # src/lorairo/gui/widgets/filter_search_panel.py
 
+from concurrent.futures import Future, ThreadPoolExecutor
 from datetime import datetime
 from enum import Enum
 from typing import TYPE_CHECKING, Any
 
 from PySide6.QtCore import QStringListModel, Qt, QTimer, Signal
+from PySide6.QtGui import QCloseEvent
 from PySide6.QtWidgets import QCompleter, QScrollArea
 
 from ...gui.designer.FilterSearchPanel_ui import Ui_FilterSearchPanel
@@ -12,9 +14,9 @@ from ...utils.log import logger
 from .custom_range_slider import CustomRangeSlider
 
 if TYPE_CHECKING:
+    from ...services.search_models import SearchConditions
     from ...services.tag_suggestion_service import TagSuggestionService
     from ..services.search_filter_service import SearchFilterService
-    from ...services.search_models import SearchConditions
     from ..services.worker_service import WorkerService
 
 
@@ -44,6 +46,7 @@ class FilterSearchPanel(QScrollArea):
 
     # Phase 3: Pipeline State Management
     pipeline_state_changed = Signal(object)  # PipelineState
+    tag_suggestions_loaded = Signal(str, list)
 
     def __init__(self, parent=None):
         super().__init__(parent)
@@ -67,6 +70,12 @@ class FilterSearchPanel(QScrollArea):
         self._tag_suggestion_timer = QTimer(self)
         self._tag_suggestion_timer.setSingleShot(True)
         self._tag_suggestion_timer.setInterval(300)
+        self._tag_suggestion_executor = ThreadPoolExecutor(
+            max_workers=1,
+            thread_name_prefix="tag-suggestion",
+        )
+        self._tag_suggestion_future: Future[list[str]] | None = None
+        self._pending_tag_token: str | None = None
 
         # 現在のSearchWorkerのID
         self._current_search_worker_id: str | None = None
@@ -184,6 +193,7 @@ class FilterSearchPanel(QScrollArea):
         self.ui.lineEditSearch.setCompleter(self._tag_completer)
         self._tag_suggestion_timer.timeout.connect(self._update_tag_completions)
         self._tag_completer.activated[str].connect(self._on_tag_completion_activated)
+        self.tag_suggestions_loaded.connect(self._apply_tag_suggestions)
 
     def set_tag_suggestion_service(self, service: "TagSuggestionService | None") -> None:
         """TagSuggestionService を設定する（依存注入）。
@@ -235,19 +245,70 @@ class FilterSearchPanel(QScrollArea):
             return
 
         token = self._extract_last_token(self.ui.lineEditSearch.text())
-        suggestions = self.tag_suggestion_service.get_suggestions(token)
-        self._tag_completer_model.setStringList(suggestions)
+        self._request_tag_suggestions(token)
 
-        if suggestions and self.ui.lineEditSearch.hasFocus():
-            # P2 修正: QCompleter のプレフィックスをトークンに合わせる
-            # これにより "1girl, bl" 入力時も "bl" を prefix として候補をフィルタリングできる
-            self._tag_completer.setCompletionPrefix(token)
-            self._tag_completer.complete()
+    def _request_tag_suggestions(self, token: str) -> None:
+        """タグ候補取得をバックグラウンドで実行する。
+
+        単一ワーカースレッド + 最新トークン優先のキューイングで、
+        入力連打時のDBアクセスを抑制しつつUIフリーズを防ぐ。
+        """
+        if self.tag_suggestion_service is None:
+            return
+
+        running = self._tag_suggestion_future is not None and not self._tag_suggestion_future.done()
+        if running:
+            self._pending_tag_token = token
+            return
+
+        service = self.tag_suggestion_service
+        self._pending_tag_token = None
+        self._tag_suggestion_future = self._tag_suggestion_executor.submit(service.get_suggestions, token)
+        self._tag_suggestion_future.add_done_callback(
+            lambda future, requested_token=token: self._on_tag_suggestions_ready(requested_token, future),
+        )
+
+    def _on_tag_suggestions_ready(self, token: str, future: Future[list[str]]) -> None:
+        """バックグラウンド検索完了時のコールバック。"""
+        try:
+            suggestions = future.result()
+        except Exception as e:
+            logger.warning("タグ候補の非同期取得に失敗: token='{}', error={}", token, e)
+            suggestions = []
+
+        # 別スレッドからでも安全にメインスレッドへ反映
+        self.tag_suggestions_loaded.emit(token, suggestions)
+
+    def _apply_tag_suggestions(self, token: str, suggestions: list[str]) -> None:
+        """最新トークンに一致する候補のみUIへ適用する。"""
+        self._tag_suggestion_future = None
+
+        current_token = self._extract_last_token(self.ui.lineEditSearch.text())
+        if token == current_token:
+            self._tag_completer_model.setStringList(suggestions)
+            if suggestions and self.ui.lineEditSearch.hasFocus():
+                # P2 修正: QCompleter のプレフィックスをトークンに合わせる
+                # これにより "1girl, bl" 入力時も "bl" を prefix として候補をフィルタリングできる
+                self._tag_completer.setCompletionPrefix(token)
+                self._tag_completer.complete()
+
+        if self._pending_tag_token is not None and self._pending_tag_token != token:
+            pending = self._pending_tag_token
+            self._pending_tag_token = None
+            self._request_tag_suggestions(pending)
 
     def _clear_tag_suggestions(self) -> None:
         """タグ候補をクリアしてデバウンスタイマーを停止する。"""
         self._tag_suggestion_timer.stop()
+        self._pending_tag_token = None
         self._tag_completer_model.setStringList([])
+
+    def closeEvent(self, event: QCloseEvent) -> None:
+        """終了時にタグ候補用スレッドプールをクリーンアップする。"""
+        self._tag_suggestion_timer.stop()
+        self._pending_tag_token = None
+        self._tag_suggestion_executor.shutdown(wait=False, cancel_futures=True)
+        super().closeEvent(event)
 
     def _on_tag_completion_activated(self, selected_tag: str) -> None:
         """候補選択時にカンマ区切り入力の最後のトークンを置換する。

--- a/src/lorairo/services/tag_suggestion_service.py
+++ b/src/lorairo/services/tag_suggestion_service.py
@@ -5,7 +5,9 @@
 
 from __future__ import annotations
 
+import inspect
 from collections import OrderedDict
+from collections.abc import Mapping
 from time import monotonic
 from typing import TYPE_CHECKING, Any
 
@@ -31,6 +33,7 @@ class TagSuggestionService:
         max_results: int = 20,
         cache_size: int = 256,
         cache_ttl_seconds: float = 300.0,
+        db_fetch_limit_factor: int = 4,
     ) -> None:
         """TagSuggestionService を初期化する。
 
@@ -41,10 +44,13 @@ class TagSuggestionService:
             max_results: 取得する候補の最大件数。
             cache_size: LRU キャッシュの最大エントリ数。
             cache_ttl_seconds: キャッシュの有効期限（秒）。
+            db_fetch_limit_factor: DB側 limit 指定時に max_results へ乗算する係数。
+                重複・別名展開を見越して余剰件数を取得し、最終的に max_results へ整形する。
         """
         self._merged_reader = merged_reader
         self.min_chars = min_chars
         self.max_results = max_results
+        self._db_fetch_limit = max_results * max(db_fetch_limit_factor, 1)
         self._cache_size = cache_size
         self._cache_ttl = cache_ttl_seconds
         # OrderedDict で LRU + TTL キャッシュを実装: key -> (timestamp, list[str])
@@ -85,27 +91,15 @@ class TagSuggestionService:
             from genai_tag_db_tools import search_tags
             from genai_tag_db_tools.models import TagSearchRequest
 
-            request = TagSearchRequest(
-                query=query,
-                partial=True,
-                resolve_preferred=False,
-                include_aliases=True,
-                include_deprecated=False,
-            )
-            result = search_tags(self._merged_reader, request)
-
-            # TagSearchResult.items は list[TagRecordPublic]、各 item.tag がタグ文字列
             candidates: list[str] = []
             seen: set[str] = set()
-            for item in result.items:
-                tag_name = self._extract_tag_name(item)
-                if not tag_name:
-                    continue
-                key = tag_name.casefold()
-                if key in seen:
-                    continue
-                seen.add(key)
-                candidates.append(tag_name)
+
+            # 前方一致優先: "keyword*" で先に取得し、不足時のみ従来の部分一致へフォールバック
+            prefix_query = query if query.endswith("*") else f"{query}*"
+            for current_query in (prefix_query, query):
+                request_kwargs = self._build_search_request_kwargs(TagSearchRequest, current_query)
+                result = search_tags(self._merged_reader, TagSearchRequest(**request_kwargs))
+                self._collect_candidates(result, seen, candidates)
                 if len(candidates) >= self.max_results:
                     break
 
@@ -114,6 +108,60 @@ class TagSuggestionService:
         except Exception as e:
             logger.warning("タグ候補取得に失敗: query='{}', error={}", query, e)
             return []
+
+    def _build_search_request_kwargs(self, request_cls: type[Any], query: str) -> dict[str, Any]:
+        """TagSearchRequest の互換性を保ちながら kwargs を構築する。"""
+        kwargs = {
+            "query": query,
+            "partial": True,
+            "resolve_preferred": False,
+            "include_aliases": True,
+            "include_deprecated": False,
+        }
+        accepted = self._accepted_request_fields(request_cls)
+        if accepted is None or "limit" in accepted:
+            kwargs["limit"] = self._db_fetch_limit
+        return kwargs
+
+    @staticmethod
+    def _accepted_request_fields(request_cls: type[Any]) -> set[str] | None:
+        """TagSearchRequest が受け取るフィールド名一覧を返す。
+
+        Returns:
+            set[str] | None:
+                - フィールド一覧が分かる場合は set
+                - 可変 kwargs のみで判定できない場合は None
+        """
+        model_fields = getattr(request_cls, "model_fields", None)
+        if isinstance(model_fields, Mapping):
+            return set(model_fields.keys())
+
+        try:
+            signature = inspect.signature(request_cls)
+        except (TypeError, ValueError):
+            return None
+
+        accepted: set[str] = set()
+        for name, param in signature.parameters.items():
+            if param.kind in (inspect.Parameter.POSITIONAL_OR_KEYWORD, inspect.Parameter.KEYWORD_ONLY):
+                accepted.add(name)
+            elif param.kind is inspect.Parameter.VAR_KEYWORD:
+                return None
+        return accepted
+
+    def _collect_candidates(self, result: Any, seen: set[str], candidates: list[str]) -> None:
+        """TagSearchResult から候補を重複排除しつつ収集する。"""
+        for item in getattr(result, "items", []):
+            tag_name = self._extract_tag_name(item)
+            if not tag_name:
+                continue
+            key = tag_name.casefold()
+            if key in seen:
+                continue
+            seen.add(key)
+            candidates.append(tag_name)
+            if len(candidates) >= self.max_results:
+                break
 
     @staticmethod
     def _extract_tag_name(item: Any) -> str | None:

--- a/tests/unit/services/test_tag_suggestion_service.py
+++ b/tests/unit/services/test_tag_suggestion_service.py
@@ -29,9 +29,10 @@ class _FakeResult:
 def _make_fake_genai(items: list, call_counter: dict | None = None) -> tuple:
     """genai_tag_db_tools のモジュールモックと呼び出しカウンターを返す。"""
 
-    def fake_search_tags(_reader, _request):
+    def fake_search_tags(_reader, request):
         if call_counter is not None:
             call_counter["count"] = call_counter.get("count", 0) + 1
+            call_counter.setdefault("requests", []).append(request)
         return _FakeResult(items)
 
     fake_models = types.SimpleNamespace(TagSearchRequest=lambda **kwargs: kwargs)
@@ -142,6 +143,29 @@ class TestTagSuggestionServiceMaxResults:
         result = service.get_suggestions("gi")
 
         assert result.count("1girl") == 1
+
+    def test_prefix_first_then_fallback_search(self, patch_genai):
+        """前方一致→部分一致の順で2回検索される。"""
+        counter: dict = {}
+        patch_genai([_FakeItem("blue_hair")], counter)
+
+        service = TagSuggestionService(object())
+        service.get_suggestions("bl")
+
+        assert counter["count"] == 2
+        assert counter["requests"][0]["query"] == "bl*"
+        assert counter["requests"][1]["query"] == "bl"
+
+    def test_limit_is_passed_to_search_request(self, patch_genai):
+        """DB側limitがTagSearchRequestへ渡される。"""
+        counter: dict = {}
+        patch_genai([_FakeItem("blue_hair")], counter)
+
+        service = TagSuggestionService(object(), max_results=7, db_fetch_limit_factor=3)
+        service.get_suggestions("bl")
+
+        assert counter["requests"][0]["limit"] == 21
+        assert counter["requests"][1]["limit"] == 21
 
 
 class TestExtractTagName:


### PR DESCRIPTION
### Motivation

- The tag autocomplete UI was blocked by synchronous DB searches on the GUI thread and returned large result sets due to `%`-style matching and missing DB-side limits, degrading typing responsiveness (Issue #36).
- The goal is to avoid UI freezes, reduce unnecessary DB work and network/IO, and make results appear deterministically for the latest input token.

### Description

- Run tag suggestion lookups off the GUI thread by adding a single-worker `ThreadPoolExecutor` in `FilterSearchPanel` and applying results via a new `tag_suggestions_loaded` signal. The executor is cleaned up in `closeEvent` to avoid leaks. (`src/lorairo/gui/widgets/filter_search_panel.py`)
- Add latest-token coalescing: while a lookup is running the panel stores the newest token and only issues one follow-up lookup after completion so stale results are not applied and redundant DB queries are reduced. (`src/lorairo/gui/widgets/filter_search_panel.py`)
- Improve `TagSuggestionService` search strategy to prefer prefix searches (`query*`) and fall back to the previous contains search, and deduplicate/trim results client-side to `max_results`. (`src/lorairo/services/tag_suggestion_service.py`)
- Add optional DB-side `limit` support by detecting if the installed `TagSearchRequest` accepts a `limit` field (via `model_fields` or `inspect.signature`) and passing a conservative `limit` (`max_results * db_fetch_limit_factor`) to reduce data transfer when supported. (`src/lorairo/services/tag_suggestion_service.py`)
- Extend unit tests to assert prefix-first/fallback ordering and that the `limit` value is propagated when available, and record request kwargs in the fake `search_tags` for verification. (`tests/unit/services/test_tag_suggestion_service.py`)

### Testing

- `python -m compileall src/lorairo/services/tag_suggestion_service.py src/lorairo/gui/widgets/filter_search_panel.py tests/unit/services/test_tag_suggestion_service.py` completed successfully. ✅
- `uv run pytest tests/unit/services/test_tag_suggestion_service.py` could not complete in this environment due to a missing local editable dependency (`local_packages/image-annotator-lib`), so full pytest run was not executed here. ⚠️
- `pytest tests/unit/services/test_tag_suggestion_service.py` failed to run in this environment because `sqlalchemy` is not installed and `tests/conftest.py` imports it, so tests could not be validated end-to-end here. ⚠️

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69babfade2e88329a329171a4af23476)