### PR TITLE
fix: ISSUE #94 残存 # type: ignore 4件を解消

### DIFF
--- a/src/lorairo/annotations/annotator_adapter.py
+++ b/src/lorairo/annotations/annotator_adapter.py
@@ -4,7 +4,7 @@ Data Access Layer: image-annotator-libとLoRAIroを統合
 ConfigurationServiceからAPIキーを取得し、api_keysパラメータとして明示的に渡す
 """
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 from image_annotator_lib import list_available_annotators_with_metadata
 from PIL import Image
@@ -50,7 +50,8 @@ class AnnotatorLibraryAdapter:
             logger.debug("image-annotator-libからモデルメタデータを取得中...")
 
             # image-annotator-lib API呼び出し
-            models: list[dict[str, Any]] = list_available_annotators_with_metadata()  # type: ignore[assignment]
+            # 外部ライブラリの戻り値型が未定義のためcastで明示
+            models = cast(list[dict[str, Any]], list_available_annotators_with_metadata())
 
             logger.info(f"image-annotator-libからモデルメタデータ取得完了: {len(models)}件")
             return models

--- a/src/lorairo/database/db_manager.py
+++ b/src/lorairo/database/db_manager.py
@@ -529,9 +529,9 @@ class ImageDatabaseManager:
             metadata = self.repository.get_processed_image(image_id, resolution=0, all_data=False)
             if isinstance(metadata, dict):  # None でなく dict であることを確認
                 path = metadata.get("stored_image_path")
-                if path:
+                if isinstance(path, str) and path:
                     logger.debug(f"画像ID {image_id} の低解像度画像パスを取得しました。")
-                    return path  # type: ignore[no-any-return]
+                    return path
                 logger.warning(
                     f"画像ID {image_id} の低解像度画像のパスが見つかりません。 Metadata: {metadata}",
                 )

--- a/src/lorairo/gui/widgets/custom_range_slider.py
+++ b/src/lorairo/gui/widgets/custom_range_slider.py
@@ -1,4 +1,5 @@
-from typing import Any, Callable, cast
+from collections.abc import Callable
+from typing import Any, cast
 
 from PySide6.QtCore import QDate, QDateTime, Qt, QTime, QTimeZone, Signal, Slot
 from PySide6.QtWidgets import QHBoxLayout, QLabel, QVBoxLayout, QWidget

--- a/src/lorairo/services/annotator_library_adapter.py
+++ b/src/lorairo/services/annotator_library_adapter.py
@@ -7,7 +7,7 @@ Phase 4-5: APIキー管理統合（引数ベース方式）
 ConfigurationServiceからAPIキーを取得し、api_keysパラメータとして明示的に渡す
 """
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 from image_annotator_lib import list_available_annotators_with_metadata
 from PIL import Image
@@ -53,7 +53,8 @@ class AnnotatorLibraryAdapter:
             logger.debug("image-annotator-libからモデルメタデータを取得中...")
 
             # image-annotator-lib API呼び出し
-            models: list[dict[str, Any]] = list_available_annotators_with_metadata()  # type: ignore[assignment]
+            # 外部ライブラリの戻り値型が未定義のためcastで明示
+            models = cast(list[dict[str, Any]], list_available_annotators_with_metadata())
 
             logger.info(f"image-annotator-libからモデルメタデータ取得完了: {len(models)}件")
             return models

--- a/src/lorairo/storage/file_system.py
+++ b/src/lorairo/storage/file_system.py
@@ -2,11 +2,12 @@ import json
 import math
 import os
 import shutil
+from collections.abc import Callable
 from datetime import datetime
 from io import BytesIO
 from itertools import islice
 from pathlib import Path
-from typing import Any, Callable, ClassVar, Literal, cast
+from typing import Any, ClassVar, Literal, cast
 
 import toml
 from PIL import Image, ImageCms

--- a/src/lorairo/utils/tools.py
+++ b/src/lorairo/utils/tools.py
@@ -74,4 +74,5 @@ def read_text_with_fallback(file_path: Path, encodings: tuple[str, ...] = _FALLB
         except UnicodeDecodeError as e:
             last_error = e
             continue
-    raise last_error  # type: ignore[misc]  # latin-1が最終フォールバックのため到達しないが安全策
+    assert last_error is not None  # encodingsは非空契約。latin-1で到達しないが型ナロウイング用
+    raise last_error


### PR DESCRIPTION
## Summary

ISSUE #94 (mypy 型負債返済ロードマップ) の完了条件「`# type: ignore` を使わずに解決」を達成するため、残存 4件を根本原因修正で解消。

### 変更内容

| ファイル | 修正内容 |
|---------|---------|
| `src/lorairo/utils/tools.py` | `raise last_error` 前に `assert last_error is not None` を追加して型ナロウイング |
| `src/lorairo/database/db_manager.py` | `isinstance(path, str)` チェックで `Any` 型を `str` に絞り込み |
| `src/lorairo/annotations/annotator_adapter.py` | `cast(list[dict[str, Any]], ...)` で外部ライブラリ戻り値の型を明示 |
| `src/lorairo/services/annotator_library_adapter.py` | 同上 (別アダプター) |
| `src/lorairo/gui/widgets/custom_range_slider.py` | Ruff UP規則: `typing.Callable` → `collections.abc.Callable` (auto-fix) |
| `src/lorairo/storage/file_system.py` | 同上 |

### 完了条件の達成状況

- ✅ `uv run mypy -p lorairo`: 0 errors in 142 source files
- ✅ CI Type Check (mypy): success
- ✅ `# type: ignore` 残存: **0件**
- ✅ 子 Issue #87〜#93: 全 CLOSED

### 範囲外 (別 Issue で対応)

- `# noqa: C901` 3件 (Ruff C901 / ISSUE #81 フォローアップ)
- CI Unit Tests 失敗 (`splitterBatchTagMain` widget 不足)

🤖 Generated with [Claude Code](https://claude.com/claude-code)