### PR TITLE
fix: TypedDict 二重定義と PHashAnnotationResults 型エラーを解消 Closes #88

### DIFF
--- a/src/lorairo/database/db_repository.py
+++ b/src/lorairo/database/db_repository.py
@@ -2,7 +2,7 @@
 
 import datetime
 from pathlib import Path
-from typing import Any, TypedDict, cast
+from typing import Any, cast
 
 from genai_tag_db_tools import search_tags
 from genai_tag_db_tools.db.repository import MergedTagReader, get_default_reader
@@ -17,6 +17,9 @@ from ..utils.log import logger
 from .db_core import DefaultSessionLocal
 from .filter_criteria import ImageFilterCriteria
 from .schema import (
+    AnnotationsDict as AnnotationsDict,
+)
+from .schema import (
     Caption,
     ErrorRecord,
     Image,
@@ -28,44 +31,18 @@ from .schema import (
     Score,
     Tag,
 )
-
-
-# --- データ構造の型定義 (例) ---
-# 呼び出し側はこの構造に合わせてデータを用意する想定
-class TagAnnotationData(TypedDict):
-    tag: str
-    model_id: int | None
-    confidence_score: float | None
-    existing: bool
-    is_edited_manually: bool | None
-    tag_id: int | None
-
-
-class CaptionAnnotationData(TypedDict):
-    caption: str
-    model_id: int | None
-    existing: bool
-    is_edited_manually: bool | None
-
-
-class ScoreAnnotationData(TypedDict):
-    score: float
-    model_id: int
-    is_edited_manually: bool
-
-
-class RatingAnnotationData(TypedDict):
-    raw_rating_value: str
-    normalized_rating: str
-    model_id: int  # Rating must have a model
-    confidence_score: float | None
-
-
-class AnnotationsDict(TypedDict):
-    tags: list[TagAnnotationData]
-    captions: list[CaptionAnnotationData]
-    scores: list[ScoreAnnotationData]
-    ratings: list[RatingAnnotationData]
+from .schema import (
+    CaptionAnnotationData as CaptionAnnotationData,
+)
+from .schema import (
+    RatingAnnotationData as RatingAnnotationData,
+)
+from .schema import (
+    ScoreAnnotationData as ScoreAnnotationData,
+)
+from .schema import (
+    TagAnnotationData as TagAnnotationData,
+)
 
 
 class ImageRepository:

--- a/src/lorairo/gui/services/image_db_write_service.py
+++ b/src/lorairo/gui/services/image_db_write_service.py
@@ -244,8 +244,9 @@ class ImageDBWriteService:
                     "tag_id": None,  # 手動編集時はNone（自動生成）
                     "model_id": self.db_manager.get_manual_edit_model_id(),
                     "tag": tag,
-                    "source": "manual",  # 手動編集ソース
                     "confidence_score": None,  # 手動編集時は信頼度スコアなし
+                    "existing": False,
+                    "is_edited_manually": True,
                 }
                 tags_data.append(tag_data)
 
@@ -283,6 +284,7 @@ class ImageDBWriteService:
                 "model_id": self.db_manager.get_manual_edit_model_id(),
                 "caption": caption.strip(),
                 "existing": False,  # 手動編集時は新規作成
+                "is_edited_manually": True,
             }
 
             # Repositoryの save_annotations を呼び出し

--- a/src/lorairo/gui/window/main_window.py
+++ b/src/lorairo/gui/window/main_window.py
@@ -804,11 +804,11 @@ class MainWindow(QMainWindow, Ui_MainWindow):
             dialog.exec()
             raw_results = result.results
         else:
-            # 後方互換: 旧形式の生dict
+            # 後方互換: 旧形式の生dict（PHashAnnotationResults は dict サブクラス）
             self._delegate_to_result_handler(
                 "handle_annotation_finished", result, status_bar=self.statusBar()
             )
-            raw_results = result if isinstance(result, PHashAnnotationResults) else None
+            raw_results = cast(PHashAnnotationResults, result) if isinstance(result, dict) else None
 
         # Phase 2: 検索結果キャッシュ更新
         # ワークスペースタブで選択中の画像がアノテーション対象に含まれていた場合、

--- a/src/lorairo/gui/window/main_window.py
+++ b/src/lorairo/gui/window/main_window.py
@@ -792,10 +792,13 @@ class MainWindow(QMainWindow, Ui_MainWindow):
             - Phase 1: サマリーダイアログ表示
             - Phase 2: 検索結果キャッシュ更新（選択中画像の詳細パネル反映）
         """
+        from image_annotator_lib import PHashAnnotationResults
+
         from lorairo.gui.widgets.annotation_summary_dialog import AnnotationSummaryDialog
         from lorairo.gui.workers.annotation_worker import AnnotationExecutionResult
 
         # Phase 1: サマリーダイアログ表示
+        raw_results: PHashAnnotationResults | None = None
         if isinstance(result, AnnotationExecutionResult):
             dialog = AnnotationSummaryDialog(result, parent=self)
             dialog.exec()
@@ -805,7 +808,7 @@ class MainWindow(QMainWindow, Ui_MainWindow):
             self._delegate_to_result_handler(
                 "handle_annotation_finished", result, status_bar=self.statusBar()
             )
-            raw_results = result if isinstance(result, dict) else None
+            raw_results = result if isinstance(result, PHashAnnotationResults) else None
 
         # Phase 2: 検索結果キャッシュ更新
         # ワークスペースタブで選択中の画像がアノテーション対象に含まれていた場合、

--- a/src/lorairo/gui/workers/annotation_worker.py
+++ b/src/lorairo/gui/workers/annotation_worker.py
@@ -154,7 +154,7 @@ class AnnotationWorker(LoRAIroWorkerBase["AnnotationExecutionResult"]):
         Returns:
             (マージされたアノテーション結果, モデルエラー詳細リスト) のタプル。
         """
-        merged_results: PHashAnnotationResults = {}
+        merged_results: PHashAnnotationResults = PHashAnnotationResults()
         model_errors: list[ModelErrorDetail] = []
         total_models = len(self.models)
 
@@ -611,7 +611,7 @@ class AnnotationWorker(LoRAIroWorkerBase["AnnotationExecutionResult"]):
             - model_id解決はmodels_cacheから取得(N+1回避)
             - 正しいキー名: "tag", "caption", "raw_rating_value", "normalized_rating"
         """
-        from lorairo.database.db_repository import AnnotationsDict
+        from lorairo.database.schema import AnnotationsDict
 
         result: AnnotationsDict = {
             "scores": [],


### PR DESCRIPTION
- db_repository.py: TagAnnotationData/CaptionAnnotationData/ScoreAnnotationData/ RatingAnnotationData/AnnotationsDict の重複定義を削除し、 schema.py から明示的再エクスポート (as X 形式) に統一
- image_db_write_service.py: TagAnnotationData に existing/is_edited_manually を追加・存在しない source キーを削除。CaptionAnnotationData に is_edited_manually を追加
- annotation_worker.py: runtime import を schema に統一、 PHashAnnotationResults() コンストラクタを使用
- main_window.py: isinstance チェックを PHashAnnotationResults に変更し raw_results 型を明示 (PHashAnnotationResults | None)
- image-annotator-lib サブモジュール: PHashAnnotationResults を __all__ に追加

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>