### PR TITLE
fix: BatchImportWorkerのエラーDBロギング漏れを修正 (Issue #159 フォローアップ)

### DIFF
--- a/src/lorairo/database/db_repository.py
+++ b/src/lorairo/database/db_repository.py
@@ -2959,7 +2959,7 @@ class ImageRepository:
                 session.flush()
                 error_id = record.id
                 session.commit()
-                logger.info(
+                logger.debug(
                     f"エラーレコードを保存しました: ID={error_id}, "
                     f"operation={operation_type}, type={error_type}",
                 )

--- a/src/lorairo/gui/services/worker_service.py
+++ b/src/lorairo/gui/services/worker_service.py
@@ -400,6 +400,7 @@ class WorkerService(QObject):
             jsonl_files,
             dry_run=dry_run,
             model_name_override=model_name_override,
+            db_manager=self.db_manager,
         )
         worker_id = f"batch_import_{uuid.uuid4().hex[:8]}"
 

--- a/src/lorairo/gui/workers/batch_import_worker.py
+++ b/src/lorairo/gui/workers/batch_import_worker.py
@@ -4,16 +4,24 @@
 進捗とキャンセルをGUIに統合する。
 """
 
+from __future__ import annotations
+
 from pathlib import Path
+from typing import TYPE_CHECKING, ClassVar
 
 from ...database.db_repository import ImageRepository
 from ...services.batch_import_service import BatchImportResult, BatchImportService
 from ...utils.log import logger
 from .base import LoRAIroWorkerBase
 
+if TYPE_CHECKING:
+    from ...database.db_manager import ImageDatabaseManager
+
 
 class BatchImportWorker(LoRAIroWorkerBase[BatchImportResult]):
     """OpenAI Batch API JSONL インポートワーカー。"""
+
+    _OPERATION_TYPE: ClassVar[str] = "batch_import"
 
     def __init__(
         self,
@@ -22,6 +30,7 @@ class BatchImportWorker(LoRAIroWorkerBase[BatchImportResult]):
         *,
         dry_run: bool = False,
         model_name_override: str | None = None,
+        db_manager: ImageDatabaseManager | None = None,
     ) -> None:
         """ワーカー初期化。
 
@@ -30,8 +39,9 @@ class BatchImportWorker(LoRAIroWorkerBase[BatchImportResult]):
             jsonl_files: インポート対象のJSONLファイルリスト。
             dry_run: Trueの場合、DB書き込みを行わない。
             model_name_override: モデル名上書き。
+            db_manager: エラー記録用DBマネージャー。
         """
-        super().__init__()
+        super().__init__(db_manager=db_manager)
         self._repository = repository
         self._jsonl_files = jsonl_files
         self._dry_run = dry_run

--- a/tests/integration/gui/workers/test_worker_error_recording.py
+++ b/tests/integration/gui/workers/test_worker_error_recording.py
@@ -311,6 +311,63 @@ class TestSearchWorkerErrorRecording:
         assert "Database Error" in error_records[0].error_message
 
 
+class TestBatchImportWorkerErrorRecording:
+    """BatchImportWorker のエラー記録テスト"""
+
+    def test_batch_import_error_creates_error_record(self, db_manager, tmp_path):
+        """バッチインポートエラー時にエラーレコードが作成される"""
+        from unittest.mock import patch
+
+        from lorairo.gui.workers.batch_import_worker import BatchImportWorker
+
+        jsonl_file = tmp_path / "result.jsonl"
+        jsonl_file.touch()
+
+        worker = BatchImportWorker(
+            repository=db_manager.repository,
+            jsonl_files=[jsonl_file],
+            db_manager=db_manager,
+        )
+
+        with patch(
+            "lorairo.gui.workers.batch_import_worker.BatchImportService",
+            side_effect=Exception("JSONL parse error"),
+        ):
+            worker.run()
+
+        error_count = db_manager.repository.get_error_count_unresolved(operation_type="batch_import")
+        assert error_count > 0
+
+        error_records = db_manager.repository.get_error_records(operation_type="batch_import")
+        assert len(error_records) > 0
+        assert "JSONL parse error" in error_records[0].error_message
+
+    def test_batch_import_operation_type_stored_correctly(self, db_manager, tmp_path):
+        """operation_type が 'batch_import' で記録される"""
+        from unittest.mock import patch
+
+        from lorairo.gui.workers.batch_import_worker import BatchImportWorker
+
+        jsonl_file = tmp_path / "result.jsonl"
+        jsonl_file.touch()
+
+        worker = BatchImportWorker(
+            repository=db_manager.repository,
+            jsonl_files=[jsonl_file],
+            db_manager=db_manager,
+        )
+
+        with patch(
+            "lorairo.gui.workers.batch_import_worker.BatchImportService",
+            side_effect=RuntimeError("Unexpected error"),
+        ):
+            worker.run()
+
+        error_records = db_manager.repository.get_error_records(operation_type="batch_import")
+        assert len(error_records) > 0
+        assert error_records[0].operation_type == "batch_import"
+
+
 class TestErrorRecordIntegration:
     """エラーレコード統合テスト"""
 

--- a/tests/unit/gui/workers/test_batch_import_worker.py
+++ b/tests/unit/gui/workers/test_batch_import_worker.py
@@ -28,6 +28,18 @@ def sample_result():
 class TestBatchImportWorkerInit:
     """BatchImportWorker 初期化テスト。"""
 
+    def test_operation_type_is_batch_import(self):
+        assert BatchImportWorker._OPERATION_TYPE == "batch_import"
+
+    def test_init_with_db_manager(self, mock_repository, tmp_path):
+        from unittest.mock import Mock
+
+        mock_db_manager = Mock()
+        jsonl_file = tmp_path / "result.jsonl"
+        jsonl_file.touch()
+        worker = BatchImportWorker(mock_repository, [jsonl_file], db_manager=mock_db_manager)
+        assert worker._db_manager is mock_db_manager
+
     def test_init_defaults(self, mock_repository, tmp_path):
         jsonl_file = tmp_path / "result.jsonl"
         jsonl_file.touch()
@@ -36,6 +48,7 @@ class TestBatchImportWorkerInit:
         assert worker._jsonl_files == [jsonl_file]
         assert worker._dry_run is False
         assert worker._model_name_override is None
+        assert worker._db_manager is None
 
     def test_init_with_options(self, mock_repository, tmp_path):
         jsonl_file = tmp_path / "result.jsonl"


### PR DESCRIPTION
## Summary

- PR #162 (Issue #159) の実装で `BatchImportWorker` のエラーDB記録対応が漏れていたため修正
- バッチインポート中に未ハンドル例外が発生しても `db_manager is None` により DB に記録されない状態だった

## Changes

| ファイル | 変更内容 |
|---------|---------|
| `src/lorairo/gui/workers/batch_import_worker.py` | `_OPERATION_TYPE = "batch_import"` 追加、`db_manager` パラメータ追加 |
| `src/lorairo/gui/services/worker_service.py` | `BatchImportWorker` 生成時に `db_manager=self.db_manager` を渡す |
| `src/lorairo/database/db_repository.py` | `save_error_record()` の `logger.info` → `logger.debug`（ログルール準拠） |
| `tests/unit/gui/workers/test_batch_import_worker.py` | `_OPERATION_TYPE` と `db_manager` の初期化テスト追加 |
| `tests/integration/gui/workers/test_worker_error_recording.py` | `BatchImportWorkerErrorRecording` 統合テスト追加 |

## Test plan

- [x] `uv run pytest tests/unit/gui/workers/test_batch_import_worker.py` — 全テスト PASSED
- [x] `uv run pytest tests/integration/gui/workers/test_worker_error_recording.py` — 全テスト PASSED
- [x] `uv run pytest tests/unit/gui/workers/ tests/integration/gui/workers/` — 90/90 PASSED
- [x] `uv run mypy -p lorairo` — `no issues found in 134 source files`

🤖 Generated with [Claude Code](https://claude.com/claude-code)