### PR TITLE
fix: ThumbnailWorker の例外時エラーレコード保存を追加 Closes #116

### DIFF
--- a/src/lorairo/gui/workers/thumbnail_worker.py
+++ b/src/lorairo/gui/workers/thumbnail_worker.py
@@ -216,9 +216,15 @@ class ThumbnailWorker(LoRAIroWorkerBase[ThumbnailLoadResult]):
 
             except Exception as e:
                 batch_failed += 1
-                # ワーカースレッドではDB保存不可（スレッドセーフティ）、ログのみ
                 logger.error(
                     f"サムネイル読み込みエラー: image_id={image_id}, path={thumbnail_path}, error={e}"
+                )
+                self.db_manager.save_error_record(
+                    operation_type="thumbnail",
+                    error_type=type(e).__name__,
+                    error_message=str(e),
+                    image_id=image_id,
+                    file_path=str(thumbnail_path) if thumbnail_path else None,
                 )
 
         return batch_loaded, batch_failed


### PR DESCRIPTION
## Summary

- `ThumbnailWorker._process_batch` の `except` ブロックで `db_manager.save_error_record()` を呼び出し、例外発生時にエラーレコードをDBに保存するよう修正
- 誤ったコメント「ワーカースレッドではDB保存不可（スレッドセーフティ）」を削除
- `AnnotationWorker` / `DatabaseRegistrationWorker` と同一パターンに統一

## Root Cause

`thumbnail_worker.py` の `except` ブロックにスレッドセーフティを理由としたコメントがあり、DB保存を意図的に省略していた。しかし他ワーカー（Issue #108で修正済み）は同じスレッドから `save_error_record()` を問題なく呼んでおり、コメントは誤りだった。

## Test plan

- [x] `test_thumbnail_exception_creates_error_record` がREDからGREENに変化することを確認
- [x] `tests/integration/gui/workers/` 全8件パス

## Related

- Closes #116
- 同種パターン: #108 (AnnotationWorker)

🤖 Generated with [Claude Code](https://claude.com/claude-code)