### PR TITLE
fix: batch-resolve tag IDs during folder registration

### DIFF
--- a/src/lorairo/database/db_manager.py
+++ b/src/lorairo/database/db_manager.py
@@ -411,7 +411,13 @@ class ImageDatabaseManager:
             )
             return None
 
-    def save_tags(self, image_id: int, tags_data: list[TagAnnotationData]) -> None:
+    def save_tags(
+        self,
+        image_id: int,
+        tags_data: list[TagAnnotationData],
+        *,
+        tag_id_cache: dict[str, int | None] | None = None,
+    ) -> None:
         """指定された画像のタグ情報を保存・更新します。"""
         try:
             annotations_to_save: AnnotationsDict = {
@@ -420,7 +426,11 @@ class ImageDatabaseManager:
                 "scores": [],
                 "ratings": [],
             }
-            self.repository.save_annotations(image_id, annotations_to_save)
+            self.repository.save_annotations(
+                image_id,
+                annotations_to_save,
+                tag_id_cache=tag_id_cache,
+            )
             logger.debug(f"画像 ID {image_id} のタグ {len(tags_data)} 件を保存しました。")
         except Exception as e:
             logger.error(f"画像 ID {image_id} のタグ保存中にエラー: {e}", exc_info=True)

--- a/src/lorairo/gui/workers/registration_worker.py
+++ b/src/lorairo/gui/workers/registration_worker.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from ...annotations.caption_tags import TagCleaner
 from ...annotations.existing_file_reader import ExistingFileReader
 from ...utils.log import logger
 from .base import LoRAIroWorkerBase
@@ -65,6 +66,10 @@ class DatabaseRegistrationWorker(LoRAIroWorkerBase[DatabaseRegistrationResult]):
 
         logger.info(f"登録対象画像: {total_count}件")
 
+        # タグID一括解決のため関連アノテーションを事前収集
+        self._report_progress(8, "関連アノテーションを解析中...")
+        annotations_cache, tag_id_cache = self._prepare_annotations_cache(image_files)
+
         # 統計情報初期化
         stats = {"registered": 0, "skipped": 0, "errors": 0}
         processed_paths: list[Path] = []
@@ -77,7 +82,15 @@ class DatabaseRegistrationWorker(LoRAIroWorkerBase[DatabaseRegistrationResult]):
             self._check_cancellation()
 
             # 単一画像の登録と統計更新
-            self._process_single_image_in_batch(image_path, i, total_count, stats, processed_paths)
+            self._process_single_image_in_batch(
+                image_path,
+                i,
+                total_count,
+                stats,
+                processed_paths,
+                annotations_cache=annotations_cache,
+                tag_id_cache=tag_id_cache,
+            )
 
         # 完了処理
         self._report_progress(100, "データベース登録完了")
@@ -90,6 +103,9 @@ class DatabaseRegistrationWorker(LoRAIroWorkerBase[DatabaseRegistrationResult]):
         total_count: int,
         stats: dict[str, int],
         processed_paths: list[Path],
+        *,
+        annotations_cache: dict[Path, dict[str, list[str]]],
+        tag_id_cache: dict[str, int | None],
     ) -> None:
         """バッチ処理内で単一画像を処理し、統計情報を更新する。
 
@@ -102,7 +118,13 @@ class DatabaseRegistrationWorker(LoRAIroWorkerBase[DatabaseRegistrationResult]):
         """
         try:
             # 単一画像の登録処理
-            result_type, _ = self._register_single_image(image_path, i, total_count)
+            result_type, _ = self._register_single_image(
+                image_path,
+                i,
+                total_count,
+                annotations=annotations_cache.get(image_path),
+                tag_id_cache=tag_id_cache,
+            )
 
             # 統計情報更新
             stats[result_type] += 1
@@ -127,7 +149,15 @@ class DatabaseRegistrationWorker(LoRAIroWorkerBase[DatabaseRegistrationResult]):
             except Exception as save_error:
                 logger.error(f"エラーレコード保存失敗（二次エラー）: {save_error}")
 
-    def _register_single_image(self, image_path: Path, i: int, total_count: int) -> tuple[str, int]:
+    def _register_single_image(
+        self,
+        image_path: Path,
+        i: int,
+        total_count: int,
+        *,
+        annotations: dict[str, list[str]] | None = None,
+        tag_id_cache: dict[str, int | None] | None = None,
+    ) -> tuple[str, int]:
         """単一画像の登録処理を実行
 
         重複検出を行い、重複していない場合はデータベースに登録する。
@@ -150,7 +180,12 @@ class DatabaseRegistrationWorker(LoRAIroWorkerBase[DatabaseRegistrationResult]):
         duplicate_image_id = self.db_manager.detect_duplicate_image(image_path)
         if duplicate_image_id:
             # 重複画像でも関連ファイル（.txt/.caption）を処理
-            self._process_associated_files(image_path, duplicate_image_id)
+            self._process_associated_files(
+                image_path,
+                duplicate_image_id,
+                annotations=annotations,
+                tag_id_cache=tag_id_cache,
+            )
             # ファイル名エイリアスを登録（バッチインポート時のマッチング用）
             self.db_manager.repository.add_filename_alias(duplicate_image_id, image_path.stem)
             logger.debug(f"スキップ (重複): {image_path} - 関連ファイルは処理")
@@ -162,7 +197,12 @@ class DatabaseRegistrationWorker(LoRAIroWorkerBase[DatabaseRegistrationResult]):
             if result:
                 image_id, _ = result
                 # 関連ファイル（.txt/.caption）の処理
-                self._process_associated_files(image_path, image_id)
+                self._process_associated_files(
+                    image_path,
+                    image_id,
+                    annotations=annotations,
+                    tag_id_cache=tag_id_cache,
+                )
                 logger.debug(f"登録完了: {image_path}")
                 result_type = "registered"
             else:
@@ -181,6 +221,30 @@ class DatabaseRegistrationWorker(LoRAIroWorkerBase[DatabaseRegistrationResult]):
         )
 
         return result_type, image_id
+
+    def _prepare_annotations_cache(
+        self, image_files: list[Path]
+    ) -> tuple[dict[Path, dict[str, list[str]]], dict[str, int | None]]:
+        """画像ごとの既存アノテーションとtag_idキャッシュを作成する。"""
+        annotations_cache: dict[Path, dict[str, list[str]]] = {}
+        normalized_tags: set[str] = set()
+
+        for image_path in image_files:
+            annotations = self.file_reader.get_existing_annotations(image_path)
+            if not annotations:
+                continue
+
+            annotations_cache[image_path] = annotations
+            for tag in annotations.get("tags", []):
+                normalized = TagCleaner.clean_format(tag).strip()
+                if normalized:
+                    normalized_tags.add(normalized)
+
+        if not normalized_tags:
+            return annotations_cache, {}
+
+        tag_id_cache = self.db_manager.repository.batch_resolve_tag_ids(normalized_tags)
+        return annotations_cache, tag_id_cache
 
     def _build_registration_result(
         self, stats: dict[str, int], processed_paths: list[Path], start_time: float
@@ -218,14 +282,22 @@ class DatabaseRegistrationWorker(LoRAIroWorkerBase[DatabaseRegistrationResult]):
 
         return registration_result
 
-    def _process_associated_files(self, image_path: Path, image_id: int) -> None:
+    def _process_associated_files(
+        self,
+        image_path: Path,
+        image_id: int,
+        *,
+        annotations: dict[str, list[str]] | None = None,
+        tag_id_cache: dict[str, int | None] | None = None,
+    ) -> None:
         """画像ファイルに関連する.txtと.captionファイルを処理し、データベースに登録する。
 
         Args:
             image_path: 画像ファイルのパス。
             image_id: データベースの画像ID。
         """
-        annotations = self.file_reader.get_existing_annotations(image_path)
+        if annotations is None:
+            annotations = self.file_reader.get_existing_annotations(image_path)
         if not annotations:
             return
 
@@ -235,7 +307,11 @@ class DatabaseRegistrationWorker(LoRAIroWorkerBase[DatabaseRegistrationResult]):
 
             tags_data: list[TagAnnotationData] = [
                 {
-                    "tag_id": None,
+                    "tag_id": (
+                        tag_id_cache.get(TagCleaner.clean_format(tag).strip())
+                        if tag_id_cache is not None
+                        else None
+                    ),
                     "model_id": None,
                     "tag": tag,
                     "confidence_score": None,
@@ -244,7 +320,7 @@ class DatabaseRegistrationWorker(LoRAIroWorkerBase[DatabaseRegistrationResult]):
                 }
                 for tag in tags
             ]
-            self.db_manager.save_tags(image_id, tags_data)
+            self.db_manager.save_tags(image_id, tags_data, tag_id_cache=tag_id_cache)
             logger.debug(f"タグを追加: {image_path.name} - {len(tags)}個のタグ")
 
         captions = annotations.get("captions", [])


### PR DESCRIPTION
### Motivation
- Reduce N+1 external tag DB lookups during folder (batch) registration by resolving all `.txt`/`.caption` tags once before image processing. 
- Ensure tags discovered during folder import are reflected in the local `user_tags.sqlite` (autocomplete candidates) without per-tag remote registration overhead.

### Description
- Add a pre-processing phase `_prepare_annotations_cache()` in `DatabaseRegistrationWorker.execute()` to collect existing annotations and build a normalized tag set.
- Call `batch_resolve_tag_ids()` once and pass the resulting `tag_id_cache` through to per-image processing and `_process_associated_files()` so saved tags carry resolved `tag_id` when available.
- Propagate `tag_id_cache` into the DB layer by adding a `tag_id_cache` keyword-only parameter to `ImageDatabaseManager.save_tags()` and passing it into `repository.save_annotations(...)`.
- Use `TagCleaner.clean_format()` when normalizing tags and set `tag_id` on generated `tags_data` entries where the cache provides a value.

### Testing
- Ran `ruff format src/lorairo/gui/workers/registration_worker.py src/lorairo/database/db_manager.py` and `ruff check ...` which completed successfully. 
- Ran `python -m compileall src/lorairo/gui/workers/registration_worker.py src/lorairo/database/db_manager.py` which compiled without errors. 
- Attempted `pytest tests/unit/workers/test_database_worker.py -q` but it failed to run due to missing dependency (`ModuleNotFoundError: No module named 'sqlalchemy'`).
- `uv run ruff ...` in the project environment failed earlier because `local_packages/genai-tag-db-tools` is not recognized as a Python project in this environment, unrelated to the code changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bb6b6230bc83299d0caeacb3791f25)