### PR TITLE
fix: _apply_nsfw_filter にタグベース NSFW 判定を追加 Closes #118

### DIFF
--- a/docs/specs/civitai-content-levels.md
+++ b/docs/specs/civitai-content-levels.md
@@ -1,0 +1,22 @@
+# Civitai コンテンツ分類レベル
+
+出典: https://education.civitai.com/civitais-guide-to-content-levels/
+
+## 分類体系
+
+Civitai のすべてのコンテンツは映画レーティングに準拠した5段階で分類される。
+
+| レベル | 内容 |
+|--------|------|
+| PG     | Safe For Work。成人向けコンテンツなし |
+| PG-13  | 露出度の高い服装・セクシーな衣装、暴力、軽度のゴア |
+| R      | 成人向けテーマ・状況、部分的なヌード、グラフィックな暴力・死亡描写 |
+| X      | グラフィックなヌード、成人向けオブジェクト・設定 |
+| XXX    | 露骨な性的コンテンツ、または不穏なグラフィックコンテンツ |
+
+## プロジェクト内での使用箇所
+
+- `images.manual_rating` カラム（手動評価）
+- `ratings.normalized_rating` カラム（AI/手動編集モデルによるレーティング結果）
+- `_apply_nsfw_filter` での除外判定: `["r", "x", "xxx"]` を NSFW とみなす
+- UI の Rating 選択肢: `PG / PG-13 / R / X / XXX`

--- a/src/lorairo/database/db_repository.py
+++ b/src/lorairo/database/db_repository.py
@@ -2107,8 +2107,15 @@ class ImageRepository:
                 .correlate(Image)
             )
 
-            # AIレーティングまたは手動レーティングがNSFWである画像を除外
-            query = query.where(not_(or_(ai_nsfw_condition, manual_nsfw_condition)))
+            # タグベースのNSFW判定（"nsfw" / "explicit" タグが付いている画像を除外）
+            tag_nsfw_condition = (
+                exists()
+                .where(Tag.image_id == Image.id, func.lower(Tag.tag).in_(["nsfw", "explicit"]))
+                .correlate(Image)
+            )
+
+            # AIレーティング、手動レーティング、またはタグがNSFWである画像を除外
+            query = query.where(not_(or_(ai_nsfw_condition, manual_nsfw_condition, tag_nsfw_condition)))
             # レーティング情報がない (NULL) 画像は除外しない
         return query
 


### PR DESCRIPTION
## Summary

- `_apply_nsfw_filter` が `ratings` テーブルのみ参照していたため、タグ（"nsfw", "explicit"）でNSFW判定された画像がフィルターをすり抜けていた
- `tags` テーブルに対する `exists()` サブクエリを OR 条件として追加し、タグベースのNSFW除外を実装
- Civitai コンテンツ分類レベルの参照ドキュメントを `docs/specs/civitai-content-levels.md` に追加

## Test plan

- [x] `tests/bdd/` - `test_nsfwコンテンツの除外検索` が PASS（修正前は `期待: 2, 実際: 3` で FAIL）
- [x] `tests/unit/` `tests/integration/` - 1549 passed, 18 skipped（リグレッションなし）
- [ ] `test_手動レーティングによるフィルタリング` は修正前から失敗している既存バグ（別Issue対応）

🤖 Generated with [Claude Code](https://claude.com/claude-code)