### PR TITLE
fix: Ruff check エラー 87件→14件に削減

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,6 +98,11 @@ ignore = [
     "F401",   # Unused imports (IDEでの管理が困難なため)
     "B008",   # typer.Option/Argument in function defaults (typer標準パターン)
 ]
+
+[tool.ruff.lint.per-file-ignores]
+# tests/conftest.py はモックを先に設定してから lorairo モジュールをインポートする必要があるため
+# モジュール先頭以外の import は意図的
+"tests/conftest.py" = ["E402"]
 fixable = ["ALL"]
 
 [tool.ruff.format]

--- a/src/lorairo/services/ui_responsive_conversion_service.py
+++ b/src/lorairo/services/ui_responsive_conversion_service.py
@@ -223,7 +223,7 @@ class UIResponsiveConversionService:
             tree = ET.parse(file_path)
             root = tree.getroot()
         except ET.ParseError as e:
-            raise ValueError(f"XML parse error in {file_path}: {e}")
+            raise ValueError(f"XML parse error in {file_path}: {e}") from e
 
         # XML構造検証
         if not self._validate_xml_structure(root):
@@ -676,7 +676,11 @@ class UIResponsiveConversionService:
         return True
 
     def _find_widgets_by_criteria(
-        self, root: ET.Element, widget_class: str = None, widget_name: str = None, has_property: str = None
+        self,
+        root: ET.Element,
+        widget_class: str | None = None,
+        widget_name: str | None = None,
+        has_property: str | None = None,
     ) -> list[ET.Element]:
         """複合条件でのウィジェット検索
 
@@ -709,7 +713,7 @@ class UIResponsiveConversionService:
         return widgets
 
     def _get_widget_property_value(
-        self, widget: ET.Element, property_name: str, sub_element: str = None
+        self, widget: ET.Element, property_name: str, sub_element: str | None = None
     ) -> str | None:
         """ウィジェットプロパティ値取得
 

--- a/tests/bdd/steps/test_database_management.py
+++ b/tests/bdd/steps/test_database_management.py
@@ -475,12 +475,13 @@ def when_save_annotations_with_datatable(
                 continue
 
             # ヘルパー関数で値を取得 (列が存在しない場合は None)
-            def get_value(col_name):
+            # デフォルト引数でループ変数 row_values を束縛し、クロージャの遅延評価を回避
+            def get_value(col_name, _row=row_values):
                 return (
-                    row_values[header_map[col_name]].strip()
+                    _row[header_map[col_name]].strip()
                     if col_name in header_map
-                    and header_map[col_name] < len(row_values)
-                    and row_values[header_map[col_name]] is not None
+                    and header_map[col_name] < len(_row)
+                    and _row[header_map[col_name]] is not None
                     else None
                 )
 

--- a/tests/integration/gui/test_filter_search_integration.py
+++ b/tests/integration/gui/test_filter_search_integration.py
@@ -316,7 +316,7 @@ class TestFilterSearchIntegration:
 
     def test_memory_management_integration(self, filter_panel):
         """メモリ管理統合テスト"""
-        initial_conditions = filter_panel.search_filter_service.get_current_conditions()
+        filter_panel.search_filter_service.get_current_conditions()
 
         # 複数回の検索実行
         for i in range(10):
@@ -397,13 +397,13 @@ class TestServiceLayerIntegration:
     def test_cross_service_communication(self, service_integration):
         """サービス間通信統合テスト"""
         processor = service_integration["criteria_processor"]
-        model_service = service_integration["model_filter_service"]
+        service_integration["model_filter_service"]
 
         # 検索実行後、結果に対してモデルフィルター適用
         conditions = SearchConditions(search_type="tags", keywords=["test"], tag_logic="and")
 
         # 1. 検索実行
-        images, count = processor.execute_search_with_filters(conditions)
+        images, _count = processor.execute_search_with_filters(conditions)
 
         # 2. アノテーション状態フィルタリング
         filtered_images = processor.filter_images_by_annotation_status(images, "annotated")

--- a/tests/integration/gui/workers/test_worker_error_recording.py
+++ b/tests/integration/gui/workers/test_worker_error_recording.py
@@ -295,7 +295,7 @@ class TestSearchWorkerErrorRecording:
         worker = SearchWorker(db_manager=db_manager, search_conditions=conditions)
 
         with patch.object(db_manager, "get_images_by_filter", side_effect=Exception("Database Error")):
-            with pytest.raises(Exception):
+            with pytest.raises(Exception, match="Database Error"):
                 worker.execute()
 
         # error_recordsテーブルにエラーが記録されていることを確認

--- a/tests/integration/test_ai_rating_filter_integration.py
+++ b/tests/integration/test_ai_rating_filter_integration.py
@@ -58,7 +58,7 @@ class TestAIRatingFilterIntegration:
         )
 
         # SearchCriteriaProcessor 経由で検索実行
-        results, count = criteria_processor.execute_search_with_filters(conditions)
+        _results, _count = criteria_processor.execute_search_with_filters(conditions)
 
         # Repository が正しいパラメータで呼ばれたことを確認
         mock_repository.get_images_by_filter.assert_called_once()

--- a/tests/integration/test_upscaler_database_integration.py
+++ b/tests/integration/test_upscaler_database_integration.py
@@ -2,6 +2,7 @@
 
 import tempfile
 from pathlib import Path
+from unittest.mock import MagicMock
 
 import pytest
 from PIL import Image

--- a/tests/unit/database/test_db_repository_ai_rating_filter.py
+++ b/tests/unit/database/test_db_repository_ai_rating_filter.py
@@ -130,7 +130,7 @@ class TestGetImagesByFilterAIRating:
 
     def test_priority_based_manual_over_ai(self, mock_session_and_repository):
         """manual_rating_filter が ai_rating_filter より優先されることを確認"""
-        repository, mock_session = mock_session_and_repository
+        repository, _mock_session = mock_session_and_repository
 
         with patch.object(repository, "_apply_manual_filters") as mock_manual:
             with patch.object(repository, "_apply_ai_rating_filter") as mock_ai:
@@ -147,7 +147,7 @@ class TestGetImagesByFilterAIRating:
 
     def test_ai_rating_filter_only(self, mock_session_and_repository):
         """ai_rating_filter のみが指定された場合、適用されることを確認"""
-        repository, mock_session = mock_session_and_repository
+        repository, _mock_session = mock_session_and_repository
 
         with patch.object(repository, "_apply_ai_rating_filter") as mock_ai:
             mock_ai.return_value = select(Image.id)
@@ -163,7 +163,7 @@ class TestGetImagesByFilterAIRating:
         repository, mock_session = mock_session_and_repository
 
         # include_unrated=False を指定して検索
-        results, count = repository.get_images_by_filter(include_unrated=False)
+        _results, _count = repository.get_images_by_filter(include_unrated=False)
 
         # クエリが実行されたことを確認
         assert mock_session.execute.called
@@ -173,11 +173,11 @@ class TestGetImagesByFilterAIRating:
         repository, mock_session = mock_session_and_repository
 
         # NSFW値を ai_rating_filter に指定した場合、NSFW除外は無効化される
-        results1, count1 = repository.get_images_by_filter(ai_rating_filter="R", include_nsfw=False)
+        _results1, _count1 = repository.get_images_by_filter(ai_rating_filter="R", include_nsfw=False)
         assert mock_session.execute.called
 
         # 非NSFW値を ai_rating_filter に指定した場合、NSFW除外が有効
-        results2, count2 = repository.get_images_by_filter(ai_rating_filter="PG", include_nsfw=False)
+        _results2, _count2 = repository.get_images_by_filter(ai_rating_filter="PG", include_nsfw=False)
         assert mock_session.execute.called
 
 

--- a/tests/unit/database/test_db_repository_error_records.py
+++ b/tests/unit/database/test_db_repository_error_records.py
@@ -28,7 +28,7 @@ class TestSaveErrorRecord:
         mock_record.id = 1
         repository.session_factory.return_value.__enter__.return_value = mock_session
 
-        error_id = repository.save_error_record(
+        repository.save_error_record(
             operation_type="annotation",
             error_type="API error",
             error_message="Test error",
@@ -49,7 +49,7 @@ class TestSaveErrorRecord:
         mock_record.id = 2
         repository.session_factory.return_value.__enter__.return_value = mock_session
 
-        error_id = repository.save_error_record(
+        repository.save_error_record(
             operation_type="annotation",
             error_type="API error",
             error_message="Test error",

--- a/tests/unit/database/test_db_repository_score_filter.py
+++ b/tests/unit/database/test_db_repository_score_filter.py
@@ -120,7 +120,7 @@ class TestGetImagesByFilterScoreIntegration:
         """score_min のみが指定された場合、適用されることを確認"""
         repository, mock_session = mock_session_and_repository
 
-        results, count = repository.get_images_by_filter(score_min=5.0)
+        _results, _count = repository.get_images_by_filter(score_min=5.0)
 
         # クエリが実行されたことを確認
         assert mock_session.execute.called
@@ -129,7 +129,7 @@ class TestGetImagesByFilterScoreIntegration:
         """score_max のみが指定された場合、適用されることを確認"""
         repository, mock_session = mock_session_and_repository
 
-        results, count = repository.get_images_by_filter(score_max=8.0)
+        _results, _count = repository.get_images_by_filter(score_max=8.0)
 
         # クエリが実行されたことを確認
         assert mock_session.execute.called

--- a/tests/unit/gui/widgets/test_model_checkbox_widget.py
+++ b/tests/unit/gui/widgets/test_model_checkbox_widget.py
@@ -244,7 +244,7 @@ class TestProviderStylesConstant:
 
     def test_styles_are_valid_qss(self):
         """スタイル文字列が有効なQSS形式であることを確認"""
-        for provider, style in PROVIDER_STYLES.items():
+        for _provider, style in PROVIDER_STYLES.items():
             # 基本的なQSS構文チェック
             assert "QLabel" in style
             assert "{" in style

--- a/tests/unit/test_model_sync_service.py
+++ b/tests/unit/test_model_sync_service.py
@@ -232,7 +232,7 @@ class TestModelSyncServiceWithRealDB:
         assert registered_model_1 is not None
         assert registered_model_1.provider == "openai"
         assert len(registered_model_1.model_types) == 2
-        assert set(mt.name for mt in registered_model_1.model_types) == {"llm", "captioner"}
+        assert {mt.name for mt in registered_model_1.model_types} == {"llm", "captioner"}
 
         registered_model_2 = temp_db_repository.get_model_by_name("test-model-new-2")
         assert registered_model_2 is not None
@@ -296,7 +296,7 @@ class TestModelSyncServiceWithRealDB:
     def test_update_existing_models_success(self, model_sync_service, temp_db_repository):
         """既存モデル更新処理（実DB操作）"""
         # 事前にモデルを登録
-        model_id = temp_db_repository.insert_model(
+        temp_db_repository.insert_model(
             name="update-test-model", provider="openai", model_types=["captioner"], estimated_size_gb=1.0
         )
 
@@ -325,7 +325,7 @@ class TestModelSyncServiceWithRealDB:
         assert updated_model is not None
         assert updated_model.estimated_size_gb == 2.5
         assert len(updated_model.model_types) == 2
-        assert set(mt.name for mt in updated_model.model_types) == {"llm", "captioner"}
+        assert {mt.name for mt in updated_model.model_types} == {"llm", "captioner"}
 
     def test_update_existing_models_no_changes(self, model_sync_service, temp_db_repository):
         """既存モデル更新処理（変更なし）"""

--- a/tests/unit/workers/test_database_worker.py
+++ b/tests/unit/workers/test_database_worker.py
@@ -354,7 +354,7 @@ class TestRegisterSingleImage:
 
     def test_register_single_image_normal_registration(self, temp_dir, worker_setup):
         """新規画像を登録（重複なし、関連ファイルなし）"""
-        worker, mock_db_manager, mock_fsm = worker_setup
+        worker, mock_db_manager, _mock_fsm = worker_setup
 
         image_path = temp_dir / "test.jpg"
         image_path.write_bytes(b"fake_image")
@@ -378,7 +378,7 @@ class TestRegisterSingleImage:
 
     def test_register_single_image_duplicate_detection(self, temp_dir, worker_setup):
         """pHash一致で重複検出 → スキップ"""
-        worker, mock_db_manager, mock_fsm = worker_setup
+        worker, mock_db_manager, _mock_fsm = worker_setup
 
         image_path = temp_dir / "test.jpg"
         image_path.write_bytes(b"fake_image")
@@ -402,7 +402,7 @@ class TestRegisterSingleImage:
 
     def test_register_single_image_with_tags_only(self, temp_dir, worker_setup):
         """ ".txt 存在、.caption 不在"""
-        worker, mock_db_manager, mock_fsm = worker_setup
+        worker, mock_db_manager, _mock_fsm = worker_setup
 
         image_path = temp_dir / "test.jpg"
         image_path.write_bytes(b"fake_image")
@@ -427,7 +427,7 @@ class TestRegisterSingleImage:
 
     def test_register_single_image_with_caption_only(self, temp_dir, worker_setup):
         """.caption 存在、.txt 不在"""
-        worker, mock_db_manager, mock_fsm = worker_setup
+        worker, mock_db_manager, _mock_fsm = worker_setup
 
         image_path = temp_dir / "test.jpg"
         image_path.write_bytes(b"fake_image")
@@ -452,7 +452,7 @@ class TestRegisterSingleImage:
 
     def test_register_single_image_with_both_files(self, temp_dir, worker_setup):
         """.txt と .caption の両方存在"""
-        worker, mock_db_manager, mock_fsm = worker_setup
+        worker, mock_db_manager, _mock_fsm = worker_setup
 
         image_path = temp_dir / "test.jpg"
         image_path.write_bytes(b"fake_image")
@@ -477,7 +477,7 @@ class TestRegisterSingleImage:
 
     def test_register_single_image_without_associated_files(self, temp_dir, worker_setup):
         """.txt/.caption 不在"""
-        worker, mock_db_manager, mock_fsm = worker_setup
+        worker, mock_db_manager, _mock_fsm = worker_setup
 
         image_path = temp_dir / "test.jpg"
         image_path.write_bytes(b"fake_image")
@@ -499,7 +499,7 @@ class TestRegisterSingleImage:
 
     def test_register_single_image_db_registration_returns_none(self, temp_dir, worker_setup):
         """register_original_image() が None を返す（失敗）"""
-        worker, mock_db_manager, mock_fsm = worker_setup
+        worker, mock_db_manager, _mock_fsm = worker_setup
 
         image_path = temp_dir / "test.jpg"
         image_path.write_bytes(b"fake_image")
@@ -521,7 +521,7 @@ class TestRegisterSingleImage:
 
     def test_register_single_image_progress_reporting(self, temp_dir, worker_setup):
         """_report_batch_progress() と _report_progress() が呼ばれる"""
-        worker, mock_db_manager, mock_fsm = worker_setup
+        worker, mock_db_manager, _mock_fsm = worker_setup
 
         image_path = temp_dir / "test.jpg"
         image_path.write_bytes(b"fake_image")
@@ -534,7 +534,7 @@ class TestRegisterSingleImage:
         with patch.object(worker, "file_reader") as mock_file_reader:
             mock_file_reader.get_existing_annotations.return_value = None
 
-            result_type, image_id = worker._register_single_image(image_path, 5, 100)
+            _result_type, _image_id = worker._register_single_image(image_path, 5, 100)
 
             # _report_batch_progress の呼び出しを確認
             worker._report_batch_progress.assert_called_once_with(6, 100, image_path.name)
@@ -546,7 +546,7 @@ class TestRegisterSingleImage:
 
     def test_register_single_image_associated_file_processing_error(self, temp_dir, worker_setup):
         """save_tags() で例外発生 - エラーが適切にハンドルされる"""
-        worker, mock_db_manager, mock_fsm = worker_setup
+        worker, mock_db_manager, _mock_fsm = worker_setup
 
         image_path = temp_dir / "test.jpg"
         image_path.write_bytes(b"fake_image")
@@ -570,7 +570,7 @@ class TestRegisterSingleImage:
 
     def test_register_single_image_multiple_tags_parsing(self, temp_dir, worker_setup):
         """複数タグのパース - TagAnnotationData を複数個作成"""
-        worker, mock_db_manager, mock_fsm = worker_setup
+        worker, mock_db_manager, _mock_fsm = worker_setup
 
         image_path = temp_dir / "test.jpg"
         image_path.write_bytes(b"fake_image")
@@ -586,7 +586,7 @@ class TestRegisterSingleImage:
                 "captions": [],
             }
 
-            result_type, image_id = worker._register_single_image(image_path, 0, 1)
+            result_type, _image_id = worker._register_single_image(image_path, 0, 1)
 
             assert result_type == "registered"
 
@@ -733,7 +733,7 @@ class TestBuildRegistrationResult:
             patch("time.time", return_value=2.0),
             patch("lorairo.gui.workers.registration_worker.logger") as mock_logger,
         ):
-            result = worker._build_registration_result(stats, processed_paths, start_time)
+            worker._build_registration_result(stats, processed_paths, start_time)
 
             # INFO ログが呼ばれたことを確認
             mock_logger.info.assert_called_once()
@@ -755,7 +755,7 @@ class TestBuildRegistrationResult:
             patch("time.time", return_value=1.5),
             patch("lorairo.gui.workers.registration_worker.logger") as mock_logger,
         ):
-            result = worker._build_registration_result(stats, processed_paths, start_time)
+            worker._build_registration_result(stats, processed_paths, start_time)
 
             # DEBUG ログが呼ばれていないことを確認
             mock_logger.debug.assert_not_called()
@@ -1154,7 +1154,7 @@ class TestRegisterSingleImageUnits:
         ):
             mock_file_reader.get_existing_annotations.return_value = None
 
-            result_type, image_id = worker._register_single_image(image_path, 0, 10)
+            result_type, _image_id = worker._register_single_image(image_path, 0, 10)
 
             assert result_type == "registered"
             # _process_associated_files は呼ばれるが、内部で None チェックして早期return
@@ -1175,7 +1175,7 @@ class TestRegisterSingleImageUnits:
                 "captions": [],
             }
 
-            result_type, image_id = worker._register_single_image(image_path, 0, 10)
+            result_type, _image_id = worker._register_single_image(image_path, 0, 10)
 
             assert result_type == "registered"
             mock_db_manager.save_tags.assert_called_once()
@@ -1196,7 +1196,7 @@ class TestRegisterSingleImageUnits:
                 "captions": ["test caption"],
             }
 
-            result_type, image_id = worker._register_single_image(image_path, 0, 10)
+            result_type, _image_id = worker._register_single_image(image_path, 0, 10)
 
             assert result_type == "registered"
             mock_db_manager.save_tags.assert_not_called()
@@ -1237,7 +1237,7 @@ class TestRegisterSingleImageUnits:
             mock_file_reader.get_existing_annotations.return_value = None
             mock_calc.return_value = 45
 
-            result_type, image_id = worker._register_single_image(image_path, 5, 100)
+            _result_type, _image_id = worker._register_single_image(image_path, 5, 100)
 
             mock_calc.assert_called_once_with(6, 100, 10, 85)
 
@@ -1291,7 +1291,7 @@ class TestRegisterSingleImageUnits:
                 "captions": [],
             }
 
-            result_type, image_id = worker._register_single_image(image_path, 0, 10)
+            result_type, _image_id = worker._register_single_image(image_path, 0, 10)
 
             assert result_type == "registered"
             mock_db_manager.save_tags.assert_called_once()


### PR DESCRIPTION
## Summary

- Issue #72 の Ruff check エラー 87件を 14件（C901のみ）に削減
- C901（複雑度超過）は Issue #81 で別途対応

## 修正内容

| 件数 | コード | 対応方法 |
|------|--------|---------|
| 48 | 各種 | `--unsafe-fixes` 自動修正（RUF059, F841, RUF013 等） |
| 18 | E402 | `tests/conftest.py` に `per-file-ignores` 追加（意図的な import 順序のため） |
| 2 | F821 | `MagicMock` import 追加 |
| 1 | B904 | `raise ... from e` に修正 |
| 1 | B017 | `pytest.raises` に `match=` 引数追加 |
| 3 | B023 | `get_value` のデフォルト引数でループ変数をバインド |

## Test plan

- [ ] `uv run ruff check src/ tests/` → C901 のみ 14件残存を確認
- [ ] CI Lint (Ruff) ジョブの通過を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)