### PR TITLE
fix(#177): CLIプロジェクトDB接続管理とlorairo_data/への保存場所統一

### DIFF
--- a/src/lorairo/cli/commands/annotate.py
+++ b/src/lorairo/cli/commands/annotate.py
@@ -123,13 +123,14 @@ def run(
     プロジェクトの画像に対してアノテーションを実行します。
     """
     try:
-        # API層経由でプロジェクト確認
+        # API層経由でプロジェクト確認 & DB 接続切り替え
         try:
             project_info = api_get_project(project)
         except ProjectNotFoundError as e:
             console.print(f"[red]Error:[/red] Project not found: {project}")
             raise typer.Exit(code=1) from e
 
+        get_service_container().set_active_project(project)
         project_dir = project_info.path
 
         # プロジェクトの画像ディレクトリ
@@ -305,6 +306,7 @@ def import_batch(
         lorairo annotate import-batch jsonl/ -p my_project --dry-run
     """
     try:
+        get_service_container().set_active_project(project)
         result = import_batch_annotations(
             jsonl_dir,
             project,

--- a/src/lorairo/cli/commands/export.py
+++ b/src/lorairo/cli/commands/export.py
@@ -265,19 +265,13 @@ def create(
             console.print("詳細: lorairo-cli export create --help")
             raise typer.Exit(code=2)
 
-        # ServiceContainer を取得
+        # ServiceContainer を取得してプロジェクト DB に切り替え
         container = get_service_container()
+        container.set_active_project(project)
         repository = container.image_repository
         export_service = container.dataset_export_service
 
         console.print(f"[cyan]Loading project database: {project}[/cyan]")
-
-        # NOTE: Current architecture limitation - LoRAIro initializes database globally
-        # through db_core.py. For now, we work with the currently configured database.
-        console.print(
-            "[yellow]Note:[/yellow] Working with currently configured database. "
-            "Ensure config/lorairo.toml points to the correct project."
-        )
 
         # フィルタ条件を適用して画像を取得
         with Progress(

--- a/src/lorairo/cli/commands/images.py
+++ b/src/lorairo/cli/commands/images.py
@@ -14,6 +14,7 @@ from lorairo.api.exceptions import ImageRegistrationError, ProjectNotFoundError
 from lorairo.api.images import register_images as api_register_images
 from lorairo.api.project import get_project as api_get_project
 from lorairo.api.types import RegistrationResult
+from lorairo.services.service_container import get_service_container
 
 # サブコマンドアプリ定義
 app = typer.Typer(help="Image management commands")
@@ -81,12 +82,14 @@ def register(
             console.print(f"[red]Error:[/red] Not a directory: {directory}")
             raise typer.Exit(code=1)
 
-        # プロジェクト存在確認
+        # プロジェクト存在確認 & DB 接続切り替え
         try:
             api_get_project(project)
         except ProjectNotFoundError as e:
             console.print(f"[red]Error:[/red] Project not found: {project}")
             raise typer.Exit(code=1) from e
+
+        get_service_container().set_active_project(project)
 
         # API層経由で画像登録（プロジェクトコンテキスト付き）
         result = api_register_images(dir_path, skip_duplicates, project_name=project)

--- a/src/lorairo/database/db_core.py
+++ b/src/lorairo/database/db_core.py
@@ -268,6 +268,26 @@ def create_session_factory(engine: Engine) -> sessionmaker[Session]:
     return sessionmaker(autocommit=False, autoflush=False, bind=engine)
 
 
+def create_project_session_factory(project_db_path: Path) -> sessionmaker[Session]:
+    """指定プロジェクト DB 用セッションファクトリを生成。
+
+    新規 DB（touch で空ファイル）の場合はスキーマを初期化する。
+    既存テーブルは変更しない（create_all は冪等）。
+
+    Args:
+        project_db_path: プロジェクト DB ファイルの絶対パス。
+
+    Returns:
+        sessionmaker[Session]: プロジェクト専用セッションファクトリ。
+    """
+    from .schema import Base
+
+    db_url = f"sqlite:///{project_db_path.resolve()}?check_same_thread=False"
+    engine = create_db_engine(db_url)
+    Base.metadata.create_all(engine)
+    return create_session_factory(engine)
+
+
 # --- デフォルトの Engine と Session Factory --- #
 # 通常のアプリケーション実行時に使用される
 default_engine = create_db_engine(DATABASE_URL)

--- a/src/lorairo/services/project_management_service.py
+++ b/src/lorairo/services/project_management_service.py
@@ -18,13 +18,14 @@ from lorairo.api.exceptions import (
     ProjectOperationError,
 )
 from lorairo.api.types import ProjectInfo
+from lorairo.utils.config import get_config
 
 
 class ProjectManagementService:
     """プロジェクト管理 Service。
 
     プロジェクトディレクトリの CRUD操作を担当。
-    ~/.lorairo/projects/ 配下にプロジェクトディレクトリを管理する。
+    config/lorairo.toml の database_base_dir 配下にプロジェクトディレクトリを管理する。
     """
 
     def __init__(self, projects_base_dir: Path | None = None) -> None:
@@ -32,9 +33,22 @@ class ProjectManagementService:
 
         Args:
             projects_base_dir: プロジェクトベースディレクトリ。
-                              未指定時は ~/.lorairo/projects
+                              未指定時は config/lorairo.toml の database_base_dir
         """
-        self.projects_base_dir = projects_base_dir or (Path.home() / ".lorairo" / "projects")
+        if projects_base_dir is not None:
+            self.projects_base_dir = projects_base_dir
+        else:
+            config = get_config()
+            base_dir_str = config.get("directories", {}).get("database_base_dir", "lorairo_data")
+            self.projects_base_dir = Path(base_dir_str).resolve()
+
+            # 旧ディレクトリ残存チェック（移行案内）
+            old_dir = Path.home() / ".lorairo" / "projects"
+            if old_dir.exists():
+                logger.info(
+                    f"旧プロジェクトディレクトリが検出されました: {old_dir}"
+                    f" → {self.projects_base_dir} への移動を検討してください"
+                )
         logger.debug(f"ProjectManagementService 初期化: {self.projects_base_dir}")
 
     def create_project(self, name: str, description: str = "") -> ProjectInfo:

--- a/src/lorairo/services/service_container.py
+++ b/src/lorairo/services/service_container.py
@@ -266,6 +266,36 @@ class ServiceContainer:
             logger.debug("ImageRegistrationService初期化完了")
         return self._image_registration_service
 
+    def set_active_project(self, project_name: str) -> None:
+        """CLI用: アクティブプロジェクトの DB に接続を切り替える。
+
+        ProjectManagementService でプロジェクトパスを解決し、
+        そのプロジェクト専用のセッションファクトリで image_repository を再初期化する。
+        依存するサービス (db_manager, dataset_export_service 等) もリセットし、
+        次回参照時に新しい image_repository を使って再初期化させる。
+
+        Args:
+            project_name: 切り替えるプロジェクト名。
+
+        Raises:
+            ProjectNotFoundError: プロジェクトが見つからない場合。
+        """
+        from ..database.db_core import create_project_session_factory
+
+        project_info = self.project_management_service.get_project(project_name)
+        db_path = project_info.path / "image_database.db"
+
+        session_factory = create_project_session_factory(db_path)
+        self._image_repository = ImageRepository(session_factory=session_factory)
+
+        # 依存サービスをリセット（次参照時に新しい image_repository で再初期化）
+        self._db_manager = None
+        self._dataset_export_service = None
+        self._image_processing_service = None
+        self._model_sync_service = None
+
+        logger.info(f"アクティブプロジェクト切替: {project_name} -> {db_path}")
+
     def get_service_summary(self) -> dict[str, Any]:
         """サービス初期化状況のサマリー取得
 

--- a/tests/integration/test_project_directory_integration.py
+++ b/tests/integration/test_project_directory_integration.py
@@ -3,9 +3,11 @@
 db_core.py の変更をテストする
 """
 
+import json
 import tempfile
 from datetime import datetime
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
@@ -242,3 +244,160 @@ class TestProjectDirectoryIntegration:
                 dir_name = project_dir.name
                 assert len(dir_name) > 0
                 assert dir_name not in [".", ".."]
+
+
+class TestProjectManagementServiceDefaultPath:
+    """ProjectManagementService のデフォルトパステスト（ADR 0018）"""
+
+    def test_default_path_uses_config_database_base_dir(self, tmp_path: Path) -> None:
+        """デフォルト projects_base_dir が config の database_base_dir を参照する"""
+        from lorairo.services.project_management_service import ProjectManagementService
+
+        fake_config = {
+            "directories": {"database_base_dir": str(tmp_path)},
+        }
+        with patch("lorairo.services.project_management_service.get_config", return_value=fake_config):
+            service = ProjectManagementService()
+
+        assert service.projects_base_dir == tmp_path.resolve()
+
+    def test_explicit_path_overrides_config(self, tmp_path: Path) -> None:
+        """明示的に指定した projects_base_dir が設定より優先される"""
+        from lorairo.services.project_management_service import ProjectManagementService
+
+        explicit_dir = tmp_path / "explicit"
+        service = ProjectManagementService(projects_base_dir=explicit_dir)
+
+        assert service.projects_base_dir == explicit_dir
+
+    def test_old_dir_migration_log_emitted(self, tmp_path: Path) -> None:
+        """~/.lorairo/projects/ が残存する場合に移行案内ログが出力される"""
+        from unittest.mock import MagicMock
+
+        from lorairo.services.project_management_service import ProjectManagementService
+
+        # Path.home() が tmp_path を返すとき、old_dir = tmp_path / ".lorairo" / "projects"
+        old_dir = tmp_path / ".lorairo" / "projects"
+        old_dir.mkdir(parents=True)
+        fake_config = {
+            "directories": {"database_base_dir": str(tmp_path / "new_base")},
+        }
+
+        mock_info = MagicMock()
+        with (
+            patch("lorairo.services.project_management_service.get_config", return_value=fake_config),
+            patch("lorairo.services.project_management_service.Path.home", return_value=tmp_path),
+            patch("lorairo.services.project_management_service.logger.info", mock_info),
+        ):
+            ProjectManagementService()
+
+        called_msgs = [str(call.args[0]) for call in mock_info.call_args_list]
+        assert any("旧プロジェクトディレクトリが検出されました" in msg for msg in called_msgs)
+
+    def test_no_migration_log_when_old_dir_absent(self, tmp_path: Path) -> None:
+        """旧ディレクトリが存在しない場合は移行案内ログが出ない"""
+        from unittest.mock import MagicMock
+
+        from lorairo.services.project_management_service import ProjectManagementService
+
+        fake_config = {
+            "directories": {"database_base_dir": str(tmp_path)},
+        }
+        mock_info = MagicMock()
+        # tmp_path 配下には old ".lorairo/projects" を作らない
+        with (
+            patch("lorairo.services.project_management_service.get_config", return_value=fake_config),
+            patch("lorairo.services.project_management_service.Path.home", return_value=tmp_path),
+            patch("lorairo.services.project_management_service.logger.info", mock_info),
+        ):
+            ProjectManagementService()
+
+        called_msgs = [str(call.args[0]) for call in mock_info.call_args_list]
+        assert not any("旧プロジェクトディレクトリが検出されました" in msg for msg in called_msgs)
+
+
+class TestServiceContainerSetActiveProject:
+    """ServiceContainer.set_active_project テスト（ADR 0009 + ADR 0018）"""
+
+    def setup_method(self) -> None:
+        """各テストの前に ServiceContainer をリセット"""
+        from lorairo.services.service_container import ServiceContainer
+
+        ServiceContainer.reset_for_testing()
+
+    def teardown_method(self) -> None:
+        """各テストの後に ServiceContainer をリセット"""
+        from lorairo.services.service_container import ServiceContainer
+
+        ServiceContainer.reset_for_testing()
+
+    def _create_project_dir(self, base: Path, name: str) -> Path:
+        """テスト用プロジェクトディレクトリを作成する。"""
+        project_dir = base / f"{name}_20260101_001"
+        project_dir.mkdir(parents=True)
+        (project_dir / "image_dataset" / "original_images").mkdir(parents=True)
+        metadata = {"name": name, "created": "20260101_000000", "description": ""}
+        (project_dir / ".lorairo-project").write_text(json.dumps(metadata))
+        (project_dir / "image_database.db").touch()
+        return project_dir
+
+    def test_set_active_project_switches_repository(self, tmp_path: Path) -> None:
+        """set_active_project でリポジトリが対象プロジェクト DB に切り替わる"""
+        import os
+
+        from lorairo.services.service_container import ServiceContainer
+
+        os.environ["LORAIRO_CLI_MODE"] = "1"
+        try:
+            ServiceContainer.reset_for_testing()
+            container = ServiceContainer()
+
+            project_dir = self._create_project_dir(tmp_path, "foo")
+            fake_config = {"directories": {"database_base_dir": str(tmp_path)}}
+
+            with patch(
+                "lorairo.services.project_management_service.get_config",
+                return_value=fake_config,
+            ):
+                container.set_active_project("foo")
+
+            # リポジトリが差し替わっていること（新しいインスタンスを参照）
+            repo = container.image_repository
+            assert repo is not None
+            # DB ファイルが存在すること（create_project_session_factory でスキーマ初期化済み）
+            assert (project_dir / "image_database.db").exists()
+        finally:
+            del os.environ["LORAIRO_CLI_MODE"]
+
+    def test_set_active_project_resets_dependent_services(self, tmp_path: Path) -> None:
+        """set_active_project 後に依存サービスがリセットされる"""
+        import os
+
+        from lorairo.services.service_container import ServiceContainer
+
+        os.environ["LORAIRO_CLI_MODE"] = "1"
+        try:
+            ServiceContainer.reset_for_testing()
+            container = ServiceContainer()
+
+            # 先にサービスを初期化して参照を取得
+            _ = container.db_manager  # _db_manager を初期化
+            _ = container.dataset_export_service  # _dataset_export_service を初期化
+
+            assert container._db_manager is not None
+            assert container._dataset_export_service is not None
+
+            self._create_project_dir(tmp_path, "bar")
+            fake_config = {"directories": {"database_base_dir": str(tmp_path)}}
+
+            with patch(
+                "lorairo.services.project_management_service.get_config",
+                return_value=fake_config,
+            ):
+                container.set_active_project("bar")
+
+            # 依存サービスがリセットされていること
+            assert container._db_manager is None
+            assert container._dataset_export_service is None
+        finally:
+            del os.environ["LORAIRO_CLI_MODE"]

--- a/tests/unit/cli/test_annotate_import_batch.py
+++ b/tests/unit/cli/test_annotate_import_batch.py
@@ -34,6 +34,14 @@ def _make_batch_result(**overrides: object) -> BatchImportResult:
 class TestImportBatchCommand:
     """import-batch CLIコマンドのテスト。"""
 
+    @pytest.fixture(autouse=True)
+    def mock_set_active_project(self) -> MagicMock:
+        """set_active_project をモックして DB 接続切り替えをスキップする。"""
+        with patch("lorairo.cli.commands.annotate.get_service_container") as mock_container_factory:
+            mock_container = MagicMock()
+            mock_container_factory.return_value = mock_container
+            yield mock_container
+
     @patch("lorairo.cli.commands.annotate.import_batch_annotations")
     def test_normal_invocation(self, mock_import: MagicMock, tmp_path: Path) -> None:
         """正常呼び出しで結果テーブルが表示される。"""


### PR DESCRIPTION
## Summary

- `ProjectManagementService` のデフォルト保存先を `~/.lorairo/projects/` ハードコードから `config/lorairo.toml` の `database_base_dir` に変更（ADR 0018）
- `db_core.py` に `create_project_session_factory()` を追加し、CLI でプロジェクト専用 DB に接続できる基盤を整備
- `ServiceContainer.set_active_project()` を追加し、`--project foo` 指定時に `foo` の DB に動的切り替えを実現
- `export create` / `images register` / `annotate run,import-batch` の各 CLI コマンドで `set_active_project()` を呼び出すよう修正

## 変更ファイル

| ファイル | 変更内容 |
|---------|---------|
| `src/lorairo/services/project_management_service.py` | デフォルト `projects_base_dir` を `database_base_dir` から取得に変更、旧ディレクトリ移行案内ログを追加 |
| `src/lorairo/database/db_core.py` | `create_project_session_factory(project_db_path)` を追加 |
| `src/lorairo/services/service_container.py` | `set_active_project(project_name)` を追加 |
| `src/lorairo/cli/commands/export.py` | NOTE コメント（未実装警告）を `set_active_project()` 呼び出しに置き換え |
| `src/lorairo/cli/commands/images.py` | `set_active_project()` 呼び出しを追加 |
| `src/lorairo/cli/commands/annotate.py` | `run` / `import-batch` に `set_active_project()` 呼び出しを追加 |
| `tests/integration/test_project_directory_integration.py` | デフォルトパス変更・移行案内ログ・`set_active_project` 動作の統合テストを追加（+6件） |
| `tests/unit/cli/test_annotate_import_batch.py` | `get_service_container` の autouse モックを追加 |

## 受け入れ条件

- [x] `export create --project foo --tags cat` が `foo` プロジェクトの DB に接続する
- [x] GUI と CLI が同じ `lorairo_data/` 配下にプロジェクトを作成する
- [x] `~/.lorairo/projects/` が残存する場合に起動ログに移行案内が出る
- [x] `ServiceContainer.reset_for_testing()` が正常動作する
- [x] Qt 非依存のまま動作する

## Test plan

- [x] `uv run ruff check src/ tests/` — 0 errors
- [x] `uv run mypy -p lorairo` — no issues (135 files)
- [x] `uv run pytest tests/` — 2042 passed, 2 skipped, coverage 78.24% (≥75%)

Closes #177

🤖 Generated with [Claude Code](https://claude.ai/claude-code)