### PR TITLE
docs: ADR-0016 coverage source 除外ポリシー明文化 Closes #153

### DIFF
--- a/docs/decisions/0016-coverage-threshold-policy.md
+++ b/docs/decisions/0016-coverage-threshold-policy.md
@@ -1,7 +1,7 @@
 # ADR 0016: Coverage Threshold Policy
 
 - **日付**: 2026-04-19
-- **ステータス**: Accepted
+- **ステータス**: Accepted (amended 2026-04-20: `source` 除外基準を追記 — Issue #153)
 
 ## Context
 
@@ -63,6 +63,17 @@ Issue #138–142 群の前提判断材料として固定することが必要。
 5. **ポリシー参照義務**:
    `[tool.coverage.run] omit` への新規追加、および `src/` 配下のファイル削除を伴う PR は
    本 ADR (0016) をコミットメッセージまたは PR 説明で参照すること。
+
+6. **`source` 除外基準** (`omit` とは別概念):
+   - `omit`: 計測対象に含めてから特定ファイルを除外する
+   - `source` 除外: 計測対象そのものに含めない（より強い除外）
+   - **除外許可条件**: 外部 API リクエストや ML モデルロード等、headless CI 環境で
+     実行できない初期化処理を含むローカルパッケージ
+   - **現状の適用例**: `image-annotator-lib` — torch/ML モデルロードが headless CI で
+     ハングするため `tests/conftest.py` でモジュールレベルの `sys.modules` injection
+     によりモック化。CI では 0% となるため `source` から除外する
+   - **含有例**: `genai-tag-db-tools` — SQLite 操作のみで CI 実行可能なため `source` に含める
+   - `source` リストの変更を伴う PR も本 ADR (0016) を参照すること
 
 ## Rationale
 

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -19,7 +19,7 @@ LoRAIro の重要な設計判断を記録するドキュメント群。
 | [0013](0013-legacy-tag-db-cleanup.md) | Legacy Tag DB Cleanup | 2026-01-02 | Accepted |
 | [0014](0014-agent-teams-integration.md) | Agent Teams Integration | 2026-04-09 | Accepted |
 | [0015](0015-manual-rating-storage-unification.md) | Manual Rating Storage Unification | 2026-04-18 | Accepted |
-| [0016](0016-coverage-threshold-policy.md) | Coverage Threshold Policy | 2026-04-19 | Accepted |
+| [0016](0016-coverage-threshold-policy.md) | Coverage Threshold Policy | 2026-04-20 | Accepted (amended) |
 
 ## ADR テンプレート
 


### PR DESCRIPTION
## Summary

- ADR-0016 に `source` 除外基準（Decision 項目6）を追記
- `omit`（計測後除外）と `source` 除外（計測対象外）の概念的違いを明文化
- 除外許可条件: 外部 API リクエストや ML モデルロード等、headless CI で実行できない初期化処理を含むローカルパッケージ
- 適用例として `image-annotator-lib`（除外）と `genai-tag-db-tools`（含有）を記載
- `docs/decisions/README.md` のステータスを `Accepted (amended)` に更新

## Test plan

- [ ] `docs/decisions/0016-coverage-threshold-policy.md` に「source 除外基準」節が追記されている
- [ ] `docs/decisions/README.md` のインデックスが更新されている（日付と Status）
- [ ] `pyproject.toml` の該当コメントと ADR の内容が整合している

## 関連

- Closes #153
- ADR: `docs/decisions/0016-coverage-threshold-policy.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)