### PR TITLE
fix: BDD テストで resized_images_dir が None のまま参照される TypeError を修正

### DIFF
--- a/tests/bdd/steps/test_database_management.py
+++ b/tests/bdd/steps/test_database_management.py
@@ -377,7 +377,8 @@ def when_register_processed_image(
     """ダミーの処理済み画像を作成し、DBに登録する"""
     # ダミーの処理済み画像情報を作成
     processed_filename = f"{test_image_path.stem}_processed.webp"
-    processed_path = fs_manager.resized_images_dir / processed_filename  # 属性名を修正
+    resized_dir = fs_manager.get_resolution_dir(256)
+    processed_path = resized_dir / processed_filename
     dummy_info = {
         "width": 256,
         "height": 256,


### PR DESCRIPTION
## Summary

- `FileSystemManager.resized_images_dir` は `initialize()` 後も `None` のまま（`get_resolution_dir()` は `self.resized_images_dir` を更新しない）
- BDD テストの `when_register_processed_image` が `fs_manager.resized_images_dir / filename` と直接アクセスしていたため `TypeError` が発生
- `get_resolution_dir(256)` の戻り値を直接使用するよう修正

## Test plan

- [x] `test_処理済み画像の登録` BDD シナリオが PASS
- [x] `tests/` 全テスト実行で回帰なし（1576 passed）

Closes #117

🤖 Generated with [Claude Code](https://claude.com/claude-code)