### PR TITLE
fix: CI環境でのTyper/Rich ANSIエスケープによるhelpテスト失敗

### DIFF
--- a/tests/unit/cli/conftest.py
+++ b/tests/unit/cli/conftest.py
@@ -1,0 +1,20 @@
+"""CLI テスト共通設定。
+
+Rich/Typer のカラー出力を無効化する autouse フィクスチャを提供する。
+"""
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def disable_rich_color(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Rich/Typer のカラー出力をテスト環境で無効化する。
+
+    Rich は help 出力中の `--flag` パターンに ANSI エスケープ (`\\x1b[1;36m`) を挿入するため、
+    CI 環境のようにカラーが強制される条件下では `assert "--project" in result.stdout` が
+    `\\x1b[1;36m-\\x1b[0m\\x1b[1;36m-project\\x1b[0m` との比較になり失敗する。
+
+    NO_COLOR と TERM=dumb を設定して Rich の自動検出を抑制する。
+    """
+    monkeypatch.setenv("NO_COLOR", "1")
+    monkeypatch.setenv("TERM", "dumb")


### PR DESCRIPTION
## Summary

Fixes #74

`tests/unit/cli/conftest.py` に autouse fixture で `NO_COLOR=1` / `TERM=dumb` を設定し、Rich が help 出力の `--flag` に挿入するカラーエスケープを抑制する。

## 根本原因

CI 環境では Rich が `CliRunner` の `StringIO` stdout をターミナルと誤検出し、help 出力の `--flag` パターンに ANSI エスケープを挿入する:
```
\x1b[1;36m-\x1b[0m\x1b[1;36m-project\x1b[0m
```

このため `assert "--project" in result.stdout` が失敗していた。

## 採用した方針 (複数案から比較)

| 方針 | 採用 | 理由 |
|------|------|------|
| A: 該当テストに `env={"NO_COLOR": "1"}` 追加 | × | 将来の `--flag` テスト追加時に毎回対応が必要 |
| B: ANSI strip ヘルパー関数 | × | 毎 assertion でヘルパー呼び出しが必要 |
| **C: `conftest.py` に autouse fixture** | **○** | **1ファイル追加のみ・全CLIテスト自動適用・本番CLIのUXに影響なし** |
| D: Typer app に `rich_markup_mode=None` | × | 本番 CLI のカラーヘルプが失われる |
| E: CliRunner ラッパー fixture | × | 既存7テストファイルのリファクタが必要 |

## 検証

- `FORCE_COLOR=1` (CI失敗を再現する条件) で `*_help` テスト5件全てが PASSED
- 通常環境で CLI テスト 70/70 PASSED

## Test plan

- [ ] CI `Unit Tests` ジョブで `test_export_create_help` が PASS することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)