### PR TITLE
feat: async tag autocomplete, prefix-priority ordering, and adaptive limit support

### DIFF
--- a/src/lorairo/gui/widgets/filter_search_panel.py
+++ b/src/lorairo/gui/widgets/filter_search_panel.py
@@ -4,7 +4,7 @@ from datetime import datetime
 from enum import Enum
 from typing import TYPE_CHECKING, Any
 
-from PySide6.QtCore import QStringListModel, Qt, QTimer, Signal
+from PySide6.QtCore import QObject, QRunnable, QStringListModel, Qt, QThreadPool, QTimer, Signal
 from PySide6.QtWidgets import QCompleter, QScrollArea
 
 from ...gui.designer.FilterSearchPanel_ui import Ui_FilterSearchPanel
@@ -12,9 +12,9 @@ from ...utils.log import logger
 from .custom_range_slider import CustomRangeSlider
 
 if TYPE_CHECKING:
+    from ...services.search_models import SearchConditions
     from ...services.tag_suggestion_service import TagSuggestionService
     from ..services.search_filter_service import SearchFilterService
-    from ...services.search_models import SearchConditions
     from ..services.worker_service import WorkerService
 
 
@@ -27,6 +27,27 @@ class PipelineState(Enum):
     DISPLAYING = "displaying"  # 結果表示中
     ERROR = "error"  # エラー状態
     CANCELED = "canceled"  # キャンセル状態
+
+
+class _TagSuggestionWorkerSignals(QObject):
+    """タグ候補検索ワーカー用シグナル。"""
+
+    finished = Signal(int, str, list)  # request_id, token, suggestions
+
+
+class _TagSuggestionWorker(QRunnable):
+    """TagSuggestionService をバックグラウンド実行するQRunnable。"""
+
+    def __init__(self, request_id: int, token: str, tag_suggestion_service: "TagSuggestionService") -> None:
+        super().__init__()
+        self.request_id = request_id
+        self.token = token
+        self.tag_suggestion_service = tag_suggestion_service
+        self.signals = _TagSuggestionWorkerSignals()
+
+    def run(self) -> None:
+        suggestions = self.tag_suggestion_service.get_suggestions(self.token)
+        self.signals.finished.emit(self.request_id, self.token, suggestions)
 
 
 class FilterSearchPanel(QScrollArea):
@@ -67,6 +88,10 @@ class FilterSearchPanel(QScrollArea):
         self._tag_suggestion_timer = QTimer(self)
         self._tag_suggestion_timer.setSingleShot(True)
         self._tag_suggestion_timer.setInterval(300)
+        self._tag_suggestion_thread_pool = QThreadPool.globalInstance()
+        self._tag_request_sequence = 0
+        self._latest_tag_request_id = 0
+        self._active_tag_workers: dict[int, _TagSuggestionWorker] = {}
 
         # 現在のSearchWorkerのID
         self._current_search_worker_id: str | None = None
@@ -235,18 +260,39 @@ class FilterSearchPanel(QScrollArea):
             return
 
         token = self._extract_last_token(self.ui.lineEditSearch.text())
-        suggestions = self.tag_suggestion_service.get_suggestions(token)
-        self._tag_completer_model.setStringList(suggestions)
+        if len(token) < self.tag_suggestion_service.min_chars:
+            self._clear_tag_suggestions()
+            return
 
+        self._tag_request_sequence += 1
+        request_id = self._tag_request_sequence
+        self._latest_tag_request_id = request_id
+
+        worker = _TagSuggestionWorker(request_id, token, self.tag_suggestion_service)
+        worker.signals.finished.connect(self._on_tag_suggestions_ready)
+        self._active_tag_workers[request_id] = worker
+        self._tag_suggestion_thread_pool.start(worker)
+
+    def _on_tag_suggestions_ready(self, request_id: int, token: str, suggestions: list[str]) -> None:
+        """バックグラウンドで取得したタグ候補をUIへ反映する。"""
+        self._active_tag_workers.pop(request_id, None)
+
+        if request_id != self._latest_tag_request_id:
+            return
+
+        current_token = self._extract_last_token(self.ui.lineEditSearch.text())
+        if current_token.casefold() != token.casefold():
+            return
+
+        self._tag_completer_model.setStringList(suggestions)
         if suggestions and self.ui.lineEditSearch.hasFocus():
-            # P2 修正: QCompleter のプレフィックスをトークンに合わせる
-            # これにより "1girl, bl" 入力時も "bl" を prefix として候補をフィルタリングできる
             self._tag_completer.setCompletionPrefix(token)
             self._tag_completer.complete()
 
     def _clear_tag_suggestions(self) -> None:
         """タグ候補をクリアしてデバウンスタイマーを停止する。"""
         self._tag_suggestion_timer.stop()
+        self._latest_tag_request_id = self._tag_request_sequence
         self._tag_completer_model.setStringList([])
 
     def _on_tag_completion_activated(self, selected_tag: str) -> None:

--- a/src/lorairo/gui/widgets/filter_search_panel.py
+++ b/src/lorairo/gui/widgets/filter_search_panel.py
@@ -5,6 +5,7 @@ from enum import Enum
 from typing import TYPE_CHECKING, Any
 
 from PySide6.QtCore import QObject, QRunnable, QStringListModel, Qt, QThreadPool, QTimer, Signal
+from PySide6.QtGui import QCloseEvent
 from PySide6.QtWidgets import QCompleter, QScrollArea
 
 from ...gui.designer.FilterSearchPanel_ui import Ui_FilterSearchPanel
@@ -33,6 +34,7 @@ class _TagSuggestionWorkerSignals(QObject):
     """タグ候補検索ワーカー用シグナル。"""
 
     finished = Signal(int, str, list)  # request_id, token, suggestions
+    failed = Signal(int, str, str)  # request_id, token, error_message
 
 
 class _TagSuggestionWorker(QRunnable):
@@ -46,8 +48,11 @@ class _TagSuggestionWorker(QRunnable):
         self.signals = _TagSuggestionWorkerSignals()
 
     def run(self) -> None:
-        suggestions = self.tag_suggestion_service.get_suggestions(self.token)
-        self.signals.finished.emit(self.request_id, self.token, suggestions)
+        try:
+            suggestions = self.tag_suggestion_service.get_suggestions(self.token)
+            self.signals.finished.emit(self.request_id, self.token, suggestions)
+        except Exception as e:
+            self.signals.failed.emit(self.request_id, self.token, str(e))
 
 
 class FilterSearchPanel(QScrollArea):
@@ -88,9 +93,12 @@ class FilterSearchPanel(QScrollArea):
         self._tag_suggestion_timer = QTimer(self)
         self._tag_suggestion_timer.setSingleShot(True)
         self._tag_suggestion_timer.setInterval(300)
-        self._tag_suggestion_thread_pool = QThreadPool.globalInstance()
+        self._tag_suggestion_thread_pool = QThreadPool(self)
+        self._tag_suggestion_thread_pool.setMaxThreadCount(1)
         self._tag_request_sequence = 0
         self._latest_tag_request_id = 0
+        self._tag_lookup_in_flight = False
+        self._pending_tag_token: str | None = None
         self._active_tag_workers: dict[int, _TagSuggestionWorker] = {}
 
         # 現在のSearchWorkerのID
@@ -248,6 +256,11 @@ class FilterSearchPanel(QScrollArea):
             self._clear_tag_suggestions()
             return
 
+        cached = self.tag_suggestion_service.get_cached_suggestions(token)
+        if cached is not None:
+            self._show_tag_suggestions(token, cached)
+            return
+
         self._tag_suggestion_timer.start()
 
     def _update_tag_completions(self) -> None:
@@ -264,26 +277,62 @@ class FilterSearchPanel(QScrollArea):
             self._clear_tag_suggestions()
             return
 
+        if self._tag_lookup_in_flight:
+            self._pending_tag_token = token
+            return
+
+        self._start_tag_lookup(token)
+
+    def _start_tag_lookup(self, token: str) -> None:
+        """非同期タグ候補検索を開始する。"""
         self._tag_request_sequence += 1
         request_id = self._tag_request_sequence
         self._latest_tag_request_id = request_id
+        self._tag_lookup_in_flight = True
 
         worker = _TagSuggestionWorker(request_id, token, self.tag_suggestion_service)
         worker.signals.finished.connect(self._on_tag_suggestions_ready)
+        worker.signals.failed.connect(self._on_tag_suggestions_failed)
         self._active_tag_workers[request_id] = worker
         self._tag_suggestion_thread_pool.start(worker)
 
     def _on_tag_suggestions_ready(self, request_id: int, token: str, suggestions: list[str]) -> None:
         """バックグラウンドで取得したタグ候補をUIへ反映する。"""
         self._active_tag_workers.pop(request_id, None)
+        self._tag_lookup_in_flight = False
 
         if request_id != self._latest_tag_request_id:
+            self._start_pending_lookup_if_needed()
             return
 
         current_token = self._extract_last_token(self.ui.lineEditSearch.text())
         if current_token.casefold() != token.casefold():
+            self._start_pending_lookup_if_needed()
             return
 
+        self._show_tag_suggestions(token, suggestions)
+        self._start_pending_lookup_if_needed()
+
+    def _on_tag_suggestions_failed(self, request_id: int, token: str, error_message: str) -> None:
+        """バックグラウンド候補取得失敗時のハンドリング。"""
+        self._active_tag_workers.pop(request_id, None)
+        self._tag_lookup_in_flight = False
+        logger.warning("Tag suggestion lookup failed: request_id={}, token='{}', error={}", request_id, token, error_message)
+        self._start_pending_lookup_if_needed()
+
+    def _start_pending_lookup_if_needed(self) -> None:
+        """in-flight完了後に保留中トークンがあれば検索を再開する。"""
+        if self._tag_lookup_in_flight or self._pending_tag_token is None or self.tag_suggestion_service is None:
+            return
+        pending_token = self._pending_tag_token
+        self._pending_tag_token = None
+        if len(pending_token) < self.tag_suggestion_service.min_chars:
+            self._clear_tag_suggestions()
+            return
+        self._start_tag_lookup(pending_token)
+
+    def _show_tag_suggestions(self, token: str, suggestions: list[str]) -> None:
+        """候補モデル更新と completer ポップアップ表示。"""
         self._tag_completer_model.setStringList(suggestions)
         if suggestions and self.ui.lineEditSearch.hasFocus():
             self._tag_completer.setCompletionPrefix(token)
@@ -293,7 +342,16 @@ class FilterSearchPanel(QScrollArea):
         """タグ候補をクリアしてデバウンスタイマーを停止する。"""
         self._tag_suggestion_timer.stop()
         self._latest_tag_request_id = self._tag_request_sequence
+        self._pending_tag_token = None
         self._tag_completer_model.setStringList([])
+
+    def closeEvent(self, event: QCloseEvent) -> None:
+        """ウィジェット破棄時にタグ候補スレッドプールをクリーンアップする。"""
+        self._tag_suggestion_timer.stop()
+        self._pending_tag_token = None
+        self._active_tag_workers.clear()
+        self._tag_suggestion_thread_pool.waitForDone(1000)
+        super().closeEvent(event)
 
     def _on_tag_completion_activated(self, selected_tag: str) -> None:
         """候補選択時にカンマ区切り入力の最後のトークンを置換する。

--- a/src/lorairo/services/tag_suggestion_service.py
+++ b/src/lorairo/services/tag_suggestion_service.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+import inspect
 from collections import OrderedDict
 from time import monotonic
 from typing import TYPE_CHECKING, Any
@@ -85,18 +86,24 @@ class TagSuggestionService:
             from genai_tag_db_tools import search_tags
             from genai_tag_db_tools.models import TagSearchRequest
 
-            request = TagSearchRequest(
-                query=query,
-                partial=True,
-                resolve_preferred=False,
-                include_aliases=True,
-                include_deprecated=False,
-            )
+            request_kwargs: dict[str, Any] = {
+                "query": query,
+                "partial": True,
+                "resolve_preferred": False,
+                "include_aliases": True,
+                "include_deprecated": False,
+            }
+            if self._supports_limit_parameter(TagSearchRequest):
+                request_kwargs["limit"] = self.max_results
+
+            request = TagSearchRequest(**request_kwargs)
             result = search_tags(self._merged_reader, request)
 
             # TagSearchResult.items は list[TagRecordPublic]、各 item.tag がタグ文字列
-            candidates: list[str] = []
+            prefix_matches: list[str] = []
+            partial_matches: list[str] = []
             seen: set[str] = set()
+            query_key = query.casefold()
             for item in result.items:
                 tag_name = self._extract_tag_name(item)
                 if not tag_name:
@@ -105,15 +112,34 @@ class TagSuggestionService:
                 if key in seen:
                     continue
                 seen.add(key)
-                candidates.append(tag_name)
-                if len(candidates) >= self.max_results:
+
+                if key.startswith(query_key):
+                    prefix_matches.append(tag_name)
+                else:
+                    partial_matches.append(tag_name)
+
+                if len(prefix_matches) + len(partial_matches) >= self.max_results:
                     break
 
-            return candidates
+            return (prefix_matches + partial_matches)[: self.max_results]
 
         except Exception as e:
             logger.warning("タグ候補取得に失敗: query='{}', error={}", query, e)
             return []
+
+    @staticmethod
+    def _supports_limit_parameter(tag_search_request_cls: type) -> bool:
+        """TagSearchRequest が limit パラメータを受け付けるか判定する。"""
+        model_fields = getattr(tag_search_request_cls, "model_fields", None)
+        if isinstance(model_fields, dict):
+            return "limit" in model_fields
+
+        try:
+            signature = inspect.signature(tag_search_request_cls)
+        except (TypeError, ValueError):
+            return False
+
+        return "limit" in signature.parameters
 
     @staticmethod
     def _extract_tag_name(item: Any) -> str | None:

--- a/src/lorairo/services/tag_suggestion_service.py
+++ b/src/lorairo/services/tag_suggestion_service.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import inspect
 from collections import OrderedDict
+from threading import RLock
 from time import monotonic
 from typing import TYPE_CHECKING, Any
 
@@ -48,6 +49,7 @@ class TagSuggestionService:
         self.max_results = max_results
         self._cache_size = cache_size
         self._cache_ttl = cache_ttl_seconds
+        self._cache_lock = RLock()
         # OrderedDict で LRU + TTL キャッシュを実装: key -> (timestamp, list[str])
         self._cache: OrderedDict[str, tuple[float, list[str]]] = OrderedDict()
 
@@ -72,13 +74,40 @@ class TagSuggestionService:
         if cached is not None:
             return cached
 
-        suggestions = self._search_tags(normalized)
+        subset = self._get_cached_subset(normalized)
+        if subset is not None:
+            self._set_cache(cache_key, subset)
+            return subset
+
+        suggestions = self._rank_candidates(normalized, self._search_tags(normalized))
         self._set_cache(cache_key, suggestions)
         return suggestions
 
     def clear_cache(self) -> None:
         """キャッシュをクリアする。"""
-        self._cache.clear()
+        with self._cache_lock:
+            self._cache.clear()
+
+    def get_cached_suggestions(self, query: str) -> list[str] | None:
+        """キャッシュのみを利用して候補を返す（UIスレッド高速表示用）。"""
+        if self._merged_reader is None:
+            return []
+
+        normalized = query.strip()
+        if len(normalized) < self.min_chars:
+            return []
+
+        cache_key = normalized.casefold()
+        cached = self._get_cache(cache_key)
+        if cached is not None:
+            return cached
+
+        subset = self._get_cached_subset(normalized)
+        if subset is not None:
+            self._set_cache(cache_key, subset)
+            return subset
+
+        return None
 
     def _search_tags(self, query: str) -> list[str]:
         """genai-tag-db-tools で タグ検索を実行する。"""
@@ -100,10 +129,8 @@ class TagSuggestionService:
             result = search_tags(self._merged_reader, request)
 
             # TagSearchResult.items は list[TagRecordPublic]、各 item.tag がタグ文字列
-            prefix_matches: list[str] = []
-            partial_matches: list[str] = []
+            candidates: list[str] = []
             seen: set[str] = set()
-            query_key = query.casefold()
             for item in result.items:
                 tag_name = self._extract_tag_name(item)
                 if not tag_name:
@@ -112,16 +139,8 @@ class TagSuggestionService:
                 if key in seen:
                     continue
                 seen.add(key)
-
-                if key.startswith(query_key):
-                    prefix_matches.append(tag_name)
-                else:
-                    partial_matches.append(tag_name)
-
-                if len(prefix_matches) + len(partial_matches) >= self.max_results:
-                    break
-
-            return (prefix_matches + partial_matches)[: self.max_results]
+                candidates.append(tag_name)
+            return candidates
 
         except Exception as e:
             logger.warning("タグ候補取得に失敗: query='{}', error={}", query, e)
@@ -164,23 +183,63 @@ class TagSuggestionService:
 
     def _get_cache(self, key: str) -> list[str] | None:
         """キャッシュからエントリを取得する（TTL チェック込み）。"""
-        if key not in self._cache:
-            return None
+        with self._cache_lock:
+            if key not in self._cache:
+                return None
 
-        created_at, data = self._cache[key]
-        if monotonic() - created_at > self._cache_ttl:
-            del self._cache[key]
-            return None
+            created_at, data = self._cache[key]
+            if monotonic() - created_at > self._cache_ttl:
+                del self._cache[key]
+                return None
 
-        # LRU: 最近アクセスしたエントリを末尾へ移動
-        self._cache.move_to_end(key)
-        return data
+            # LRU: 最近アクセスしたエントリを末尾へ移動
+            self._cache.move_to_end(key)
+            return data
 
     def _set_cache(self, key: str, suggestions: list[str]) -> None:
         """キャッシュにエントリを追加する（LRU サイズ制限付き）。"""
-        self._cache[key] = (monotonic(), suggestions)
-        self._cache.move_to_end(key)
+        with self._cache_lock:
+            self._cache[key] = (monotonic(), suggestions)
+            self._cache.move_to_end(key)
 
-        # LRU: サイズ超過時は最古のエントリを削除
-        while len(self._cache) > self._cache_size:
-            self._cache.popitem(last=False)
+            # LRU: サイズ超過時は最古のエントリを削除
+            while len(self._cache) > self._cache_size:
+                self._cache.popitem(last=False)
+
+    def _get_cached_subset(self, query: str) -> list[str] | None:
+        """既存キャッシュから query の部分集合候補を作成する。"""
+        query_key = query.casefold()
+        for length in range(len(query_key) - 1, self.min_chars - 1, -1):
+            prefix_key = query_key[:length]
+            if prefix_key == query_key:
+                continue
+            cached = self._get_cache(prefix_key)
+            if cached is None:
+                continue
+            return self._rank_candidates(query, cached)
+        return None
+
+    def _rank_candidates(self, query: str, candidates: list[str]) -> list[str]:
+        """候補を exact > prefix > contains の順で並べ替える。"""
+        exact_matches: list[str] = []
+        prefix_matches: list[str] = []
+        contains_matches: list[str] = []
+        query_key = query.casefold()
+        seen: set[str] = set()
+
+        for tag_name in candidates:
+            key = tag_name.casefold()
+            if key in seen or query_key not in key:
+                continue
+            seen.add(key)
+            if key == query_key:
+                exact_matches.append(tag_name)
+            elif key.startswith(query_key):
+                prefix_matches.append(tag_name)
+            else:
+                contains_matches.append(tag_name)
+
+            if len(exact_matches) + len(prefix_matches) + len(contains_matches) >= self.max_results:
+                break
+
+        return (exact_matches + prefix_matches + contains_matches)[: self.max_results]

--- a/tests/unit/gui/widgets/test_filter_search_panel_autocomplete.py
+++ b/tests/unit/gui/widgets/test_filter_search_panel_autocomplete.py
@@ -1,6 +1,8 @@
 # tests/unit/gui/widgets/test_filter_search_panel_autocomplete.py
 # FilterSearchPanel のタグオートコンプリート機能テスト。
 
+from unittest.mock import MagicMock
+
 import pytest
 from PySide6.QtWidgets import QCompleter
 
@@ -71,8 +73,6 @@ class TestTagSuggestionServiceInjection:
 
     def test_set_tag_suggestion_service(self, panel):
         """set_tag_suggestion_service でサービスが設定される。"""
-        from unittest.mock import MagicMock
-
         mock_service = MagicMock()
         panel.set_tag_suggestion_service(mock_service)
 
@@ -117,4 +117,34 @@ class TestClearTagSuggestions:
         assert panel._tag_suggestion_timer.isActive()
 
         panel._clear_tag_suggestions()
+        assert not panel._tag_suggestion_timer.isActive()
+
+
+class TestCacheFirstAutocomplete:
+    """キャッシュ優先で候補表示する動作テスト。"""
+
+    def test_cached_suggestions_shown_without_timer(self, panel):
+        mock_service = MagicMock()
+        mock_service.min_chars = 2
+        mock_service.get_cached_suggestions.return_value = ["blue_hair", "blush"]
+        panel.set_tag_suggestion_service(mock_service)
+        panel.ui.checkboxTags.setChecked(True)
+        panel.ui.lineEditSearch.setEnabled(True)
+
+        panel._on_search_text_edited("bl")
+
+        assert panel._tag_completer_model.stringList() == ["blue_hair", "blush"]
+        assert not panel._tag_suggestion_timer.isActive()
+
+
+class TestWidgetCloseCleanup:
+    """closeEvent 時のクリーンアップ動作。"""
+
+    def test_close_event_stops_timer_and_clears_pending(self, panel):
+        panel._pending_tag_token = "blue"
+        panel._tag_suggestion_timer.start(5000)
+
+        panel.close()
+
+        assert panel._pending_tag_token is None
         assert not panel._tag_suggestion_timer.isActive()

--- a/tests/unit/services/test_tag_suggestion_service.py
+++ b/tests/unit/services/test_tag_suggestion_service.py
@@ -26,7 +26,13 @@ class _FakeResult:
         self.items = items
 
 
-def _make_fake_genai(items: list, call_counter: dict | None = None) -> tuple:
+def _make_fake_genai(
+    items: list,
+    call_counter: dict | None = None,
+    request_sink: dict | None = None,
+    *,
+    supports_limit: bool = False,
+) -> tuple:
     """genai_tag_db_tools のモジュールモックと呼び出しカウンターを返す。"""
 
     def fake_search_tags(_reader, _request):
@@ -34,17 +40,54 @@ def _make_fake_genai(items: list, call_counter: dict | None = None) -> tuple:
             call_counter["count"] = call_counter.get("count", 0) + 1
         return _FakeResult(items)
 
-    fake_models = types.SimpleNamespace(TagSearchRequest=lambda **kwargs: kwargs)
+    if supports_limit:
+        fake_models = types.SimpleNamespace(TagSearchRequest=lambda **kwargs: kwargs)
+    else:
+        fake_models = types.SimpleNamespace(TagSearchRequest=_make_tag_search_request_without_limit(request_sink))
+
+    if request_sink is not None and supports_limit:
+        fake_models.TagSearchRequest = _make_tag_search_request_with_limit(request_sink)
+
     fake_module = types.SimpleNamespace(search_tags=fake_search_tags)
     return fake_module, fake_models
+
+
+def _make_tag_search_request_with_limit(request_sink: dict):
+    def _factory(**kwargs):
+        request_sink["kwargs"] = kwargs
+        return kwargs
+
+    _factory.model_fields = {"query": object(), "limit": object()}
+    return _factory
+
+
+def _make_tag_search_request_without_limit(request_sink: dict | None):
+    def _factory(**kwargs):
+        if request_sink is not None:
+            request_sink["kwargs"] = kwargs
+        return kwargs
+
+    _factory.model_fields = {"query": object()}
+    return _factory
 
 
 @pytest.fixture()
 def patch_genai(monkeypatch):
     """genai_tag_db_tools をモジュールレベルでモックするフィクスチャ。"""
 
-    def _patch(items: list, call_counter: dict | None = None):
-        fake_module, fake_models = _make_fake_genai(items, call_counter)
+    def _patch(
+        items: list,
+        call_counter: dict | None = None,
+        request_sink: dict | None = None,
+        *,
+        supports_limit: bool = False,
+    ):
+        fake_module, fake_models = _make_fake_genai(
+            items,
+            call_counter,
+            request_sink,
+            supports_limit=supports_limit,
+        )
         monkeypatch.setitem(sys.modules, "genai_tag_db_tools", fake_module)
         monkeypatch.setitem(sys.modules, "genai_tag_db_tools.models", fake_models)
 
@@ -142,6 +185,32 @@ class TestTagSuggestionServiceMaxResults:
         result = service.get_suggestions("gi")
 
         assert result.count("1girl") == 1
+
+    def test_prefix_matches_prioritized(self, patch_genai):
+        patch_genai([_FakeItem("blue_hair"), _FakeItem("long_blue_hair"), _FakeItem("blush")])
+
+        service = TagSuggestionService(object(), max_results=5)
+        result = service.get_suggestions("bl")
+
+        assert result == ["blue_hair", "blush", "long_blue_hair"]
+
+    def test_limit_passed_when_supported(self, patch_genai):
+        request_sink: dict = {}
+        patch_genai([_FakeItem("blue_hair")], request_sink=request_sink, supports_limit=True)
+
+        service = TagSuggestionService(object(), max_results=7)
+        _ = service.get_suggestions("bl")
+
+        assert request_sink["kwargs"]["limit"] == 7
+
+    def test_limit_not_passed_when_unsupported(self, patch_genai):
+        request_sink: dict = {}
+        patch_genai([_FakeItem("blue_hair")], request_sink=request_sink, supports_limit=False)
+
+        service = TagSuggestionService(object(), max_results=7)
+        _ = service.get_suggestions("bl")
+
+        assert "limit" not in request_sink["kwargs"]
 
 
 class TestExtractTagName:

--- a/tests/unit/services/test_tag_suggestion_service.py
+++ b/tests/unit/services/test_tag_suggestion_service.py
@@ -135,6 +135,35 @@ class TestTagSuggestionServiceCache:
         assert "bb" in service._cache
         assert "cc" in service._cache
 
+    def test_get_cached_subset_reuses_prefix_cache(self, patch_genai):
+        counter: dict = {}
+        patch_genai([_FakeItem("blue_hair"), _FakeItem("blush"), _FakeItem("solo")], counter)
+
+        service = TagSuggestionService(object(), cache_ttl_seconds=60)
+        first = service.get_suggestions("bl")
+        second = service.get_suggestions("blu")
+
+        assert first == ["blue_hair", "blush"]
+        assert second == ["blue_hair"]
+        assert counter["count"] == 1
+
+    def test_get_cached_suggestions_returns_none_when_cache_miss(self, patch_genai):
+        patch_genai([_FakeItem("blue_hair")])
+        service = TagSuggestionService(object(), cache_ttl_seconds=60)
+        assert service.get_cached_suggestions("bl") is None
+
+    def test_get_cached_suggestions_uses_subset_without_db(self, patch_genai):
+        counter: dict = {}
+        patch_genai([_FakeItem("blue_hair"), _FakeItem("blush")], counter)
+        service = TagSuggestionService(object(), cache_ttl_seconds=60)
+        _ = service.get_suggestions("bl")
+        before = counter["count"]
+
+        cached = service.get_cached_suggestions("blu")
+
+        assert cached == ["blue_hair"]
+        assert counter["count"] == before
+
 
 class TestTagSuggestionServiceMinChars:
     """最小文字数チェックのテスト。"""
@@ -187,12 +216,12 @@ class TestTagSuggestionServiceMaxResults:
         assert result.count("1girl") == 1
 
     def test_prefix_matches_prioritized(self, patch_genai):
-        patch_genai([_FakeItem("blue_hair"), _FakeItem("long_blue_hair"), _FakeItem("blush")])
+        patch_genai([_FakeItem("bl"), _FakeItem("blue_hair"), _FakeItem("long_blue_hair"), _FakeItem("blush")])
 
         service = TagSuggestionService(object(), max_results=5)
         result = service.get_suggestions("bl")
 
-        assert result == ["blue_hair", "blush", "long_blue_hair"]
+        assert result == ["bl", "blue_hair", "blush", "long_blue_hair"]
 
     def test_limit_passed_when_supported(self, patch_genai):
         request_sink: dict = {}


### PR DESCRIPTION
### Motivation
- Improve responsiveness of tag autocomplete by avoiding blocking the GUI thread during DB lookups.
- Make autocomplete results more relevant by prioritizing prefix matches over mid-string matches.
- Support newer `genai-tag-db-tools` that accept a `limit` parameter while remaining compatible with older versions.

### Description
- Run tag lookup off the GUI thread by adding `_TagSuggestionWorker` (`QRunnable`) and using `QThreadPool` in `FilterSearchPanel`, plus request sequencing to ignore stale async responses.
- Update UI flow to apply completions only when the token still matches the worker response and to cancel/clear stale requests when appropriate.
- Enhance `TagSuggestionService` to optionally pass `limit=self.max_results` when `TagSearchRequest` supports it and to return prefix matches first followed by partial matches while preserving deduplication.
- Add unit test coverage for prefix-priority ordering and both `limit`-supported and `limit`-unsupported `TagSearchRequest` cases, and update test fixtures accordingly (modified files: `src/lorairo/gui/widgets/filter_search_panel.py`, `src/lorairo/services/tag_suggestion_service.py`, `tests/unit/services/test_tag_suggestion_service.py`).

### Testing
- `python -m py_compile src/lorairo/services/tag_suggestion_service.py src/lorairo/gui/widgets/filter_search_panel.py tests/unit/services/test_tag_suggestion_service.py` succeeded.
- `python -m ruff check src/lorairo/services/tag_suggestion_service.py src/lorairo/gui/widgets/filter_search_panel.py tests/unit/services/test_tag_suggestion_service.py` reported an existing complexity warning (`C901`) for a separate function (`_on_search_requested`).
- `uv run pytest tests/unit/services/test_tag_suggestion_service.py tests/unit/gui/widgets/test_filter_search_panel_autocomplete.py` could not complete due to local editable package metadata issues (`local_packages/image-annotator-lib` missing `pyproject.toml`).
- `python -m pytest` runs were blocked by missing environment dependencies (errors loading `conftest.py` due to missing packages such as `sqlalchemy`/`toml`), so full test execution could not be completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bb3a2d3b90832983af5f22f322da0e)