### PR TITLE
fix: test_load_models_without_service を fail-fast 設計に修正 Closes #112

### DIFF
--- a/tests/unit/gui/widgets/test_model_selection_table_widget.py
+++ b/tests/unit/gui/widgets/test_model_selection_table_widget.py
@@ -182,11 +182,10 @@ class TestModelSelectionTableWidget:
         assert info.selected_models == [sample_models[0]["name"]]
 
     def test_load_models_without_service(self, widget):
-        # サービス未設定でも例外にならず、テーブルがクリアされる
-        widget.load_models()
-        assert widget.all_models == []
-        assert widget.filtered_models == []
-        assert widget.tableWidgetModels.rowCount() == 0
+        # サービス未設定時は RuntimeError を送出する（fail-fast 設計）
+        with pytest.raises(RuntimeError) as exc_info:
+            widget.load_models()
+        assert "SearchFilterService not available" in str(exc_info.value)
 
     def test_apply_filters_without_service_warns(self, widget, sample_models):
         # サービス未設定でフィルタしても落ちない


### PR DESCRIPTION
## Summary

- `test_load_models_without_service` が no-op を期待していたが、実装・integration テストの契約（service 未設定時は `RuntimeError` を送出）と矛盾していた
- unit テストを `pytest.raises(RuntimeError)` で検証するよう修正し、3者の契約を統一した

## 根拠

| 比較対象 | 期待動作 |
|---------|---------|
| `load_models()` 実装 | `RuntimeError` 送出（fail-fast） |
| integration テスト | `RuntimeError` を明示的に検証 |
| unit テスト（修正前） | no-op（矛盾） |
| unit テスト（修正後） | `RuntimeError` を検証（統一） |

## Test plan

- [ ] `tests/unit/gui/widgets/test_model_selection_table_widget.py::TestModelSelectionTableWidget::test_load_models_without_service` がパスすること
- [ ] `tests/integration/gui/widgets/test_model_selection_table_widget_critical_initialization.py` がパスすること
- [ ] 既存テスト全体がリグレッションしないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)