### PR TITLE
feat: async tag autocomplete with cache-reuse and thread-safe TagSuggestionService

### DIFF
--- a/src/lorairo/gui/widgets/filter_search_panel.py
+++ b/src/lorairo/gui/widgets/filter_search_panel.py
@@ -4,7 +4,8 @@ from datetime import datetime
 from enum import Enum
 from typing import TYPE_CHECKING, Any
 
-from PySide6.QtCore import QStringListModel, Qt, QTimer, Signal
+from PySide6.QtCore import QObject, QRunnable, QStringListModel, Qt, QThreadPool, QTimer, Signal, Slot
+from PySide6.QtGui import QCloseEvent
 from PySide6.QtWidgets import QCompleter, QScrollArea
 
 from ...gui.designer.FilterSearchPanel_ui import Ui_FilterSearchPanel
@@ -16,6 +17,33 @@ if TYPE_CHECKING:
     from ..services.search_filter_service import SearchFilterService
     from ...services.search_models import SearchConditions
     from ..services.worker_service import WorkerService
+
+
+class _TagSuggestionTaskSignals(QObject):
+    """タグ候補非同期取得タスク用シグナル。"""
+
+    finished = Signal(int, str, list)
+    failed = Signal(int, str, str)
+
+
+class _TagSuggestionTask(QRunnable):
+    """タグ候補をバックグラウンドで取得する QRunnable。"""
+
+    def __init__(self, request_id: int, query: str, service: "TagSuggestionService") -> None:
+        super().__init__()
+        self.request_id = request_id
+        self.query = query
+        self.service = service
+        self.signals = _TagSuggestionTaskSignals()
+
+    @Slot()
+    def run(self) -> None:
+        """バックグラウンドで候補取得して UI スレッドへ通知する。"""
+        try:
+            suggestions = self.service.get_suggestions(self.query)
+            self.signals.finished.emit(self.request_id, self.query, suggestions)
+        except Exception as e:
+            self.signals.failed.emit(self.request_id, self.query, str(e))
 
 
 class PipelineState(Enum):
@@ -67,6 +95,11 @@ class FilterSearchPanel(QScrollArea):
         self._tag_suggestion_timer = QTimer(self)
         self._tag_suggestion_timer.setSingleShot(True)
         self._tag_suggestion_timer.setInterval(300)
+        self._tag_thread_pool = QThreadPool(self)
+        self._tag_thread_pool.setMaxThreadCount(1)
+        self._tag_lookup_in_flight = False
+        self._pending_tag_query: str | None = None
+        self._latest_tag_request_id = 0
 
         # 現在のSearchWorkerのID
         self._current_search_worker_id: str | None = None
@@ -235,7 +268,19 @@ class FilterSearchPanel(QScrollArea):
             return
 
         token = self._extract_last_token(self.ui.lineEditSearch.text())
-        suggestions = self.tag_suggestion_service.get_suggestions(token)
+        if len(token) < self.tag_suggestion_service.min_chars:
+            self._clear_tag_suggestions()
+            return
+
+        cached = self.tag_suggestion_service.get_cached_suggestions(token)
+        if cached is not None:
+            self._apply_tag_suggestions(token, cached)
+            return
+
+        self._request_tag_suggestions_async(token)
+
+    def _apply_tag_suggestions(self, token: str, suggestions: list[str]) -> None:
+        """候補をモデルへ反映し、必要なら補完ポップアップを表示する。"""
         self._tag_completer_model.setStringList(suggestions)
 
         if suggestions and self.ui.lineEditSearch.hasFocus():
@@ -243,6 +288,59 @@ class FilterSearchPanel(QScrollArea):
             # これにより "1girl, bl" 入力時も "bl" を prefix として候補をフィルタリングできる
             self._tag_completer.setCompletionPrefix(token)
             self._tag_completer.complete()
+
+    def _request_tag_suggestions_async(self, token: str) -> None:
+        """タグ候補を非同期取得する（最新入力のみ処理）。"""
+        if self.tag_suggestion_service is None:
+            return
+
+        if self._tag_lookup_in_flight:
+            self._pending_tag_query = token
+            return
+
+        self._tag_lookup_in_flight = True
+        self._pending_tag_query = None
+        self._latest_tag_request_id += 1
+        request_id = self._latest_tag_request_id
+
+        task = _TagSuggestionTask(request_id, token, self.tag_suggestion_service)
+        task.signals.finished.connect(self._on_tag_suggestion_task_finished)
+        task.signals.failed.connect(self._on_tag_suggestion_task_failed)
+        self._tag_thread_pool.start(task)
+
+    @Slot(int, str, list)
+    def _on_tag_suggestion_task_finished(self, request_id: int, query: str, suggestions: list[str]) -> None:
+        """非同期タグ候補取得の完了ハンドラ。"""
+        self._tag_lookup_in_flight = False
+
+        current_token = self._extract_last_token(self.ui.lineEditSearch.text())
+        if request_id == self._latest_tag_request_id and query.casefold() == current_token.casefold():
+            self._apply_tag_suggestions(query, suggestions)
+
+        self._start_pending_tag_lookup_if_needed()
+
+    @Slot(int, str, str)
+    def _on_tag_suggestion_task_failed(self, _request_id: int, query: str, error: str) -> None:
+        """非同期タグ候補取得のエラーハンドラ。"""
+        self._tag_lookup_in_flight = False
+        logger.warning("非同期タグ候補取得に失敗: query='{}', error={}", query, error)
+        self._start_pending_tag_lookup_if_needed()
+
+    def _start_pending_tag_lookup_if_needed(self) -> None:
+        """保留中の最新入力があれば非同期取得を再開する。"""
+        if self.tag_suggestion_service is None:
+            self._pending_tag_query = None
+            return
+
+        next_query = self._pending_tag_query
+        self._pending_tag_query = None
+
+        if next_query is None:
+            return
+        if len(next_query) < self.tag_suggestion_service.min_chars:
+            return
+
+        self._request_tag_suggestions_async(next_query)
 
     def _clear_tag_suggestions(self) -> None:
         """タグ候補をクリアしてデバウンスタイマーを停止する。"""
@@ -1492,6 +1590,14 @@ class FilterSearchPanel(QScrollArea):
         """強制的にパイプライン状態をリセット（緊急時用）"""
         logger.warning("Force pipeline reset requested")
         self._transition_to_state(PipelineState.IDLE)
+
+    def closeEvent(self, event: QCloseEvent) -> None:
+        """ウィジェット破棄時に非同期タグ検索リソースをクリーンアップする。"""
+        self._tag_suggestion_timer.stop()
+        self._pending_tag_query = None
+        self._tag_thread_pool.clear()
+        self._tag_thread_pool.waitForDone(1500)
+        super().closeEvent(event)
 
 
 if __name__ == "__main__":

--- a/src/lorairo/services/tag_suggestion_service.py
+++ b/src/lorairo/services/tag_suggestion_service.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 from collections import OrderedDict
+from threading import RLock
 from time import monotonic
 from typing import TYPE_CHECKING, Any
 
@@ -47,6 +48,7 @@ class TagSuggestionService:
         self.max_results = max_results
         self._cache_size = cache_size
         self._cache_ttl = cache_ttl_seconds
+        self._cache_lock = RLock()
         # OrderedDict で LRU + TTL キャッシュを実装: key -> (timestamp, list[str])
         self._cache: OrderedDict[str, tuple[float, list[str]]] = OrderedDict()
 
@@ -66,18 +68,48 @@ class TagSuggestionService:
         if len(normalized) < self.min_chars:
             return []
 
-        cache_key = normalized.casefold()
-        cached = self._get_cache(cache_key)
+        cached = self.get_cached_suggestions(normalized)
         if cached is not None:
             return cached
 
         suggestions = self._search_tags(normalized)
+        cache_key = normalized.casefold()
         self._set_cache(cache_key, suggestions)
         return suggestions
 
+    def get_cached_suggestions(self, query: str) -> list[str] | None:
+        """キャッシュから候補を取得する（DB検索は行わない）。
+
+        完全一致キャッシュがない場合は、より短いクエリのキャッシュ部分集合を再利用する。
+
+        Args:
+            query: 検索クエリ。
+
+        Returns:
+            キャッシュヒット時は候補一覧、未ヒット時は None。
+        """
+        normalized = query.strip()
+        if len(normalized) < self.min_chars:
+            return []
+
+        cache_key = normalized.casefold()
+
+        with self._cache_lock:
+            exact = self._get_cache_unlocked(cache_key)
+            if exact is not None:
+                return exact
+
+            subset = self._get_cached_subset_unlocked(cache_key)
+            if subset is None:
+                return None
+
+            self._set_cache_unlocked(cache_key, subset)
+            return subset
+
     def clear_cache(self) -> None:
         """キャッシュをクリアする。"""
-        self._cache.clear()
+        with self._cache_lock:
+            self._cache.clear()
 
     def _search_tags(self, query: str) -> list[str]:
         """genai-tag-db-tools で タグ検索を実行する。"""
@@ -91,6 +123,7 @@ class TagSuggestionService:
                 resolve_preferred=False,
                 include_aliases=True,
                 include_deprecated=False,
+                limit=self.max_results,
             )
             result = search_tags(self._merged_reader, request)
 
@@ -109,7 +142,7 @@ class TagSuggestionService:
                 if len(candidates) >= self.max_results:
                     break
 
-            return candidates
+            return self._rank_candidates(candidates, query)
 
         except Exception as e:
             logger.warning("タグ候補取得に失敗: query='{}', error={}", query, e)
@@ -136,8 +169,28 @@ class TagSuggestionService:
 
         return None
 
+    @staticmethod
+    def _rank_candidates(candidates: list[str], query: str) -> list[str]:
+        """候補を優先度順に並び替える（exact > prefix > contains）。"""
+        needle = query.casefold()
+
+        def _score(tag: str) -> tuple[int, str]:
+            folded = tag.casefold()
+            if folded == needle:
+                return (0, folded)
+            if folded.startswith(needle):
+                return (1, folded)
+            return (2, folded)
+
+        return sorted(candidates, key=_score)
+
     def _get_cache(self, key: str) -> list[str] | None:
         """キャッシュからエントリを取得する（TTL チェック込み）。"""
+        with self._cache_lock:
+            return self._get_cache_unlocked(key)
+
+    def _get_cache_unlocked(self, key: str) -> list[str] | None:
+        """ロック取得済み前提のキャッシュ読み出し。"""
         if key not in self._cache:
             return None
 
@@ -152,9 +205,41 @@ class TagSuggestionService:
 
     def _set_cache(self, key: str, suggestions: list[str]) -> None:
         """キャッシュにエントリを追加する（LRU サイズ制限付き）。"""
+        with self._cache_lock:
+            self._set_cache_unlocked(key, suggestions)
+
+    def _set_cache_unlocked(self, key: str, suggestions: list[str]) -> None:
+        """ロック取得済み前提のキャッシュ更新。"""
         self._cache[key] = (monotonic(), suggestions)
         self._cache.move_to_end(key)
 
         # LRU: サイズ超過時は最古のエントリを削除
         while len(self._cache) > self._cache_size:
             self._cache.popitem(last=False)
+
+    def _get_cached_subset_unlocked(self, key: str) -> list[str] | None:
+        """ロック取得済み前提でキャッシュ部分集合を取得する。"""
+        best_source: list[str] | None = None
+        best_len = -1
+
+        for candidate_key in list(self._cache.keys()):
+            if not key.startswith(candidate_key) or len(candidate_key) >= len(key):
+                continue
+
+            cached_values = self._get_cache_unlocked(candidate_key)
+            if cached_values is None:
+                continue
+
+            if len(candidate_key) > best_len:
+                best_len = len(candidate_key)
+                best_source = cached_values
+
+        if best_source is None:
+            return None
+
+        filtered = [tag for tag in best_source if key in tag.casefold()]
+        if not filtered:
+            return []
+
+        ranked = self._rank_candidates(filtered, key)
+        return ranked[: self.max_results]

--- a/tests/unit/gui/widgets/test_filter_search_panel_autocomplete.py
+++ b/tests/unit/gui/widgets/test_filter_search_panel_autocomplete.py
@@ -118,3 +118,40 @@ class TestClearTagSuggestions:
 
         panel._clear_tag_suggestions()
         assert not panel._tag_suggestion_timer.isActive()
+
+
+class _FakeSuggestionService:
+    def __init__(self, *, cached: list[str] | None, async_result: list[str] | None = None):
+        self.min_chars = 2
+        self._cached = cached
+        self._async_result = async_result or []
+
+    def get_cached_suggestions(self, _query: str) -> list[str] | None:
+        return self._cached
+
+    def get_suggestions(self, _query: str) -> list[str]:
+        return self._async_result
+
+
+class TestAsyncAutocomplete:
+    """非同期オートコンプリートの基本動作テスト。"""
+
+    def test_update_uses_cached_suggestions_first(self, panel):
+        panel.ui.checkboxTags.setChecked(True)
+        panel.ui.lineEditSearch.setText("blue")
+        panel.set_tag_suggestion_service(_FakeSuggestionService(cached=["blue_hair", "blue_eyes"]))
+
+        panel._update_tag_completions()
+
+        assert panel._tag_completer_model.stringList() == ["blue_hair", "blue_eyes"]
+        assert not panel._tag_lookup_in_flight
+
+    def test_async_lookup_updates_model(self, panel, qtbot):
+        panel.ui.checkboxTags.setChecked(True)
+        panel.ui.lineEditSearch.setText("blue")
+        panel.set_tag_suggestion_service(_FakeSuggestionService(cached=None, async_result=["blue_hair"]))
+
+        panel._update_tag_completions()
+
+        qtbot.waitUntil(lambda: panel._tag_completer_model.stringList() == ["blue_hair"], timeout=2000)
+        assert not panel._tag_lookup_in_flight

--- a/tests/unit/services/test_tag_suggestion_service.py
+++ b/tests/unit/services/test_tag_suggestion_service.py
@@ -29,9 +29,10 @@ class _FakeResult:
 def _make_fake_genai(items: list, call_counter: dict | None = None) -> tuple:
     """genai_tag_db_tools のモジュールモックと呼び出しカウンターを返す。"""
 
-    def fake_search_tags(_reader, _request):
+    def fake_search_tags(_reader, request):
         if call_counter is not None:
             call_counter["count"] = call_counter.get("count", 0) + 1
+            call_counter["last_request"] = request
         return _FakeResult(items)
 
     fake_models = types.SimpleNamespace(TagSearchRequest=lambda **kwargs: kwargs)
@@ -92,6 +93,25 @@ class TestTagSuggestionServiceCache:
         assert "bb" in service._cache
         assert "cc" in service._cache
 
+    def test_cached_subset_reuse_avoids_additional_db_query(self, patch_genai):
+        """長いクエリは短いクエリのキャッシュ部分集合を再利用する。"""
+        counter: dict = {}
+        patch_genai([_FakeItem("blue_hair"), _FakeItem("blue_eyes"), _FakeItem("black_hair")], counter)
+
+        service = TagSuggestionService(object(), cache_ttl_seconds=60)
+        first = service.get_suggestions("bl")
+        second = service.get_suggestions("blue")
+
+        assert first == ["black_hair", "blue_eyes", "blue_hair"]
+        assert second == ["blue_eyes", "blue_hair"]
+        assert counter["count"] == 1
+
+    def test_get_cached_suggestions_returns_none_when_cache_miss(self, patch_genai):
+        """get_cached_suggestions は未ヒット時に None を返す。"""
+        patch_genai([_FakeItem("blue_hair")])
+        service = TagSuggestionService(object(), cache_ttl_seconds=60)
+        assert service.get_cached_suggestions("bl") is None
+
 
 class TestTagSuggestionServiceMinChars:
     """最小文字数チェックのテスト。"""
@@ -142,6 +162,16 @@ class TestTagSuggestionServiceMaxResults:
         result = service.get_suggestions("gi")
 
         assert result.count("1girl") == 1
+
+    def test_db_request_contains_limit(self, patch_genai):
+        """TagSearchRequest に DB側limit が設定される。"""
+        counter: dict = {}
+        patch_genai([_FakeItem("tag_1")], counter)
+
+        service = TagSuggestionService(object(), max_results=7)
+        service.get_suggestions("tag")
+
+        assert counter["last_request"]["limit"] == 7
 
 
 class TestExtractTagName:


### PR DESCRIPTION
### Motivation
- Tag autocomplete was blocking the GUI due to synchronous DB lookups on the main thread and repeated full-query work across multiple DBs, degrading typing responsiveness (Issue #36 root causes: main-thread DB search, repeated DB merging, expensive LIKE scans, no DB-side limit). 
- Improve UX by making suggestions immediate when cached and non-blocking when a DB lookup is required, while preventing thread-safety bugs and worker leaks.

### Description
- Reworked `FilterSearchPanel` autocomplete to use a dedicated single-thread `QThreadPool` + `QRunnable` (`_TagSuggestionTask`) and signals, with pending-query handling and stale-response guarding to ensure only the latest result updates the UI. 
- Implemented cache-first flow in the panel that calls `TagSuggestionService.get_cached_suggestions()` and only schedules an async task when the cache misses. 
- Added `closeEvent` cleanup in `FilterSearchPanel` to stop timers and clear/wait the thread pool to prevent worker leakage. 
- Enhanced `TagSuggestionService` with `RLock` for thread-safe cache access, a new `get_cached_suggestions()` API, cached-subset reuse for incremental queries, DB-side `limit` propagation to `TagSearchRequest`, and deterministic ranking (`exact > prefix > contains`). 
- Updated and added unit tests covering cache-subset reuse, DB `limit` propagation, cache-first UI updates, and async model update behavior (modified files: `src/lorairo/gui/widgets/filter_search_panel.py`, `src/lorairo/services/tag_suggestion_service.py`, `tests/unit/services/test_tag_suggestion_service.py`, `tests/unit/gui/widgets/test_filter_search_panel_autocomplete.py`).

### Testing
- `python -m py_compile src/lorairo/services/tag_suggestion_service.py src/lorairo/gui/widgets/filter_search_panel.py tests/unit/services/test_tag_suggestion_service.py tests/unit/gui/widgets/test_filter_search_panel_autocomplete.py` completed successfully. 
- Attempted `uv run pytest tests/unit/services/test_tag_suggestion_service.py tests/unit/gui/widgets/test_filter_search_panel_autocomplete.py` failed in this environment because the editable local package `local_packages/genai-tag-db-tools` is not present as a Python project (`pyproject.toml`/`setup.py` missing). 
- Running `pytest tests/unit/services/test_tag_suggestion_service.py tests/unit/gui/widgets/test_filter_search_panel_autocomplete.py` also failed in this environment due to a missing test dependency (`sqlalchemy`) reported during `tests/conftest.py` import.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bb3a2d3b90832983af5f22f322da0e)