### PR TITLE
fix(#167): annotate run がモデル設定エラー時でも成功終了するバグを修正

### DIFF
--- a/src/lorairo/cli/commands/annotate.py
+++ b/src/lorairo/cli/commands/annotate.py
@@ -7,7 +7,7 @@ API層（lorairo.api）を経由してService層を利用する。
 from __future__ import annotations
 
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import typer
 from PIL import Image
@@ -91,6 +91,57 @@ def _load_images(image_dataset_dir: Path) -> tuple[list[Image.Image], int, int]:
     return pil_images, loaded_count, failed_count
 
 
+def _check_annotation_errors(
+    results: Any,
+) -> tuple[bool, set[str]]:
+    """アノテーション結果のエラーを検出する。
+
+    Args:
+        results: PHashAnnotationResults ({phash: {model_name: UnifiedAnnotationResult}})
+
+    Returns:
+        tuple: (成功結果あり, エラーが発生したモデル名の集合)
+    """
+    error_detected_models: set[str] = set()
+    success_detected = False
+
+    for model_results in results.values():
+        for m_name, m_result in model_results.items():
+            if getattr(m_result, "error", None) is not None:
+                error_detected_models.add(m_name)
+            else:
+                success_detected = True
+
+    return success_detected, error_detected_models
+
+
+def _handle_annotation_results(results: Any) -> None:
+    """アノテーション結果を検証し、全モデルが失敗した場合は typer.Exit(code=1) を発生させる。
+
+    Args:
+        results: PHashAnnotationResults ({phash: {model_name: UnifiedAnnotationResult}})
+
+    Raises:
+        typer.Exit: 結果が空またはすべてのモデルが失敗した場合 (code=1)。
+    """
+    if not results:
+        console.print("[red]Error:[/red] Annotation produced no results")
+        raise typer.Exit(code=1)
+
+    success_detected, error_detected_models = _check_annotation_errors(results)
+
+    if not success_detected and error_detected_models:
+        console.print(
+            f"[red]Error:[/red] All annotation models failed: {', '.join(sorted(error_detected_models))}"
+        )
+        raise typer.Exit(code=1)
+    elif error_detected_models:
+        console.print(
+            f"[yellow]Warning:[/yellow] Some models encountered errors: "
+            f"{', '.join(sorted(error_detected_models))}"
+        )
+
+
 @app.command("run")
 def run(
     project: str = typer.Option(
@@ -143,8 +194,8 @@ def run(
         pil_images, loaded_count, failed_count = _load_images(image_dataset_dir)
 
         if not pil_images and loaded_count == 0:
-            console.print(f"[yellow]Warning:[/yellow] No image files found in {image_dataset_dir}")
-            raise typer.Exit(code=0)
+            console.print(f"[red]Error:[/red] No image files found in {image_dataset_dir}")
+            raise typer.Exit(code=1)
 
         console.print(f"[cyan]Found {loaded_count + failed_count} image(s)[/cyan]")
         console.print(f"[cyan]Using model(s): {', '.join(model)}[/cyan]")
@@ -195,6 +246,9 @@ def run(
             console.print(f"[red]Error:[/red] Annotation failed: {e}")
             logger.error(f"Annotation error: {e}", exc_info=True)
             raise typer.Exit(code=1) from e
+
+        # モデルエラーを検出（全失敗時は Exit(code=1)、部分失敗時は Warning 表示）
+        _handle_annotation_results(results)
 
         # 結果サマリー表示
         console.print("\n[bold cyan]Annotation Summary[/bold cyan]")

--- a/tests/unit/cli/test_commands_annotate.py
+++ b/tests/unit/cli/test_commands_annotate.py
@@ -128,7 +128,7 @@ def test_annotate_run_no_images(mock_projects_dir: Path) -> None:
         ],
     )
 
-    assert result.exit_code == 0
+    assert result.exit_code == 1
     assert "No image files found" in result.stdout
 
 
@@ -581,3 +581,90 @@ def test_annotate_run_image_load_failure(
     assert "Found 3 image(s)" in result.stdout
     # 失敗メッセージが表示されるか
     assert "Warning" in result.stdout or "Failed" in result.stdout or result.exit_code in [0, 1]
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+@patch("lorairo.cli.commands.annotate.get_service_container")
+def test_annotate_run_all_models_failed_exits_nonzero(
+    mock_get_container: MagicMock,
+    test_project_with_images: tuple[Path, list[Path]],
+) -> None:
+    """Test: annotate run - 全モデルがエラー結果を返した場合は exit_code=1。"""
+    _project_dir, _image_files = test_project_with_images
+
+    mock_container = MagicMock()
+    mock_annotator = MagicMock()
+    mock_config = MagicMock()
+    mock_config.get_setting.return_value = "test_key"
+
+    # 全モデルがエラー結果を返す (UnifiedAnnotationResult.error != None)
+    error_result = MagicMock()
+    error_result.error = "Model 'gpt-4o-mini' not found in registry"
+    mock_annotator.annotate.return_value = {
+        "hash1": {"gpt-4o-mini": error_result},
+        "hash2": {"gpt-4o-mini": error_result},
+        "hash3": {"gpt-4o-mini": error_result},
+    }
+
+    mock_container.annotator_library = mock_annotator
+    mock_container.config_service = mock_config
+    mock_get_container.return_value = mock_container
+
+    result = runner.invoke(
+        app,
+        ["annotate", "run", "--project", "test_dataset", "--model", "gpt-4o-mini"],
+    )
+
+    assert result.exit_code == 1
+    assert "Error" in result.stdout
+    assert "gpt-4o-mini" in result.stdout
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+@patch("lorairo.cli.commands.annotate.get_service_container")
+def test_annotate_run_partial_model_failure_shows_warning(
+    mock_get_container: MagicMock,
+    test_project_with_images: tuple[Path, list[Path]],
+) -> None:
+    """Test: annotate run - 一部モデルがエラー、一部が成功の場合は exit_code=0 + Warning。"""
+    _project_dir, _image_files = test_project_with_images
+
+    mock_container = MagicMock()
+    mock_annotator = MagicMock()
+    mock_config = MagicMock()
+    mock_config.get_setting.return_value = "test_key"
+
+    error_result = MagicMock()
+    error_result.error = "Model config error"
+    success_result = MagicMock()
+    success_result.error = None
+
+    mock_annotator.annotate.return_value = {
+        "hash1": {"gpt-4o-mini": error_result, "wdtagger": success_result},
+        "hash2": {"gpt-4o-mini": error_result, "wdtagger": success_result},
+        "hash3": {"gpt-4o-mini": error_result, "wdtagger": success_result},
+    }
+
+    mock_container.annotator_library = mock_annotator
+    mock_container.config_service = mock_config
+    mock_get_container.return_value = mock_container
+
+    result = runner.invoke(
+        app,
+        [
+            "annotate",
+            "run",
+            "--project",
+            "test_dataset",
+            "--model",
+            "gpt-4o-mini",
+            "--model",
+            "wdtagger",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert "Warning" in result.stdout
+    assert "gpt-4o-mini" in result.stdout


### PR DESCRIPTION
- 画像ゼロ件時の exit_code を 0 → 1 に修正 (Bug A)
- _check_annotation_errors / _handle_annotation_results ヘルパーを追加し、 PHashAnnotationResults 内の error フィールドを検査:
  - 全モデルが失敗した場合は exit_code=1
  - 一部モデルのみ失敗した場合は Warning + exit_code=0
- テスト: 既存テスト1件の exit_code 期待値を修正 + 新テスト2件追加

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>