### PR TITLE
fix: CI カバレッジ判定を合算評価に変更 (coverage-gate ジョブ新設)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,15 +108,23 @@ jobs:
             --cov=local_packages/image-annotator-lib/src/image_annotator_lib \
             --cov-report=xml:coverage-unit.xml \
             --cov-report=term-missing \
+            --cov-fail-under=0 \
             --timeout=120 \
             -x
 
-      - name: Upload coverage
+      - name: Upload coverage XML
         uses: actions/upload-artifact@v4
         if: always()
         with:
           name: coverage-unit
           path: coverage-unit.xml
+
+      - name: Upload coverage data
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: coverage-unit-data
+          path: .coverage
 
   test-integration:
     name: Integration Tests
@@ -162,12 +170,60 @@ jobs:
             --cov=local_packages/image-annotator-lib/src/image_annotator_lib \
             --cov-report=xml:coverage-integration.xml \
             --cov-report=term-missing \
+            --cov-fail-under=0 \
             --timeout=300 \
             -x
 
-      - name: Upload coverage
+      - name: Upload coverage XML
         uses: actions/upload-artifact@v4
         if: always()
         with:
           name: coverage-integration
           path: coverage-integration.xml
+
+      - name: Upload coverage data
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: coverage-integration-data
+          path: .coverage
+
+  coverage-gate:
+    name: Coverage Gate (Combined ≥ 75%)
+    needs: [test-unit, test-integration]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+          cache-dependency-glob: "pyproject.toml"
+
+      - name: Install dependencies
+        run: uv sync --dev
+
+      - name: Download unit coverage data
+        uses: actions/download-artifact@v4
+        with:
+          name: coverage-unit-data
+          path: coverage-data/unit
+
+      - name: Download integration coverage data
+        uses: actions/download-artifact@v4
+        with:
+          name: coverage-integration-data
+          path: coverage-data/integration
+
+      - name: Combine and check coverage
+        run: |
+          cp coverage-data/unit/.coverage .coverage.unit
+          cp coverage-data/integration/.coverage .coverage.integration
+          uv run coverage combine
+          uv run coverage report

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,6 +125,7 @@ jobs:
         with:
           name: coverage-unit-data
           path: .coverage
+          include-hidden-files: true
 
   test-integration:
     name: Integration Tests
@@ -187,6 +188,7 @@ jobs:
         with:
           name: coverage-integration-data
           path: .coverage
+          include-hidden-files: true
 
   coverage-gate:
     name: Coverage Gate (Combined ≥ 75%)


### PR DESCRIPTION
## Summary

- `test-unit` / `test-integration` ジョブに `--cov-fail-under=0` を追加し、per-job 単独でのカバレッジ閾値判定を無効化
- 各ジョブの `.coverage` バイナリを artifact (`coverage-unit-data` / `coverage-integration-data`) としてアップロード
- 新設の `coverage-gate` ジョブで両 artifact を `coverage combine` で合算し、`coverage report`（`pyproject.toml` の `fail_under = 75` を参照）で正しくカバレッジゲートを評価

## Root Cause (Issue #131)

Unit と Integration を別ジョブで実行する構造上、各ジョブが「全ソース」を対象に「自分の実行範囲だけ」で計測するため、個別 75% は構造的に到達不能だった。

## Test plan

- [ ] CI の `lint` / `typecheck` / `test-unit` / `test-integration` が success になること
- [ ] `coverage-gate` ジョブが `test-unit` と `test-integration` 完了後に実行され、合算カバレッジで 75% を評価すること
- [ ] ローカルで `uv run pytest --cov=src --cov-report=term-missing` を実行した際に `fail_under=75` が引き続き機能すること（`pyproject.toml` の設定は変更なし）

Closes #131

🤖 Generated with [Claude Code](https://claude.com/claude-code)