### PR TITLE
fix: Integration Tests CIの旧パス参照を修正 Fixes #73

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,7 +155,7 @@ jobs:
 
       - name: Run integration tests
         run: |
-          uv run pytest tests/integration tests/step_defs \
+          uv run pytest tests/integration tests/bdd \
             -m "not gui_show and not real_api and not slow" \
             --cov=src \
             --cov=local_packages/genai-tag-db-tools/src/genai_tag_db_tools \


### PR DESCRIPTION
tests/step_defs から tests/bdd へのパス変更に追従していなかった .github/workflows/ci.yml を更新。

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>