### PR TITLE
feat: rework tag autocomplete responsiveness (async lookup + cache reuse)

### DIFF
--- a/src/lorairo/gui/widgets/filter_search_panel.py
+++ b/src/lorairo/gui/widgets/filter_search_panel.py
@@ -4,7 +4,7 @@ from datetime import datetime
 from enum import Enum
 from typing import TYPE_CHECKING, Any
 
-from PySide6.QtCore import QStringListModel, Qt, QTimer, Signal
+from PySide6.QtCore import QObject, QRunnable, QStringListModel, Qt, QThreadPool, QTimer, Signal
 from PySide6.QtWidgets import QCompleter, QScrollArea
 
 from ...gui.designer.FilterSearchPanel_ui import Ui_FilterSearchPanel
@@ -27,6 +27,33 @@ class PipelineState(Enum):
     DISPLAYING = "displaying"  # 結果表示中
     ERROR = "error"  # エラー状態
     CANCELED = "canceled"  # キャンセル状態
+
+
+class _TagSuggestionTaskSignals(QObject):
+    """タグ候補検索タスクのシグナル。"""
+
+    finished = Signal(int, str, list)
+    failed = Signal(int, str, str)
+
+
+class _TagSuggestionTask(QRunnable):
+    """TagSuggestionService をバックグラウンドで実行するタスク。"""
+
+    def __init__(self, token: int, query: str, service: "TagSuggestionService") -> None:
+        super().__init__()
+        self._token = token
+        self._query = query
+        self._service = service
+        self.signals = _TagSuggestionTaskSignals()
+
+    def run(self) -> None:
+        try:
+            suggestions = self._service.get_suggestions(self._query)
+        except Exception as e:
+            self.signals.failed.emit(self._token, self._query, str(e))
+            return
+
+        self.signals.finished.emit(self._token, self._query, suggestions)
 
 
 class FilterSearchPanel(QScrollArea):
@@ -67,6 +94,11 @@ class FilterSearchPanel(QScrollArea):
         self._tag_suggestion_timer = QTimer(self)
         self._tag_suggestion_timer.setSingleShot(True)
         self._tag_suggestion_timer.setInterval(300)
+        self._tag_lookup_pool = QThreadPool(self)
+        self._tag_lookup_pool.setMaxThreadCount(1)
+        self._tag_lookup_in_flight = False
+        self._tag_lookup_token = 0
+        self._pending_lookup_query: str | None = None
 
         # 現在のSearchWorkerのID
         self._current_search_worker_id: str | None = None
@@ -235,12 +267,68 @@ class FilterSearchPanel(QScrollArea):
             return
 
         token = self._extract_last_token(self.ui.lineEditSearch.text())
-        suggestions = self.tag_suggestion_service.get_suggestions(token)
-        self._tag_completer_model.setStringList(suggestions)
+        if len(token) < self.tag_suggestion_service.min_chars:
+            self._clear_tag_suggestions()
+            return
 
+        cached_suggestions = self.tag_suggestion_service.get_cached_suggestions(token)
+        if cached_suggestions is not None:
+            self._apply_tag_suggestions(token, cached_suggestions)
+            return
+
+        if self._tag_lookup_in_flight:
+            self._pending_lookup_query = token
+            return
+
+        self._start_tag_lookup(token)
+
+    def _start_tag_lookup(self, token: str) -> None:
+        """タグ候補検索タスクを起動する。"""
+        if self.tag_suggestion_service is None:
+            return
+
+        self._tag_lookup_token += 1
+        request_token = self._tag_lookup_token
+        self._tag_lookup_in_flight = True
+        self._pending_lookup_query = None
+
+        task = _TagSuggestionTask(request_token, token, self.tag_suggestion_service)
+        task.signals.finished.connect(self._on_tag_lookup_finished)
+        task.signals.failed.connect(self._on_tag_lookup_failed)
+        self._tag_lookup_pool.start(task)
+
+    def _on_tag_lookup_finished(self, request_token: int, query: str, suggestions: list[str]) -> None:
+        """非同期タグ候補検索の完了ハンドラ。"""
+        self._tag_lookup_in_flight = False
+        if request_token == self._tag_lookup_token:
+            current_token = self._extract_last_token(self.ui.lineEditSearch.text())
+            if current_token.casefold() == query.casefold():
+                self._apply_tag_suggestions(current_token, suggestions)
+
+        self._dispatch_pending_lookup()
+
+    def _on_tag_lookup_failed(self, request_token: int, query: str, error: str) -> None:
+        """非同期タグ候補検索の失敗ハンドラ。"""
+        self._tag_lookup_in_flight = False
+        if request_token == self._tag_lookup_token:
+            logger.warning("タグ候補非同期検索に失敗: query='{}', error={}", query, error)
+            self._clear_tag_suggestions()
+        self._dispatch_pending_lookup()
+
+    def _dispatch_pending_lookup(self) -> None:
+        """保留中クエリがあれば次の検索を起動する。"""
+        pending_query = self._pending_lookup_query
+        if not pending_query:
+            return
+
+        self._pending_lookup_query = None
+        if self.tag_suggestion_service and len(pending_query) >= self.tag_suggestion_service.min_chars:
+            self._start_tag_lookup(pending_query)
+
+    def _apply_tag_suggestions(self, token: str, suggestions: list[str]) -> None:
+        """候補をモデルに反映し、必要に応じてポップアップ表示する。"""
+        self._tag_completer_model.setStringList(suggestions)
         if suggestions and self.ui.lineEditSearch.hasFocus():
-            # P2 修正: QCompleter のプレフィックスをトークンに合わせる
-            # これにより "1girl, bl" 入力時も "bl" を prefix として候補をフィルタリングできる
             self._tag_completer.setCompletionPrefix(token)
             self._tag_completer.complete()
 
@@ -248,6 +336,7 @@ class FilterSearchPanel(QScrollArea):
         """タグ候補をクリアしてデバウンスタイマーを停止する。"""
         self._tag_suggestion_timer.stop()
         self._tag_completer_model.setStringList([])
+        self._pending_lookup_query = None
 
     def _on_tag_completion_activated(self, selected_tag: str) -> None:
         """候補選択時にカンマ区切り入力の最後のトークンを置換する。
@@ -264,6 +353,14 @@ class FilterSearchPanel(QScrollArea):
 
         self.ui.lineEditSearch.setText(new_text)
         self.ui.lineEditSearch.setCursorPosition(len(new_text))
+
+    def closeEvent(self, event) -> None:  # type: ignore[override]
+        """Widget破棄時にタグ検索関連リソースを解放する。"""
+        self._tag_suggestion_timer.stop()
+        self._pending_lookup_query = None
+        self._tag_lookup_pool.clear()
+        self._tag_lookup_pool.waitForDone(1000)
+        super().closeEvent(event)
 
     def setup_favorite_filters_ui(self) -> None:
         """お気に入りフィルターUIを作成してメインレイアウトに追加 (Phase 4)"""

--- a/src/lorairo/services/tag_suggestion_service.py
+++ b/src/lorairo/services/tag_suggestion_service.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 from collections import OrderedDict
+from threading import RLock
 from time import monotonic
 from typing import TYPE_CHECKING, Any
 
@@ -47,6 +48,7 @@ class TagSuggestionService:
         self.max_results = max_results
         self._cache_size = cache_size
         self._cache_ttl = cache_ttl_seconds
+        self._cache_lock = RLock()
         # OrderedDict で LRU + TTL キャッシュを実装: key -> (timestamp, list[str])
         self._cache: OrderedDict[str, tuple[float, list[str]]] = OrderedDict()
 
@@ -69,15 +71,39 @@ class TagSuggestionService:
         cache_key = normalized.casefold()
         cached = self._get_cache(cache_key)
         if cached is not None:
-            return cached
+            return cached[:]
+
+        subset_cached = self._get_cached_subset(cache_key)
+        if subset_cached is not None:
+            self._set_cache(cache_key, subset_cached)
+            return subset_cached[:]
 
         suggestions = self._search_tags(normalized)
         self._set_cache(cache_key, suggestions)
-        return suggestions
+        return suggestions[:]
+
+    def get_cached_suggestions(self, query: str) -> list[str] | None:
+        """クエリに一致するキャッシュ済み候補を返す（未ヒット時は None）。"""
+        normalized = query.strip()
+        if len(normalized) < self.min_chars:
+            return []
+
+        cache_key = normalized.casefold()
+        cached = self._get_cache(cache_key)
+        if cached is not None:
+            return cached[:]
+
+        subset_cached = self._get_cached_subset(cache_key)
+        if subset_cached is not None:
+            self._set_cache(cache_key, subset_cached)
+            return subset_cached[:]
+
+        return None
 
     def clear_cache(self) -> None:
         """キャッシュをクリアする。"""
-        self._cache.clear()
+        with self._cache_lock:
+            self._cache.clear()
 
     def _search_tags(self, query: str) -> list[str]:
         """genai-tag-db-tools で タグ検索を実行する。"""
@@ -85,13 +111,20 @@ class TagSuggestionService:
             from genai_tag_db_tools import search_tags
             from genai_tag_db_tools.models import TagSearchRequest
 
-            request = TagSearchRequest(
-                query=query,
-                partial=True,
-                resolve_preferred=False,
-                include_aliases=True,
-                include_deprecated=False,
-            )
+            request_kwargs = {
+                "query": query,
+                "partial": True,
+                "resolve_preferred": False,
+                "include_aliases": True,
+                "include_deprecated": False,
+                "limit": self.max_results,
+            }
+            try:
+                request = TagSearchRequest(**request_kwargs)
+            except Exception:
+                # 互換性のため、limit 未対応の旧APIでは limit を除外して再試行
+                request_kwargs.pop("limit", None)
+                request = TagSearchRequest(**request_kwargs)
             result = search_tags(self._merged_reader, request)
 
             # TagSearchResult.items は list[TagRecordPublic]、各 item.tag がタグ文字列
@@ -109,7 +142,7 @@ class TagSuggestionService:
                 if len(candidates) >= self.max_results:
                     break
 
-            return candidates
+            return self._sort_candidates(query, candidates)
 
         except Exception as e:
             logger.warning("タグ候補取得に失敗: query='{}', error={}", query, e)
@@ -138,23 +171,57 @@ class TagSuggestionService:
 
     def _get_cache(self, key: str) -> list[str] | None:
         """キャッシュからエントリを取得する（TTL チェック込み）。"""
-        if key not in self._cache:
-            return None
+        with self._cache_lock:
+            if key not in self._cache:
+                return None
 
-        created_at, data = self._cache[key]
-        if monotonic() - created_at > self._cache_ttl:
-            del self._cache[key]
-            return None
+            created_at, data = self._cache[key]
+            if monotonic() - created_at > self._cache_ttl:
+                del self._cache[key]
+                return None
 
-        # LRU: 最近アクセスしたエントリを末尾へ移動
-        self._cache.move_to_end(key)
-        return data
+            # LRU: 最近アクセスしたエントリを末尾へ移動
+            self._cache.move_to_end(key)
+            return data
 
     def _set_cache(self, key: str, suggestions: list[str]) -> None:
         """キャッシュにエントリを追加する（LRU サイズ制限付き）。"""
-        self._cache[key] = (monotonic(), suggestions)
-        self._cache.move_to_end(key)
+        with self._cache_lock:
+            self._cache[key] = (monotonic(), suggestions)
+            self._cache.move_to_end(key)
 
-        # LRU: サイズ超過時は最古のエントリを削除
-        while len(self._cache) > self._cache_size:
-            self._cache.popitem(last=False)
+            # LRU: サイズ超過時は最古のエントリを削除
+            while len(self._cache) > self._cache_size:
+                self._cache.popitem(last=False)
+
+    def _get_cached_subset(self, key: str) -> list[str] | None:
+        """親クエリのキャッシュから部分集合候補を再利用する。"""
+        with self._cache_lock:
+            now = monotonic()
+            for existing_key, (created_at, cached_items) in reversed(self._cache.items()):
+                if now - created_at > self._cache_ttl:
+                    continue
+                if not key.startswith(existing_key):
+                    continue
+
+                subset = [item for item in cached_items if key in item.casefold()]
+                if not subset:
+                    return []
+                return self._sort_candidates(key, subset)[: self.max_results]
+
+        return None
+
+    @staticmethod
+    def _sort_candidates(query: str, candidates: list[str]) -> list[str]:
+        """候補を exact > prefix > contains の優先度でソートする。"""
+        folded_query = query.casefold()
+
+        def rank(tag: str) -> tuple[int, str]:
+            folded = tag.casefold()
+            if folded == folded_query:
+                return (0, folded)
+            if folded.startswith(folded_query):
+                return (1, folded)
+            return (2, folded)
+
+        return sorted(candidates, key=rank)

--- a/tests/unit/gui/widgets/test_filter_search_panel_autocomplete.py
+++ b/tests/unit/gui/widgets/test_filter_search_panel_autocomplete.py
@@ -118,3 +118,38 @@ class TestClearTagSuggestions:
 
         panel._clear_tag_suggestions()
         assert not panel._tag_suggestion_timer.isActive()
+
+
+class _FakeAsyncSuggestionService:
+    min_chars = 2
+
+    def __init__(self) -> None:
+        self.cached: dict[str, list[str]] = {}
+
+    def get_cached_suggestions(self, query: str) -> list[str] | None:
+        return self.cached.get(query)
+
+    def get_suggestions(self, query: str) -> list[str]:
+        return [f"{query}_tag"]
+
+
+class TestAsyncTagLookup:
+    def test_uses_cached_result_without_async_lookup(self, panel):
+        service = _FakeAsyncSuggestionService()
+        service.cached["bl"] = ["blue_hair"]
+        panel.set_tag_suggestion_service(service)
+        panel.ui.checkboxTags.setChecked(True)
+        panel.ui.lineEditSearch.setText("bl")
+
+        panel._update_tag_completions()
+
+        assert panel._tag_completer_model.stringList() == ["blue_hair"]
+
+    def test_background_lookup_updates_model(self, panel, qtbot):
+        service = _FakeAsyncSuggestionService()
+        panel.set_tag_suggestion_service(service)
+        panel.ui.checkboxTags.setChecked(True)
+        panel.ui.lineEditSearch.setText("blue")
+
+        panel._update_tag_completions()
+        qtbot.waitUntil(lambda: panel._tag_completer_model.stringList() == ["blue_tag"], timeout=1500)

--- a/tests/unit/services/test_tag_suggestion_service.py
+++ b/tests/unit/services/test_tag_suggestion_service.py
@@ -92,6 +92,19 @@ class TestTagSuggestionServiceCache:
         assert "bb" in service._cache
         assert "cc" in service._cache
 
+    def test_cached_subset_reuse(self, patch_genai):
+        """先頭一致する親クエリのキャッシュを再利用して DB 再検索を回避する。"""
+        counter: dict = {}
+        patch_genai([_FakeItem("blue_hair"), _FakeItem("blue_eyes"), _FakeItem("black_hair")], counter)
+        service = TagSuggestionService(object(), cache_ttl_seconds=60)
+
+        first = service.get_suggestions("bl")
+        second = service.get_suggestions("blue")
+
+        assert first == ["black_hair", "blue_eyes", "blue_hair"]
+        assert second == ["blue_eyes", "blue_hair"]
+        assert counter["count"] == 1
+
 
 class TestTagSuggestionServiceMinChars:
     """最小文字数チェックのテスト。"""
@@ -142,6 +155,15 @@ class TestTagSuggestionServiceMaxResults:
         result = service.get_suggestions("gi")
 
         assert result.count("1girl") == 1
+
+    def test_contains_sort_priority(self, patch_genai):
+        """候補は exact > prefix > contains の順で並ぶ。"""
+        patch_genai([_FakeItem("blue_hair"), _FakeItem("hair_blue"), _FakeItem("blue")])
+        service = TagSuggestionService(object())
+
+        result = service.get_suggestions("blue")
+
+        assert result == ["blue", "blue_hair", "hair_blue"]
 
 
 class TestExtractTagName:


### PR DESCRIPTION
### Motivation
- Tag autocomplete was blocking the GUI thread causing UI freezes when DB searches were slow, and repeated incremental queries resulted in unnecessary DB work.
- The goal is to make suggestions non-blocking, reuse previously fetched results for incremental typing, and ensure thread-safe cache access.
- Also provide better relevance ordering for suggestions and reduce unnecessary data transfer by applying server-side `limit` when supported.

### Description
- Move tag lookup off the GUI thread by introducing `_TagSuggestionTask` (a `QRunnable`) and a dedicated `QThreadPool` with single-threaded execution, with stale-request guards and error signaling in `FilterSearchPanel`.
- Add cache-first flow in `FilterSearchPanel` so `get_cached_suggestions()` returns immediate results when available, and implement pending-query dispatch plus `closeEvent` cleanup to avoid worker leaks.
- Enhance `TagSuggestionService` with a thread-safe LRU+TTL cache guarded by an `RLock`, implement `_get_cached_subset()` to reuse parent-query caches for incremental typing, and add `_sort_candidates()` to prefer exact > prefix > contains ordering.
- Use a `limit` parameter when constructing `TagSearchRequest` with a compatibility fallback for older API shapes, and add/adjust unit tests to cover cache-subset reuse, sort priority, and the panel cache-first / background lookup behavior.

### Testing
- `python -m compileall src/lorairo/services/tag_suggestion_service.py src/lorairo/gui/widgets/filter_search_panel.py tests/unit/services/test_tag_suggestion_service.py tests/unit/gui/widgets/test_filter_search_panel_autocomplete.py` completed successfully.
- `uv run pytest tests/unit/services/test_tag_suggestion_service.py tests/unit/gui/widgets/test_filter_search_panel_autocomplete.py` failed in this environment because `local_packages/genai-tag-db-tools` is not present as a proper Python project (missing `pyproject.toml`/`setup.py`).
- `python -m pytest tests/unit/services/test_tag_suggestion_service.py tests/unit/gui/widgets/test_filter_search_panel_autocomplete.py` could not run in this environment due to missing dependency `sqlalchemy` (import error during test collection).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bb3a2d3b90832983af5f22f322da0e)