### PR TITLE
fix: batch-resolve tag_ids during folder registration to avoid N+1

### DIFF
--- a/src/lorairo/database/db_manager.py
+++ b/src/lorairo/database/db_manager.py
@@ -411,7 +411,13 @@ class ImageDatabaseManager:
             )
             return None
 
-    def save_tags(self, image_id: int, tags_data: list[TagAnnotationData]) -> None:
+    def save_tags(
+        self,
+        image_id: int,
+        tags_data: list[TagAnnotationData],
+        *,
+        tag_id_cache: dict[str, int | None] | None = None,
+    ) -> None:
         """指定された画像のタグ情報を保存・更新します。"""
         try:
             annotations_to_save: AnnotationsDict = {
@@ -420,7 +426,7 @@ class ImageDatabaseManager:
                 "scores": [],
                 "ratings": [],
             }
-            self.repository.save_annotations(image_id, annotations_to_save)
+            self.repository.save_annotations(image_id, annotations_to_save, tag_id_cache=tag_id_cache)
             logger.debug(f"画像 ID {image_id} のタグ {len(tags_data)} 件を保存しました。")
         except Exception as e:
             logger.error(f"画像 ID {image_id} のタグ保存中にエラー: {e}", exc_info=True)

--- a/src/lorairo/gui/workers/registration_worker.py
+++ b/src/lorairo/gui/workers/registration_worker.py
@@ -37,6 +37,8 @@ class DatabaseRegistrationWorker(LoRAIroWorkerBase[DatabaseRegistrationResult]):
         self.db_manager = db_manager
         self.fsm = fsm
         self.file_reader = ExistingFileReader()
+        self._annotation_cache: dict[Path, dict[str, object] | None] = {}
+        self._tag_id_cache: dict[str, int | None] = {}
 
     def execute(self) -> DatabaseRegistrationResult:
         """データベース登録処理を実行
@@ -65,6 +67,9 @@ class DatabaseRegistrationWorker(LoRAIroWorkerBase[DatabaseRegistrationResult]):
 
         logger.info(f"登録対象画像: {total_count}件")
 
+        # 事前にアノテーションを読み込み、タグIDを一括解決（N+1回避）
+        self._prepare_annotation_caches(image_files)
+
         # 統計情報初期化
         stats = {"registered": 0, "skipped": 0, "errors": 0}
         processed_paths: list[Path] = []
@@ -81,7 +86,26 @@ class DatabaseRegistrationWorker(LoRAIroWorkerBase[DatabaseRegistrationResult]):
 
         # 完了処理
         self._report_progress(100, "データベース登録完了")
-        return self._build_registration_result(stats, processed_paths, start_time)
+        result = self._build_registration_result(stats, processed_paths, start_time)
+        self._annotation_cache.clear()
+        self._tag_id_cache.clear()
+        return result
+
+    def _prepare_annotation_caches(self, image_files: list[Path]) -> None:
+        """画像ごとの既存アノテーションをキャッシュし、タグIDを一括解決する。"""
+        all_tags: set[str] = set()
+        for image_path in image_files:
+            annotations = self.file_reader.get_existing_annotations(image_path)
+            self._annotation_cache[image_path] = annotations
+            if annotations:
+                tags = annotations.get("tags", [])
+                if isinstance(tags, list):
+                    all_tags.update(tag for tag in tags if isinstance(tag, str) and tag)
+
+        if all_tags:
+            self._tag_id_cache = self.db_manager.repository.batch_resolve_tag_ids(all_tags)
+        else:
+            self._tag_id_cache = {}
 
     def _process_single_image_in_batch(
         self,
@@ -225,7 +249,9 @@ class DatabaseRegistrationWorker(LoRAIroWorkerBase[DatabaseRegistrationResult]):
             image_path: 画像ファイルのパス。
             image_id: データベースの画像ID。
         """
-        annotations = self.file_reader.get_existing_annotations(image_path)
+        annotations = self._annotation_cache.get(image_path)
+        if annotations is None:
+            annotations = self.file_reader.get_existing_annotations(image_path)
         if not annotations:
             return
 
@@ -235,7 +261,7 @@ class DatabaseRegistrationWorker(LoRAIroWorkerBase[DatabaseRegistrationResult]):
 
             tags_data: list[TagAnnotationData] = [
                 {
-                    "tag_id": None,
+                    "tag_id": self._tag_id_cache.get(tag),
                     "model_id": None,
                     "tag": tag,
                     "confidence_score": None,
@@ -244,7 +270,7 @@ class DatabaseRegistrationWorker(LoRAIroWorkerBase[DatabaseRegistrationResult]):
                 }
                 for tag in tags
             ]
-            self.db_manager.save_tags(image_id, tags_data)
+            self.db_manager.save_tags(image_id, tags_data, tag_id_cache=self._tag_id_cache)
             logger.debug(f"タグを追加: {image_path.name} - {len(tags)}個のタグ")
 
         captions = annotations.get("captions", [])


### PR DESCRIPTION
### Motivation
- Folder/batch image registration caused repeated per-tag external lookups (N+1) and resulted in `tag_id` being `None` for imported tags, so a single-batch resolution is needed to improve performance and correctness.

### Description
- Added per-batch annotation caching and a `_prepare_annotation_caches` step in `DatabaseRegistrationWorker` to read `.txt`/`.caption` files once and collect all tags before processing.
- Resolved collected tags with a single call to `repository.batch_resolve_tag_ids(...)` and stored the results in `self._tag_id_cache` for reuse during the batch.
- Updated `_process_associated_files` to use the cached annotations and attach resolved `tag_id` values to `TagAnnotationData`, and pass the shared `tag_id_cache` to `ImageDatabaseManager.save_tags` to avoid fallback queries.
- Extended `ImageDatabaseManager.save_tags` signature to accept an optional `tag_id_cache` and forwarded it to `repository.save_annotations(...)` (backwards compatible because the new parameter is optional).

### Testing
- `python -m py_compile src/lorairo/gui/workers/registration_worker.py src/lorairo/database/db_manager.py` succeeded.
- Attempted `uv run pytest tests/unit/workers/test_database_worker.py -k "multiple_tags_parsing or associated_file_processing_error or register_single_image_progress_reporting"` but test environment bootstrap failed because `local_packages/genai-tag-db-tools` is not installable in this environment (missing `pyproject.toml`/`setup.py`), so pytest did not run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bb6b6230bc83299d0caeacb3791f25)