### PR TITLE
fix: setupUi untyped call エラー 10件を解消 Closes #91

### DIFF
--- a/scripts/generate_ui.py
+++ b/scripts/generate_ui.py
@@ -14,6 +14,7 @@ Author: Claude Code (Anthropic)
 Date: 2025-09-04
 """
 
+import re
 import subprocess
 import sys
 from pathlib import Path
@@ -48,6 +49,31 @@ def find_ui_files() -> list[Path]:
     return ui_files
 
 
+def add_type_hints_to_ui(py_file: Path) -> None:
+    """Add QWidget type hints to setupUi and retranslateUi methods.
+
+    pyside6-uic generates untyped method signatures. This post-processing step
+    adds 'QWidget' type annotation and '-> None' return type so mypy does not
+    report no-untyped-call errors when these methods are called from typed code.
+    """
+    content = py_file.read_text(encoding="utf-8")
+    # def setupUi(self, SomeName):  →  def setupUi(self, SomeName: QWidget) -> None:
+    content = re.sub(
+        r"(def setupUi\(self, \w+)\):\s*$",
+        r"\1: QWidget) -> None:",
+        content,
+        flags=re.MULTILINE,
+    )
+    # def retranslateUi(self, SomeName):  →  def retranslateUi(self, SomeName: QWidget) -> None:
+    content = re.sub(
+        r"(def retranslateUi\(self, \w+)\):\s*$",
+        r"\1: QWidget) -> None:",
+        content,
+        flags=re.MULTILINE,
+    )
+    py_file.write_text(content, encoding="utf-8")
+
+
 def generate_python_from_ui(ui_file: Path) -> bool:
     """Generate Python code from a UI file using pyside6-uic."""
     # Calculate output filename
@@ -70,6 +96,7 @@ def generate_python_from_ui(ui_file: Path) -> bool:
         )
 
         if result.returncode == 0:
+            add_type_hints_to_ui(py_file)
             print(f"✅ Generated {py_file.name} from {ui_file.name}")
             return True
         else:

--- a/src/lorairo/gui/designer/AnnotationDataDisplayWidget_ui.py
+++ b/src/lorairo/gui/designer/AnnotationDataDisplayWidget_ui.py
@@ -20,7 +20,7 @@ from PySide6.QtWidgets import (QAbstractItemView, QApplication, QGridLayout, QGr
     QTableWidgetItem, QTextEdit, QVBoxLayout, QWidget)
 
 class Ui_AnnotationDataDisplayWidget(object):
-    def setupUi(self, AnnotationDataDisplayWidget):
+    def setupUi(self, AnnotationDataDisplayWidget: QWidget) -> None:
         if not AnnotationDataDisplayWidget.objectName():
             AnnotationDataDisplayWidget.setObjectName(u"AnnotationDataDisplayWidget")
         AnnotationDataDisplayWidget.resize(400, 600)
@@ -123,7 +123,7 @@ class Ui_AnnotationDataDisplayWidget(object):
         QMetaObject.connectSlotsByName(AnnotationDataDisplayWidget)
     # setupUi
 
-    def retranslateUi(self, AnnotationDataDisplayWidget):
+    def retranslateUi(self, AnnotationDataDisplayWidget: QWidget) -> None:
         AnnotationDataDisplayWidget.setWindowTitle(QCoreApplication.translate("AnnotationDataDisplayWidget", u"Annotation Data Display", None))
         self.groupBoxTags.setTitle(QCoreApplication.translate("AnnotationDataDisplayWidget", u"\u30bf\u30b0", None))
         ___qtablewidgetitem = self.tableWidgetTags.horizontalHeaderItem(0)

--- a/src/lorairo/gui/designer/AnnotationResultsWidget_ui.py
+++ b/src/lorairo/gui/designer/AnnotationResultsWidget_ui.py
@@ -20,7 +20,7 @@ from PySide6.QtWidgets import (QAbstractItemView, QApplication, QHeaderView, QLa
     QVBoxLayout, QWidget)
 
 class Ui_AnnotationResultsWidget(object):
-    def setupUi(self, AnnotationResultsWidget):
+    def setupUi(self, AnnotationResultsWidget: QWidget) -> None:
         if not AnnotationResultsWidget.objectName():
             AnnotationResultsWidget.setObjectName(u"AnnotationResultsWidget")
         AnnotationResultsWidget.resize(400, 400)
@@ -132,7 +132,7 @@ class Ui_AnnotationResultsWidget(object):
         QMetaObject.connectSlotsByName(AnnotationResultsWidget)
     # setupUi
 
-    def retranslateUi(self, AnnotationResultsWidget):
+    def retranslateUi(self, AnnotationResultsWidget: QWidget) -> None:
         AnnotationResultsWidget.setWindowTitle(QCoreApplication.translate("AnnotationResultsWidget", u"Annotation Results", None))
         self.labelResultsTitle.setText(QCoreApplication.translate("AnnotationResultsWidget", u"\u30a2\u30ce\u30c6\u30fc\u30b7\u30e7\u30f3\u7d50\u679c", None))
         ___qtablewidgetitem = self.tableWidgetCaption.horizontalHeaderItem(0)

--- a/src/lorairo/gui/designer/AnnotationStatusFilterWidget_ui.py
+++ b/src/lorairo/gui/designer/AnnotationStatusFilterWidget_ui.py
@@ -20,7 +20,7 @@ from PySide6.QtWidgets import (QApplication, QCheckBox, QGridLayout, QGroupBox,
     QSpacerItem, QVBoxLayout, QWidget)
 
 class Ui_AnnotationStatusFilterWidget(object):
-    def setupUi(self, AnnotationStatusFilterWidget):
+    def setupUi(self, AnnotationStatusFilterWidget: QWidget) -> None:
         if not AnnotationStatusFilterWidget.objectName():
             AnnotationStatusFilterWidget.setObjectName(u"AnnotationStatusFilterWidget")
         AnnotationStatusFilterWidget.resize(251, 167)
@@ -93,7 +93,7 @@ class Ui_AnnotationStatusFilterWidget(object):
         QMetaObject.connectSlotsByName(AnnotationStatusFilterWidget)
     # setupUi
 
-    def retranslateUi(self, AnnotationStatusFilterWidget):
+    def retranslateUi(self, AnnotationStatusFilterWidget: QWidget) -> None:
         AnnotationStatusFilterWidget.setWindowTitle(QCoreApplication.translate("AnnotationStatusFilterWidget", u"Annotation Status Filter", None))
         self.groupBoxStatusFilter.setTitle(QCoreApplication.translate("AnnotationStatusFilterWidget", u"\u30a2\u30ce\u30c6\u30fc\u30b7\u30e7\u30f3\u72b6\u614b", None))
         self.checkBoxError.setText(QCoreApplication.translate("AnnotationStatusFilterWidget", u"\u30a8\u30e9\u30fc", None))

--- a/src/lorairo/gui/designer/ConfigurationWindow_ui.py
+++ b/src/lorairo/gui/designer/ConfigurationWindow_ui.py
@@ -24,7 +24,7 @@ from ..widgets.directory_picker import DirectoryPickerWidget
 from ..widgets.file_picker import FilePickerWidget
 
 class Ui_ConfigurationWindow(object):
-    def setupUi(self, ConfigurationWindow):
+    def setupUi(self, ConfigurationWindow: QWidget) -> None:
         if not ConfigurationWindow.objectName():
             ConfigurationWindow.setObjectName(u"ConfigurationWindow")
         ConfigurationWindow.resize(718, 681)
@@ -245,7 +245,7 @@ class Ui_ConfigurationWindow(object):
         QMetaObject.connectSlotsByName(ConfigurationWindow)
     # setupUi
 
-    def retranslateUi(self, ConfigurationWindow):
+    def retranslateUi(self, ConfigurationWindow: QWidget) -> None:
         ConfigurationWindow.setWindowTitle(QCoreApplication.translate("ConfigurationWindow", u"Form", None))
         self.groupBoxFolders.setTitle(QCoreApplication.translate("ConfigurationWindow", u"\u30d5\u30a9\u30eb\u30c0\u8a2d\u5b9a", None))
         self.groupBoxApiSettings.setTitle(QCoreApplication.translate("ConfigurationWindow", u"API KEY", None))

--- a/src/lorairo/gui/designer/DatasetExportWidget_ui.py
+++ b/src/lorairo/gui/designer/DatasetExportWidget_ui.py
@@ -26,7 +26,7 @@ from ..widgets.image_preview import ImagePreviewWidget
 from ..widgets.thumbnail import ThumbnailSelectorWidget
 
 class Ui_DatasetExportWidget(object):
-    def setupUi(self, DatasetExportWidget):
+    def setupUi(self, DatasetExportWidget: QWidget) -> None:
         if not DatasetExportWidget.objectName():
             DatasetExportWidget.setObjectName(u"DatasetExportWidget")
         DatasetExportWidget.resize(1200, 800)
@@ -254,7 +254,7 @@ class Ui_DatasetExportWidget(object):
         QMetaObject.connectSlotsByName(DatasetExportWidget)
     # setupUi
 
-    def retranslateUi(self, DatasetExportWidget):
+    def retranslateUi(self, DatasetExportWidget: QWidget) -> None:
         DatasetExportWidget.setWindowTitle(QCoreApplication.translate("DatasetExportWidget", u"Dataset Export", None))
         self.imageCountLabel.setText("")
         self.exportGroupBox.setTitle(QCoreApplication.translate("DatasetExportWidget", u"Export Settings", None))

--- a/src/lorairo/gui/designer/DatasetOverviewWidget_ui.py
+++ b/src/lorairo/gui/designer/DatasetOverviewWidget_ui.py
@@ -24,7 +24,7 @@ from ..widgets.image_preview import ImagePreviewWidget
 from ..widgets.thumbnail import ThumbnailSelectorWidget
 
 class Ui_DatasetOverviewWidget(object):
-    def setupUi(self, DatasetOverviewWidget):
+    def setupUi(self, DatasetOverviewWidget: QWidget) -> None:
         if not DatasetOverviewWidget.objectName():
             DatasetOverviewWidget.setObjectName(u"DatasetOverviewWidget")
         DatasetOverviewWidget.resize(350, 777)
@@ -267,7 +267,7 @@ class Ui_DatasetOverviewWidget(object):
         QMetaObject.connectSlotsByName(DatasetOverviewWidget)
     # setupUi
 
-    def retranslateUi(self, DatasetOverviewWidget):
+    def retranslateUi(self, DatasetOverviewWidget: QWidget) -> None:
         DatasetOverviewWidget.setWindowTitle(QCoreApplication.translate("DatasetOverviewWidget", u"Dataset Overview", None))
         self.metadataGroupBox.setTitle("")
         self.fileNameLabel.setText(QCoreApplication.translate("DatasetOverviewWidget", u"\u30d5\u30a1\u30a4\u30eb\u540d:", None))

--- a/src/lorairo/gui/designer/DirectoryPickerWidget_ui.py
+++ b/src/lorairo/gui/designer/DirectoryPickerWidget_ui.py
@@ -20,7 +20,7 @@ from PySide6.QtWidgets import (QApplication, QHBoxLayout, QSizePolicy, QWidget)
 from ..widgets.picker import PickerWidget
 
 class Ui_DirectoryPickerWidget(object):
-    def setupUi(self, DirectoryPickerWidget):
+    def setupUi(self, DirectoryPickerWidget: QWidget) -> None:
         if not DirectoryPickerWidget.objectName():
             DirectoryPickerWidget.setObjectName(u"DirectoryPickerWidget")
         DirectoryPickerWidget.resize(562, 253)
@@ -42,7 +42,7 @@ class Ui_DirectoryPickerWidget(object):
         QMetaObject.connectSlotsByName(DirectoryPickerWidget)
     # setupUi
 
-    def retranslateUi(self, DirectoryPickerWidget):
+    def retranslateUi(self, DirectoryPickerWidget: QWidget) -> None:
         DirectoryPickerWidget.setWindowTitle(QCoreApplication.translate("DirectoryPickerWidget", u"Form", None))
     # retranslateUi
 

--- a/src/lorairo/gui/designer/FilePickerWidget_ui.py
+++ b/src/lorairo/gui/designer/FilePickerWidget_ui.py
@@ -20,7 +20,7 @@ from PySide6.QtWidgets import (QApplication, QHBoxLayout, QSizePolicy, QWidget)
 from ..widgets.picker import PickerWidget
 
 class Ui_FilePickerWidget(object):
-    def setupUi(self, FilePickerWidget):
+    def setupUi(self, FilePickerWidget: QWidget) -> None:
         if not FilePickerWidget.objectName():
             FilePickerWidget.setObjectName(u"FilePickerWidget")
         FilePickerWidget.resize(562, 253)
@@ -42,7 +42,7 @@ class Ui_FilePickerWidget(object):
         QMetaObject.connectSlotsByName(FilePickerWidget)
     # setupUi
 
-    def retranslateUi(self, FilePickerWidget):
+    def retranslateUi(self, FilePickerWidget: QWidget) -> None:
         FilePickerWidget.setWindowTitle(QCoreApplication.translate("FilePickerWidget", u"Form", None))
     # retranslateUi
 

--- a/src/lorairo/gui/designer/FilterSearchPanel_ui.py
+++ b/src/lorairo/gui/designer/FilterSearchPanel_ui.py
@@ -21,7 +21,7 @@ from PySide6.QtWidgets import (QApplication, QCheckBox, QComboBox, QFrame,
     QSpacerItem, QVBoxLayout, QWidget)
 
 class Ui_FilterSearchPanel(object):
-    def setupUi(self, FilterSearchPanel):
+    def setupUi(self, FilterSearchPanel: QWidget) -> None:
         if not FilterSearchPanel.objectName():
             FilterSearchPanel.setObjectName(u"FilterSearchPanel")
         FilterSearchPanel.setVerticalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAsNeeded)
@@ -301,7 +301,7 @@ class Ui_FilterSearchPanel(object):
         QMetaObject.connectSlotsByName(FilterSearchPanel)
     # setupUi
 
-    def retranslateUi(self, FilterSearchPanel):
+    def retranslateUi(self, FilterSearchPanel: QWidget) -> None:
         FilterSearchPanel.setWindowTitle(QCoreApplication.translate("FilterSearchPanel", u"Filter Search Panel", None))
         self.searchGroup.setTitle(QCoreApplication.translate("FilterSearchPanel", u"\u691c\u7d22", None))
         self.searchTypeLabel.setText(QCoreApplication.translate("FilterSearchPanel", u"\u691c\u7d22\u5bfe\u8c61:", None))

--- a/src/lorairo/gui/designer/ImageEditWidget_ui.py
+++ b/src/lorairo/gui/designer/ImageEditWidget_ui.py
@@ -23,7 +23,7 @@ from PySide6.QtWidgets import (QAbstractItemView, QApplication, QComboBox, QFram
 from ..widgets.image_preview import ImagePreviewWidget
 
 class Ui_ImageEditWidget(object):
-    def setupUi(self, ImageEditWidget):
+    def setupUi(self, ImageEditWidget: QWidget) -> None:
         if not ImageEditWidget.objectName():
             ImageEditWidget.setObjectName(u"ImageEditWidget")
         ImageEditWidget.resize(758, 781)
@@ -170,7 +170,7 @@ class Ui_ImageEditWidget(object):
         QMetaObject.connectSlotsByName(ImageEditWidget)
     # setupUi
 
-    def retranslateUi(self, ImageEditWidget):
+    def retranslateUi(self, ImageEditWidget: QWidget) -> None:
         ImageEditWidget.setWindowTitle(QCoreApplication.translate("ImageEditWidget", u"Form", None))
         ___qtablewidgetitem = self.tableWidgetImageList.horizontalHeaderItem(0)
         ___qtablewidgetitem.setText(QCoreApplication.translate("ImageEditWidget", u"\u30b5\u30e0\u30cd\u30a4\u30eb", None));

--- a/src/lorairo/gui/designer/ImagePreviewWidget_ui.py
+++ b/src/lorairo/gui/designer/ImagePreviewWidget_ui.py
@@ -19,7 +19,7 @@ from PySide6.QtWidgets import (QApplication, QGraphicsView, QSizePolicy, QVBoxLa
     QWidget)
 
 class Ui_ImagePreviewWidget(object):
-    def setupUi(self, ImagePreviewWidget):
+    def setupUi(self, ImagePreviewWidget: QWidget) -> None:
         if not ImagePreviewWidget.objectName():
             ImagePreviewWidget.setObjectName(u"ImagePreviewWidget")
         self.verticalLayout = QVBoxLayout(ImagePreviewWidget)
@@ -37,7 +37,7 @@ class Ui_ImagePreviewWidget(object):
         QMetaObject.connectSlotsByName(ImagePreviewWidget)
     # setupUi
 
-    def retranslateUi(self, ImagePreviewWidget):
+    def retranslateUi(self, ImagePreviewWidget: QWidget) -> None:
         ImagePreviewWidget.setWindowTitle(QCoreApplication.translate("ImagePreviewWidget", u"Form", None))
     # retranslateUi
 

--- a/src/lorairo/gui/designer/MainWindow_ui.py
+++ b/src/lorairo/gui/designer/MainWindow_ui.py
@@ -28,7 +28,7 @@ from ..widgets.selected_image_details_widget import SelectedImageDetailsWidget
 from ..widgets.thumbnail import ThumbnailSelectorWidget
 
 class Ui_MainWindow(object):
-    def setupUi(self, MainWindow):
+    def setupUi(self, MainWindow: QWidget) -> None:
         if not MainWindow.objectName():
             MainWindow.setObjectName(u"MainWindow")
         MainWindow.resize(1287, 1178)
@@ -441,7 +441,7 @@ class Ui_MainWindow(object):
         QMetaObject.connectSlotsByName(MainWindow)
     # setupUi
 
-    def retranslateUi(self, MainWindow):
+    def retranslateUi(self, MainWindow: QWidget) -> None:
         MainWindow.setWindowTitle(QCoreApplication.translate("MainWindow", u"LoRAIro - \u30ef\u30fc\u30af\u30b9\u30da\u30fc\u30b9", None))
         self.actionOpenDataset.setText(QCoreApplication.translate("MainWindow", u"\u30c7\u30fc\u30bf\u30bb\u30c3\u30c8\u3092\u958b\u304f", None))
 #if QT_CONFIG(shortcut)

--- a/src/lorairo/gui/designer/ModelCheckboxWidget_ui.py
+++ b/src/lorairo/gui/designer/ModelCheckboxWidget_ui.py
@@ -19,7 +19,7 @@ from PySide6.QtWidgets import (QApplication, QCheckBox, QHBoxLayout, QLabel,
     QSizePolicy, QWidget)
 
 class Ui_ModelCheckboxWidget(object):
-    def setupUi(self, ModelCheckboxWidget):
+    def setupUi(self, ModelCheckboxWidget: QWidget) -> None:
         if not ModelCheckboxWidget.objectName():
             ModelCheckboxWidget.setObjectName(u"ModelCheckboxWidget")
         ModelCheckboxWidget.resize(300, 28)
@@ -111,7 +111,7 @@ class Ui_ModelCheckboxWidget(object):
         QMetaObject.connectSlotsByName(ModelCheckboxWidget)
     # setupUi
 
-    def retranslateUi(self, ModelCheckboxWidget):
+    def retranslateUi(self, ModelCheckboxWidget: QWidget) -> None:
         ModelCheckboxWidget.setWindowTitle(QCoreApplication.translate("ModelCheckboxWidget", u"Model Checkbox", None))
         self.checkboxModel.setText("")
         self.labelModelName.setText(QCoreApplication.translate("ModelCheckboxWidget", u"Model Name", None))

--- a/src/lorairo/gui/designer/ModelResultTab_ui.py
+++ b/src/lorairo/gui/designer/ModelResultTab_ui.py
@@ -21,7 +21,7 @@ from PySide6.QtWidgets import (QApplication, QFrame, QGroupBox, QHBoxLayout,
     QWidget)
 
 class Ui_ModelResultTab(object):
-    def setupUi(self, ModelResultTab):
+    def setupUi(self, ModelResultTab: QWidget) -> None:
         if not ModelResultTab.objectName():
             ModelResultTab.setObjectName(u"ModelResultTab")
         ModelResultTab.resize(500, 400)
@@ -263,7 +263,7 @@ class Ui_ModelResultTab(object):
         QMetaObject.connectSlotsByName(ModelResultTab)
     # setupUi
 
-    def retranslateUi(self, ModelResultTab):
+    def retranslateUi(self, ModelResultTab: QWidget) -> None:
         self.labelModelName.setText(QCoreApplication.translate("ModelResultTab", u"\u30e2\u30c7\u30eb\u540d: GPT-4o", None))
         self.labelProcessingTime.setText(QCoreApplication.translate("ModelResultTab", u"\u51e6\u7406\u6642\u9593: 2.3s", None))
         self.labelStatus.setText(QCoreApplication.translate("ModelResultTab", u"\u2713 \u6210\u529f", None))

--- a/src/lorairo/gui/designer/ModelSelectionTableWidget_ui.py
+++ b/src/lorairo/gui/designer/ModelSelectionTableWidget_ui.py
@@ -19,7 +19,7 @@ from PySide6.QtWidgets import (QAbstractItemView, QApplication, QHeaderView, QSi
     QTableWidget, QTableWidgetItem, QVBoxLayout, QWidget)
 
 class Ui_ModelSelectionTableWidget(object):
-    def setupUi(self, ModelSelectionTableWidget):
+    def setupUi(self, ModelSelectionTableWidget: QWidget) -> None:
         if not ModelSelectionTableWidget.objectName():
             ModelSelectionTableWidget.setObjectName(u"ModelSelectionTableWidget")
         ModelSelectionTableWidget.resize(400, 300)
@@ -70,7 +70,7 @@ class Ui_ModelSelectionTableWidget(object):
         QMetaObject.connectSlotsByName(ModelSelectionTableWidget)
     # setupUi
 
-    def retranslateUi(self, ModelSelectionTableWidget):
+    def retranslateUi(self, ModelSelectionTableWidget: QWidget) -> None:
         ModelSelectionTableWidget.setWindowTitle(QCoreApplication.translate("ModelSelectionTableWidget", u"Model Selection Table", None))
         ___qtablewidgetitem = self.tableWidgetModels.horizontalHeaderItem(0)
         ___qtablewidgetitem.setText(QCoreApplication.translate("ModelSelectionTableWidget", u"\u9078\u629e", None));

--- a/src/lorairo/gui/designer/ModelSelectionWidget_ui.py
+++ b/src/lorairo/gui/designer/ModelSelectionWidget_ui.py
@@ -20,7 +20,7 @@ from PySide6.QtWidgets import (QApplication, QComboBox, QFrame, QHBoxLayout,
     QSpacerItem, QVBoxLayout, QWidget)
 
 class Ui_ModelSelectionWidget(object):
-    def setupUi(self, ModelSelectionWidget):
+    def setupUi(self, ModelSelectionWidget: QWidget) -> None:
         if not ModelSelectionWidget.objectName():
             ModelSelectionWidget.setObjectName(u"ModelSelectionWidget")
         ModelSelectionWidget.resize(320, 300)
@@ -174,7 +174,7 @@ class Ui_ModelSelectionWidget(object):
         QMetaObject.connectSlotsByName(ModelSelectionWidget)
     # setupUi
 
-    def retranslateUi(self, ModelSelectionWidget):
+    def retranslateUi(self, ModelSelectionWidget: QWidget) -> None:
         ModelSelectionWidget.setWindowTitle(QCoreApplication.translate("ModelSelectionWidget", u"Model Selection", None))
         self.btnSelectAll.setText(QCoreApplication.translate("ModelSelectionWidget", u"\u5168\u9078\u629e", None))
         self.btnDeselectAll.setText(QCoreApplication.translate("ModelSelectionWidget", u"\u5168\u89e3\u9664", None))

--- a/src/lorairo/gui/designer/PickerWidget_ui.py
+++ b/src/lorairo/gui/designer/PickerWidget_ui.py
@@ -19,7 +19,7 @@ from PySide6.QtWidgets import (QApplication, QComboBox, QHBoxLayout, QLabel,
     QLineEdit, QPushButton, QSizePolicy, QWidget)
 
 class Ui_PickerWidget(object):
-    def setupUi(self, PickerWidget):
+    def setupUi(self, PickerWidget: QWidget) -> None:
         if not PickerWidget.objectName():
             PickerWidget.setObjectName(u"PickerWidget")
         PickerWidget.resize(540, 210)
@@ -73,7 +73,7 @@ class Ui_PickerWidget(object):
         QMetaObject.connectSlotsByName(PickerWidget)
     # setupUi
 
-    def retranslateUi(self, PickerWidget):
+    def retranslateUi(self, PickerWidget: QWidget) -> None:
         PickerWidget.setWindowTitle(QCoreApplication.translate("PickerWidget", u"Form", None))
         self.labelPicker.setText(QCoreApplication.translate("PickerWidget", u"Path", None))
         self.pushButtonPicker.setText(QCoreApplication.translate("PickerWidget", u"\u9078\u629e...", None))

--- a/src/lorairo/gui/designer/ProgressWidget_ui.py
+++ b/src/lorairo/gui/designer/ProgressWidget_ui.py
@@ -19,7 +19,7 @@ from PySide6.QtWidgets import (QApplication, QLabel, QProgressBar, QPushButton,
     QSizePolicy, QVBoxLayout, QWidget)
 
 class Ui_ProgressWidget(object):
-    def setupUi(self, ProgressWidget):
+    def setupUi(self, ProgressWidget: QWidget) -> None:
         if not ProgressWidget.objectName():
             ProgressWidget.setObjectName(u"ProgressWidget")
         ProgressWidget.setWindowModality(Qt.WindowModality.WindowModal)
@@ -60,7 +60,7 @@ class Ui_ProgressWidget(object):
         QMetaObject.connectSlotsByName(ProgressWidget)
     # setupUi
 
-    def retranslateUi(self, ProgressWidget):
+    def retranslateUi(self, ProgressWidget: QWidget) -> None:
         ProgressWidget.setWindowTitle(QCoreApplication.translate("ProgressWidget", u"Form", None))
         self.statusLabel.setText(QCoreApplication.translate("ProgressWidget", u"\u5f85\u6a5f\u4e2d...", None))
         self.progressBar.setFormat(QCoreApplication.translate("ProgressWidget", u"%v / %m", None))

--- a/src/lorairo/gui/designer/SelectedImageDetailsWidget_ui.py
+++ b/src/lorairo/gui/designer/SelectedImageDetailsWidget_ui.py
@@ -22,7 +22,7 @@ from PySide6.QtWidgets import (QApplication, QGridLayout, QGroupBox, QLabel,
 from ..widgets.annotation_data_display_widget import AnnotationDataDisplayWidget
 
 class Ui_SelectedImageDetailsWidget(object):
-    def setupUi(self, SelectedImageDetailsWidget):
+    def setupUi(self, SelectedImageDetailsWidget: QWidget) -> None:
         if not SelectedImageDetailsWidget.objectName():
             SelectedImageDetailsWidget.setObjectName(u"SelectedImageDetailsWidget")
         SelectedImageDetailsWidget.resize(250, 400)
@@ -172,7 +172,7 @@ class Ui_SelectedImageDetailsWidget(object):
         QMetaObject.connectSlotsByName(SelectedImageDetailsWidget)
     # setupUi
 
-    def retranslateUi(self, SelectedImageDetailsWidget):
+    def retranslateUi(self, SelectedImageDetailsWidget: QWidget) -> None:
         SelectedImageDetailsWidget.setWindowTitle(QCoreApplication.translate("SelectedImageDetailsWidget", u"Selected Image Details", None))
         self.groupBoxImageInfo.setTitle(QCoreApplication.translate("SelectedImageDetailsWidget", u"\u753b\u50cf\u60c5\u5831", None))
         self.labelFileName.setText(QCoreApplication.translate("SelectedImageDetailsWidget", u"\u30d5\u30a1\u30a4\u30eb\u540d:", None))

--- a/src/lorairo/gui/designer/ThumbnailSelectorWidget_ui.py
+++ b/src/lorairo/gui/designer/ThumbnailSelectorWidget_ui.py
@@ -20,7 +20,7 @@ from PySide6.QtWidgets import (QApplication, QFrame, QHBoxLayout, QLabel,
     QVBoxLayout, QWidget)
 
 class Ui_ThumbnailSelectorWidget(object):
-    def setupUi(self, ThumbnailSelectorWidget):
+    def setupUi(self, ThumbnailSelectorWidget: QWidget) -> None:
         if not ThumbnailSelectorWidget.objectName():
             ThumbnailSelectorWidget.setObjectName(u"ThumbnailSelectorWidget")
         self.verticalLayout = QVBoxLayout(ThumbnailSelectorWidget)
@@ -88,7 +88,7 @@ class Ui_ThumbnailSelectorWidget(object):
         QMetaObject.connectSlotsByName(ThumbnailSelectorWidget)
     # setupUi
 
-    def retranslateUi(self, ThumbnailSelectorWidget):
+    def retranslateUi(self, ThumbnailSelectorWidget: QWidget) -> None:
         self.labelThumbnailCount.setText(QCoreApplication.translate("ThumbnailSelectorWidget", u"\u753b\u50cf: 0\u4ef6", None))
         self.labelThumbnailSize.setText(QCoreApplication.translate("ThumbnailSelectorWidget", u"\u30b5\u30a4\u30ba:", None))
         pass


### PR DESCRIPTION
pyside6-uic 生成の Ui_*.py は setupUi/retranslateUi が untyped のため typed context から呼ぶと no-untyped-call エラーが発生していた。

- scripts/generate_ui.py に add_type_hints_to_ui() を追加し、 生成後に setupUi/retranslateUi へ QWidget 型ヒントと -> None を付与
- 既存の全 *_ui.py (tracked 分) へ同様の型ヒントを適用

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>