### PR TITLE
feat: タグ翻訳取得のN+1クエリを解消 Closes #77

### DIFF
--- a/src/lorairo/gui/widgets/selected_image_details_widget.py
+++ b/src/lorairo/gui/widgets/selected_image_details_widget.py
@@ -413,16 +413,17 @@ class SelectedImageDetailsWidget(QWidget):
         caption_text = metadata.get("caption_text", "")
         tags_text = metadata.get("tags_text", "")
 
-        # 翻訳データ取得（merged_readerがある場合のみバッチ取得）
+        # 翻訳データ取得（N+1回避のためバッチ取得）
         tag_translations: dict[int, dict[str, str]] = {}
         if self._merged_reader is not None:
-            for tag_dict in tags_list:
-                tag_id = tag_dict.get("tag_id")
-                if tag_id is None:
-                    continue
-                for tr in self._merged_reader.get_translations(tag_id):
-                    if tr.language and tr.translation:
-                        tag_translations.setdefault(tag_id, {})[tr.language] = tr.translation
+            valid_tag_ids = [
+                tag_dict["tag_id"] for tag_dict in tags_list if tag_dict.get("tag_id") is not None
+            ]
+            if valid_tag_ids:
+                for tag_id, trs in self._merged_reader.get_translations_batch(valid_tag_ids).items():
+                    for tr in trs:
+                        if tr.language and tr.translation:
+                            tag_translations.setdefault(tag_id, {})[tr.language] = tr.translation
 
         annotation_data = AnnotationData(
             tags=tags_list,  # ← list[dict] をそのまま渡す

--- a/tests/unit/gui/widgets/test_selected_image_details_widget.py
+++ b/tests/unit/gui/widgets/test_selected_image_details_widget.py
@@ -186,7 +186,7 @@ class TestSelectedImageDetailsWidget:
         tr_mock = Mock()
         tr_mock.language = "japanese"
         tr_mock.translation = "1人の女の子"
-        mock_reader.get_translations.return_value = [tr_mock]
+        mock_reader.get_translations_batch.return_value = {42: [tr_mock]}
         widget.set_merged_reader(mock_reader)
 
         metadata = {
@@ -217,7 +217,7 @@ class TestSelectedImageDetailsWidget:
         """tag_id=Noneのタグは翻訳取得をスキップすること"""
         mock_reader = Mock()
         mock_reader.get_tag_languages.return_value = ["japanese"]
-        mock_reader.get_translations.return_value = []
+        mock_reader.get_translations_batch.return_value = {}
         widget.set_merged_reader(mock_reader)
 
         metadata = {
@@ -240,7 +240,39 @@ class TestSelectedImageDetailsWidget:
         }
         details = widget._build_image_details_from_metadata(metadata)
 
-        # tag_id=Noneのタグはスキップ → get_translationsは呼ばれない
-        mock_reader.get_translations.assert_not_called()
+        # tag_id=Noneのタグはスキップ → get_translations_batchは呼ばれない
+        mock_reader.get_translations_batch.assert_not_called()
         assert details.annotation_data is not None
         assert details.annotation_data.tag_translations == {}
+
+    def test_build_metadata_translations_uses_single_batch_call(self, widget):
+        """N個タグが存在してもget_translations_batchは1回だけ呼ばれること"""
+        mock_reader = Mock()
+        mock_reader.get_tag_languages.return_value = []
+        mock_reader.get_translations_batch.return_value = {}
+        widget.set_merged_reader(mock_reader)
+
+        metadata = {
+            "id": 1,
+            "file_path": "/test/img.jpg",
+            "tags": [
+                {
+                    "tag": f"tag{i}",
+                    "tag_id": i,
+                    "model_name": "wd",
+                    "source": "AI",
+                    "confidence_score": 0.9,
+                    "is_edited_manually": False,
+                }
+                for i in range(1, 11)
+            ],
+            "caption_text": "",
+            "tags_text": "",
+            "score_value": 0,
+            "rating_value": "",
+        }
+        widget._build_image_details_from_metadata(metadata)
+
+        mock_reader.get_translations_batch.assert_called_once()
+        call_args = mock_reader.get_translations_batch.call_args[0][0]
+        assert len(call_args) == 10


### PR DESCRIPTION
SelectedImageDetailsWidgetのN+1翻訳取得ループを get_translations_batch呼び出し1回に置き換えた。 genai-tag-db-toolsサブモジュールにバッチAPI追加(feat/issue-77-translations-batch)。

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>