### PR TITLE
fix: ワーカー実行エラーをDBエラーログに記録する

### DIFF
--- a/src/lorairo/gui/workers/annotation_worker.py
+++ b/src/lorairo/gui/workers/annotation_worker.py
@@ -89,6 +89,8 @@ class AnnotationWorker(LoRAIroWorkerBase["AnnotationExecutionResult"]):
     - AnnotationLogic呼び出し
     """
 
+    _OPERATION_TYPE = "annotation"
+
     def __init__(
         self,
         annotation_logic: AnnotationLogic,
@@ -271,6 +273,7 @@ class AnnotationWorker(LoRAIroWorkerBase["AnnotationExecutionResult"]):
         except Exception as e:
             logger.error(f"アノテーション処理エラー: {e}", exc_info=True)
             self._save_error_records(e, self.image_paths, model_name=None)
+            self._error_already_recorded = True
             raise
 
     def _save_results_to_database(

--- a/src/lorairo/gui/workers/annotation_worker.py
+++ b/src/lorairo/gui/workers/annotation_worker.py
@@ -104,7 +104,7 @@ class AnnotationWorker(LoRAIroWorkerBase["AnnotationExecutionResult"]):
             models: 使用モデル名リスト
             db_manager: データベースマネージャ（必須: DB保存・エラー記録用）
         """
-        super().__init__()
+        super().__init__(db_manager=db_manager)
 
         self.annotation_logic = annotation_logic
         self.image_paths = image_paths

--- a/src/lorairo/gui/workers/base.py
+++ b/src/lorairo/gui/workers/base.py
@@ -1,13 +1,18 @@
 # src/lorairo/workers/base.py
 
 import time
+import traceback
 from abc import abstractmethod
 from dataclasses import dataclass
 from enum import Enum
+from typing import TYPE_CHECKING
 
 from PySide6.QtCore import QObject, Signal
 
 from ...utils.log import logger
+
+if TYPE_CHECKING:
+    from ...database.db_manager import ImageDatabaseManager
 
 
 class WorkerStatus(Enum):
@@ -96,8 +101,9 @@ class LoRAIroWorkerBase[T](QObject):
     finished = Signal(object)  # result: T
     error_occurred = Signal(str)
 
-    def __init__(self) -> None:
+    def __init__(self, db_manager: "ImageDatabaseManager | None" = None) -> None:
         super().__init__()
+        self._db_manager = db_manager
         self.cancellation = CancellationController()
         self.progress = ProgressReporter()
         self.status = WorkerStatus.IDLE
@@ -137,7 +143,22 @@ class LoRAIroWorkerBase[T](QObject):
             self._set_status(WorkerStatus.FAILED)
             error_msg = f"ワーカー実行エラー: {e!s}"
             logger.error(error_msg, exc_info=True)
+            self._record_unhandled_error(e)
             self.error_occurred.emit(error_msg)
+
+    def _record_unhandled_error(self, e: Exception) -> None:
+        """ハンドルされなかった例外をDBエラーログに記録する。"""
+        if self._db_manager is None:
+            return
+        try:
+            self._db_manager.save_error_record(
+                operation_type=self.__class__.__name__,
+                error_type=type(e).__name__,
+                error_message=str(e),
+                stack_trace=traceback.format_exc(),
+            )
+        except Exception as save_error:
+            logger.error(f"エラーレコード保存失敗（二次エラー）: {save_error}")
 
     def cancel(self) -> None:
         """ワーカーキャンセル要求"""

--- a/src/lorairo/gui/workers/base.py
+++ b/src/lorairo/gui/workers/base.py
@@ -5,7 +5,7 @@ import traceback
 from abc import abstractmethod
 from dataclasses import dataclass
 from enum import Enum
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, ClassVar
 
 from PySide6.QtCore import QObject, Signal
 
@@ -101,9 +101,12 @@ class LoRAIroWorkerBase[T](QObject):
     finished = Signal(object)  # result: T
     error_occurred = Signal(str)
 
+    _OPERATION_TYPE: ClassVar[str] = ""
+
     def __init__(self, db_manager: "ImageDatabaseManager | None" = None) -> None:
         super().__init__()
         self._db_manager = db_manager
+        self._error_already_recorded: bool = False
         self.cancellation = CancellationController()
         self.progress = ProgressReporter()
         self.status = WorkerStatus.IDLE
@@ -147,12 +150,19 @@ class LoRAIroWorkerBase[T](QObject):
             self.error_occurred.emit(error_msg)
 
     def _record_unhandled_error(self, e: Exception) -> None:
-        """ハンドルされなかった例外をDBエラーログに記録する。"""
+        """ハンドルされなかった例外をDBエラーログに記録する。
+
+        サブクラスが既に save_error_record() を呼び出してから re-raise した場合は
+        self._error_already_recorded = True をセットすることで二重記録を防ぐ。
+        """
+        if self._error_already_recorded:
+            self._error_already_recorded = False
+            return
         if self._db_manager is None:
             return
         try:
             self._db_manager.save_error_record(
-                operation_type=self.__class__.__name__,
+                operation_type=self._OPERATION_TYPE or self.__class__.__name__,
                 error_type=type(e).__name__,
                 error_message=str(e),
                 stack_trace=traceback.format_exc(),

--- a/src/lorairo/gui/workers/registration_worker.py
+++ b/src/lorairo/gui/workers/registration_worker.py
@@ -31,6 +31,8 @@ class DatabaseRegistrationResult:
 class DatabaseRegistrationWorker(LoRAIroWorkerBase[DatabaseRegistrationResult]):
     """データベース登録専用ワーカー"""
 
+    _OPERATION_TYPE = "registration"
+
     def __init__(
         self, directory: Path, db_manager: "ImageDatabaseManager", fsm: "FileSystemManager"
     ) -> None:

--- a/src/lorairo/gui/workers/registration_worker.py
+++ b/src/lorairo/gui/workers/registration_worker.py
@@ -34,7 +34,7 @@ class DatabaseRegistrationWorker(LoRAIroWorkerBase[DatabaseRegistrationResult]):
     def __init__(
         self, directory: Path, db_manager: "ImageDatabaseManager", fsm: "FileSystemManager"
     ) -> None:
-        super().__init__()
+        super().__init__(db_manager=db_manager)
         self.directory = directory
         self.db_manager = db_manager
         self.fsm = fsm

--- a/src/lorairo/gui/workers/search_worker.py
+++ b/src/lorairo/gui/workers/search_worker.py
@@ -27,7 +27,7 @@ class SearchWorker(LoRAIroWorkerBase[SearchResult]):
     """データベース検索専用ワーカー"""
 
     def __init__(self, db_manager: "ImageDatabaseManager", search_conditions: "SearchConditions"):
-        super().__init__()
+        super().__init__(db_manager=db_manager)
         self.db_manager = db_manager
         self.criteria_processor = SearchCriteriaProcessor(db_manager)
         self.search_conditions = search_conditions

--- a/src/lorairo/gui/workers/search_worker.py
+++ b/src/lorairo/gui/workers/search_worker.py
@@ -26,6 +26,8 @@ class SearchResult:
 class SearchWorker(LoRAIroWorkerBase[SearchResult]):
     """データベース検索専用ワーカー"""
 
+    _OPERATION_TYPE = "search"
+
     def __init__(self, db_manager: "ImageDatabaseManager", search_conditions: "SearchConditions"):
         super().__init__(db_manager=db_manager)
         self.db_manager = db_manager
@@ -99,4 +101,5 @@ class SearchWorker(LoRAIroWorkerBase[SearchResult]):
             except Exception as save_error:
                 logger.error(f"エラーレコード保存失敗（二次エラー）: {save_error}")
 
+            self._error_already_recorded = True
             raise

--- a/src/lorairo/gui/workers/thumbnail_worker.py
+++ b/src/lorairo/gui/workers/thumbnail_worker.py
@@ -34,6 +34,8 @@ class ThumbnailLoadResult:
 class ThumbnailWorker(LoRAIroWorkerBase[ThumbnailLoadResult]):
     """サムネイル読み込み専用ワーカー"""
 
+    _OPERATION_TYPE = "thumbnail"
+
     def __init__(
         self,
         search_result: "SearchResult",

--- a/src/lorairo/gui/workers/thumbnail_worker.py
+++ b/src/lorairo/gui/workers/thumbnail_worker.py
@@ -43,7 +43,7 @@ class ThumbnailWorker(LoRAIroWorkerBase[ThumbnailLoadResult]):
         request_id: str | None = None,
         page_num: int | None = None,
     ):
-        super().__init__()
+        super().__init__(db_manager=db_manager)
         self.search_result = search_result
         self.thumbnail_size = thumbnail_size
         self.db_manager = db_manager

--- a/tests/unit/gui/workers/test_base_worker.py
+++ b/tests/unit/gui/workers/test_base_worker.py
@@ -285,6 +285,58 @@ class TestLoRAIroWorkerBase:
         status_mock.assert_called_once_with(WorkerStatus.RUNNING)
 
 
+class ConcreteWorkerWithDb(LoRAIroWorkerBase[str]):
+    """db_manager付きテスト用具象ワーカー"""
+
+    def __init__(self, db_manager=None, should_fail: bool = False):
+        super().__init__(db_manager=db_manager)
+        self.should_fail = should_fail
+
+    def execute(self) -> str:
+        if self.should_fail:
+            raise RuntimeError("テスト例外")
+        return "completed"
+
+
+class TestLoRAIroWorkerBaseUnhandledError:
+    """ハンドルされない例外のDB記録テスト"""
+
+    def test_run_records_error_to_db_when_db_manager_provided(self):
+        """db_manager提供時、ハンドルされない例外がDBに記録される"""
+        mock_db = Mock()
+        worker = ConcreteWorkerWithDb(db_manager=mock_db, should_fail=True)
+
+        worker.run()
+
+        mock_db.save_error_record.assert_called_once()
+        call_kwargs = mock_db.save_error_record.call_args.kwargs
+        assert call_kwargs["error_type"] == "RuntimeError"
+        assert "テスト例外" in call_kwargs["error_message"]
+        assert call_kwargs["stack_trace"] is not None
+
+    def test_run_skips_db_record_when_db_manager_is_none(self):
+        """db_manager=None時、エラー記録をスキップしてもクラッシュしない"""
+        worker = ConcreteWorkerWithDb(db_manager=None, should_fail=True)
+        error_mock = Mock()
+        worker.error_occurred.connect(error_mock)
+
+        worker.run()
+
+        error_mock.assert_called_once()
+
+    def test_run_handles_save_error_record_secondary_failure(self):
+        """save_error_record失敗（二次エラー）でもrun()は正常終了し error_occurred が発行される"""
+        mock_db = Mock()
+        mock_db.save_error_record.side_effect = RuntimeError("DB障害")
+        worker = ConcreteWorkerWithDb(db_manager=mock_db, should_fail=True)
+        error_mock = Mock()
+        worker.error_occurred.connect(error_mock)
+
+        worker.run()
+
+        error_mock.assert_called_once()
+
+
 class TestLoRAIroWorkerBaseAlias:
     """LoRAIroWorkerBase エイリアステスト"""
 

--- a/tests/unit/gui/workers/test_base_worker.py
+++ b/tests/unit/gui/workers/test_base_worker.py
@@ -288,6 +288,8 @@ class TestLoRAIroWorkerBase:
 class ConcreteWorkerWithDb(LoRAIroWorkerBase[str]):
     """db_manager付きテスト用具象ワーカー"""
 
+    _OPERATION_TYPE = "test_op"
+
     def __init__(self, db_manager=None, should_fail: bool = False):
         super().__init__(db_manager=db_manager)
         self.should_fail = should_fail
@@ -296,6 +298,28 @@ class ConcreteWorkerWithDb(LoRAIroWorkerBase[str]):
         if self.should_fail:
             raise RuntimeError("テスト例外")
         return "completed"
+
+
+class ConcreteWorkerPreRecords(LoRAIroWorkerBase[str]):
+    """自前でDB記録してから re-raise するテスト用ワーカー"""
+
+    _OPERATION_TYPE = "pre_record_op"
+
+    def __init__(self, db_manager=None):
+        super().__init__(db_manager=db_manager)
+
+    def execute(self) -> str:
+        try:
+            raise RuntimeError("内部エラー")
+        except Exception as e:
+            self._db_manager.save_error_record(
+                operation_type="pre_record_op",
+                error_type=type(e).__name__,
+                error_message=str(e),
+                stack_trace="trace",
+            )
+            self._error_already_recorded = True
+            raise
 
 
 class TestLoRAIroWorkerBaseUnhandledError:
@@ -335,6 +359,25 @@ class TestLoRAIroWorkerBaseUnhandledError:
         worker.run()
 
         error_mock.assert_called_once()
+
+    def test_run_uses_operation_type_class_variable(self):
+        """_OPERATION_TYPE クラス変数が operation_type として使われる"""
+        mock_db = Mock()
+        worker = ConcreteWorkerWithDb(db_manager=mock_db, should_fail=True)
+
+        worker.run()
+
+        call_kwargs = mock_db.save_error_record.call_args.kwargs
+        assert call_kwargs["operation_type"] == "test_op"
+
+    def test_run_does_not_double_record_when_error_already_recorded(self):
+        """_error_already_recorded=True の場合、基底クラスは再記録しない"""
+        mock_db = Mock()
+        worker = ConcreteWorkerPreRecords(db_manager=mock_db)
+
+        worker.run()
+
+        assert mock_db.save_error_record.call_count == 1
 
 
 class TestLoRAIroWorkerBaseAlias:


### PR DESCRIPTION
## Summary

- `LoRAIroWorkerBase.run()` のexceptブロックでキャッチされた例外がDBエラーログに記録されないバグを修正
- 基底クラスに `db_manager` オプション引数を追加し、`_record_unhandled_error()` メソッドを実装
- 4つのワーカーサブクラス（registration/annotation/thumbnail/search）が `super().__init__(db_manager=db_manager)` を渡すよう更新

## Test plan

- [x] `TestLoRAIroWorkerBaseUnhandledError` 新規テストクラス（3件）追加 — RED→GREEN確認済み
  - `test_run_records_error_to_db_when_db_manager_provided`: db_manager提供時にDBへ記録される
  - `test_run_skips_db_record_when_db_manager_is_none`: db_manager=Noneでもクラッシュしない
  - `test_run_handles_save_error_record_secondary_failure`: save_error_record失敗でもrun()は正常終了
- [x] 既存ワーカーテスト 28件すべてPASS
- [x] `mypy -p lorairo` 134ファイル エラーなし
- [x] `BatchImportWorker` は `db_manager` を持たないため変更なし（デフォルトNone）

Closes #159

🤖 Generated with [Claude Code](https://claude.com/claude-code)