### PR TITLE
style: テストメソッド内の重複インポートを削除 (Ruff F811)

### DIFF
--- a/tests/unit/database/test_db_repository_error_records.py
+++ b/tests/unit/database/test_db_repository_error_records.py
@@ -372,7 +372,6 @@ class TestMarkErrorsResolvedBatch:
 
     def test_mark_errors_resolved_batch_sets_resolved_at_to_now(self, repository):
         """resolved_atが現在時刻(UTC)に設定されることを確認"""
-        from datetime import UTC, datetime
 
         mock_session = Mock()
         mock_record = Mock(spec=ErrorRecord)


### PR DESCRIPTION
from datetime import UTC, datetime がモジュールトップレベルで既に インポートされているため、メソッド内のインラインインポートを削除。

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>