### PR TITLE
fix: main()の戻り値型アノテーションをNoneからintに修正 Fixes #79

### DIFF
--- a/src/lorairo/main.py
+++ b/src/lorairo/main.py
@@ -180,7 +180,7 @@ def parse_arguments() -> argparse.Namespace:
     return parser.parse_args()
 
 
-def main() -> None:
+def main() -> int:
     """メイン実行関数"""
     # コマンドライン引数解析
     args = parse_arguments()


### PR DESCRIPTION
main()関数はexit_codeやエラー時に1を返しているにもかかわらず 戻り値型が-> Noneと宣言されていた。-> intに修正することで mypyの[return-value]および[func-returns-value]エラーを解消。

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>