### PR TITLE
feat: 画像詳細タグの多言語切替表示 (#50)

### DIFF
--- a/src/lorairo/gui/services/widget_setup_service.py
+++ b/src/lorairo/gui/services/widget_setup_service.py
@@ -122,6 +122,13 @@ class WidgetSetupService:
         else:
             logger.warning("⚠️ DatasetStateManager が None - 接続スキップ")
 
+        # MergedTagReaderを注入してタグ翻訳機能を有効化
+        from ...services import get_service_container
+
+        service_container = get_service_container()
+        widget.set_merged_reader(service_container.image_repository.merged_reader)
+        logger.info("✅ MergedTagReader注入完了")
+
         logger.info("✅ SelectedImageDetailsWidget設定完了")
 
     @staticmethod

--- a/src/lorairo/gui/widgets/annotation_data_display_widget.py
+++ b/src/lorairo/gui/widgets/annotation_data_display_widget.py
@@ -9,8 +9,11 @@ from dataclasses import dataclass, field
 from typing import Any
 
 from PySide6.QtCore import Qt, Signal, Slot
+from PySide6.QtGui import QResizeEvent
 from PySide6.QtWidgets import (
     QAbstractScrollArea,
+    QComboBox,
+    QHBoxLayout,
     QLabel,
     QSizePolicy,
     QTableWidgetItem,
@@ -30,6 +33,10 @@ class AnnotationData:
     aesthetic_score: float | None = None
     overall_score: int = 0
     score_type: str = "Aesthetic"
+    # 翻訳データ: {tag_id: {language: translated_text}}
+    tag_translations: dict[int, dict[str, str]] = field(default_factory=dict)
+    # 利用可能な言語リスト（get_tag_languages()から取得）
+    available_languages: list[str] = field(default_factory=list)
 
 
 @dataclass
@@ -80,6 +87,9 @@ class AnnotationDataDisplayWidget(QWidget, Ui_AnnotationDataDisplayWidget):
         self._setup_caption_compact_view()
         self._adjust_content_heights()
 
+        # 言語コンボボックスのシグナル接続
+        self._lang_combo.currentTextChanged.connect(self._on_language_changed)
+
         logger.debug("AnnotationDataDisplayWidget initialized")
 
     def _setup_widget_properties(self) -> None:
@@ -92,11 +102,23 @@ class AnnotationDataDisplayWidget(QWidget, Ui_AnnotationDataDisplayWidget):
         self.textEditCaption.setVerticalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
 
     def _setup_tags_compact_view(self) -> None:
+        # 言語切り替えバー（コンボボックス付き）を先頭に動的追加
+        self._lang_bar = QWidget(self.groupBoxTags)
+        lang_layout = QHBoxLayout(self._lang_bar)
+        lang_layout.setContentsMargins(0, 0, 0, 2)
+        lang_label = QLabel("言語:", self._lang_bar)
+        lang_layout.addWidget(lang_label)
+        self._lang_combo = QComboBox(self._lang_bar)
+        self._lang_combo.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed)
+        lang_layout.addWidget(self._lang_combo)
+        self._lang_bar.setVisible(False)  # merged_readerがない場合は非表示
+        self.verticalLayoutTags.insertWidget(0, self._lang_bar)
+
         self._tags_compact_label = QLabel(self.groupBoxTags)
         self._tags_compact_label.setWordWrap(True)
         self._tags_compact_label.setText("-")
         self._tags_compact_label.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum)
-        self.verticalLayoutTags.insertWidget(0, self._tags_compact_label)
+        self.verticalLayoutTags.insertWidget(1, self._tags_compact_label)
 
         self.tableWidgetTags.setVisible(False)
 
@@ -182,10 +204,69 @@ class AnnotationDataDisplayWidget(QWidget, Ui_AnnotationDataDisplayWidget):
 
             self._tags_compact_label.setText(", ".join([name for name in tag_names if name]) or "-")
 
+            # 英語以外の言語が選択されている場合は翻訳で再描画
+            # isHidden()で判定（isVisible()は親ウィジェット未表示時にFalseを返すため）
+            current_lang = self._lang_combo.currentText() if not self._lang_bar.isHidden() else "english"
+            if current_lang and current_lang != "english":
+                self._refresh_tags_for_language(current_lang)
+
             logger.debug(f"Updated tags display: {len(tags)} rows")
 
         except Exception as e:
             logger.error(f"Error updating tags display: {e}")
+
+    def initialize_language_selector(self, available_languages: list[str]) -> None:
+        """言語コンボボックスを初期化する。
+
+        Args:
+            available_languages: 利用可能な言語リスト。空の場合はコンボボックスを非表示にする。
+        """
+        if not available_languages:
+            self._lang_bar.setVisible(False)
+            return
+
+        self._lang_combo.blockSignals(True)
+        self._lang_combo.clear()
+        self._lang_combo.addItem("english")  # 常に先頭（原文）
+        for lang in available_languages:
+            if lang != "english":
+                self._lang_combo.addItem(lang)
+        self._lang_combo.blockSignals(False)
+        self._lang_bar.setVisible(True)
+
+    @Slot(str)
+    def _on_language_changed(self, language: str) -> None:
+        """言語コンボボックス変更時にタグ表示を更新する。"""
+        self._refresh_tags_for_language(language)
+
+    def _refresh_tags_for_language(self, language: str) -> None:
+        """現在のタグデータを指定言語で再描画する。
+
+        Args:
+            language: 表示言語名。"english" または available_languages の要素。
+                      翻訳がないタグは英語原文でフォールバック。
+        """
+        tags = self.current_data.tags
+        translations = self.current_data.tag_translations
+        use_english = language == "english" or not language
+
+        tag_names: list[str] = []
+        for row, tag_dict in enumerate(tags):
+            tag_id = tag_dict.get("tag_id")
+            original = tag_dict.get("tag", "")
+            if use_english or tag_id is None:
+                display = original
+            else:
+                # 翻訳がなければ英語原文にフォールバック
+                display = translations.get(tag_id, {}).get(language, original)
+            tag_names.append(display)
+
+            # テーブルのTag列（列0）も更新
+            item = self.tableWidgetTags.item(row, 0)
+            if item is not None:
+                item.setText(display)
+
+        self._tags_compact_label.setText(", ".join(n for n in tag_names if n) or "-")
 
     def _update_caption_display(self, caption: str) -> None:
         """キャプション表示を更新"""
@@ -265,7 +346,7 @@ class AnnotationDataDisplayWidget(QWidget, Ui_AnnotationDataDisplayWidget):
         self.groupBoxCaption.setVisible(caption)
         self.groupBoxScores.setVisible(scores)
 
-    def resizeEvent(self, event) -> None:  # type: ignore[override]
+    def resizeEvent(self, event: QResizeEvent) -> None:
         super().resizeEvent(event)
         self._adjust_caption_height()
 

--- a/src/lorairo/gui/widgets/selected_image_details_widget.py
+++ b/src/lorairo/gui/widgets/selected_image_details_widget.py
@@ -33,6 +33,8 @@ from .annotation_data_display_widget import (
 from .rating_score_edit_widget import RatingScoreEditWidget
 
 if TYPE_CHECKING:
+    from genai_tag_db_tools.db.repository import MergedTagReader
+
     from ..state.dataset_state import DatasetStateManager
 
 
@@ -93,6 +95,10 @@ class SelectedImageDetailsWidget(QWidget):
 
         # DatasetStateManagerへの参照（後でset_dataset_state_managerで設定）
         self._dataset_state_manager: DatasetStateManager | None = None
+
+        # タグ翻訳用（後でset_merged_readerで設定）
+        self._merged_reader: MergedTagReader | None = None
+        self._available_languages: list[str] = []
 
         # 内部状態
         self.current_details: ImageDetails | None = None
@@ -247,6 +253,17 @@ class SelectedImageDetailsWidget(QWidget):
         """
         logger.debug("Annotation data loaded in AnnotationDataDisplayWidget")
 
+    def set_merged_reader(self, reader: "MergedTagReader | None") -> None:
+        """MergedTagReaderを設定し、言語セレクターを初期化する。
+
+        Args:
+            reader: タグ翻訳取得用のMergedTagReader。Noneの場合は翻訳機能無効。
+        """
+        self._merged_reader = reader
+        self._available_languages = reader.get_tag_languages() if reader is not None else []
+        self.annotation_display.initialize_language_selector(self._available_languages)
+        logger.debug(f"MergedTagReader設定完了: 利用可能言語={self._available_languages}")
+
     # Phase 3: Direct Widget Communication Pattern
     def connect_to_data_signals(self, state_manager: "DatasetStateManager") -> None:
         """データシグナル接続（Phase 2互換）
@@ -396,11 +413,24 @@ class SelectedImageDetailsWidget(QWidget):
         caption_text = metadata.get("caption_text", "")
         tags_text = metadata.get("tags_text", "")
 
+        # 翻訳データ取得（merged_readerがある場合のみバッチ取得）
+        tag_translations: dict[int, dict[str, str]] = {}
+        if self._merged_reader is not None:
+            for tag_dict in tags_list:
+                tag_id = tag_dict.get("tag_id")
+                if tag_id is None:
+                    continue
+                for tr in self._merged_reader.get_translations(tag_id):
+                    if tr.language and tr.translation:
+                        tag_translations.setdefault(tag_id, {})[tr.language] = tr.translation
+
         annotation_data = AnnotationData(
             tags=tags_list,  # ← list[dict] をそのまま渡す
             caption=caption_text,
             aesthetic_score=score_value,
             overall_score=0,  # Rating値は文字列なのでoverall_scoreには使用しない
+            tag_translations=tag_translations,
+            available_languages=self._available_languages,
         )
 
         details = ImageDetails(

--- a/tests/unit/gui/widgets/test_annotation_data_display_widget.py
+++ b/tests/unit/gui/widgets/test_annotation_data_display_widget.py
@@ -1,0 +1,194 @@
+# tests/unit/gui/widgets/test_annotation_data_display_widget.py
+
+import pytest
+
+from lorairo.gui.widgets.annotation_data_display_widget import AnnotationData, AnnotationDataDisplayWidget
+
+
+class TestAnnotationDataDisplayWidget:
+    """AnnotationDataDisplayWidget単体テスト（言語切り替え機能含む）"""
+
+    @pytest.fixture
+    def widget(self, qtbot):
+        """テスト用AnnotationDataDisplayWidget"""
+        w = AnnotationDataDisplayWidget()
+        qtbot.addWidget(w)
+        return w
+
+    @pytest.fixture
+    def sample_tags(self):
+        """テスト用タグリスト（tag_id付き）"""
+        return [
+            {
+                "tag": "1girl",
+                "tag_id": 10,
+                "model_name": "wd",
+                "source": "AI",
+                "confidence_score": 0.9,
+                "is_edited_manually": False,
+            },
+            {
+                "tag": "flower",
+                "tag_id": 20,
+                "model_name": "wd",
+                "source": "AI",
+                "confidence_score": 0.8,
+                "is_edited_manually": False,
+            },
+            {
+                "tag": "solo",
+                "tag_id": None,
+                "model_name": "wd",
+                "source": "AI",
+                "confidence_score": 0.7,
+                "is_edited_manually": False,
+            },
+        ]
+
+    # ─── initialize_language_selector ───────────────────────────────────
+
+    def test_language_bar_hidden_by_default(self, widget):
+        """デフォルト状態では言語バーが非表示であること"""
+        # isHidden()はisVisible()と異なり親ウィジェットの表示状態に依存しない
+        assert widget._lang_bar.isHidden()
+
+    def test_language_bar_hidden_when_empty_list(self, widget):
+        """空リスト渡しで言語バーが非表示になること"""
+        widget.initialize_language_selector([])
+        assert widget._lang_bar.isHidden()
+
+    def test_language_bar_visible_when_languages_provided(self, widget):
+        """言語リスト渡しで言語バーが表示されること"""
+        widget.initialize_language_selector(["japanese", "chinese"])
+        assert not widget._lang_bar.isHidden()
+
+    def test_combo_includes_english_as_first_item(self, widget):
+        """コンボボックスの先頭は常にenglishであること"""
+        widget.initialize_language_selector(["japanese", "chinese"])
+        assert widget._lang_combo.itemText(0) == "english"
+
+    def test_combo_total_count_includes_english(self, widget):
+        """コンボボックスのアイテム数は言語数+1（english）"""
+        widget.initialize_language_selector(["japanese", "chinese"])
+        assert widget._lang_combo.count() == 3  # english + japanese + chinese
+
+    def test_combo_excludes_english_from_additional_items(self, widget):
+        """english を含む言語リストでも english が重複しないこと"""
+        widget.initialize_language_selector(["english", "japanese"])
+        # english は先頭の1つだけ
+        texts = [widget._lang_combo.itemText(i) for i in range(widget._lang_combo.count())]
+        assert texts.count("english") == 1
+
+    # ─── _refresh_tags_for_language ──────────────────────────────────────
+
+    def test_compact_label_shows_english_by_default(self, widget, sample_tags):
+        """初期表示は英語タグ名のコンパクトラベルであること"""
+        data = AnnotationData(tags=sample_tags)
+        widget.update_data(data)
+        assert "1girl" in widget._tags_compact_label.text()
+        assert "flower" in widget._tags_compact_label.text()
+
+    def test_compact_label_switches_to_japanese(self, widget, sample_tags):
+        """japanese選択でラベルが翻訳テキストに切り替わること"""
+        translations = {10: {"japanese": "1人の女の子"}, 20: {"japanese": "花"}}
+        data = AnnotationData(
+            tags=sample_tags,
+            tag_translations=translations,
+            available_languages=["japanese"],
+        )
+        widget.update_data(data)
+        widget.initialize_language_selector(["japanese"])
+
+        widget._lang_combo.setCurrentText("japanese")
+
+        assert "1人の女の子" in widget._tags_compact_label.text()
+        assert "花" in widget._tags_compact_label.text()
+
+    def test_fallback_to_english_when_no_translation(self, widget, sample_tags):
+        """翻訳がないタグは英語原文でフォールバックすること"""
+        # 翻訳データなし（空dict）
+        data = AnnotationData(
+            tags=sample_tags,
+            tag_translations={},
+            available_languages=["japanese"],
+        )
+        widget.update_data(data)
+        widget.initialize_language_selector(["japanese"])
+
+        widget._lang_combo.setCurrentText("japanese")
+
+        # 翻訳なしなので英語のまま
+        assert "1girl" in widget._tags_compact_label.text()
+        assert "flower" in widget._tags_compact_label.text()
+
+    def test_tag_without_tag_id_shows_english(self, widget, sample_tags):
+        """tag_id=Noneのタグは言語切り替えに関わらず英語原文を表示すること"""
+        translations = {10: {"japanese": "1人の女の子"}, 20: {"japanese": "花"}}
+        data = AnnotationData(
+            tags=sample_tags,
+            tag_translations=translations,
+            available_languages=["japanese"],
+        )
+        widget.update_data(data)
+        widget.initialize_language_selector(["japanese"])
+
+        widget._lang_combo.setCurrentText("japanese")
+
+        label_text = widget._tags_compact_label.text()
+        # tag_id=Noneの"solo"は英語原文のまま
+        assert "solo" in label_text
+
+    def test_switch_back_to_english_restores_original(self, widget, sample_tags):
+        """englishに戻すと英語タグ名が復元されること"""
+        translations = {10: {"japanese": "1人の女の子"}, 20: {"japanese": "花"}}
+        data = AnnotationData(
+            tags=sample_tags,
+            tag_translations=translations,
+            available_languages=["japanese"],
+        )
+        widget.update_data(data)
+        widget.initialize_language_selector(["japanese"])
+
+        widget._lang_combo.setCurrentText("japanese")
+        widget._lang_combo.setCurrentText("english")
+
+        label_text = widget._tags_compact_label.text()
+        assert "1girl" in label_text
+        assert "flower" in label_text
+
+    def test_table_tag_column_updates_on_language_change(self, widget, sample_tags):
+        """言語切り替え時にテーブルTag列（列0）も更新されること"""
+        translations = {10: {"japanese": "1人の女の子"}}
+        data = AnnotationData(
+            tags=sample_tags,
+            tag_translations=translations,
+            available_languages=["japanese"],
+        )
+        widget.update_data(data)
+
+        # テーブルを表示状態にして確認
+        widget.tableWidgetTags.setVisible(True)
+        widget.initialize_language_selector(["japanese"])
+        widget._lang_combo.setCurrentText("japanese")
+
+        # 行0（1girl / tag_id=10）のTag列が翻訳テキストに更新されていること
+        item = widget.tableWidgetTags.item(0, 0)
+        assert item is not None
+        assert item.text() == "1人の女の子"
+
+    # ─── update_data との統合 ───────────────────────────────────────────
+
+    def test_update_data_with_translations_applies_current_language(self, widget, sample_tags):
+        """update_data呼び出し時に選択中言語が適用されること"""
+        widget.initialize_language_selector(["japanese"])
+        widget._lang_combo.setCurrentText("japanese")
+
+        translations = {10: {"japanese": "1人の女の子"}, 20: {"japanese": "花"}}
+        data = AnnotationData(
+            tags=sample_tags,
+            tag_translations=translations,
+            available_languages=["japanese"],
+        )
+        widget.update_data(data)
+
+        assert "1人の女の子" in widget._tags_compact_label.text()

--- a/tests/unit/gui/widgets/test_selected_image_details_widget.py
+++ b/tests/unit/gui/widgets/test_selected_image_details_widget.py
@@ -161,3 +161,86 @@ class TestSelectedImageDetailsWidget:
         # 表示がクリアされる
         assert widget.current_image_id is None
         assert widget.current_details is None
+
+    def test_set_merged_reader_none_hides_language_selector(self, widget):
+        """set_merged_reader(None)でコンボボックスが非表示になること"""
+        widget.set_merged_reader(None)
+        # isHidden()はisVisible()と異なり親ウィジェットの表示状態に依存しない
+        assert widget.annotation_display._lang_bar.isHidden()
+
+    def test_set_merged_reader_with_valid_reader_shows_selector(self, widget):
+        """有効なMergedTagReaderでコンボボックスが表示されること"""
+        mock_reader = Mock()
+        mock_reader.get_tag_languages.return_value = ["japanese", "chinese"]
+
+        widget.set_merged_reader(mock_reader)
+
+        assert not widget.annotation_display._lang_bar.isHidden()
+        # "english" + 2言語 = 3アイテム
+        assert widget.annotation_display._lang_combo.count() == 3
+
+    def test_build_metadata_with_translations(self, widget):
+        """翻訳データが正しくAnnotationData.tag_translationsに入ること"""
+        mock_reader = Mock()
+        mock_reader.get_tag_languages.return_value = ["japanese"]
+        tr_mock = Mock()
+        tr_mock.language = "japanese"
+        tr_mock.translation = "1人の女の子"
+        mock_reader.get_translations.return_value = [tr_mock]
+        widget.set_merged_reader(mock_reader)
+
+        metadata = {
+            "id": 1,
+            "file_path": "/test/img.jpg",
+            "tags": [
+                {
+                    "tag": "1girl",
+                    "tag_id": 42,
+                    "model_name": "wd",
+                    "source": "AI",
+                    "confidence_score": 0.9,
+                    "is_edited_manually": False,
+                }
+            ],
+            "caption_text": "",
+            "tags_text": "1girl",
+            "score_value": 0,
+            "rating_value": "",
+        }
+        details = widget._build_image_details_from_metadata(metadata)
+
+        assert details.annotation_data is not None
+        assert 42 in details.annotation_data.tag_translations
+        assert details.annotation_data.tag_translations[42]["japanese"] == "1人の女の子"
+
+    def test_build_metadata_skips_tag_without_tag_id(self, widget):
+        """tag_id=Noneのタグは翻訳取得をスキップすること"""
+        mock_reader = Mock()
+        mock_reader.get_tag_languages.return_value = ["japanese"]
+        mock_reader.get_translations.return_value = []
+        widget.set_merged_reader(mock_reader)
+
+        metadata = {
+            "id": 1,
+            "file_path": "/test/img.jpg",
+            "tags": [
+                {
+                    "tag": "1girl",
+                    "tag_id": None,
+                    "model_name": "wd",
+                    "source": "AI",
+                    "confidence_score": 0.9,
+                    "is_edited_manually": False,
+                }
+            ],
+            "caption_text": "",
+            "tags_text": "1girl",
+            "score_value": 0,
+            "rating_value": "",
+        }
+        details = widget._build_image_details_from_metadata(metadata)
+
+        # tag_id=Noneのタグはスキップ → get_translationsは呼ばれない
+        mock_reader.get_translations.assert_not_called()
+        assert details.annotation_data is not None
+        assert details.annotation_data.tag_translations == {}


### PR DESCRIPTION
## Summary
- 画像詳細ペインのタグ表示を言語切替可能に（QComboBox による言語セレクター追加）
- `MergedTagReader` 経由でタグ翻訳データを取得し、英語/日本語/中国語等を切替表示
- 翻訳未登録タグは英語原文にフォールバック
- `MergedTagReader` 未注入時は言語バーを非表示

## 実装ファイル
- `src/lorairo/gui/widgets/annotation_data_display_widget.py`: `initialize_language_selector()`, `_refresh_tags_for_language()`, `AnnotationData` に `tag_translations` / `available_languages` 追加
- `src/lorairo/gui/widgets/selected_image_details_widget.py`: `set_merged_reader()` 追加、翻訳データ構築。`_available_languages` を `set_merged_reader` 内でキャッシュし、`get_tag_languages()` の二重呼び出しを回避
- `src/lorairo/gui/services/widget_setup_service.py`: `SelectedImageDetailsWidget` 初期化時に `MergedTagReader` を注入

## Test plan
- [x] `test_annotation_data_display_widget.py` 新規作成（言語切替/fallback/空リスト/english重複排除など 13 tests）
- [x] `test_selected_image_details_widget.py` 追記（`set_merged_reader` 呼び出し、翻訳データ構築、tag_id=None スキップ 11 tests）
- [x] `ruff check` / `ruff format` 対象ファイルパス
- [x] 手動: 画像選択 → 言語コンボ切替 → タグ表示更新
- [x] 手動: `MergedTagReader` 未注入時に言語バーが非表示

## フォローアップ (別 Issue で追跡予定)
- N+1 クエリ: `selected_image_details_widget.py` でタグごとに `get_translations(tag_id)` を呼び出している点を、`genai-tag-db-tools` 側にバッチ API (`get_translations_batch`) を追加して解消する

Fixes #50

🤖 Generated with [Claude Code](https://claude.com/claude-code)