### PR TITLE
fix: add_filename_alias の SQLAlchemyError を握り潰して重複スキップ扱いを維持 Closes #128

### DIFF
--- a/src/lorairo/gui/workers/registration_worker.py
+++ b/src/lorairo/gui/workers/registration_worker.py
@@ -5,6 +5,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from sqlalchemy.exc import SQLAlchemyError
+
 from ...annotations.existing_file_reader import ExistingFileReader
 from ...utils.log import logger
 from .base import LoRAIroWorkerBase
@@ -184,7 +186,11 @@ class DatabaseRegistrationWorker(LoRAIroWorkerBase[DatabaseRegistrationResult]):
                 image_path, duplicate_image_id, annotations=annotations, tag_id_cache=tag_id_cache
             )
             # ファイル名エイリアスを登録（バッチインポート時のマッチング用）
-            self.db_manager.repository.add_filename_alias(duplicate_image_id, image_path.stem)
+            # DBが未初期化の場合でも重複扱い（skipped）は変わらないため例外を握り潰す
+            try:
+                self.db_manager.repository.add_filename_alias(duplicate_image_id, image_path.stem)
+            except SQLAlchemyError as e:
+                logger.warning(f"エイリアス登録失敗（スキップ扱いは継続）: {image_path.stem}, {e}")
             logger.debug(f"スキップ (重複): {image_path} - 関連ファイルは処理")
             result_type = "skipped"
             image_id = duplicate_image_id

--- a/tests/unit/workers/test_database_worker.py
+++ b/tests/unit/workers/test_database_worker.py
@@ -1026,6 +1026,34 @@ class TestRegistrationErrorHandling:
             # スキップ数が増加することを確認
             assert result.skipped_count == 1
 
+    def test_duplicate_skipped_even_if_alias_registration_fails(self, temp_dir, real_db_manager, mock_fsm):
+        """add_filename_alias が SQLAlchemyError を送出しても skipped_count が増加する"""
+        from sqlalchemy.exc import SQLAlchemyError
+
+        image_file = temp_dir / "alias_fail_test.jpg"
+        tag_file = temp_dir / "alias_fail_test.txt"
+        image_file.write_bytes(b"fake_image")
+        tag_file.write_text("tag1", encoding="utf-8")
+        mock_fsm.get_image_files.return_value = [image_file]
+
+        with (
+            patch.object(real_db_manager, "detect_duplicate_image") as mock_detect,
+            patch.object(real_db_manager, "save_tags"),
+            patch.object(real_db_manager, "save_captions"),
+            patch.object(
+                real_db_manager.repository,
+                "add_filename_alias",
+                side_effect=SQLAlchemyError("table not found"),
+            ),
+        ):
+            mock_detect.return_value = 999
+
+            worker = DatabaseRegistrationWorker(temp_dir, real_db_manager, mock_fsm)
+            result = worker.execute()
+
+            assert result.skipped_count == 1
+            assert result.error_count == 0
+
     def test_high_volume_image_processing(self, temp_dir, real_db_manager):
         """100個の画像処理時のパフォーマンステスト"""
         # 100個の画像ファイルを作成


### PR DESCRIPTION
## Summary

- `registration_worker.py` の `_register_single_image` で `add_filename_alias` の呼び出しを `try/except SQLAlchemyError` でラップ
- DB テーブル未初期化環境（CI fresh env）でも重複画像は `skipped_count` として集計されるよう修正
- 回帰テスト `test_duplicate_skipped_even_if_alias_registration_fails` を追加（`add_filename_alias` が `SQLAlchemyError` を送出するシナリオを明示的にテスト）

## 根本原因

`add_filename_alias` は `IntegrityError`（重複キー）を無視するが `SQLAlchemyError` を **re-raise** する。  
CI の fresh 環境では `image_filename_aliases` テーブルが存在せず `OperationalError`（`SQLAlchemyError` のサブクラス）が発生、上位の `except Exception` に捕捉されて `error_count += 1` になっていた。  
エイリアス登録はバッチマッチング用の最適化であり、失敗しても重複判定には影響しない。

## Test plan

- [x] `test_duplicate_skipped_even_if_alias_registration_fails` — RED → GREEN で確認
- [x] `test_integration_duplicate_detection_with_file_processing` — 既存テストも引き続き PASS
- [x] `test_database_worker.py` 全 53 テスト PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)