### PR TITLE
fix: ServiceContainer signal_manager のテスト分離不足を修正 Closes #115

### DIFF
--- a/src/lorairo/cli/__init__.py
+++ b/src/lorairo/cli/__init__.py
@@ -3,10 +3,5 @@
 LoRAIroのCLIツール群。GUI なし環境でのデータセット操作、
 バッチ処理自動化、プログラマティックアクセスを提供する。
 
-環境変数 LORAIRO_CLI_MODE を有効化してから CLI を実行する。
+環境変数 LORAIRO_CLI_MODE は main() 実行時に自動設定される。
 """
-
-import os
-
-# CLI モード有効化: ServiceContainer が NoOpSignalManager を自動選択
-os.environ.setdefault("LORAIRO_CLI_MODE", "true")

--- a/src/lorairo/cli/main.py
+++ b/src/lorairo/cli/main.py
@@ -70,7 +70,14 @@ def status() -> None:
 
 
 def main() -> None:
-    """CLIメインエントリポイント。"""
+    """CLIメインエントリポイント。
+
+    ServiceContainer が NoOpSignalManager を自動選択するよう
+    LORAIRO_CLI_MODE を設定してから app を起動する。
+    """
+    import os
+
+    os.environ.setdefault("LORAIRO_CLI_MODE", "true")
     app()
 
 

--- a/src/lorairo/services/service_container.py
+++ b/src/lorairo/services/service_container.py
@@ -325,6 +325,23 @@ class ServiceContainer:
 
         logger.warning("ServiceContainer状態リセット完了")
 
+    @classmethod
+    def reset_for_testing(cls) -> None:
+        """シングルトン状態を完全にリセット（テスト専用）。
+
+        インスタンス化せずクラスレベルで `_instance` と `_initialized` を
+        クリアする。LORAIRO_CLI_MODE 環境変数の変化が次回の
+        ServiceContainer() 呼び出しで確実に反映される。
+
+        Warning:
+            本番コードからは絶対に呼び出さない。テスト用 autouse fixture
+            (tests/unit/services/conftest.py) からの使用を想定。
+        """
+        if cls._instance is not None:
+            cls._instance.reset_container()
+        else:
+            cls._initialized = False
+
     def set_production_mode(self, enable: bool) -> None:
         """プロダクションモード設定（主にテスト用）
 

--- a/tests/unit/services/conftest.py
+++ b/tests/unit/services/conftest.py
@@ -1,0 +1,27 @@
+"""services ユニットテスト共通設定。
+
+ServiceContainer シングルトンのテスト間分離を保証する autouse fixture。
+LORAIRO_CLI_MODE 環境変数や遅延初期化済みサービス状態が他テストから
+漏洩しないよう、function-scope で事前・事後に reset する。
+"""
+
+import pytest
+
+from lorairo.services.service_container import ServiceContainer
+
+
+@pytest.fixture(autouse=True)
+def reset_service_container(monkeypatch: pytest.MonkeyPatch) -> None:
+    """各 services テストの前後で ServiceContainer を完全リセット。
+
+    事前リセット: 他テストで汚染された singleton/env をクリア。
+    事後リセット: 次の services テストにも他ディレクトリにも状態を残さない。
+
+    Layer 1 の修正 (cli/__init__.py の import-time 副作用除去) で
+    大部分の汚染は解消されるが、明示的に env を操作するテストに
+    対する防御層として機能する。
+    """
+    monkeypatch.delenv("LORAIRO_CLI_MODE", raising=False)
+    ServiceContainer.reset_for_testing()
+    yield
+    ServiceContainer.reset_for_testing()

--- a/tests/unit/services/test_service_container_signal_manager.py
+++ b/tests/unit/services/test_service_container_signal_manager.py
@@ -13,18 +13,9 @@ from lorairo.services.signal_manager_service import SignalManagerService
 class TestServiceContainerSignalManager:
     """ServiceContainer での signal_manager 管理テスト"""
 
-    def teardown_method(self) -> None:
-        """テスト後のクリーンアップ"""
-        container = ServiceContainer()
-        container.reset_container()
-        # 環境変数をクリア
-        os.environ.pop("LORAIRO_CLI_MODE", None)
-
     def test_signal_manager_gui_mode_default(self) -> None:
         """デフォルト（GUI モード）での signal_manager 取得"""
         # 環境変数が設定されていない場合は GUI モード
-        os.environ.pop("LORAIRO_CLI_MODE", None)
-
         container = ServiceContainer()
         signal_manager = container.signal_manager
 
@@ -32,12 +23,12 @@ class TestServiceContainerSignalManager:
         assert isinstance(signal_manager, SignalManagerService)
         assert not isinstance(signal_manager, NoOpSignalManager)
 
-    def test_signal_manager_cli_mode_true(self) -> None:
+    def test_signal_manager_cli_mode_true(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """CLI モード（環境変数 true）での signal_manager 取得"""
-        os.environ["LORAIRO_CLI_MODE"] = "true"
+        monkeypatch.setenv("LORAIRO_CLI_MODE", "true")
 
         # 新しいコンテナを作成
-        ServiceContainer().reset_container()
+        ServiceContainer.reset_for_testing()
         container = ServiceContainer()
 
         signal_manager = container.signal_manager
@@ -46,12 +37,12 @@ class TestServiceContainerSignalManager:
         assert isinstance(signal_manager, NoOpSignalManager)
         assert not isinstance(signal_manager, SignalManagerService)
 
-    def test_signal_manager_cli_mode_1(self) -> None:
+    def test_signal_manager_cli_mode_1(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """CLI モード（環境変数 1）での signal_manager 取得"""
-        os.environ["LORAIRO_CLI_MODE"] = "1"
+        monkeypatch.setenv("LORAIRO_CLI_MODE", "1")
 
         # 新しいコンテナを作成
-        ServiceContainer().reset_container()
+        ServiceContainer.reset_for_testing()
         container = ServiceContainer()
 
         signal_manager = container.signal_manager
@@ -107,7 +98,7 @@ class TestServiceContainerSignalManager:
         # 異なるインスタンスとなるはず
         assert signal_manager1 is not signal_manager2
 
-    def test_signal_manager_environment_detection(self) -> None:
+    def test_signal_manager_environment_detection(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """環境変数による正しいモード検出"""
         test_cases = [
             ("", SignalManagerService),  # 未設定
@@ -121,13 +112,13 @@ class TestServiceContainerSignalManager:
 
         for env_value, expected_type in test_cases:
             # コンテナをリセット
-            ServiceContainer().reset_container()
+            ServiceContainer.reset_for_testing()
 
             # 環境変数を設定
             if env_value:
-                os.environ["LORAIRO_CLI_MODE"] = env_value
+                monkeypatch.setenv("LORAIRO_CLI_MODE", env_value)
             else:
-                os.environ.pop("LORAIRO_CLI_MODE", None)
+                monkeypatch.delenv("LORAIRO_CLI_MODE", raising=False)
 
             # 新しいコンテナを作成
             container = ServiceContainer()
@@ -140,8 +131,6 @@ class TestServiceContainerSignalManager:
 
     def test_service_summary_includes_environment(self) -> None:
         """service_summary に environment 情報が含まれるか確認"""
-        os.environ.pop("LORAIRO_CLI_MODE", None)
-
         container = ServiceContainer()
         summary = container.get_service_summary()
 
@@ -150,3 +139,29 @@ class TestServiceContainerSignalManager:
 
         # GUI モードの確認
         assert summary["environment"] == "GUI"
+
+    def test_signal_manager_isolation(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """autouse fixture により前テスト状態が漏れないことを検証 (Issue #115)。
+
+        他テスト（特に CLI テスト）が LORAIRO_CLI_MODE=true を設定したままでも、
+        当該テストは GUI モード初期状態から開始できる必要がある。
+        """
+        # 前提: autouse fixture + Layer 1 修正で事前リセット完了
+        assert "LORAIRO_CLI_MODE" not in os.environ
+
+        # GUI モードでコンテナ初期化
+        container = ServiceContainer()
+        assert container._cli_mode is False
+        assert container._signal_manager is None  # 遅延初期化前
+
+        signal_manager = container.signal_manager
+        assert isinstance(signal_manager, SignalManagerService)
+
+        # CLI モードに切替え + reset で別種取得
+        monkeypatch.setenv("LORAIRO_CLI_MODE", "1")
+        ServiceContainer.reset_for_testing()
+        container2 = ServiceContainer()
+        assert isinstance(container2.signal_manager, NoOpSignalManager)
+
+        # 異なるインスタンス
+        assert signal_manager is not container2.signal_manager


### PR DESCRIPTION
## Summary

- `src/lorairo/cli/__init__.py` の import-time 副作用（`os.environ.setdefault`）を除去し、`main()` 内に移動してプロダクション側の根本原因を修正
- `ServiceContainer.reset_for_testing()` classmethod を追加してテスト用リセット API を整備
- `tests/unit/services/conftest.py` を新規作成し、autouse fixture で全 services テストのシングルトン分離を保証
- `test_signal_manager_isolation` テストを追加（Issue #115 が要求する欠落テスト）

## 根本原因

CLI テストが `from lorairo.cli.main import app` を import した際に `cli/__init__.py:12` の `os.environ.setdefault("LORAIRO_CLI_MODE", "true")` が実行され、pytest セッション全体に漏洩していた。

再現:
```bash
uv run pytest tests/unit/cli/test_commands_project.py::test_project_create_success \
              tests/unit/services/test_service_container_signal_manager.py
# 修正前: FAILED test_signal_manager_gui_mode_default
# 修正後: 10 passed
```

## Test plan

- [x] `import lorairo.cli` で `LORAIRO_CLI_MODE` が設定されないことを確認
- [x] 漏洩再現テスト: 修正前 1 failed → 修正後 10 passed
- [x] `tests/unit/services/` 全 256 テスト PASS
- [x] `tests/unit/cli/` 全 70 テスト PASS（Step 5 対応不要）
- [x] `tests/unit/` 全 1379 テスト PASS、リグレッションなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)