### PR TITLE
feat: make tag autocomplete non-blocking and cache-safe

### DIFF
--- a/src/lorairo/gui/widgets/filter_search_panel.py
+++ b/src/lorairo/gui/widgets/filter_search_panel.py
@@ -4,7 +4,8 @@ from datetime import datetime
 from enum import Enum
 from typing import TYPE_CHECKING, Any
 
-from PySide6.QtCore import QStringListModel, Qt, QTimer, Signal
+from PySide6.QtCore import QObject, QRunnable, QStringListModel, Qt, QThreadPool, QTimer, Signal, Slot
+from PySide6.QtGui import QCloseEvent
 from PySide6.QtWidgets import QCompleter, QScrollArea
 
 from ...gui.designer.FilterSearchPanel_ui import Ui_FilterSearchPanel
@@ -12,9 +13,9 @@ from ...utils.log import logger
 from .custom_range_slider import CustomRangeSlider
 
 if TYPE_CHECKING:
+    from ...services.search_models import SearchConditions
     from ...services.tag_suggestion_service import TagSuggestionService
     from ..services.search_filter_service import SearchFilterService
-    from ...services.search_models import SearchConditions
     from ..services.worker_service import WorkerService
 
 
@@ -27,6 +28,27 @@ class PipelineState(Enum):
     DISPLAYING = "displaying"  # 結果表示中
     ERROR = "error"  # エラー状態
     CANCELED = "canceled"  # キャンセル状態
+
+
+class _TagSuggestionSignals(QObject):
+    finished = Signal(str, list)
+    failed = Signal(str, str)
+
+
+class _TagSuggestionTask(QRunnable):
+    def __init__(self, service: "TagSuggestionService", token: str) -> None:
+        super().__init__()
+        self.service = service
+        self.token = token
+        self.signals = _TagSuggestionSignals()
+
+    @Slot()
+    def run(self) -> None:
+        try:
+            suggestions = self.service.get_suggestions(self.token)
+            self.signals.finished.emit(self.token, suggestions)
+        except Exception as exc:  # pragma: no cover - safety net
+            self.signals.failed.emit(self.token, str(exc))
 
 
 class FilterSearchPanel(QScrollArea):
@@ -67,6 +89,11 @@ class FilterSearchPanel(QScrollArea):
         self._tag_suggestion_timer = QTimer(self)
         self._tag_suggestion_timer.setSingleShot(True)
         self._tag_suggestion_timer.setInterval(300)
+        self._tag_lookup_pool = QThreadPool(self)
+        self._tag_lookup_pool.setMaxThreadCount(1)
+        self._tag_lookup_in_flight = False
+        self._active_lookup_token: str | None = None
+        self._pending_lookup_token: str | None = None
 
         # 現在のSearchWorkerのID
         self._current_search_worker_id: str | None = None
@@ -235,7 +262,65 @@ class FilterSearchPanel(QScrollArea):
             return
 
         token = self._extract_last_token(self.ui.lineEditSearch.text())
-        suggestions = self.tag_suggestion_service.get_suggestions(token)
+        if len(token) < self.tag_suggestion_service.min_chars:
+            self._clear_tag_suggestions()
+            return
+
+        cached = self.tag_suggestion_service.get_cached_suggestions(token)
+        if cached is not None:
+            self._apply_tag_suggestions(token, cached)
+            return
+
+        cached_subset = self.tag_suggestion_service.get_cached_subset(token)
+        if cached_subset is not None:
+            self._apply_tag_suggestions(token, cached_subset)
+            return
+
+        if self._tag_lookup_in_flight:
+            self._pending_lookup_token = token
+            return
+
+        self._start_tag_lookup(token)
+
+    def _start_tag_lookup(self, token: str) -> None:
+        """タグ候補検索タスクをワーカースレッドで開始する。"""
+        if self.tag_suggestion_service is None:
+            return
+
+        self._tag_lookup_in_flight = True
+        self._active_lookup_token = token
+        task = _TagSuggestionTask(self.tag_suggestion_service, token)
+        task.signals.finished.connect(self._on_tag_lookup_finished)
+        task.signals.failed.connect(self._on_tag_lookup_failed)
+        self._tag_lookup_pool.start(task)
+
+    def _on_tag_lookup_finished(self, token: str, suggestions: list[str]) -> None:
+        """タグ候補検索成功時の処理。"""
+        self._tag_lookup_in_flight = False
+        self._active_lookup_token = None
+
+        current_token = self._extract_last_token(self.ui.lineEditSearch.text())
+        if token == current_token:
+            self._apply_tag_suggestions(token, suggestions)
+
+        self._drain_pending_tag_lookup(token)
+
+    def _on_tag_lookup_failed(self, token: str, error: str) -> None:
+        """タグ候補検索失敗時の処理。"""
+        logger.warning("Tag suggestion lookup failed: token='{}', error={}", token, error)
+        self._tag_lookup_in_flight = False
+        self._active_lookup_token = None
+        self._drain_pending_tag_lookup(token)
+
+    def _drain_pending_tag_lookup(self, completed_token: str) -> None:
+        """保留中の検索要求があれば次の検索を開始する。"""
+        pending = self._pending_lookup_token
+        self._pending_lookup_token = None
+        if pending and pending != completed_token:
+            self._start_tag_lookup(pending)
+
+    def _apply_tag_suggestions(self, token: str, suggestions: list[str]) -> None:
+        """補完候補をモデルへ適用してポップアップを表示する。"""
         self._tag_completer_model.setStringList(suggestions)
 
         if suggestions and self.ui.lineEditSearch.hasFocus():
@@ -248,6 +333,7 @@ class FilterSearchPanel(QScrollArea):
         """タグ候補をクリアしてデバウンスタイマーを停止する。"""
         self._tag_suggestion_timer.stop()
         self._tag_completer_model.setStringList([])
+        self._pending_lookup_token = None
 
     def _on_tag_completion_activated(self, selected_tag: str) -> None:
         """候補選択時にカンマ区切り入力の最後のトークンを置換する。
@@ -264,6 +350,13 @@ class FilterSearchPanel(QScrollArea):
 
         self.ui.lineEditSearch.setText(new_text)
         self.ui.lineEditSearch.setCursorPosition(len(new_text))
+
+    def closeEvent(self, event: QCloseEvent) -> None:
+        """終了時にタグ候補検索ワーカーをクリーンアップする。"""
+        self._clear_tag_suggestions()
+        self._tag_lookup_pool.clear()
+        self._tag_lookup_pool.waitForDone(1000)
+        super().closeEvent(event)
 
     def setup_favorite_filters_ui(self) -> None:
         """お気に入りフィルターUIを作成してメインレイアウトに追加 (Phase 4)"""

--- a/src/lorairo/services/tag_suggestion_service.py
+++ b/src/lorairo/services/tag_suggestion_service.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 from collections import OrderedDict
+from threading import RLock
 from time import monotonic
 from typing import TYPE_CHECKING, Any
 
@@ -49,6 +50,7 @@ class TagSuggestionService:
         self._cache_ttl = cache_ttl_seconds
         # OrderedDict で LRU + TTL キャッシュを実装: key -> (timestamp, list[str])
         self._cache: OrderedDict[str, tuple[float, list[str]]] = OrderedDict()
+        self._cache_lock = RLock()
 
     def get_suggestions(self, query: str) -> list[str]:
         """入力文字列からタグ候補一覧を取得する。
@@ -67,9 +69,14 @@ class TagSuggestionService:
             return []
 
         cache_key = normalized.casefold()
-        cached = self._get_cache(cache_key)
+        cached = self.get_cached_suggestions(normalized)
         if cached is not None:
             return cached
+
+        cached_subset = self.get_cached_subset(normalized)
+        if cached_subset is not None:
+            self._set_cache(cache_key, cached_subset)
+            return cached_subset
 
         suggestions = self._search_tags(normalized)
         self._set_cache(cache_key, suggestions)
@@ -77,7 +84,44 @@ class TagSuggestionService:
 
     def clear_cache(self) -> None:
         """キャッシュをクリアする。"""
-        self._cache.clear()
+        with self._cache_lock:
+            self._cache.clear()
+
+    def get_cached_suggestions(self, query: str) -> list[str] | None:
+        """完全一致キーでキャッシュ済み候補を取得する。"""
+        normalized = query.strip()
+        if len(normalized) < self.min_chars:
+            return None
+        return self._get_cache(normalized.casefold())
+
+    def get_cached_subset(self, query: str) -> list[str] | None:
+        """既存キャッシュの部分集合から候補を再利用する。"""
+        normalized = query.strip()
+        if len(normalized) < self.min_chars:
+            return None
+
+        target = normalized.casefold()
+        with self._cache_lock:
+            now = monotonic()
+            best_key: str | None = None
+            best_data: list[str] | None = None
+
+            for key, (created_at, data) in list(self._cache.items()):
+                if now - created_at > self._cache_ttl:
+                    del self._cache[key]
+                    continue
+                if not target.startswith(key):
+                    continue
+                if best_key is None or len(key) > len(best_key):
+                    best_key = key
+                    best_data = data
+
+            if best_key is None or best_data is None:
+                return None
+
+            self._cache.move_to_end(best_key)
+
+        return self._filter_and_rank(target, best_data)
 
     def _search_tags(self, query: str) -> list[str]:
         """genai-tag-db-tools で タグ検索を実行する。"""
@@ -85,13 +129,20 @@ class TagSuggestionService:
             from genai_tag_db_tools import search_tags
             from genai_tag_db_tools.models import TagSearchRequest
 
-            request = TagSearchRequest(
-                query=query,
-                partial=True,
-                resolve_preferred=False,
-                include_aliases=True,
-                include_deprecated=False,
-            )
+            request_kwargs = {
+                "query": query,
+                "partial": True,
+                "resolve_preferred": False,
+                "include_aliases": True,
+                "include_deprecated": False,
+                "limit": self.max_results,
+            }
+            try:
+                request = TagSearchRequest(**request_kwargs)
+            except TypeError:
+                # 古い API では limit を受け付けないためフォールバックする
+                request_kwargs.pop("limit", None)
+                request = TagSearchRequest(**request_kwargs)
             result = search_tags(self._merged_reader, request)
 
             # TagSearchResult.items は list[TagRecordPublic]、各 item.tag がタグ文字列
@@ -109,7 +160,7 @@ class TagSuggestionService:
                 if len(candidates) >= self.max_results:
                     break
 
-            return candidates
+            return self._filter_and_rank(query.casefold(), candidates)
 
         except Exception as e:
             logger.warning("タグ候補取得に失敗: query='{}', error={}", query, e)
@@ -138,23 +189,44 @@ class TagSuggestionService:
 
     def _get_cache(self, key: str) -> list[str] | None:
         """キャッシュからエントリを取得する（TTL チェック込み）。"""
-        if key not in self._cache:
-            return None
+        with self._cache_lock:
+            if key not in self._cache:
+                return None
 
-        created_at, data = self._cache[key]
-        if monotonic() - created_at > self._cache_ttl:
-            del self._cache[key]
-            return None
+            created_at, data = self._cache[key]
+            if monotonic() - created_at > self._cache_ttl:
+                del self._cache[key]
+                return None
 
-        # LRU: 最近アクセスしたエントリを末尾へ移動
-        self._cache.move_to_end(key)
-        return data
+            # LRU: 最近アクセスしたエントリを末尾へ移動
+            self._cache.move_to_end(key)
+            return data
 
     def _set_cache(self, key: str, suggestions: list[str]) -> None:
         """キャッシュにエントリを追加する（LRU サイズ制限付き）。"""
-        self._cache[key] = (monotonic(), suggestions)
-        self._cache.move_to_end(key)
+        with self._cache_lock:
+            self._cache[key] = (monotonic(), suggestions)
+            self._cache.move_to_end(key)
 
-        # LRU: サイズ超過時は最古のエントリを削除
-        while len(self._cache) > self._cache_size:
-            self._cache.popitem(last=False)
+            # LRU: サイズ超過時は最古のエントリを削除
+            while len(self._cache) > self._cache_size:
+                self._cache.popitem(last=False)
+
+    def _filter_and_rank(self, query_key: str, candidates: list[str]) -> list[str]:
+        """候補をクエリ関連度でソートし、max_results に制限する。"""
+        if not query_key:
+            return candidates[: self.max_results]
+
+        def _rank(tag: str) -> tuple[int, str]:
+            key = tag.casefold()
+            if key == query_key:
+                return (0, key)
+            if key.startswith(query_key):
+                return (1, key)
+            if query_key in key:
+                return (2, key)
+            return (3, key)
+
+        filtered = [tag for tag in candidates if query_key in tag.casefold()]
+        filtered.sort(key=_rank)
+        return filtered[: self.max_results]

--- a/tests/unit/gui/widgets/test_filter_search_panel_autocomplete.py
+++ b/tests/unit/gui/widgets/test_filter_search_panel_autocomplete.py
@@ -118,3 +118,41 @@ class TestClearTagSuggestions:
 
         panel._clear_tag_suggestions()
         assert not panel._tag_suggestion_timer.isActive()
+
+
+class TestAsyncAutocompleteFlow:
+    """非同期オートコンプリート制御のテスト。"""
+
+    def test_cache_first_avoids_async_lookup(self, panel, monkeypatch):
+        from unittest.mock import MagicMock
+
+        service = MagicMock()
+        service.min_chars = 2
+        service.get_cached_suggestions.return_value = ["blue_hair", "blue_eyes"]
+        service.get_cached_subset.return_value = None
+        service.get_suggestions.side_effect = AssertionError("should not call get_suggestions")
+        panel.set_tag_suggestion_service(service)
+        panel.ui.lineEditSearch.setText("blu")
+
+        started: list[str] = []
+        monkeypatch.setattr(panel, "_start_tag_lookup", lambda token: started.append(token))
+
+        panel._update_tag_completions()
+
+        assert started == []
+        assert panel._tag_completer_model.stringList() == ["blue_hair", "blue_eyes"]
+
+    def test_queues_pending_request_while_lookup_in_flight(self, panel):
+        from unittest.mock import MagicMock
+
+        service = MagicMock()
+        service.min_chars = 2
+        service.get_cached_suggestions.return_value = None
+        service.get_cached_subset.return_value = None
+        panel.set_tag_suggestion_service(service)
+        panel._tag_lookup_in_flight = True
+        panel.ui.lineEditSearch.setText("blue")
+
+        panel._update_tag_completions()
+
+        assert panel._pending_lookup_token == "blue"

--- a/tests/unit/services/test_tag_suggestion_service.py
+++ b/tests/unit/services/test_tag_suggestion_service.py
@@ -26,12 +26,14 @@ class _FakeResult:
         self.items = items
 
 
-def _make_fake_genai(items: list, call_counter: dict | None = None) -> tuple:
+def _make_fake_genai(items: list, call_counter: dict | None = None, request_store: dict | None = None) -> tuple:
     """genai_tag_db_tools のモジュールモックと呼び出しカウンターを返す。"""
 
     def fake_search_tags(_reader, _request):
         if call_counter is not None:
             call_counter["count"] = call_counter.get("count", 0) + 1
+        if request_store is not None:
+            request_store["request"] = _request
         return _FakeResult(items)
 
     fake_models = types.SimpleNamespace(TagSearchRequest=lambda **kwargs: kwargs)
@@ -43,8 +45,8 @@ def _make_fake_genai(items: list, call_counter: dict | None = None) -> tuple:
 def patch_genai(monkeypatch):
     """genai_tag_db_tools をモジュールレベルでモックするフィクスチャ。"""
 
-    def _patch(items: list, call_counter: dict | None = None):
-        fake_module, fake_models = _make_fake_genai(items, call_counter)
+    def _patch(items: list, call_counter: dict | None = None, request_store: dict | None = None):
+        fake_module, fake_models = _make_fake_genai(items, call_counter, request_store)
         monkeypatch.setitem(sys.modules, "genai_tag_db_tools", fake_module)
         monkeypatch.setitem(sys.modules, "genai_tag_db_tools.models", fake_models)
 
@@ -91,6 +93,19 @@ class TestTagSuggestionServiceCache:
         assert "aa" not in service._cache
         assert "bb" in service._cache
         assert "cc" in service._cache
+
+    def test_incremental_query_reuses_cached_subset(self, patch_genai):
+        """連続入力時に既存キャッシュの部分集合が再利用される。"""
+        counter: dict = {}
+        patch_genai([_FakeItem("blue_hair"), _FakeItem("blue_eyes"), _FakeItem("black_hair")], counter)
+
+        service = TagSuggestionService(object(), cache_ttl_seconds=60)
+        first = service.get_suggestions("bl")
+        second = service.get_suggestions("blu")
+
+        assert first == ["black_hair", "blue_eyes", "blue_hair"]
+        assert second == ["blue_eyes", "blue_hair"]
+        assert counter["count"] == 1
 
 
 class TestTagSuggestionServiceMinChars:
@@ -142,6 +157,16 @@ class TestTagSuggestionServiceMaxResults:
         result = service.get_suggestions("gi")
 
         assert result.count("1girl") == 1
+
+    def test_limit_is_passed_to_search_request(self, patch_genai):
+        """DB 側の limit パラメータが TagSearchRequest に渡される。"""
+        request_store: dict = {}
+        patch_genai([_FakeItem("tag_1"), _FakeItem("tag_2")], request_store=request_store)
+
+        service = TagSuggestionService(object(), max_results=7)
+        service.get_suggestions("ta")
+
+        assert request_store["request"]["limit"] == 7
 
 
 class TestExtractTagName:


### PR DESCRIPTION
### Motivation
- Tag autocomplete was blocking the GUI because synchronous DB searches were run on the main thread and repeated queries caused UI freezes and excessive DB work.
- Incremental typing caused many redundant DB lookups (multiple SQLite sources, no DB-side `limit`, and `LIKE '%...%'` scans), so reuse of cached results and limiting results at the DB side is required to reduce load.
- The implementation must be thread-safe and robust against worker exceptions and lifecycle termination to avoid deadlocks and thread leaks.

### Description
- Move autocomplete lookups off the GUI thread by adding a single-thread `QThreadPool` + `QRunnable` task (`_TagSuggestionTask`) with `finished`/`failed` signals and `try/except` in `run()` for safety, plus `closeEvent` cleanup in `FilterSearchPanel` to avoid leaks and deadlocks.
- Implement cache-first UI flow in `FilterSearchPanel._update_tag_completions()` that checks `get_cached_suggestions()` then `get_cached_subset()` before starting an async lookup, and coalesce rapid inputs via a `_pending_lookup_token` queue so only the latest pending lookup runs after completion.
- Harden `TagSuggestionService` with an `RLock` for thread-safe cache access, add `get_cached_suggestions()` and `get_cached_subset()` to reuse cached subsets for incremental queries, forward `limit=self.max_results` to `TagSearchRequest` with backward-compatible fallback if the API does not accept `limit`, and add deterministic ranking (`exact > prefix > contains`) with `_filter_and_rank()`.
- Extend unit tests to cover cached-subset reuse and `limit` forwarding on the service and to cover the panel-side cache-first and pending-request behaviors (`tests/unit/services/test_tag_suggestion_service.py` and `tests/unit/gui/widgets/test_filter_search_panel_autocomplete.py`).

### Testing
- Ran `python -m compileall src/lorairo/services/tag_suggestion_service.py src/lorairo/gui/widgets/filter_search_panel.py tests/unit/services/test_tag_suggestion_service.py tests/unit/gui/widgets/test_filter_search_panel_autocomplete.py` and compilation succeeded.
- Ran `python -m ruff check ...` over the modified files which executed but reported a pre-existing complexity rule `C901` on `_on_search_requested` (remains to be addressed separately).
- Attempted `uv run pytest tests/unit/services/test_tag_suggestion_service.py tests/unit/gui/widgets/test_filter_search_panel_autocomplete.py` which failed in this environment because `local_packages/genai-tag-db-tools` is not populated as an installable Python project.
- Attempted `python -m pytest ...` which failed in this environment due to missing test dependencies (`sqlalchemy`) so unit tests could not be executed end-to-end here; the new/updated tests are included in the PR and should pass in CI with the repository test environment configured.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bb3a2d3b90832983af5f22f322da0e)