### PR TITLE
feat: エラーログビューアで複数選択・一括解決済みマーク機能を追加 Closes #161

### DIFF
--- a/src/lorairo/database/db_manager.py
+++ b/src/lorairo/database/db_manager.py
@@ -1175,6 +1175,21 @@ class ImageDatabaseManager:
             logger.error(f"エラーレコード保存中にエラー（二次エラー）: {e}", exc_info=True)
             return -1
 
+    def mark_errors_resolved_batch(self, error_ids: list[int]) -> tuple[bool, int]:
+        """複数エラーを一括解決済みマーク（Manager層Facade）
+
+        Args:
+            error_ids: 対象エラーレコードのIDリスト
+
+        Returns:
+            (成功フラグ, 解決済みマーク件数)
+        """
+        try:
+            return self.repository.mark_errors_resolved_batch(error_ids)
+        except Exception as e:
+            logger.error(f"一括解決マーク失敗（Manager）: {e}", exc_info=True)
+            return (False, 0)
+
     def get_image_id_by_filepath(self, filepath: str) -> int | None:
         """ファイルパスから画像IDを取得（Manager層Facade）
 

--- a/src/lorairo/database/db_repository.py
+++ b/src/lorairo/database/db_repository.py
@@ -3149,6 +3149,50 @@ class ImageRepository:
                 logger.error(f"エラーレコードの解決マーク中にエラーが発生しました: {e}", exc_info=True)
                 raise
 
+    def mark_errors_resolved_batch(self, error_ids: list[int]) -> tuple[bool, int]:
+        """複数のエラーレコードを原子的に解決済みにマーク
+
+        単一トランザクションで全エラーを処理する。全件成功 or 全件ロールバック。
+        ADR-0012 (Batch Tag Atomic Transaction) パターン準拠。
+
+        Args:
+            error_ids: 対象エラーレコードのIDリスト
+
+        Returns:
+            (成功フラグ, 解決済みマーク件数)
+
+        Raises:
+            SQLAlchemyError: データベースエラー時（ロールバック後に再送出）
+        """
+        from datetime import UTC
+
+        if not error_ids:
+            logger.warning("mark_errors_resolved_batch: 空のerror_idsリストが渡されました")
+            return (False, 0)
+
+        with self.session_factory() as session:
+            try:
+                existing = (
+                    session.execute(select(ErrorRecord).where(ErrorRecord.id.in_(error_ids)))
+                    .scalars()
+                    .all()
+                )
+
+                now = datetime.datetime.now(UTC)
+                updated_count = 0
+                for record in existing:
+                    record.resolved_at = now
+                    updated_count += 1
+
+                session.commit()
+                logger.info(f"エラーレコード一括解決完了: 要求={len(error_ids)}件, 更新={updated_count}件")
+                return (True, updated_count)
+
+            except SQLAlchemyError as e:
+                session.rollback()
+                logger.error(f"エラーレコード一括解決失敗: {e}", exc_info=True)
+                raise
+
     def get_session(self) -> Session:
         """セッションを取得（Manager層で生SQLを実行する際に使用）
 

--- a/src/lorairo/gui/designer/AnnotationDataDisplayWidget_ui.py
+++ b/src/lorairo/gui/designer/AnnotationDataDisplayWidget_ui.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'AnnotationDataDisplayWidget.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.10.2
+## Created by: Qt User Interface Compiler version 6.11.0
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################
@@ -127,15 +127,15 @@ class Ui_AnnotationDataDisplayWidget(object):
         AnnotationDataDisplayWidget.setWindowTitle(QCoreApplication.translate("AnnotationDataDisplayWidget", u"Annotation Data Display", None))
         self.groupBoxTags.setTitle(QCoreApplication.translate("AnnotationDataDisplayWidget", u"\u30bf\u30b0", None))
         ___qtablewidgetitem = self.tableWidgetTags.horizontalHeaderItem(0)
-        ___qtablewidgetitem.setText(QCoreApplication.translate("AnnotationDataDisplayWidget", u"Tag", None));
+        ___qtablewidgetitem.setText(QCoreApplication.translate("AnnotationDataDisplayWidget", u"Tag", None))
         ___qtablewidgetitem1 = self.tableWidgetTags.horizontalHeaderItem(1)
-        ___qtablewidgetitem1.setText(QCoreApplication.translate("AnnotationDataDisplayWidget", u"Model", None));
+        ___qtablewidgetitem1.setText(QCoreApplication.translate("AnnotationDataDisplayWidget", u"Model", None))
         ___qtablewidgetitem2 = self.tableWidgetTags.horizontalHeaderItem(2)
-        ___qtablewidgetitem2.setText(QCoreApplication.translate("AnnotationDataDisplayWidget", u"Source", None));
+        ___qtablewidgetitem2.setText(QCoreApplication.translate("AnnotationDataDisplayWidget", u"Source", None))
         ___qtablewidgetitem3 = self.tableWidgetTags.horizontalHeaderItem(3)
-        ___qtablewidgetitem3.setText(QCoreApplication.translate("AnnotationDataDisplayWidget", u"Confidence", None));
+        ___qtablewidgetitem3.setText(QCoreApplication.translate("AnnotationDataDisplayWidget", u"Confidence", None))
         ___qtablewidgetitem4 = self.tableWidgetTags.horizontalHeaderItem(4)
-        ___qtablewidgetitem4.setText(QCoreApplication.translate("AnnotationDataDisplayWidget", u"Edited", None));
+        ___qtablewidgetitem4.setText(QCoreApplication.translate("AnnotationDataDisplayWidget", u"Edited", None))
         self.groupBoxCaption.setTitle(QCoreApplication.translate("AnnotationDataDisplayWidget", u"\u30ad\u30e3\u30d7\u30b7\u30e7\u30f3", None))
         self.textEditCaption.setPlaceholderText(QCoreApplication.translate("AnnotationDataDisplayWidget", u"\u30ad\u30e3\u30d7\u30b7\u30e7\u30f3\u304c\u8868\u793a\u3055\u308c\u307e\u3059", None))
         self.textEditCaption.setStyleSheet(QCoreApplication.translate("AnnotationDataDisplayWidget", u"QTextEdit {\n"

--- a/src/lorairo/gui/designer/ConfigurationWindow_ui.py
+++ b/src/lorairo/gui/designer/ConfigurationWindow_ui.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'ConfigurationWindow.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.10.2
+## Created by: Qt User Interface Compiler version 6.11.0
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################

--- a/src/lorairo/gui/designer/DatasetExportWidget_ui.py
+++ b/src/lorairo/gui/designer/DatasetExportWidget_ui.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'DatasetExportWidget.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.10.2
+## Created by: Qt User Interface Compiler version 6.11.0
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################

--- a/src/lorairo/gui/designer/DatasetOverviewWidget_ui.py
+++ b/src/lorairo/gui/designer/DatasetOverviewWidget_ui.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'DatasetOverviewWidget.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.10.2
+## Created by: Qt User Interface Compiler version 6.11.0
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################

--- a/src/lorairo/gui/designer/DirectoryPickerWidget_ui.py
+++ b/src/lorairo/gui/designer/DirectoryPickerWidget_ui.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'DirectoryPickerWidget.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.10.2
+## Created by: Qt User Interface Compiler version 6.11.0
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################

--- a/src/lorairo/gui/designer/ErrorLogViewerWidget.ui
+++ b/src/lorairo/gui/designer/ErrorLogViewerWidget.ui
@@ -137,7 +137,7 @@ QHeaderView::section {
       <bool>true</bool>
      </property>
      <property name="selectionMode">
-      <enum>QAbstractItemView::SelectionMode::SingleSelection</enum>
+      <enum>QAbstractItemView::SelectionMode::ExtendedSelection</enum>
      </property>
      <property name="selectionBehavior">
       <enum>QAbstractItemView::SelectionBehavior::SelectRows</enum>

--- a/src/lorairo/gui/designer/FilePickerWidget_ui.py
+++ b/src/lorairo/gui/designer/FilePickerWidget_ui.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'FilePickerWidget.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.10.2
+## Created by: Qt User Interface Compiler version 6.11.0
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################

--- a/src/lorairo/gui/designer/FilterSearchPanel_ui.py
+++ b/src/lorairo/gui/designer/FilterSearchPanel_ui.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'FilterSearchPanel.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.10.2
+## Created by: Qt User Interface Compiler version 6.11.0
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################

--- a/src/lorairo/gui/designer/ImageEditWidget_ui.py
+++ b/src/lorairo/gui/designer/ImageEditWidget_ui.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'ImageEditWidget.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.10.2
+## Created by: Qt User Interface Compiler version 6.11.0
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################
@@ -173,17 +173,17 @@ class Ui_ImageEditWidget(object):
     def retranslateUi(self, ImageEditWidget: QWidget) -> None:
         ImageEditWidget.setWindowTitle(QCoreApplication.translate("ImageEditWidget", u"Form", None))
         ___qtablewidgetitem = self.tableWidgetImageList.horizontalHeaderItem(0)
-        ___qtablewidgetitem.setText(QCoreApplication.translate("ImageEditWidget", u"\u30b5\u30e0\u30cd\u30a4\u30eb", None));
+        ___qtablewidgetitem.setText(QCoreApplication.translate("ImageEditWidget", u"\u30b5\u30e0\u30cd\u30a4\u30eb", None))
         ___qtablewidgetitem1 = self.tableWidgetImageList.horizontalHeaderItem(1)
-        ___qtablewidgetitem1.setText(QCoreApplication.translate("ImageEditWidget", u"\u30d5\u30a1\u30a4\u30eb\u540d", None));
+        ___qtablewidgetitem1.setText(QCoreApplication.translate("ImageEditWidget", u"\u30d5\u30a1\u30a4\u30eb\u540d", None))
         ___qtablewidgetitem2 = self.tableWidgetImageList.horizontalHeaderItem(2)
-        ___qtablewidgetitem2.setText(QCoreApplication.translate("ImageEditWidget", u"\u30d1\u30b9", None));
+        ___qtablewidgetitem2.setText(QCoreApplication.translate("ImageEditWidget", u"\u30d1\u30b9", None))
         ___qtablewidgetitem3 = self.tableWidgetImageList.horizontalHeaderItem(3)
-        ___qtablewidgetitem3.setText(QCoreApplication.translate("ImageEditWidget", u"\u30b5\u30a4\u30ba", None));
+        ___qtablewidgetitem3.setText(QCoreApplication.translate("ImageEditWidget", u"\u30b5\u30a4\u30ba", None))
         ___qtablewidgetitem4 = self.tableWidgetImageList.horizontalHeaderItem(4)
-        ___qtablewidgetitem4.setText(QCoreApplication.translate("ImageEditWidget", u"\u65e2\u5b58\u30bf\u30b0", None));
+        ___qtablewidgetitem4.setText(QCoreApplication.translate("ImageEditWidget", u"\u65e2\u5b58\u30bf\u30b0", None))
         ___qtablewidgetitem5 = self.tableWidgetImageList.horizontalHeaderItem(5)
-        ___qtablewidgetitem5.setText(QCoreApplication.translate("ImageEditWidget", u"\u65e2\u5b58\u30ad\u30e3\u30d7\u30b7\u30e7\u30f3", None));
+        ___qtablewidgetitem5.setText(QCoreApplication.translate("ImageEditWidget", u"\u65e2\u5b58\u30ad\u30e3\u30d7\u30b7\u30e7\u30f3", None))
         self.labelPreviewTitle.setText(QCoreApplication.translate("ImageEditWidget", u"\u30d7\u30ec\u30d3\u30e5\u30fc", None))
         self.groupBoxEditOptions.setTitle(QCoreApplication.translate("ImageEditWidget", u"\u7de8\u96c6\u30aa\u30d7\u30b7\u30e7\u30f3", None))
         self.labelResizeOption.setText(QCoreApplication.translate("ImageEditWidget", u"\u30ea\u30b5\u30a4\u30ba:", None))

--- a/src/lorairo/gui/designer/ImagePreviewWidget_ui.py
+++ b/src/lorairo/gui/designer/ImagePreviewWidget_ui.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'ImagePreviewWidget.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.10.2
+## Created by: Qt User Interface Compiler version 6.11.0
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################

--- a/src/lorairo/gui/designer/MainWindow_ui.py
+++ b/src/lorairo/gui/designer/MainWindow_ui.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'MainWindow.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.10.2
+## Created by: Qt User Interface Compiler version 6.11.0
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################

--- a/src/lorairo/gui/designer/ModelCheckboxWidget_ui.py
+++ b/src/lorairo/gui/designer/ModelCheckboxWidget_ui.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'ModelCheckboxWidget.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.10.2
+## Created by: Qt User Interface Compiler version 6.11.0
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################

--- a/src/lorairo/gui/designer/ModelResultTab_ui.py
+++ b/src/lorairo/gui/designer/ModelResultTab_ui.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'ModelResultTab.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.10.2
+## Created by: Qt User Interface Compiler version 6.11.0
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################

--- a/src/lorairo/gui/designer/ModelSelectionWidget_ui.py
+++ b/src/lorairo/gui/designer/ModelSelectionWidget_ui.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'ModelSelectionWidget.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.10.2
+## Created by: Qt User Interface Compiler version 6.11.0
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################

--- a/src/lorairo/gui/designer/PickerWidget_ui.py
+++ b/src/lorairo/gui/designer/PickerWidget_ui.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'PickerWidget.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.10.2
+## Created by: Qt User Interface Compiler version 6.11.0
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################

--- a/src/lorairo/gui/designer/ProgressWidget_ui.py
+++ b/src/lorairo/gui/designer/ProgressWidget_ui.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'ProgressWidget.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.10.2
+## Created by: Qt User Interface Compiler version 6.11.0
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################

--- a/src/lorairo/gui/designer/SelectedImageDetailsWidget_ui.py
+++ b/src/lorairo/gui/designer/SelectedImageDetailsWidget_ui.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'SelectedImageDetailsWidget.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.10.2
+## Created by: Qt User Interface Compiler version 6.11.0
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################

--- a/src/lorairo/gui/designer/ThumbnailSelectorWidget_ui.py
+++ b/src/lorairo/gui/designer/ThumbnailSelectorWidget_ui.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'ThumbnailSelectorWidget.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.10.2
+## Created by: Qt User Interface Compiler version 6.11.0
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################

--- a/src/lorairo/gui/widgets/error_log_viewer_widget.py
+++ b/src/lorairo/gui/widgets/error_log_viewer_widget.py
@@ -259,37 +259,52 @@ class ErrorLogViewerWidget(QWidget, Ui_ErrorLogViewerWidget):
                 self.error_resolved.emit(error_id)
                 self.load_error_records()
 
+    def _get_selected_error_ids(self) -> list[int]:
+        """選択行のエラーレコードIDリストを返す。選択なし時は空リスト。"""
+        selection_model = self.tableWidgetErrors.selectionModel()
+        if selection_model is None:
+            return []
+        error_ids: list[int] = []
+        for index in selection_model.selectedRows():
+            item = self.tableWidgetErrors.item(index.row(), 0)
+            if item is None:
+                continue
+            error_id = item.data(Qt.ItemDataRole.UserRole)
+            if isinstance(error_id, int):
+                error_ids.append(error_id)
+        return error_ids
+
     def _on_mark_resolved_clicked(self) -> None:
-        """解決済みマークボタンクリック処理"""
-        selected_row = self.tableWidgetErrors.currentRow()
-        if selected_row < 0:
+        """解決済みマークボタンクリック処理（複数選択対応）"""
+        error_ids = self._get_selected_error_ids()
+        if not error_ids:
             QMessageBox.warning(self, "警告", "エラーレコードを選択してください")
             return
 
-        # エラーレコードID取得
-        resolve_item = self.tableWidgetErrors.item(selected_row, 0)
-        if resolve_item is None:
-            return
-        error_id = resolve_item.data(Qt.ItemDataRole.UserRole)
-
-        # 確認ダイアログ
+        count = len(error_ids)
         reply = QMessageBox.question(
             self,
             "確認",
-            "このエラーを解決済みにマークしますか？",
+            f"選択した {count} 件のエラーを解決済みにマークしますか？",
             QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
         )
+        if reply != QMessageBox.StandardButton.Yes or self.db_manager is None:
+            return
 
-        if reply == QMessageBox.StandardButton.Yes:
-            try:
-                if self.db_manager:
-                    self.db_manager.repository.mark_error_resolved(error_id)
-                    QMessageBox.information(self, "成功", "エラーを解決済みにマークしました")
-                    self.error_resolved.emit(error_id)
-                    self.load_error_records()
-            except Exception as e:
-                logger.error(f"解決マーク失敗: {e}", exc_info=True)
-                QMessageBox.critical(self, "エラー", f"解決マークに失敗しました:\n{e}")
+        try:
+            success, updated_count = self.db_manager.mark_errors_resolved_batch(error_ids)
+            if success:
+                QMessageBox.information(
+                    self, "成功", f"{updated_count} 件のエラーを解決済みにマークしました"
+                )
+                for eid in error_ids:
+                    self.error_resolved.emit(eid)
+                self.load_error_records()
+            else:
+                QMessageBox.critical(self, "エラー", "一括解決マークに失敗しました")
+        except Exception as e:
+            logger.error(f"一括解決マーク失敗: {e}", exc_info=True)
+            QMessageBox.critical(self, "エラー", f"解決マークに失敗しました:\n{e}")
 
     def _on_export_log_clicked(self) -> None:
         """エラーログをCSVファイルにエクスポートする。

--- a/tests/unit/database/test_db_repository_error_records.py
+++ b/tests/unit/database/test_db_repository_error_records.py
@@ -303,6 +303,93 @@ class TestMarkErrorResolved:
         assert mock_session.rollback.called
 
 
+class TestMarkErrorsResolvedBatch:
+    """mark_errors_resolved_batch メソッドのテスト"""
+
+    @pytest.fixture
+    def repository(self):
+        """テスト用ImageRepository"""
+        mock_session_factory = MagicMock()
+        return ImageRepository(session_factory=mock_session_factory)
+
+    def test_mark_errors_resolved_batch_success(self, repository):
+        """複数エラーIDの一括解決済みマーク成功"""
+        mock_session = Mock()
+        mock_record_1 = Mock(spec=ErrorRecord)
+        mock_record_1.id = 1
+        mock_record_1.resolved_at = None
+        mock_record_2 = Mock(spec=ErrorRecord)
+        mock_record_2.id = 2
+        mock_record_2.resolved_at = None
+        mock_session.execute.return_value.scalars.return_value.all.return_value = [
+            mock_record_1,
+            mock_record_2,
+        ]
+        repository.session_factory.return_value.__enter__.return_value = mock_session
+
+        success, count = repository.mark_errors_resolved_batch([1, 2])
+
+        assert success is True
+        assert count == 2
+        assert mock_record_1.resolved_at is not None
+        assert mock_record_2.resolved_at is not None
+        assert mock_session.commit.called
+
+    def test_mark_errors_resolved_batch_empty_list(self, repository):
+        """空リストでの一括解決はFalse/0を返す"""
+        success, count = repository.mark_errors_resolved_batch([])
+
+        assert success is False
+        assert count == 0
+
+    def test_mark_errors_resolved_batch_partial_nonexistent(self, repository):
+        """一部IDが存在しない場合、存在するIDのみ更新"""
+        mock_session = Mock()
+        mock_record = Mock(spec=ErrorRecord)
+        mock_record.id = 1
+        mock_record.resolved_at = None
+        # id=999 は存在しないので result には含まれない
+        mock_session.execute.return_value.scalars.return_value.all.return_value = [mock_record]
+        repository.session_factory.return_value.__enter__.return_value = mock_session
+
+        success, count = repository.mark_errors_resolved_batch([1, 999])
+
+        assert success is True
+        assert count == 1
+        assert mock_record.resolved_at is not None
+        assert mock_session.commit.called
+
+    def test_mark_errors_resolved_batch_database_error(self, repository):
+        """データベースエラー時にロールバックして例外を再送出"""
+        mock_session = Mock()
+        mock_session.execute.side_effect = SQLAlchemyError("DB Error")
+        repository.session_factory.return_value.__enter__.return_value = mock_session
+
+        with pytest.raises(SQLAlchemyError):
+            repository.mark_errors_resolved_batch([1, 2])
+
+        assert mock_session.rollback.called
+
+    def test_mark_errors_resolved_batch_sets_resolved_at_to_now(self, repository):
+        """resolved_atが現在時刻(UTC)に設定されることを確認"""
+        from datetime import UTC, datetime
+
+        mock_session = Mock()
+        mock_record = Mock(spec=ErrorRecord)
+        mock_record.id = 1
+        mock_record.resolved_at = None
+        mock_session.execute.return_value.scalars.return_value.all.return_value = [mock_record]
+        repository.session_factory.return_value.__enter__.return_value = mock_session
+
+        before = datetime.now(UTC)
+        repository.mark_errors_resolved_batch([1])
+        after = datetime.now(UTC)
+
+        assert mock_record.resolved_at is not None
+        # resolved_atがbefore〜afterの間に設定されていることを確認
+        assert before <= mock_record.resolved_at <= after
+
+
 class TestGetSession:
     """get_session メソッドのテスト"""
 

--- a/tests/unit/gui/widgets/test_error_log_viewer_widget.py
+++ b/tests/unit/gui/widgets/test_error_log_viewer_widget.py
@@ -8,7 +8,8 @@ import datetime
 from unittest.mock import Mock, patch
 
 import pytest
-from PySide6.QtWidgets import QFileDialog, QMessageBox
+from PySide6.QtCore import QItemSelectionModel
+from PySide6.QtWidgets import QAbstractItemView, QFileDialog, QMessageBox
 
 from lorairo.database.schema import ErrorRecord
 from lorairo.gui.widgets.error_log_viewer_widget import ErrorLogViewerWidget
@@ -286,6 +287,120 @@ class TestErrorLogViewerWidgetActions:
         with patch.object(QFileDialog, "getSaveFileName", return_value=("", "")):
             # キャンセル時はQMessageBoxが呼ばれない
             error_log_viewer_widget._on_export_log_clicked()
+
+
+class TestMarkResolvedMultiSelect:
+    """複数選択による一括解決テスト"""
+
+    @pytest.fixture
+    def record_2(self):
+        """2件目のエラーレコード"""
+        return ErrorRecord(
+            id=2,
+            operation_type="registration",
+            error_type="FileError",
+            error_message="Second error message",
+            file_path=None,
+            model_name=None,
+            retry_count=0,
+            resolved_at=None,
+            created_at=datetime.datetime(2025, 11, 25, 12, 0, 0),
+        )
+
+    @pytest.fixture
+    def widget_with_two_records(self, error_log_viewer_widget, sample_error_record, record_2):
+        """2件のレコードが表示され ExtendedSelection が有効な widget"""
+        error_log_viewer_widget._update_table_display([sample_error_record, record_2])
+        error_log_viewer_widget.tableWidgetErrors.setSelectionMode(
+            QAbstractItemView.SelectionMode.ExtendedSelection
+        )
+        return error_log_viewer_widget
+
+    def _select_rows(self, table, row_indices: list[int]) -> None:
+        """指定行を複数選択するヘルパー"""
+        table.selectRow(row_indices[0])
+        for row in row_indices[1:]:
+            table.selectionModel().select(
+                table.model().index(row, 0),
+                QItemSelectionModel.SelectionFlag.Select | QItemSelectionModel.SelectionFlag.Rows,
+            )
+
+    def test_multi_select_calls_batch_method(self, widget_with_two_records, mock_db_manager):
+        """複数行選択時に mark_errors_resolved_batch が全選択IDで呼ばれる"""
+        mock_db_manager.mark_errors_resolved_batch.return_value = (True, 2)
+        table = widget_with_two_records.tableWidgetErrors
+        self._select_rows(table, [0, 1])
+
+        with (
+            patch.object(QMessageBox, "question", return_value=QMessageBox.StandardButton.Yes),
+            patch.object(QMessageBox, "information"),
+        ):
+            widget_with_two_records._on_mark_resolved_clicked()
+
+        mock_db_manager.mark_errors_resolved_batch.assert_called_once()
+        called_ids = mock_db_manager.mark_errors_resolved_batch.call_args[0][0]
+        assert set(called_ids) == {1, 2}
+
+    def test_confirmation_message_shows_count(self, widget_with_two_records, mock_db_manager):
+        """確認ダイアログのメッセージに選択件数が含まれる"""
+        mock_db_manager.mark_errors_resolved_batch.return_value = (True, 2)
+        table = widget_with_two_records.tableWidgetErrors
+        self._select_rows(table, [0, 1])
+
+        captured: list[str] = []
+
+        def capture_question(parent, title, message, *args, **kwargs):
+            captured.append(message)
+            return QMessageBox.StandardButton.No
+
+        with patch.object(QMessageBox, "question", side_effect=capture_question):
+            widget_with_two_records._on_mark_resolved_clicked()
+
+        assert len(captured) == 1
+        assert "2" in captured[0]
+
+    def test_cancel_does_not_call_db(self, widget_with_two_records, mock_db_manager):
+        """ユーザーがキャンセルしたときは DB 操作を一切呼ばない"""
+        table = widget_with_two_records.tableWidgetErrors
+        self._select_rows(table, [0, 1])
+
+        with patch.object(QMessageBox, "question", return_value=QMessageBox.StandardButton.No):
+            widget_with_two_records._on_mark_resolved_clicked()
+
+        mock_db_manager.mark_errors_resolved_batch.assert_not_called()
+
+    def test_emits_signal_per_resolved_id(self, widget_with_two_records, mock_db_manager):
+        """解決済みにした各IDに対して error_resolved シグナルが発火する"""
+        mock_db_manager.mark_errors_resolved_batch.return_value = (True, 2)
+        table = widget_with_two_records.tableWidgetErrors
+        self._select_rows(table, [0, 1])
+
+        emitted: list[int] = []
+        widget_with_two_records.error_resolved.connect(emitted.append)
+
+        with (
+            patch.object(QMessageBox, "question", return_value=QMessageBox.StandardButton.Yes),
+            patch.object(QMessageBox, "information"),
+        ):
+            widget_with_two_records._on_mark_resolved_clicked()
+
+        assert set(emitted) == {1, 2}
+
+    def test_reloads_table_after_success(self, widget_with_two_records, mock_db_manager):
+        """一括解決成功後に load_error_records が呼ばれてテーブルがリロードされる"""
+        mock_db_manager.mark_errors_resolved_batch.return_value = (True, 1)
+        mock_db_manager.repository.get_error_records.return_value = []
+        mock_db_manager.repository.get_error_count_unresolved.return_value = 0
+        table = widget_with_two_records.tableWidgetErrors
+        table.selectRow(0)
+
+        with (
+            patch.object(QMessageBox, "question", return_value=QMessageBox.StandardButton.Yes),
+            patch.object(QMessageBox, "information"),
+        ):
+            widget_with_two_records._on_mark_resolved_clicked()
+
+        mock_db_manager.repository.get_error_records.assert_called()
 
 
 class TestErrorLogViewerWidgetTableDisplay:


### PR DESCRIPTION
## Summary

- `QTableWidget` を `ExtendedSelection` モードに変更し、Ctrl+Click / Shift+Click / Ctrl+A による複数行選択に対応
- `ImageRepository.mark_errors_resolved_batch()` を追加（ADR-0012準拠のアトミックトランザクション — 全件コミットまたは全件ロールバック）
- `ImageDatabaseManager.mark_errors_resolved_batch()` ファサードを追加
- `ErrorLogViewerWidget` の「解決済みにマーク」ボタンを複数選択に対応（選択件数を確認ダイアログに表示）

## Test plan

- [x] `ImageRepository.mark_errors_resolved_batch()`: 5テスト追加（成功・空リスト・部分的非存在ID・DB例外・タイムスタンプ設定）
- [x] `ErrorLogViewerWidget` 複数選択テスト: 5テスト追加（一括バッチ呼び出し・確認メッセージ件数表示・キャンセル時DB未呼び出し・Signal複数発火・テーブルリロード）
- [x] 全1906テスト通過（リグレッションなし）
- [x] `ruff check` / `mypy` クリア

🤖 Generated with [Claude Code](https://claude.com/claude-code)