### PR TITLE
perf: make tag autocomplete non-blocking and reuse cache (async + cache optimizations)

### DIFF
--- a/src/lorairo/gui/widgets/filter_search_panel.py
+++ b/src/lorairo/gui/widgets/filter_search_panel.py
@@ -4,7 +4,7 @@ from datetime import datetime
 from enum import Enum
 from typing import TYPE_CHECKING, Any
 
-from PySide6.QtCore import QStringListModel, Qt, QTimer, Signal
+from PySide6.QtCore import QObject, QRunnable, QStringListModel, Qt, QThreadPool, QTimer, Signal, Slot
 from PySide6.QtWidgets import QCompleter, QScrollArea
 
 from ...gui.designer.FilterSearchPanel_ui import Ui_FilterSearchPanel
@@ -27,6 +27,28 @@ class PipelineState(Enum):
     DISPLAYING = "displaying"  # 結果表示中
     ERROR = "error"  # エラー状態
     CANCELED = "canceled"  # キャンセル状態
+
+
+class _TagSuggestionTaskSignals(QObject):
+    """タグ候補非同期取得タスク用シグナル。"""
+
+    finished = Signal(int, str, list)
+
+
+class _TagSuggestionTask(QRunnable):
+    """タグ候補をバックグラウンドで取得する QRunnable。"""
+
+    def __init__(self, service: "TagSuggestionService", query: str, request_id: int) -> None:
+        super().__init__()
+        self._service = service
+        self._query = query
+        self._request_id = request_id
+        self.signals = _TagSuggestionTaskSignals()
+
+    @Slot()
+    def run(self) -> None:
+        suggestions = self._service.get_suggestions(self._query)
+        self.signals.finished.emit(self._request_id, self._query, suggestions)
 
 
 class FilterSearchPanel(QScrollArea):
@@ -67,6 +89,11 @@ class FilterSearchPanel(QScrollArea):
         self._tag_suggestion_timer = QTimer(self)
         self._tag_suggestion_timer.setSingleShot(True)
         self._tag_suggestion_timer.setInterval(300)
+        self._tag_suggestion_pool = QThreadPool.globalInstance()
+        self._tag_request_seq = 0
+        self._latest_tag_request_id = 0
+        self._tag_lookup_in_flight = False
+        self._pending_tag_request: tuple[int, str] | None = None
 
         # 現在のSearchWorkerのID
         self._current_search_worker_id: str | None = None
@@ -235,18 +262,54 @@ class FilterSearchPanel(QScrollArea):
             return
 
         token = self._extract_last_token(self.ui.lineEditSearch.text())
-        suggestions = self.tag_suggestion_service.get_suggestions(token)
-        self._tag_completer_model.setStringList(suggestions)
+        self._tag_request_seq += 1
+        request_id = self._tag_request_seq
+        self._latest_tag_request_id = request_id
+        self._enqueue_tag_suggestion_request(request_id, token)
 
-        if suggestions and self.ui.lineEditSearch.hasFocus():
-            # P2 修正: QCompleter のプレフィックスをトークンに合わせる
-            # これにより "1girl, bl" 入力時も "bl" を prefix として候補をフィルタリングできる
-            self._tag_completer.setCompletionPrefix(token)
-            self._tag_completer.complete()
+    def _enqueue_tag_suggestion_request(self, request_id: int, token: str) -> None:
+        """タグ候補リクエストをキューイングする。"""
+        if self.tag_suggestion_service is None:
+            return
+
+        if self._tag_lookup_in_flight:
+            self._pending_tag_request = (request_id, token)
+            return
+
+        self._tag_lookup_in_flight = True
+        task = _TagSuggestionTask(self.tag_suggestion_service, token, request_id)
+        task.signals.finished.connect(self._on_tag_suggestions_ready)
+        self._tag_suggestion_pool.start(task)
+
+    @Slot(int, str, list)
+    def _on_tag_suggestions_ready(self, request_id: int, token: str, suggestions: list[str]) -> None:
+        """バックグラウンド取得完了時に最新入力へ反映する。"""
+        self._tag_lookup_in_flight = False
+        current_token = self._extract_last_token(self.ui.lineEditSearch.text())
+
+        if (
+            request_id == self._latest_tag_request_id
+            and token == current_token
+            and self.ui.checkboxTags.isChecked()
+            and self.ui.lineEditSearch.isEnabled()
+        ):
+            self._tag_completer_model.setStringList(suggestions)
+            if suggestions and self.ui.lineEditSearch.hasFocus():
+                # P2 修正: QCompleter のプレフィックスをトークンに合わせる
+                # これにより "1girl, bl" 入力時も "bl" を prefix として候補をフィルタリングできる
+                self._tag_completer.setCompletionPrefix(token)
+                self._tag_completer.complete()
+
+        pending_request = self._pending_tag_request
+        self._pending_tag_request = None
+        if pending_request is not None:
+            pending_request_id, pending_token = pending_request
+            self._enqueue_tag_suggestion_request(pending_request_id, pending_token)
 
     def _clear_tag_suggestions(self) -> None:
         """タグ候補をクリアしてデバウンスタイマーを停止する。"""
         self._tag_suggestion_timer.stop()
+        self._pending_tag_request = None
         self._tag_completer_model.setStringList([])
 
     def _on_tag_completion_activated(self, selected_tag: str) -> None:

--- a/src/lorairo/services/tag_suggestion_service.py
+++ b/src/lorairo/services/tag_suggestion_service.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 from collections import OrderedDict
 from time import monotonic
+from threading import RLock
 from typing import TYPE_CHECKING, Any
 
 from ..utils.log import logger
@@ -49,6 +50,7 @@ class TagSuggestionService:
         self._cache_ttl = cache_ttl_seconds
         # OrderedDict で LRU + TTL キャッシュを実装: key -> (timestamp, list[str])
         self._cache: OrderedDict[str, tuple[float, list[str]]] = OrderedDict()
+        self._cache_lock = RLock()
 
     def get_suggestions(self, query: str) -> list[str]:
         """入力文字列からタグ候補一覧を取得する。
@@ -70,6 +72,10 @@ class TagSuggestionService:
         cached = self._get_cache(cache_key)
         if cached is not None:
             return cached
+        cached_from_prefix = self._get_cached_subset(cache_key)
+        if cached_from_prefix is not None:
+            self._set_cache(cache_key, cached_from_prefix)
+            return cached_from_prefix
 
         suggestions = self._search_tags(normalized)
         self._set_cache(cache_key, suggestions)
@@ -77,7 +83,8 @@ class TagSuggestionService:
 
     def clear_cache(self) -> None:
         """キャッシュをクリアする。"""
-        self._cache.clear()
+        with self._cache_lock:
+            self._cache.clear()
 
     def _search_tags(self, query: str) -> list[str]:
         """genai-tag-db-tools で タグ検索を実行する。"""
@@ -85,13 +92,21 @@ class TagSuggestionService:
             from genai_tag_db_tools import search_tags
             from genai_tag_db_tools.models import TagSearchRequest
 
-            request = TagSearchRequest(
-                query=query,
-                partial=True,
-                resolve_preferred=False,
-                include_aliases=True,
-                include_deprecated=False,
-            )
+            request_kwargs = {
+                "query": query,
+                "partial": True,
+                "resolve_preferred": False,
+                "include_aliases": True,
+                "include_deprecated": False,
+                # 新しい genai-tag-db-tools では DB 側 LIMIT が使える
+                "limit": self.max_results,
+            }
+            try:
+                request = TagSearchRequest(**request_kwargs)
+            except TypeError:
+                # 旧バージョン互換（limit 未対応）
+                request_kwargs.pop("limit", None)
+                request = TagSearchRequest(**request_kwargs)
             result = search_tags(self._merged_reader, request)
 
             # TagSearchResult.items は list[TagRecordPublic]、各 item.tag がタグ文字列
@@ -138,23 +153,38 @@ class TagSuggestionService:
 
     def _get_cache(self, key: str) -> list[str] | None:
         """キャッシュからエントリを取得する（TTL チェック込み）。"""
-        if key not in self._cache:
-            return None
+        with self._cache_lock:
+            if key not in self._cache:
+                return None
 
-        created_at, data = self._cache[key]
-        if monotonic() - created_at > self._cache_ttl:
-            del self._cache[key]
-            return None
+            created_at, data = self._cache[key]
+            if monotonic() - created_at > self._cache_ttl:
+                del self._cache[key]
+                return None
 
-        # LRU: 最近アクセスしたエントリを末尾へ移動
-        self._cache.move_to_end(key)
-        return data
+            # LRU: 最近アクセスしたエントリを末尾へ移動
+            self._cache.move_to_end(key)
+            return data
 
     def _set_cache(self, key: str, suggestions: list[str]) -> None:
         """キャッシュにエントリを追加する（LRU サイズ制限付き）。"""
-        self._cache[key] = (monotonic(), suggestions)
-        self._cache.move_to_end(key)
+        with self._cache_lock:
+            self._cache[key] = (monotonic(), suggestions)
+            self._cache.move_to_end(key)
 
-        # LRU: サイズ超過時は最古のエントリを削除
-        while len(self._cache) > self._cache_size:
-            self._cache.popitem(last=False)
+            # LRU: サイズ超過時は最古のエントリを削除
+            while len(self._cache) > self._cache_size:
+                self._cache.popitem(last=False)
+
+    def _get_cached_subset(self, key: str) -> list[str] | None:
+        """より短いキャッシュキーから部分集合を推定する。"""
+        with self._cache_lock:
+            now = monotonic()
+            for cached_key, (created_at, cached_items) in reversed(self._cache.items()):
+                if now - created_at > self._cache_ttl:
+                    continue
+                if not key.startswith(cached_key):
+                    continue
+                filtered = [item for item in cached_items if key in item.casefold()]
+                return filtered[: self.max_results]
+        return None

--- a/tests/unit/gui/widgets/test_filter_search_panel_autocomplete.py
+++ b/tests/unit/gui/widgets/test_filter_search_panel_autocomplete.py
@@ -118,3 +118,30 @@ class TestClearTagSuggestions:
 
         panel._clear_tag_suggestions()
         assert not panel._tag_suggestion_timer.isActive()
+
+
+class TestAsyncTagSuggestions:
+    """非同期タグ候補更新の動作テスト。"""
+
+    def test_ignores_stale_result(self, panel):
+        """古いリクエストIDの結果は UI に反映しない。"""
+        panel._latest_tag_request_id = 3
+        panel.ui.checkboxTags.setChecked(True)
+        panel.ui.lineEditSearch.setEnabled(True)
+        panel.ui.lineEditSearch.setText("bl")
+        panel._tag_completer_model.setStringList(["existing"])
+
+        panel._on_tag_suggestions_ready(2, "bl", ["blue_hair"])
+
+        assert panel._tag_completer_model.stringList() == ["existing"]
+
+    def test_applies_latest_result(self, panel):
+        """最新リクエストIDかつトークン一致なら UI に反映する。"""
+        panel._latest_tag_request_id = 4
+        panel.ui.checkboxTags.setChecked(True)
+        panel.ui.lineEditSearch.setEnabled(True)
+        panel.ui.lineEditSearch.setText("bl")
+
+        panel._on_tag_suggestions_ready(4, "bl", ["blue_hair", "blush"])
+
+        assert panel._tag_completer_model.stringList() == ["blue_hair", "blush"]

--- a/tests/unit/services/test_tag_suggestion_service.py
+++ b/tests/unit/services/test_tag_suggestion_service.py
@@ -32,6 +32,7 @@ def _make_fake_genai(items: list, call_counter: dict | None = None) -> tuple:
     def fake_search_tags(_reader, _request):
         if call_counter is not None:
             call_counter["count"] = call_counter.get("count", 0) + 1
+            call_counter["request"] = _request
         return _FakeResult(items)
 
     fake_models = types.SimpleNamespace(TagSearchRequest=lambda **kwargs: kwargs)
@@ -92,6 +93,19 @@ class TestTagSuggestionServiceCache:
         assert "bb" in service._cache
         assert "cc" in service._cache
 
+    def test_reuses_parent_query_cache(self, patch_genai):
+        """より短いクエリのキャッシュから部分集合を再利用できる。"""
+        counter: dict = {}
+        patch_genai([_FakeItem("blue_hair"), _FakeItem("blush"), _FakeItem("solo")], counter)
+        service = TagSuggestionService(object(), cache_ttl_seconds=60)
+
+        parent = service.get_suggestions("bl")
+        narrowed = service.get_suggestions("blu")
+
+        assert "blue_hair" in parent
+        assert narrowed == ["blue_hair"]
+        assert counter["count"] == 1
+
 
 class TestTagSuggestionServiceMinChars:
     """最小文字数チェックのテスト。"""
@@ -142,6 +156,17 @@ class TestTagSuggestionServiceMaxResults:
         result = service.get_suggestions("gi")
 
         assert result.count("1girl") == 1
+
+    def test_limit_is_passed_when_supported(self, patch_genai):
+        """TagSearchRequest が limit を受け取れる場合は DB 側 LIMIT を利用する。"""
+        counter: dict = {}
+        patch_genai([_FakeItem("1girl")], counter)
+
+        service = TagSuggestionService(object(), max_results=7)
+        service.get_suggestions("gi")
+
+        request = counter["request"]
+        assert request["limit"] == 7
 
 
 class TestExtractTagName:


### PR DESCRIPTION
### Motivation
- Improve UX for issue #36 by eliminating UI freezes and reducing redundant tag DB queries during incremental typing. 
- Make tag suggestion lookups safe for concurrent/background use and compatible with different versions of `genai-tag-db-tools`.

### Description
- Offloaded tag suggestion lookups in `FilterSearchPanel` to a background `QRunnable` task (`_TagSuggestionTask`) and used `QThreadPool` with request-id gating and single-flight + one-pending queueing to ignore stale/out-of-order results. 
- Enhanced `TagSuggestionService` with a thread-safe LRU+TTL cache protected by `RLock`, added `_get_cached_subset` to reuse broader-query cache for narrower queries, and attempt to pass a `limit` to `TagSearchRequest` with a backward-compatible fallback for older request signatures. 
- Minor UI housekeeping: ensure pending requests are cleared on `_clear_tag_suggestions` and set completer prefix only for the latest matching token. 
- Added and updated unit tests to validate stale-result ignoring, cached-subset reuse, and passing `limit` when supported (`tests/unit/gui/widgets/test_filter_search_panel_autocomplete.py` and `tests/unit/services/test_tag_suggestion_service.py`). 

### Testing
- Ran `python -m compileall src/lorairo/services/tag_suggestion_service.py src/lorairo/gui/widgets/filter_search_panel.py tests/unit/services/test_tag_suggestion_service.py tests/unit/gui/widgets/test_filter_search_panel_autocomplete.py` and compilation succeeded. 
- Attempted `uv run pytest tests/unit/services/test_tag_suggestion_service.py tests/unit/gui/widgets/test_filter_search_panel_autocomplete.py`, which was blocked because the local editable package `local_packages/genai-tag-db-tools` is not a valid installable project in this environment. 
- Attempted `python -m pytest tests/unit/services/test_tag_suggestion_service.py tests/unit/gui/widgets/test_filter_search_panel_autocomplete.py`, which failed early due to missing runtime dependencies in the environment (e.g., `sqlalchemy`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69babfade2e88329a329171a4af23476)