### PR TITLE
test: configuration_service.py のテスト拡充 (52% → 99%) Closes #142

### DIFF
--- a/tests/unit/test_configuration_service.py
+++ b/tests/unit/test_configuration_service.py
@@ -6,9 +6,10 @@
 - 単一クラスの振る舞いに焦点を当てる
 """
 
+import sys
 import tempfile
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -310,3 +311,240 @@ class TestConfigurationService:
             # フォールバックパスが返される
             expected_fallback = Path.cwd() / "database"
             assert result == expected_fallback
+
+
+class TestConfigurationServiceInitBranches:
+    """__init__ の例外分岐テスト"""
+
+    @patch("lorairo.services.configuration_service.get_config")
+    @patch("lorairo.services.configuration_service.write_config_file")
+    def test_init_file_not_found_creates_default(self, mock_write, mock_get_config, tmp_path):
+        """FileNotFoundError発生時に_create_default_config_fileが呼ばれる"""
+        mock_get_config.side_effect = FileNotFoundError("File not found")
+        config_path = tmp_path / "config.toml"
+        service = ConfigurationService(config_path=config_path)
+        mock_write.assert_called_once()
+        assert service.get_setting("api", "openai_key") == ""
+
+    @patch("lorairo.services.configuration_service.get_config")
+    @patch("lorairo.services.configuration_service.write_config_file")
+    def test_init_file_not_found_write_failure_fallback(self, mock_write, mock_get_config, tmp_path):
+        """デフォルト設定ファイル作成失敗時にメモリ上のデフォルト設定を使用する"""
+        mock_get_config.side_effect = FileNotFoundError("File not found")
+        mock_write.side_effect = PermissionError("Permission denied")
+        config_path = tmp_path / "config.toml"
+        service = ConfigurationService(config_path=config_path)
+        assert service.get_setting("api", "openai_key") == ""
+
+    @patch("lorairo.services.configuration_service.get_config")
+    def test_init_unexpected_exception_returns_empty(self, mock_get_config, tmp_path):
+        """予期せぬエラー発生時に空の設定を使用する"""
+        mock_get_config.side_effect = ValueError("Unexpected parse error")
+        config_path = tmp_path / "config.toml"
+        service = ConfigurationService(config_path=config_path)
+        assert service._config == {}
+
+
+class TestConfigurationServiceMiscMethods:
+    """その他メソッドのテスト"""
+
+    def test_get_all_settings(self):
+        """get_all_settingsが設定辞書全体を返す"""
+        config = {"section": {"key": "value"}}
+        service = ConfigurationService(shared_config=config)
+        result = service.get_all_settings()
+        assert result is config
+
+    def test_update_setting_non_secret_key(self):
+        """非機密キーの更新で値がそのまま設定される"""
+        service = ConfigurationService(shared_config={})
+        service.update_setting("image_processing", "resolution", 1024)
+        assert service.get_setting("image_processing", "resolution") == 1024
+
+    @patch("lorairo.services.configuration_service.write_config_file")
+    def test_save_settings_unexpected_exception(self, mock_write):
+        """予期せぬ例外発生時はFalseを返す"""
+        mock_write.side_effect = ValueError("Unexpected error")
+        service = ConfigurationService(shared_config={})
+        result = service.save_settings()
+        assert result is False
+
+    def test_update_image_processing_setting(self):
+        """update_image_processing_settingがimage_processingセクションを更新する"""
+        service = ConfigurationService(shared_config={})
+        service.update_image_processing_setting("upscaler", "NewModel")
+        assert service.get_setting("image_processing", "upscaler") == "NewModel"
+
+
+class TestConfigurationServiceGetters:
+    """各種ゲッターメソッドのテスト"""
+
+    def test_get_image_processing_config_non_dict(self):
+        """image_processingが辞書でない場合は空辞書を返す"""
+        config = {"image_processing": "invalid_string"}
+        service = ConfigurationService(shared_config=config)
+        result = service.get_image_processing_config()
+        assert result == {}
+
+    def test_get_preferred_resolutions_non_list(self):
+        """preferred_resolutionsがリストでない場合は空リストを返す"""
+        config = {"preferred_resolutions": "invalid_string"}
+        service = ConfigurationService(shared_config=config)
+        result = service.get_preferred_resolutions()
+        assert result == []
+
+    def test_get_upscaler_models_non_list(self):
+        """upscaler_modelsがリストでない場合は空リストを返す"""
+        config = {"upscaler_models": "invalid_string"}
+        service = ConfigurationService(shared_config=config)
+        result = service.get_upscaler_models()
+        assert result == []
+
+    def test_get_upscaler_model_by_name_found(self):
+        """指定名のアップスケーラーモデルを取得できる"""
+        model = {"name": "TestModel", "path": "/models/test.pth", "scale": 4.0}
+        config = {"upscaler_models": [model]}
+        service = ConfigurationService(shared_config=config)
+        result = service.get_upscaler_model_by_name("TestModel")
+        assert result == model
+
+    def test_get_upscaler_model_by_name_not_found(self):
+        """存在しない名前の場合はNoneを返す"""
+        model = {"name": "TestModel", "path": "/models/test.pth", "scale": 4.0}
+        config = {"upscaler_models": [model]}
+        service = ConfigurationService(shared_config=config)
+        result = service.get_upscaler_model_by_name("NonExistent")
+        assert result is None
+
+    def test_get_available_upscaler_names(self):
+        """アップスケーラーモデル名リストを取得できる"""
+        config = {
+            "upscaler_models": [
+                {"name": "Model1", "path": "/p1", "scale": 4.0},
+                {"name": "Model2", "path": "/p2", "scale": 2.0},
+            ]
+        }
+        service = ConfigurationService(shared_config=config)
+        result = service.get_available_upscaler_names()
+        assert result == ["Model1", "Model2"]
+
+
+class TestConfigurationServiceUpscaler:
+    """アップスケーラー関連メソッドのテスト"""
+
+    def test_get_default_upscaler_name_from_config(self):
+        """image_processing.upscalerが設定されている場合はその値を返す"""
+        config = {"image_processing": {"upscaler": "ConfiguredModel"}}
+        service = ConfigurationService(shared_config=config)
+        result = service.get_default_upscaler_name()
+        assert result == "ConfiguredModel"
+
+    def test_get_default_upscaler_name_from_models(self):
+        """upscalerが未設定でもupscaler_modelsの最初の名前を返す"""
+        config = {
+            "image_processing": {},
+            "upscaler_models": [
+                {"name": "FirstModel", "path": "/p", "scale": 4.0},
+            ],
+        }
+        service = ConfigurationService(shared_config=config)
+        result = service.get_default_upscaler_name()
+        assert result == "FirstModel"
+
+    def test_get_default_upscaler_name_fallback(self):
+        """設定もモデルもない場合はデフォルト値を返す"""
+        service = ConfigurationService(shared_config={})
+        result = service.get_default_upscaler_name()
+        assert result == "RealESRGAN_x4plus"
+
+    def test_validate_upscaler_config_no_models(self):
+        """モデルが設定されていない場合はFalseを返す"""
+        service = ConfigurationService(shared_config={})
+        result = service.validate_upscaler_config()
+        assert result is False
+
+    def test_validate_upscaler_config_invalid_model(self):
+        """必須キーが欠けているモデルがある場合はFalseを返す"""
+        config = {"upscaler_models": [{"name": "Model1"}]}
+        service = ConfigurationService(shared_config=config)
+        result = service.validate_upscaler_config()
+        assert result is False
+
+    def test_validate_upscaler_config_valid(self):
+        """全モデルに必須キーが揃っている場合はTrueを返す"""
+        config = {
+            "upscaler_models": [
+                {"name": "Model1", "path": "/p1", "scale": 4.0},
+                {"name": "Model2", "path": "/p2", "scale": 2.0},
+            ]
+        }
+        service = ConfigurationService(shared_config=config)
+        result = service.validate_upscaler_config()
+        assert result is True
+
+
+class TestConfigurationServiceAnnotationModels:
+    """アノテーションモデル関連メソッドのテスト"""
+
+    def test_get_available_annotation_models_import_error(self):
+        """image_annotator_libのインポートが失敗した場合は空リストを返す"""
+        service = ConfigurationService(shared_config={})
+        with patch.dict("sys.modules", {"image_annotator_lib": None}):
+            result = service.get_available_annotation_models()
+        assert result == []
+
+    def test_get_available_annotation_models_exception(self):
+        """モデルリスト取得中に例外が発生した場合は空リストを返す"""
+        service = ConfigurationService(shared_config={})
+        with patch("image_annotator_lib.list_available_annotators", side_effect=RuntimeError("error")):
+            result = service.get_available_annotation_models()
+        assert result == []
+
+    def test_get_available_annotation_models_success(self):
+        """正常にモデルリストを取得できる"""
+        service = ConfigurationService(shared_config={})
+        with patch("image_annotator_lib.list_available_annotators", return_value=["model1", "model2"]):
+            result = service.get_available_annotation_models()
+        assert result == ["model1", "model2"]
+
+    def test_get_default_annotation_model_from_config(self):
+        """設定ファイルにデフォルトモデルが明示されている場合はその値を返す"""
+        config = {"annotation": {"default_model": "configured-model"}}
+        service = ConfigurationService(shared_config=config)
+        result = service.get_default_annotation_model()
+        assert result == "configured-model"
+
+    def test_get_default_annotation_model_openai_key(self):
+        """openai_keyがある場合はgpt-4o-miniを返す"""
+        config = {"api": {"openai_key": "sk-test", "claude_key": "", "google_key": ""}}
+        service = ConfigurationService(shared_config=config)
+        result = service.get_default_annotation_model()
+        assert result == "gpt-4o-mini"
+
+    def test_get_default_annotation_model_claude_key(self):
+        """openai_keyがなくclaude_keyがある場合はclaude-3-haiku-20240307を返す"""
+        config = {"api": {"openai_key": "", "claude_key": "claude-test", "google_key": ""}}
+        service = ConfigurationService(shared_config=config)
+        result = service.get_default_annotation_model()
+        assert result == "claude-3-haiku-20240307"
+
+    def test_get_default_annotation_model_google_key(self):
+        """openai_key/claude_keyがなくgoogle_keyがある場合はgemini-1.5-flash-latestを返す"""
+        config = {"api": {"openai_key": "", "claude_key": "", "google_key": "google-test"}}
+        service = ConfigurationService(shared_config=config)
+        result = service.get_default_annotation_model()
+        assert result == "gemini-1.5-flash-latest"
+
+    def test_get_default_annotation_model_from_available_models(self):
+        """APIキーがなく利用可能なモデルがある場合は最初のモデルを返す"""
+        service = ConfigurationService(shared_config={"api": {}})
+        with patch.object(service, "get_available_annotation_models", return_value=["local-model"]):
+            result = service.get_default_annotation_model()
+        assert result == "local-model"
+
+    def test_get_default_annotation_model_none(self):
+        """APIキーも利用可能なモデルもない場合はNoneを返す"""
+        service = ConfigurationService(shared_config={"api": {}})
+        with patch.object(service, "get_available_annotation_models", return_value=[]):
+            result = service.get_default_annotation_model()
+        assert result is None


### PR DESCRIPTION
## Summary

- `tests/unit/test_configuration_service.py` にエッジケーステストを28個追加
- カバレッジ **52% → 99%** (残り2行はデッドコード)
- 6つのテストクラスで機能ごとに整理

## カバーした未カバー領域

| 領域 | テスト内容 |
|------|-----------|
| `__init__` 例外分岐 | `FileNotFoundError` / 予期せぬ例外時の挙動 |
| `_create_default_config_file` | 書き込み成功・失敗時のフォールバック |
| `get_default_annotation_model` | 全API分岐 (openai/claude/google/なし/None) |
| `get_available_annotation_models` | ImportError / Exception / 正常取得 |
| アップスケーラー関連 | `validate_upscaler_config` / `get_default_upscaler_name` 全分岐 |
| ゲッターメソッド | 非dict/非list入力時の防御的返り値 |

## Test plan

- [x] `uv run pytest tests/unit/test_configuration_service.py tests/integration/test_configuration_integration.py` — 56件全件グリーン (カバレッジ99%)
- [x] `uv run pytest tests/unit tests/integration` — 1651件全件グリーン

🤖 Generated with [Claude Code](https://claude.com/claude-code)