### PR TITLE
fix: AnnotationWorker のレイヤー違反を修正し test_annotation_model_error_creates_error_record を修正 Closes #108

### DIFF
--- a/src/lorairo/annotations/annotation_logic.py
+++ b/src/lorairo/annotations/annotation_logic.py
@@ -5,7 +5,7 @@ Qt非依存、AnnotatorLibraryAdapterとDBRepositoryを使用
 """
 
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from PIL import Image
 
@@ -89,6 +89,17 @@ class AnnotationLogic:
             error_msg = f"アノテーション処理エラー: {e}"
             logger.error(error_msg, exc_info=True)
             raise
+
+    def get_available_models_with_metadata(self) -> list[dict[str, Any]]:
+        """利用可能モデルのメタデータ付き一覧を取得する。
+
+        AnnotatorLibraryAdapter.get_available_models_with_metadata() に委譲する。
+        Worker層がAdapterの内部構造に直接アクセスしないようにするための委譲メソッド。
+
+        Returns:
+            list[dict[str, Any]]: モデルメタデータリスト
+        """
+        return self.annotator_adapter.get_available_models_with_metadata()
 
     def _load_images(self, image_paths: list[str]) -> list[Image.Image]:
         """画像パスリストからPIL.Imageリストを作成

--- a/src/lorairo/gui/workers/annotation_worker.py
+++ b/src/lorairo/gui/workers/annotation_worker.py
@@ -661,12 +661,9 @@ class AnnotationWorker(LoRAIroWorkerBase["AnnotationExecutionResult"]):
             - プロバイダー情報は メタデータの "provider" フィールド
             - capabilities は メタデータの "capabilities" フィールド
         """
-        from lorairo.annotations.annotator_adapter import AnnotatorLibraryAdapter
-
-        # モデルメタデータを取得
-        adapter = AnnotatorLibraryAdapter(self.annotation_logic.annotator_adapter.config_service)
+        # モデルメタデータを取得（AnnotationLogic経由でアダプターに委譲）
         try:
-            model_metadata_list = adapter.get_available_models_with_metadata()
+            model_metadata_list = self.annotation_logic.get_available_models_with_metadata()
             # モデル名をキーとしたメタデータマップを構築
             metadata_map: dict[str, dict[str, Any]] = {}
             for metadata in model_metadata_list:

--- a/tests/integration/gui/workers/test_worker_error_recording.py
+++ b/tests/integration/gui/workers/test_worker_error_recording.py
@@ -133,6 +133,7 @@ class TestAnnotationWorkerErrorRecording:
         # AnnotationLogic モック（エラーを引き起こす）
         mock_logic = Mock(spec=AnnotationLogic)
         mock_logic.execute_annotation.side_effect = Exception("API Error")
+        mock_logic.get_available_models_with_metadata.return_value = []
 
         # Workerの db_manager 注入をテスト
         from lorairo.gui.workers.annotation_worker import AnnotationWorker
@@ -163,6 +164,7 @@ class TestAnnotationWorkerErrorRecording:
         # AnnotationLogic モック（初期化エラーを引き起こす）
         mock_logic = Mock(spec=AnnotationLogic)
         mock_logic.execute_annotation.side_effect = RuntimeError("Logic Error")
+        mock_logic.get_available_models_with_metadata.return_value = []
 
         from lorairo.gui.workers.annotation_worker import AnnotationWorker
 

--- a/tests/unit/gui/workers/test_annotation_worker.py
+++ b/tests/unit/gui/workers/test_annotation_worker.py
@@ -32,6 +32,7 @@ def mock_annotation_logic():
             }
         }
     }
+    logic.get_available_models_with_metadata.return_value = []
     return logic
 
 


### PR DESCRIPTION
Worker が AnnotationLogic の内部構造を貫通して AnnotatorLibraryAdapter に 直接アクセスしていた (ADR 0005 の3層アーキテクチャ違反) を修正する。

- annotation_logic.py: get_available_models_with_metadata() 委譲メソッドを追加 (execute_annotation が annotate() をラップするのと同じパターン)
- annotation_worker.py: _build_model_statistics() の冗長なアダプター生成を削除し annotation_logic.get_available_models_with_metadata() 経由に変更
- テスト: Mock(spec=AnnotationLogic) との互換性を確保するため get_available_models_with_metadata.return_value = [] を設定

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>