### PR TITLE
fix: mypy エラー 40件を解消 Closes #93

### DIFF
--- a/src/lorairo/database/db_core.py
+++ b/src/lorairo/database/db_core.py
@@ -217,7 +217,7 @@ try:
         format_name="Lorairo",
     )
 
-    USER_TAG_DB_PATH = DB_DIR / "user_tags.sqlite"
+    USER_TAG_DB_PATH: Path | None = DB_DIR / "user_tags.sqlite"
     logger.info(f"Tag databases initialized: {len(results)} base DB(s) + user DB at {USER_TAG_DB_PATH}")
 
 except Exception as e:

--- a/src/lorairo/database/migrations/env.py
+++ b/src/lorairo/database/migrations/env.py
@@ -1,9 +1,10 @@
 # Add imports for your models and db core functionality
 from logging.config import fileConfig
-from typing import Any
+from typing import Any, Literal
 
 from alembic import context
 from sqlalchemy import engine_from_config, pool
+from sqlalchemy.sql.schema import SchemaItem
 
 from lorairo.database.schema import Base  # Use absolute import from src
 
@@ -29,7 +30,13 @@ target_metadata = Base.metadata  # Set your Base's metadata here
 
 
 # --- Function to ignore tag_db schema objects ---
-def include_object(object: Any, name: str, type_: str, reflected: bool, compare_to: Any) -> bool:
+def include_object(
+    object: SchemaItem,
+    name: str | None,
+    type_: Literal["schema", "table", "column", "index", "unique_constraint", "foreign_key_constraint"],
+    reflected: bool,
+    compare_to: SchemaItem | None,
+) -> bool:
     """Exclude objects belonging to the 'tag_db' schema from comparison."""
     # Only check schema for tables
     if type_ == "table" and hasattr(object, "schema") and object.schema == "tag_db":

--- a/src/lorairo/gui/services/search_filter_service.py
+++ b/src/lorairo/gui/services/search_filter_service.py
@@ -349,6 +349,33 @@ class SearchFilterService:
         """後方互換性ラッパー:ModelFilterServiceに委譲"""
         return self.model_filter_service.validate_annotation_settings(settings)
 
+    def filter_models_by_criteria(
+        self,
+        models: list[dict[str, Any]],
+        function_types: list[str],
+        providers: list[str],
+    ) -> list[dict[str, Any]]:
+        """モデルリストを機能タイプとプロバイダーでフィルタリングする。
+
+        Args:
+            models: フィルタリング対象のモデルリスト
+            function_types: 絞り込む機能タイプリスト（空リストの場合は全て）
+            providers: 絞り込むプロバイダーリスト（空リストの場合は全て）
+
+        Returns:
+            フィルタリング済みモデルリスト
+        """
+        filtered = models
+        if function_types:
+            filtered = [
+                m for m in filtered if any(ft in m.get("capabilities", []) for ft in function_types)
+            ]
+        if providers:
+            filtered = [
+                m for m in filtered if str(m.get("provider", "")).lower() in [p.lower() for p in providers]
+            ]
+        return filtered
+
     def get_annotation_status_counts(self) -> AnnotationStatusCounts:
         """アノテーション状態カウントを取得（GUI用）
 

--- a/src/lorairo/gui/services/widget_setup_service.py
+++ b/src/lorairo/gui/services/widget_setup_service.py
@@ -339,12 +339,12 @@ class WidgetSetupService:
                 placeholder.deleteLater()
                 logger.debug("🗑️ modelSelectionPlaceholder を削除")
 
-            widget = ModelSelectionWidget(mode="advanced")
-            widget.setObjectName("batchModelSelection")
-            widget.setParent(annotation_group)
-            annotation_group.layout().insertWidget(2, widget)
+            model_widget = ModelSelectionWidget(mode="advanced")
+            model_widget.setObjectName("batchModelSelection")
+            model_widget.setParent(annotation_group)
+            annotation_group.layout().insertWidget(2, model_widget)
 
-            main_window.batchModelSelection = widget
+            main_window.batchModelSelection = model_widget
             logger.info("✅ ModelSelectionWidget を追加完了 (mode=advanced)")
 
         # Signal接続

--- a/src/lorairo/gui/widgets/annotation_data_display_widget.py
+++ b/src/lorairo/gui/widgets/annotation_data_display_widget.py
@@ -76,7 +76,7 @@ class AnnotationDataDisplayWidget(QWidget, Ui_AnnotationDataDisplayWidget):
 
     def __init__(self, parent: QWidget | None = None) -> None:
         super().__init__(parent)
-        self.setupUi(self)  # type: ignore  # Justification: Qt Designer generated method signature
+        self.setupUi(self)
 
         # 現在のデータ
         self.current_data: AnnotationData = AnnotationData()

--- a/src/lorairo/gui/widgets/annotation_filter_widget.py
+++ b/src/lorairo/gui/widgets/annotation_filter_widget.py
@@ -17,7 +17,7 @@ Annotation Filter Widget - アノテーションフィルターウィジェッ�
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 from PySide6.QtCore import Signal
 from PySide6.QtWidgets import QWidget
@@ -69,7 +69,7 @@ class AnnotationFilterWidget(QWidget, Ui_AnnotationFilterWidget):
             parent: 親ウィジェット
         """
         super().__init__(parent)
-        self.setupUi(self)  # type: ignore[no-untyped-call]
+        self.setupUi(self)
 
         self._connect_signals()
         logger.debug("AnnotationFilterWidget initialized")
@@ -148,7 +148,7 @@ class AnnotationFilterWidget(QWidget, Ui_AnnotationFilterWidget):
         try:
             # 機能タイプ設定 (DB ModelType.name 値と一致: 'caption', 'tags', 'scores')
             if capabilities is not _UNSET:
-                caps = capabilities if capabilities is not None else []
+                caps = cast("list[str]", capabilities if capabilities is not None else [])
                 self.checkBoxCaption.setChecked("caption" in caps)
                 self.checkBoxTags.setChecked("tags" in caps)
                 self.checkBoxScore.setChecked("scores" in caps)

--- a/src/lorairo/gui/widgets/batch_tag_add_widget.py
+++ b/src/lorairo/gui/widgets/batch_tag_add_widget.py
@@ -111,7 +111,7 @@ class BatchTagAddWidget(QWidget):
 
         # UI設定
         self.ui = Ui_BatchTagAddWidget()
-        self.ui.setupUi(self)  # type: ignore[no-untyped-call]
+        self.ui.setupUi(self)
 
         self._staging_thumbnail_widget: ThumbnailSelectorWidget | None = None
         self._setup_staging_thumbnail_widget()
@@ -254,7 +254,9 @@ class BatchTagAddWidget(QWidget):
             if container.layout() is None:
                 layout = QVBoxLayout(container)
                 layout.setContentsMargins(0, 0, 0, 0)
-            container.layout().addWidget(tag_input)
+            container_layout = container.layout()
+            assert container_layout is not None
+            container_layout.addWidget(tag_input)
 
         splitter = getattr(self.ui, "splitterBatchTagStaging", None)
         if splitter:

--- a/src/lorairo/gui/widgets/custom_range_slider.py
+++ b/src/lorairo/gui/widgets/custom_range_slider.py
@@ -1,3 +1,5 @@
+from typing import Any, Callable, cast
+
 from PySide6.QtCore import QDate, QDateTime, Qt, QTime, QTimeZone, Signal, Slot
 from PySide6.QtWidgets import QHBoxLayout, QLabel, QVBoxLayout, QWidget
 from superqt import QDoubleRangeSlider
@@ -28,7 +30,8 @@ class CustomRangeSlider(QWidget):
         layout = QVBoxLayout(self)
 
         # superqtのQDoubleRangeSliderを直接値範囲で使用
-        self.slider = QDoubleRangeSlider(Qt.Orientation.Horizontal)
+        _DoubleRangeSlider = cast("Callable[..., Any]", QDoubleRangeSlider)
+        self.slider = _DoubleRangeSlider(Qt.Orientation.Horizontal)
         self.slider.setRange(self.min_value, self.max_value)
         self.slider.setValue((self.min_value, self.max_value))
 
@@ -48,6 +51,8 @@ class CustomRangeSlider(QWidget):
     @Slot()
     def update_labels(self) -> None:
         """ラベルを更新してシグナルを発行"""
+        min_val: float
+        max_val: float
         min_val, max_val = self.slider.value()
         min_count = int(min_val)
         max_count = int(max_val)
@@ -72,6 +77,8 @@ class CustomRangeSlider(QWidget):
 
     def get_range(self) -> tuple[int, int]:
         """現在の選択範囲を取得"""
+        min_val: float
+        max_val: float
         min_val, max_val = self.slider.value()
         return (int(min_val), int(max_val))
 

--- a/src/lorairo/gui/widgets/dataset_export_widget.py
+++ b/src/lorairo/gui/widgets/dataset_export_widget.py
@@ -126,7 +126,7 @@ class DatasetExportWidget(QDialog):
 
         # Services
         self.service_container = service_container
-        self.export_service = service_container.dataset_export_service()
+        self.export_service = service_container.dataset_export_service
 
         # Data
         self.image_ids = initial_image_ids or []
@@ -167,7 +167,7 @@ class DatasetExportWidget(QDialog):
 
         # UI state change connections
         self.ui.comboBoxResolution.currentTextChanged.connect(self._on_settings_changed)
-        self.format_button_group.idChanged.connect(self._on_settings_changed)
+        self.format_button_group.idClicked.connect(self._on_settings_changed)
         self.ui.latestOnlyCheckBox.toggled.connect(self._on_settings_changed)
 
     def _update_initial_state(self) -> None:

--- a/src/lorairo/gui/widgets/error_detail_dialog.py
+++ b/src/lorairo/gui/widgets/error_detail_dialog.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from loguru import logger
 from PySide6.QtCore import Qt
 from PySide6.QtGui import QPixmap
-from PySide6.QtWidgets import QDialog, QMessageBox
+from PySide6.QtWidgets import QDialog, QMessageBox, QWidget
 
 from ...database.db_manager import ImageDatabaseManager
 from ...database.schema import ErrorRecord
@@ -29,7 +29,7 @@ class ErrorDetailDialog(QDialog, Ui_ErrorDetailDialog):
         self,
         db_manager: ImageDatabaseManager,
         error_id: int,
-        parent: QDialog | None = None,
+        parent: QWidget | None = None,
     ):
         """ErrorDetailDialogを初期化します
 
@@ -39,7 +39,7 @@ class ErrorDetailDialog(QDialog, Ui_ErrorDetailDialog):
             parent: 親Dialog
         """
         super().__init__(parent)
-        self.setupUi(self)  # type: ignore  # Justification: Qt Designer generated method signature
+        self.setupUi(self)
 
         self.db_manager = db_manager
         self.error_id = error_id

--- a/src/lorairo/gui/widgets/error_log_viewer_widget.py
+++ b/src/lorairo/gui/widgets/error_log_viewer_widget.py
@@ -38,7 +38,7 @@ class ErrorLogViewerWidget(QWidget, Ui_ErrorLogViewerWidget):
             parent: 親Widget
         """
         super().__init__(parent)
-        self.setupUi(self)  # type: ignore  # Justification: Qt Designer generated method signature
+        self.setupUi(self)
 
         # 依存注入
         self.db_manager: ImageDatabaseManager | None = None
@@ -241,7 +241,10 @@ class ErrorLogViewerWidget(QWidget, Ui_ErrorLogViewerWidget):
             return
 
         # エラーレコードID取得
-        error_id = self.tableWidgetErrors.item(selected_row, 0).data(Qt.ItemDataRole.UserRole)
+        error_item = self.tableWidgetErrors.item(selected_row, 0)
+        if error_item is None:
+            return
+        error_id = error_item.data(Qt.ItemDataRole.UserRole)
 
         # Signal発火
         self.error_selected.emit(error_id)
@@ -264,7 +267,10 @@ class ErrorLogViewerWidget(QWidget, Ui_ErrorLogViewerWidget):
             return
 
         # エラーレコードID取得
-        error_id = self.tableWidgetErrors.item(selected_row, 0).data(Qt.ItemDataRole.UserRole)
+        resolve_item = self.tableWidgetErrors.item(selected_row, 0)
+        if resolve_item is None:
+            return
+        error_id = resolve_item.data(Qt.ItemDataRole.UserRole)
 
         # 確認ダイアログ
         reply = QMessageBox.question(

--- a/src/lorairo/gui/widgets/model_selection_table_widget.py
+++ b/src/lorairo/gui/widgets/model_selection_table_widget.py
@@ -49,7 +49,7 @@ class ModelSelectionTableWidget(QWidget, Ui_ModelSelectionTableWidget):
 
     def __init__(self, parent: QWidget | None = None):
         super().__init__(parent)
-        self.setupUi(self)  # type: ignore  # Justification: Qt Designer generated method signature
+        self.setupUi(self)
 
         # 依存関係
         self.search_filter_service: SearchFilterService | None = None

--- a/src/lorairo/gui/widgets/model_selection_widget.py
+++ b/src/lorairo/gui/widgets/model_selection_widget.py
@@ -73,7 +73,7 @@ if not __name__ == "__main__":
             mode: str = "simple",  # "simple" or "advanced"
         ) -> None:
             super().__init__(parent)
-            self.setupUi(self)  # type: ignore  # Multi-inheritance pattern - direct setupUi call
+            self.setupUi(self)
 
             self.mode = mode
 
@@ -278,12 +278,13 @@ if not __name__ == "__main__":
             # レイアウトから削除（プレースホルダーとverticalSpacer以外）
             for i in reversed(range(self.dynamicContentLayout.count())):
                 item = self.dynamicContentLayout.itemAt(i)
-                if item and item.widget():
-                    widget = item.widget()
-                    if widget != self.placeholderLabel and widget.objectName() != "verticalSpacer":
-                        self.dynamicContentLayout.removeWidget(widget)
-                        widget.setParent(None)
-                        widget.deleteLater()
+                if item is None:
+                    continue
+                w = item.widget()
+                if w is not None and w != self.placeholderLabel and w.objectName() != "verticalSpacer":
+                    self.dynamicContentLayout.removeWidget(w)
+                    w.setParent(None)
+                    w.deleteLater()
 
         @Slot(str)
         def _on_execution_env_changed(self, execution_env: str) -> None:

--- a/src/lorairo/gui/widgets/picker.py
+++ b/src/lorairo/gui/widgets/picker.py
@@ -11,7 +11,7 @@ class PickerWidget(QWidget, Ui_PickerWidget):
     def __init__(self, parent: QWidget | None = None) -> None:
         super().__init__(parent)
         self.setupUi(self)
-        self.history = []  # 履歴を保存するリスト
+        self.history: list[str] = []  # 履歴を保存するリスト
 
         self.comboBoxHistory.currentIndexChanged.connect(self.on_history_item_selected)
 

--- a/src/lorairo/gui/widgets/rating_score_edit_widget.py
+++ b/src/lorairo/gui/widgets/rating_score_edit_widget.py
@@ -76,7 +76,7 @@ class RatingScoreEditWidget(QWidget):
 
         # UI設定
         self.ui = Ui_RatingScoreEditWidget()
-        self.ui.setupUi(self)  # type: ignore[no-untyped-call]
+        self.ui.setupUi(self)
         self._apply_compact_layout()
 
         # スライダーと値ラベルの連動

--- a/src/lorairo/gui/widgets/selected_image_details_widget.py
+++ b/src/lorairo/gui/widgets/selected_image_details_widget.py
@@ -108,7 +108,7 @@ class SelectedImageDetailsWidget(QWidget):
 
         # UI設定
         self.ui = Ui_SelectedImageDetailsWidget()
-        self.ui.setupUi(self)  # type: ignore[no-untyped-call]
+        self.ui.setupUi(self)
         self.annotation_display: AnnotationDataDisplayWidget = self.ui.annotationDataDisplay
         self.annotation_display.set_group_box_visibility(scores=False)
 

--- a/src/lorairo/gui/widgets/tag_management_widget.py
+++ b/src/lorairo/gui/widgets/tag_management_widget.py
@@ -35,7 +35,7 @@ class TagManagementWidget(QWidget, Ui_TagManagementWidget):
             parent: 親Widget
         """
         super().__init__(parent)
-        self.setupUi(self)  # type: ignore  # Justification: Qt Designer generated method
+        self.setupUi(self)
 
         # 依存注入
         self.tag_service: TagManagementService | None = None
@@ -218,10 +218,13 @@ class TagManagementWidget(QWidget, Ui_TagManagementWidget):
         self.buttonUpdate.setEnabled(False)
         self.labelStatus.setText("Status: Updating...")
 
+        assert self.tag_service is not None
+        tag_service = self.tag_service
+
         # QThreadでシンプルに実行（Worker class不要）
         def run_update() -> None:
             try:
-                self.tag_service.update_tag_types(updates)
+                tag_service.update_tag_types(updates)
                 self.update_completed.emit()
             except Exception as e:
                 logger.error(f"Error updating tag types: {e}", exc_info=True)

--- a/src/lorairo/gui/workers/annotation_worker.py
+++ b/src/lorairo/gui/workers/annotation_worker.py
@@ -7,7 +7,7 @@ GUI Layer: 非同期処理とQt進捗管理のみ担当
 import traceback
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 from genai_tag_db_tools.utils.cleanup_str import TagCleaner
 from image_annotator_lib import PHashAnnotationResults
@@ -348,7 +348,7 @@ class AnnotationWorker(LoRAIroWorkerBase["AnnotationExecutionResult"]):
         logger.info(f"DB保存完了: {success_count}/{len(results)}件成功")
         return success_count, skip_count, image_summaries
 
-    def _build_phash_to_filename_map(self, phash_to_image_id: dict[str, int | None]) -> dict[str, str]:
+    def _build_phash_to_filename_map(self, phash_to_image_id: dict[str, int]) -> dict[str, str]:
         """pHashからファイル名へのマッピングを構築する。
 
         image_pathsリストとDB上のimage_idマッピングから、
@@ -499,7 +499,7 @@ class AnnotationWorker(LoRAIroWorkerBase["AnnotationExecutionResult"]):
         if hasattr(formatted_output, "scores") and isinstance(
             getattr(formatted_output, "scores", None), dict
         ):
-            return formatted_output.scores
+            return cast("dict[str, float]", formatted_output.scores)
 
         # Pipeline系(AestheticShadow): dict with "hq" key → aesthetic score
         if isinstance(formatted_output, dict) and "hq" in formatted_output:

--- a/src/lorairo/gui/workers/thumbnail_worker.py
+++ b/src/lorairo/gui/workers/thumbnail_worker.py
@@ -25,7 +25,7 @@ class ThumbnailLoadResult:
     failed_count: int
     total_count: int
     processing_time: float
-    image_metadata: list[dict[str, Any]] = None  # 検索結果メタデータ（DatasetStateManager同期用）
+    image_metadata: list[dict[str, Any]] | None = None  # 検索結果メタデータ（DatasetStateManager同期用）
     request_id: str | None = None  # リクエスト識別子（古い結果の破棄用）
     page_num: int | None = None  # ページ番号（ページネーション用）
     image_ids: list[int] | None = None  # 処理対象画像ID（ページ単位表示用）
@@ -94,7 +94,7 @@ class ThumbnailWorker(LoRAIroWorkerBase[ThumbnailLoadResult]):
             logger.info(f"サムネイル読み込み開始: {total_count}件")
 
         # 進捗初期化
-        loaded_thumbnails = []
+        loaded_thumbnails: list[tuple[int, QImage]] = []
         failed_count = 0
 
         # 初期進捗報告

--- a/src/lorairo/storage/file_system.py
+++ b/src/lorairo/storage/file_system.py
@@ -6,7 +6,7 @@ from datetime import datetime
 from io import BytesIO
 from itertools import islice
 from pathlib import Path
-from typing import Any, ClassVar, Literal
+from typing import Any, Callable, ClassVar, Literal, cast
 
 import toml
 from PIL import Image, ImageCms
@@ -116,6 +116,7 @@ class FileSystemManager:
         if not self.initialized:
             raise RuntimeError("FileSystemManagerが初期化されていません。")
 
+        assert self.image_dataset_dir is not None
         resolution_dir = self.image_dataset_dir / str(target_resolution)
         current_date = datetime.now().strftime("%Y/%m/%d")
         resized_images_dir = resolution_dir / current_date
@@ -189,7 +190,8 @@ class FileSystemManager:
             color_space = mode
             if icc_profile:
                 profile = ImageCms.ImageCmsProfile(BytesIO(icc_profile))
-                color_space = str(ImageCms.getProfileName(profile)).strip()
+                _get_profile_name = cast("Callable[[Any], str]", ImageCms.getProfileName)
+                color_space = _get_profile_name(profile).strip()
 
             return {
                 "width": width,


### PR DESCRIPTION
- 不要な `# type: ignore` コメントを10ファイルから削除（Issue #91でsetupUi型付け済み）
- picker.py: `history: list[str] = []` 型アノテーション追加
- annotation_filter_widget.py: caps の型を cast で list[str] に解決
- tag_management_widget.py: ネスト関数内の None アクセスを assert + 変数キャプチャで解決
- db_core.py: USER_TAG_DB_PATH を `Path | None` として宣言
- file_system.py: image_dataset_dir の assert + ImageCms.getProfileName の untyped-call を cast で解決
- migrations/env.py: include_object シグネチャを SchemaItem/Literal で修正
- custom_range_slider.py: QDoubleRangeSlider の untyped-call を cast で解決、min_val/max_val に float 型注釈
- error_detail_dialog.py: parent 型を QDialog | None → QWidget | None に変更
- error_log_viewer_widget.py: tableWidgetErrors.item() の None ガード追加
- annotation_worker.py: _build_phash_to_filename_map の引数型を dict[str, int] に修正、scores を cast
- thumbnail_worker.py: image_metadata を `list[...] | None`、loaded_thumbnails に型注釈追加
- search_filter_service.py: filter_models_by_criteria メソッドを追加
- model_selection_widget.py: widget 変数の再代入型競合を w に名前変更で解決
- batch_tag_add_widget.py: container.layout() の None ガード追加
- widget_setup_service.py: ModelSelectionWidget 変数を model_widget に変更し型競合を解消
- dataset_export_widget.py: dataset_export_service の誤った () 呼び出しを削除、idChanged → idClicked

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>