### PR TITLE
fix(#171): status コマンドが CLIモードで全サービスを Not Ready と表示するバグを修正

### DIFF
--- a/src/lorairo/cli/main.py
+++ b/src/lorairo/cli/main.py
@@ -13,6 +13,7 @@ from rich.table import Table
 
 from lorairo.cli.commands import annotate, export, images, project
 from lorairo.services.service_container import get_service_container
+from lorairo.utils.config import DEFAULT_CONFIG_PATH
 
 if TYPE_CHECKING:
     from lorairo.services.service_container import ServiceContainer
@@ -49,15 +50,11 @@ def _show_cli_status(container: ServiceContainer) -> None:
     table.add_column("Item", style="cyan")
     table.add_column("Status", style="green")
 
-    try:
+    config_file_found = DEFAULT_CONFIG_PATH.exists()
+    table.add_row("Config File", "✓ Found" if config_file_found else "✗ Not Found")
+
+    if config_file_found:
         config = container.config_service
-        config_ok = True
-    except Exception:
-        config_ok = False
-
-    table.add_row("Config File", "✓ Found" if config_ok else "✗ Not Found")
-
-    if config_ok:
         api_providers = {
             "OpenAI": config.get_setting("api", "openai_key", ""),
             "Anthropic": config.get_setting("api", "claude_key", ""),

--- a/src/lorairo/cli/main.py
+++ b/src/lorairo/cli/main.py
@@ -3,13 +3,19 @@
 Typer ベースの CLI フレームワークで LoRAIro コマンドを実装。
 """
 
-from typing import Optional
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
 
 import typer
 from rich.console import Console
 from rich.table import Table
 
 from lorairo.cli.commands import annotate, export, images, project
+from lorairo.services.service_container import get_service_container
+
+if TYPE_CHECKING:
+    from lorairo.services.service_container import ServiceContainer
 
 # Typer app 定義
 app = typer.Typer(
@@ -37,32 +43,64 @@ def version() -> None:
     console.print("[dim]AI-powered image annotation and dataset management[/dim]")
 
 
+def _show_cli_status(container: ServiceContainer) -> None:
+    """CLIモードのステータス表示。設定ファイルとAPIキー状況を表示する。"""
+    table = Table(title="LoRAIro CLI Status")
+    table.add_column("Item", style="cyan")
+    table.add_column("Status", style="green")
+
+    try:
+        config = container.config_service
+        config_ok = True
+    except Exception:
+        config_ok = False
+
+    table.add_row("Config File", "✓ Found" if config_ok else "✗ Not Found")
+
+    if config_ok:
+        api_providers = {
+            "OpenAI": config.get_setting("api", "openai_key", ""),
+            "Anthropic": config.get_setting("api", "claude_key", ""),
+            "Google": config.get_setting("api", "google_key", ""),
+        }
+        for provider, key in api_providers.items():
+            configured = bool(key and key.strip())
+            table.add_row(f"API Key ({provider})", "✓ Configured" if configured else "✗ Not set")
+
+    console.print(table)
+    console.print("\n[dim]Services initialize on demand when commands are executed.[/dim]")
+    console.print("[dim]Use 'lorairo-cli --help' to see available commands.[/dim]")
+
+
+def _show_gui_status(summary: dict[str, Any]) -> None:
+    """GUIモードのステータス表示。サービス初期化状況テーブルを表示する。"""
+    table = Table(title="Service Status")
+    table.add_column("Service", style="cyan")
+    table.add_column("Status", style="green")
+
+    if "initialized_services" in summary:
+        for service, is_initialized in summary["initialized_services"].items():
+            status_str = "✓ Ready" if is_initialized else "✗ Not Ready"
+            table.add_row(service, status_str)
+
+    console.print(table)
+
+
 @app.command()
 def status() -> None:
     """Show system status."""
     try:
-        from lorairo.services.service_container import get_service_container
-
         container = get_service_container()
-
-        # サービス情報テーブル
-        table = Table(title="Service Status")
-        table.add_column("Service", style="cyan")
-        table.add_column("Status", style="green")
-
         summary = container.get_service_summary()
+        environment = summary.get("environment", "Unknown")
 
-        # initialized_services セクションを表示
-        if "initialized_services" in summary:
-            for service, is_initialized in summary["initialized_services"].items():
-                status_str = "✓ Ready" if is_initialized else "✗ Not Ready"
-                table.add_row(service, status_str)
+        console.print(f"[dim]Environment:[/dim] {environment}")
+        console.print(f"[dim]Phase:[/dim] {summary.get('phase', 'Unknown')}\n")
 
-        console.print(table)
-
-        # その他の情報も表示
-        console.print(f"\n[dim]Environment:[/dim] {summary.get('environment', 'Unknown')}")
-        console.print(f"[dim]Phase:[/dim] {summary.get('phase', 'Unknown')}")
+        if environment == "CLI":
+            _show_cli_status(container)
+        else:
+            _show_gui_status(summary)
 
     except Exception as e:
         console.print(f"[red]Error:[/red] {e}")

--- a/tests/unit/cli/test_main.py
+++ b/tests/unit/cli/test_main.py
@@ -1,5 +1,7 @@
 """CLI メインモジュール テスト。"""
 
+from unittest.mock import MagicMock, patch
+
 import pytest
 from typer.testing import CliRunner
 
@@ -30,14 +32,74 @@ def test_cli_version() -> None:
 
 @pytest.mark.unit
 @pytest.mark.cli
-def test_cli_status(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Test: status command."""
-    # LORAIRO_CLI_MODE を設定してから実行
+@patch("lorairo.cli.main.get_service_container")
+def test_cli_status(mock_get_container: MagicMock, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test: status command in CLI mode shows LoRAIro CLI Status."""
     monkeypatch.setenv("LORAIRO_CLI_MODE", "true")
 
+    mock_container = MagicMock()
+    mock_container.get_service_summary.return_value = {
+        "environment": "CLI",
+        "phase": "Phase 4 (Production Integration)",
+        "initialized_services": {},
+    }
+    mock_config = MagicMock()
+    mock_config.get_setting.return_value = ""
+    mock_container.config_service = mock_config
+    mock_get_container.return_value = mock_container
+
     result = runner.invoke(app, ["status"])
+
     assert result.exit_code == 0
-    assert "Service Status" in result.stdout
+    assert "CLI" in result.stdout
+    assert "LoRAIro CLI Status" in result.stdout
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+@patch("lorairo.cli.main.get_service_container")
+def test_cli_status_shows_configured_api_key(mock_get_container: MagicMock) -> None:
+    """Test: status コマンドがAPIキー設定済みを正しく表示する。"""
+    mock_container = MagicMock()
+    mock_container.get_service_summary.return_value = {
+        "environment": "CLI",
+        "phase": "Phase 4 (Production Integration)",
+        "initialized_services": {},
+    }
+    mock_config = MagicMock()
+    mock_config.get_setting.side_effect = lambda section, key, default="": (
+        "sk-test-key" if key == "openai_key" else ""
+    )
+    mock_container.config_service = mock_config
+    mock_get_container.return_value = mock_container
+
+    result = runner.invoke(app, ["status"])
+
+    assert result.exit_code == 0
+    assert "Configured" in result.stdout
+    assert "OpenAI" in result.stdout
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+@patch("lorairo.cli.main.get_service_container")
+def test_cli_status_shows_on_demand_note(mock_get_container: MagicMock) -> None:
+    """Test: status コマンドがCLIモードのオンデマンド初期化を説明する。"""
+    mock_container = MagicMock()
+    mock_container.get_service_summary.return_value = {
+        "environment": "CLI",
+        "phase": "Phase 4 (Production Integration)",
+        "initialized_services": {},
+    }
+    mock_container.config_service = MagicMock()
+    mock_container.config_service.get_setting.return_value = ""
+    mock_get_container.return_value = mock_container
+
+    result = runner.invoke(app, ["status"])
+
+    assert result.exit_code == 0
+    assert "on demand" in result.stdout
+    assert "Not Ready" not in result.stdout
 
 
 @pytest.mark.unit

--- a/tests/unit/cli/test_main.py
+++ b/tests/unit/cli/test_main.py
@@ -32,10 +32,16 @@ def test_cli_version() -> None:
 
 @pytest.mark.unit
 @pytest.mark.cli
+@patch("lorairo.cli.main.DEFAULT_CONFIG_PATH")
 @patch("lorairo.cli.main.get_service_container")
-def test_cli_status(mock_get_container: MagicMock, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_cli_status(
+    mock_get_container: MagicMock,
+    mock_config_path: MagicMock,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """Test: status command in CLI mode shows LoRAIro CLI Status."""
     monkeypatch.setenv("LORAIRO_CLI_MODE", "true")
+    mock_config_path.exists.return_value = True
 
     mock_container = MagicMock()
     mock_container.get_service_summary.return_value = {
@@ -57,9 +63,15 @@ def test_cli_status(mock_get_container: MagicMock, monkeypatch: pytest.MonkeyPat
 
 @pytest.mark.unit
 @pytest.mark.cli
+@patch("lorairo.cli.main.DEFAULT_CONFIG_PATH")
 @patch("lorairo.cli.main.get_service_container")
-def test_cli_status_shows_configured_api_key(mock_get_container: MagicMock) -> None:
+def test_cli_status_shows_configured_api_key(
+    mock_get_container: MagicMock,
+    mock_config_path: MagicMock,
+) -> None:
     """Test: status コマンドがAPIキー設定済みを正しく表示する。"""
+    mock_config_path.exists.return_value = True
+
     mock_container = MagicMock()
     mock_container.get_service_summary.return_value = {
         "environment": "CLI",
@@ -82,17 +94,21 @@ def test_cli_status_shows_configured_api_key(mock_get_container: MagicMock) -> N
 
 @pytest.mark.unit
 @pytest.mark.cli
+@patch("lorairo.cli.main.DEFAULT_CONFIG_PATH")
 @patch("lorairo.cli.main.get_service_container")
-def test_cli_status_shows_on_demand_note(mock_get_container: MagicMock) -> None:
+def test_cli_status_shows_on_demand_note(
+    mock_get_container: MagicMock,
+    mock_config_path: MagicMock,
+) -> None:
     """Test: status コマンドがCLIモードのオンデマンド初期化を説明する。"""
+    mock_config_path.exists.return_value = False
+
     mock_container = MagicMock()
     mock_container.get_service_summary.return_value = {
         "environment": "CLI",
         "phase": "Phase 4 (Production Integration)",
         "initialized_services": {},
     }
-    mock_container.config_service = MagicMock()
-    mock_container.config_service.get_setting.return_value = ""
     mock_get_container.return_value = mock_container
 
     result = runner.invoke(app, ["status"])
@@ -100,6 +116,32 @@ def test_cli_status_shows_on_demand_note(mock_get_container: MagicMock) -> None:
     assert result.exit_code == 0
     assert "on demand" in result.stdout
     assert "Not Ready" not in result.stdout
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+@patch("lorairo.cli.main.DEFAULT_CONFIG_PATH")
+@patch("lorairo.cli.main.get_service_container")
+def test_cli_status_config_not_found(
+    mock_get_container: MagicMock,
+    mock_config_path: MagicMock,
+) -> None:
+    """Test: 設定ファイルが存在しない場合は Not Found を表示しAPIキーセクションを省略する。"""
+    mock_config_path.exists.return_value = False
+
+    mock_container = MagicMock()
+    mock_container.get_service_summary.return_value = {
+        "environment": "CLI",
+        "phase": "Phase 4 (Production Integration)",
+        "initialized_services": {},
+    }
+    mock_get_container.return_value = mock_container
+
+    result = runner.invoke(app, ["status"])
+
+    assert result.exit_code == 0
+    assert "Not Found" in result.stdout
+    assert "API Key" not in result.stdout
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary

- `lorairo-cli status` がCLIモードで全14サービスを `✗ Not Ready` と表示する誤解を招く表示を修正
- CLIモード（`environment == "CLI"`）では設定ファイルの有無・APIキー設定状況・オンデマンド初期化の説明を表示するよう変更
- GUIモードの既存の初期化状況テーブル表示は変更なし

## 変更ファイル

- `src/lorairo/cli/main.py`: `status()` をCLI/GUIモードで分岐。`_show_cli_status()`・`_show_gui_status()` ヘルパーを追加
- `tests/unit/cli/test_main.py`: 既存テスト1件修正 + 新テスト2件追加

## Test plan

- [x] `uv run pytest tests/unit/cli/test_main.py -v` — 6/6 パス
- [x] `uv run pytest tests/ -m unit` — 1842 passed
- [x] `uv run mypy src/lorairo/cli/main.py` — エラー 0
- [x] `uv run ruff check` — エラー 0

Closes #171

🤖 Generated with [Claude Code](https://claude.com/claude-code)