### PR TITLE
feat(#168): annotate run DB保存対応 (Sub-Issue A: AnnotationSaveService新設)

### DIFF
--- a/src/lorairo/cli/commands/annotate.py
+++ b/src/lorairo/cli/commands/annotate.py
@@ -45,20 +45,18 @@ console = Console()
 
 def _load_images_from_db(
     image_records: list[dict[str, Any]],
-) -> tuple[list[Image.Image], dict[str, int], int, int]:
+) -> tuple[list[Image.Image], int, int]:
     """DB の画像レコードから PIL 画像をロード。
 
     Args:
         image_records: ImageRepository.get_images_by_filter() が返すレコードリスト
 
     Returns:
-        tuple: (PIL画像リスト, phash→image_id辞書, ロード成功数, ロード失敗数)
-               phash→image_id は issue #168 (アノテーション結果の DB 保存) で利用する。
+        tuple: (PIL画像リスト, ロード成功数, ロード失敗数)
     """
     from lorairo.database.db_core import resolve_stored_path
 
     pil_images: list[Image.Image] = []
-    phash_to_image_id: dict[str, int] = {}
     loaded_count = 0
     failed_count = 0
 
@@ -73,8 +71,6 @@ def _load_images_from_db(
         task = progress.add_task("画像ロード中...", total=len(image_records))
 
         for record in image_records:
-            image_id: int | None = record.get("id")
-            phash: str = record.get("phash", "")
             stored_path_str: str | None = record.get("stored_image_path")
 
             if not stored_path_str:
@@ -88,15 +84,13 @@ def _load_images_from_db(
                 img = Image.open(image_path)
                 img.load()
                 pil_images.append(img)
-                if image_id is not None and phash:
-                    phash_to_image_id[phash] = image_id
                 loaded_count += 1
             except Exception as e:
                 console.print(f"[yellow]Warning:[/yellow] Failed to load {image_path.name}: {e}")
                 failed_count += 1
             progress.advance(task)
 
-    return pil_images, phash_to_image_id, loaded_count, failed_count
+    return pil_images, loaded_count, failed_count
 
 
 def _check_annotation_errors(
@@ -205,7 +199,7 @@ def run(
             raise typer.Exit(code=1)
 
         # DB レコードから PIL 画像をロード
-        pil_images, _phash_to_image_id, loaded_count, failed_count = _load_images_from_db(image_records)
+        pil_images, loaded_count, failed_count = _load_images_from_db(image_records)
 
         if not pil_images:
             console.print("[red]Error:[/red] No images could be loaded for annotation")
@@ -258,6 +252,11 @@ def run(
         # モデルエラーを検出（全失敗時は Exit(code=1)、部分失敗時は Warning 表示）
         _handle_annotation_results(results)
 
+        # DB保存
+        save_result = container.annotation_save_service.save_annotation_results(results)
+        if save_result.error_count:
+            console.print(f"[yellow]Warning:[/yellow] DB保存に一部失敗: {save_result.error_count}件")
+
         # 結果サマリー表示
         console.print("\n[bold cyan]Annotation Summary[/bold cyan]")
 
@@ -268,10 +267,14 @@ def run(
         summary_table.add_row("Total Images", str(len(pil_images)))
         summary_table.add_row("Models Used", ", ".join(model))
         summary_table.add_row("Results", str(len(results)))
+        summary_table.add_row("Saved to DB", str(save_result.success_count))
+        summary_table.add_row("Skipped", str(save_result.skip_count))
 
         console.print(summary_table)
 
-        console.print("\n[green]Annotation completed successfully![/green]")
+        console.print(
+            f"\n[green]Annotation completed successfully! ({save_result.success_count} saved to DB)[/green]"
+        )
 
     except typer.Exit:
         raise

--- a/src/lorairo/services/annotation_save_service.py
+++ b/src/lorairo/services/annotation_save_service.py
@@ -1,0 +1,323 @@
+"""アノテーション保存サービス。
+
+アノテーション結果をDBに保存するビジネスロジックを提供する。
+CLI・GUI・API の3経路で共有する Qt-free サービス。
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any, cast  # cast: _extract_scores_from_formatted_outputで使用
+
+from lorairo.database.db_repository import ImageRepository
+from lorairo.utils.log import logger
+
+if TYPE_CHECKING:
+    from lorairo.database.schema import AnnotationsDict
+
+
+@dataclass(frozen=True)
+class AnnotationSaveResult:
+    """アノテーション保存結果。
+
+    Attributes:
+        success_count: 保存成功件数。
+        skip_count: スキップ件数（phash不一致・アノテーションなし）。
+        error_count: 保存エラー件数。
+        total_count: 処理対象の総件数。
+        error_details: エラー詳細メッセージリスト。
+    """
+
+    success_count: int
+    skip_count: int
+    error_count: int
+    total_count: int
+    error_details: list[str] = field(default_factory=list)
+
+
+class AnnotationSaveService:
+    """アノテーション結果のDB保存サービス。
+
+    PHashAnnotationResults をDBに保存する。CLI・GUI・API の3経路で共有する。
+    Qt依存なし。
+    """
+
+    def __init__(self, repository: ImageRepository) -> None:
+        """AnnotationSaveService初期化。
+
+        Args:
+            repository: ImageRepository インスタンス。
+        """
+        self._repository = repository
+
+    @staticmethod
+    def _extract_field(result: Any, field_name: str) -> Any:
+        """UnifiedAnnotationResultからフィールドを取得する。辞書/Pydanticモデル両対応。"""
+        if isinstance(result, dict):
+            return result.get(field_name)
+        return getattr(result, field_name, None)
+
+    @staticmethod
+    def _extract_scores_from_formatted_output(formatted_output: Any) -> dict[str, float] | None:
+        """formatted_outputからスコア辞書を抽出する。
+
+        Pipeline/CLIPモデルはscoresではなくformatted_outputにスコアを格納するため変換する。
+        FIXME: image-annotator-libのUnifiedAnnotationResultスコアフィールド統一後に削除
+        """
+        if formatted_output is None:
+            return None
+
+        if hasattr(formatted_output, "scores") and isinstance(
+            getattr(formatted_output, "scores", None), dict
+        ):
+            return cast("dict[str, float]", formatted_output.scores)
+
+        if isinstance(formatted_output, dict) and "hq" in formatted_output:
+            hq_value = formatted_output.get("hq")
+            if isinstance(hq_value, (int, float)):
+                return {"aesthetic": float(hq_value)}
+
+        if isinstance(formatted_output, (int, float)):
+            return {"aesthetic": float(formatted_output)}
+
+        return None
+
+    def _append_model_result(
+        self,
+        model_id: int,
+        scores: dict[str, float] | None,
+        tags: list[str] | None,
+        captions: list[str] | None,
+        ratings: Any,
+        result: AnnotationsDict,
+    ) -> None:
+        """モデルの1件分アノテーション結果をAnnotationsDictに追加する。"""
+        if scores:
+            for _name, value in scores.items():
+                result["scores"].append(
+                    {"model_id": model_id, "score": float(value), "is_edited_manually": False}
+                )
+        if tags:
+            for tag in tags:
+                result["tags"].append(
+                    {
+                        "model_id": model_id,
+                        "tag": tag,
+                        "existing": False,
+                        "is_edited_manually": False,
+                        "confidence_score": None,
+                        "tag_id": None,
+                    }
+                )
+        if captions:
+            for caption in captions:
+                result["captions"].append(
+                    {
+                        "model_id": model_id,
+                        "caption": caption,
+                        "existing": False,
+                        "is_edited_manually": False,
+                    }
+                )
+        if ratings:
+            result["ratings"].append(
+                {
+                    "model_id": model_id,
+                    "raw_rating_value": str(ratings),
+                    "normalized_rating": str(ratings),
+                    "confidence_score": None,
+                }
+            )
+
+    def _process_model_result(
+        self,
+        model_name: str,
+        unified_result: Any,
+        models_cache: dict[str, Any],
+        result: AnnotationsDict,
+    ) -> None:
+        """1モデル分のアノテーション結果をAnnotationsDictに追記する。"""
+        if self._extract_field(unified_result, "error"):
+            logger.warning(f"モデル {model_name} エラーをスキップ")
+            return
+
+        model = models_cache.get(model_name)
+        if not model:
+            logger.warning(f"モデル '{model_name}' がDB未登録")
+            return
+
+        scores = self._extract_field(unified_result, "scores")
+        if scores is None:
+            scores = self._extract_scores_from_formatted_output(
+                self._extract_field(unified_result, "formatted_output")
+            )
+
+        self._append_model_result(
+            model.id,
+            scores,
+            self._extract_field(unified_result, "tags"),
+            self._extract_field(unified_result, "captions"),
+            self._extract_field(unified_result, "ratings"),
+            result,
+        )
+
+    def _build_annotations_dict(
+        self,
+        phash_annotations: dict[str, Any],
+        models_cache: dict[str, Any],
+    ) -> AnnotationsDict:
+        """1画像分のアノテーション結果をAnnotationsDictに変換する。
+
+        Args:
+            phash_annotations: model_name → UnifiedAnnotationResult のマッピング。
+            models_cache: model_name → Model の事前取得キャッシュ。
+
+        Returns:
+            DB保存用のAnnotationsDict。
+        """
+        result: AnnotationsDict = {"scores": [], "tags": [], "captions": [], "ratings": []}
+        for model_name, unified_result in phash_annotations.items():
+            self._process_model_result(model_name, unified_result, models_cache, result)
+        return result
+
+    def _collect_names_and_tags(self, results: Any) -> tuple[set[str], set[str]]:
+        """全結果からユニークなモデル名とタグ文字列を収集する。
+
+        Args:
+            results: PHashAnnotationResults ({phash: {model_name: UnifiedAnnotationResult}})
+
+        Returns:
+            (モデル名セット, タグ文字列セット) のタプル。
+        """
+        all_model_names: set[str] = set()
+        all_raw_tags: set[str] = set()
+        for phash_annotations in results.values():
+            for model_name, unified_result in phash_annotations.items():
+                if self._extract_field(unified_result, "error"):
+                    continue
+                all_model_names.add(model_name)
+                tags = self._extract_field(unified_result, "tags")
+                if tags:
+                    all_raw_tags.update(tags)
+        return all_model_names, all_raw_tags
+
+    def _resolve_tag_ids(self, all_raw_tags: set[str]) -> dict[str, int | None]:
+        """タグ文字列を正規化してtag_IDを一括解決する。
+
+        Args:
+            all_raw_tags: 生のタグ文字列セット。
+
+        Returns:
+            正規化済みタグ文字列 → tag_id のキャッシュ辞書。
+        """
+        from genai_tag_db_tools.utils.cleanup_str import TagCleaner
+
+        if not all_raw_tags:
+            return {}
+
+        normalized_tags: set[str] = set()
+        for raw_tag in all_raw_tags:
+            normalized = TagCleaner.clean_format(raw_tag).strip()
+            if normalized:
+                normalized_tags.add(normalized)
+
+        if not normalized_tags:
+            return {}
+
+        return self._repository.batch_resolve_tag_ids(normalized_tags)
+
+    def _save_single(
+        self,
+        phash: str,
+        phash_annotations: dict[str, Any],
+        phash_to_image_id: dict[str, int],
+        models_cache: dict[str, Any],
+        tag_id_cache: dict[str, int | None],
+    ) -> bool:
+        """単一phashのアノテーション結果をDBに保存する。
+
+        Args:
+            phash: 対象画像のpHash。
+            phash_annotations: model_name → UnifiedAnnotationResult のマッピング。
+            phash_to_image_id: pHash → image_id のマッピング。
+            models_cache: model_name → Model のキャッシュ。
+            tag_id_cache: 正規化タグ → tag_id のキャッシュ。
+
+        Returns:
+            保存成功した場合True、スキップした場合False。
+        """
+        image_id = phash_to_image_id.get(phash)
+        if image_id is None:
+            logger.warning(f"pHash {phash[:8]}... に対応する画像がDBに見つかりません。スキップします。")
+            return False
+
+        annotations_dict = self._build_annotations_dict(phash_annotations, models_cache)
+
+        if not annotations_dict or not any(annotations_dict.values()):
+            logger.debug(f"画像ID {image_id} に保存するアノテーションがありません")
+            return False
+
+        self._repository.save_annotations(
+            image_id,
+            annotations_dict,
+            skip_existence_check=True,
+            tag_id_cache=tag_id_cache if tag_id_cache else None,
+        )
+        logger.debug(f"画像ID {image_id} のアノテーション保存成功")
+        return True
+
+    def save_annotation_results(self, results: Any) -> AnnotationSaveResult:
+        """アノテーション結果をDBに保存する。
+
+        phash → image_id のマッピングはリポジトリから一括取得する。
+        エラー発生時は error_count に集計して処理を継続する。
+
+        Args:
+            results: PHashAnnotationResults ({phash: {model_name: UnifiedAnnotationResult}})
+
+        Returns:
+            AnnotationSaveResult: 保存結果（成功数・スキップ数・エラー数）
+        """
+        if not results:
+            return AnnotationSaveResult(
+                success_count=0,
+                skip_count=0,
+                error_count=0,
+                total_count=0,
+            )
+
+        phash_to_image_id = self._repository.find_image_ids_by_phashes(set(results.keys()))
+
+        all_model_names, all_raw_tags = self._collect_names_and_tags(results)
+        models_cache = self._repository.get_models_by_names(all_model_names)
+        tag_id_cache = self._resolve_tag_ids(all_raw_tags)
+
+        success_count = 0
+        skip_count = 0
+        error_count = 0
+        error_details: list[str] = []
+
+        for phash, phash_annotations in results.items():
+            try:
+                if self._save_single(
+                    phash, phash_annotations, phash_to_image_id, models_cache, tag_id_cache
+                ):
+                    success_count += 1
+                else:
+                    skip_count += 1
+            except Exception as e:
+                error_msg = f"phash={phash[:8]}...: {e}"
+                error_details.append(error_msg)
+                error_count += 1
+                logger.error(f"保存失敗 phash={phash[:8]}...: {e}", exc_info=True)
+
+        total_count = len(results)
+        logger.info(f"DB保存完了: {success_count}/{total_count}件成功")
+
+        return AnnotationSaveResult(
+            success_count=success_count,
+            skip_count=skip_count,
+            error_count=error_count,
+            total_count=total_count,
+            error_details=error_details,
+        )

--- a/src/lorairo/services/service_container.py
+++ b/src/lorairo/services/service_container.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING, Any, Optional
 
 if TYPE_CHECKING:
     from lorairo.annotations.annotator_adapter import AnnotatorLibraryAdapter
+    from lorairo.services.annotation_save_service import AnnotationSaveService
     from lorairo.services.signal_manager_protocol import SignalManagerServiceProtocol
     from lorairo.services.tag_management_service import TagManagementService
 
@@ -89,6 +90,9 @@ class ServiceContainer:
         # Phase 2: API層用新サービス
         self._project_management_service: ProjectManagementService | None = None
         self._image_registration_service: ImageRegistrationService | None = None
+
+        # アノテーション保存サービス
+        self._annotation_save_service: AnnotationSaveService | None = None
 
     @property
     def config_service(self) -> ConfigurationService:
@@ -266,6 +270,16 @@ class ServiceContainer:
             logger.debug("ImageRegistrationService初期化完了")
         return self._image_registration_service
 
+    @property
+    def annotation_save_service(self) -> "AnnotationSaveService":
+        """アノテーション保存サービス取得（遅延初期化）"""
+        if self._annotation_save_service is None:
+            from .annotation_save_service import AnnotationSaveService
+
+            self._annotation_save_service = AnnotationSaveService(self.image_repository)
+            logger.debug("AnnotationSaveService初期化完了")
+        return self._annotation_save_service
+
     def set_active_project(self, project_name: str) -> None:
         """CLI用: アクティブプロジェクトの DB に接続を切り替える。
 
@@ -302,6 +316,7 @@ class ServiceContainer:
         self._dataset_export_service = None
         self._image_processing_service = None
         self._model_sync_service = None
+        self._annotation_save_service = None
 
         logger.info(f"アクティブプロジェクト切替: {project_name} -> {db_path}")
 
@@ -357,6 +372,7 @@ class ServiceContainer:
         self._signal_manager = None
         self._project_management_service = None
         self._image_registration_service = None
+        self._annotation_save_service = None
 
         # クラスレベルリセット
         ServiceContainer._instance = None

--- a/tests/unit/cli/test_commands_annotate.py
+++ b/tests/unit/cli/test_commands_annotate.py
@@ -8,6 +8,7 @@ from PIL import Image
 from typer.testing import CliRunner
 
 from lorairo.cli.main import app
+from lorairo.services.annotation_save_service import AnnotationSaveResult
 from lorairo.services.project_management_service import ProjectManagementService
 from lorairo.services.service_container import ServiceContainer
 
@@ -730,3 +731,185 @@ def test_annotate_run_partial_model_failure_shows_warning(
     assert result.exit_code == 0
     assert "Warning" in result.stdout
     assert "gpt-4o-mini" in result.stdout
+
+
+# ===== DB保存テスト =====
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+@patch("lorairo.cli.commands.annotate.get_service_container")
+def test_annotate_run_saves_results_to_db(
+    mock_get_container: MagicMock,
+    test_project_with_images: tuple[Path, list[Path]],
+) -> None:
+    """Test: annotate run - アノテーション結果がDBに保存される。"""
+    _project_dir, image_files = test_project_with_images
+
+    mock_container = MagicMock()
+    mock_annotator = MagicMock()
+    mock_config = MagicMock()
+    mock_config.get_setting.return_value = "test_key"
+
+    mock_annotator.annotate.return_value = {
+        "hash0000000000000001": {"gpt-4o-mini": MagicMock(error=None)},
+        "hash0000000000000002": {"gpt-4o-mini": MagicMock(error=None)},
+    }
+
+    image_records = [
+        {"id": 1, "phash": "hash0000000000000001", "stored_image_path": str(image_files[0])},
+        {"id": 2, "phash": "hash0000000000000002", "stored_image_path": str(image_files[1])},
+        {"id": 3, "phash": "hash0000000000000003", "stored_image_path": str(image_files[2])},
+    ]
+
+    mock_container.annotation_save_service.save_annotation_results.return_value = AnnotationSaveResult(
+        success_count=2, skip_count=1, error_count=0, total_count=3
+    )
+    mock_container.image_repository.get_images_by_filter.return_value = (image_records, len(image_records))
+    mock_container.annotator_library = mock_annotator
+    mock_container.config_service = mock_config
+    mock_get_container.return_value = mock_container
+
+    result = runner.invoke(
+        app,
+        ["annotate", "run", "--project", "test_dataset", "--model", "gpt-4o-mini"],
+    )
+
+    assert result.exit_code == 0
+    # annotation_save_service.save_annotation_results が呼ばれたことを確認
+    assert mock_container.annotation_save_service.save_annotation_results.call_count == 1
+    # サマリーに保存件数が表示される
+    assert "Saved to DB" in result.stdout
+    assert "2" in result.stdout
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+@patch("lorairo.cli.commands.annotate.get_service_container")
+def test_annotate_run_summary_shows_saved_count(
+    mock_get_container: MagicMock,
+    test_project_with_images: tuple[Path, list[Path]],
+) -> None:
+    """Test: annotate run - 保存件数がSummaryに表示される。"""
+    _project_dir, image_files = test_project_with_images
+
+    mock_container = MagicMock()
+    mock_annotator = MagicMock()
+    mock_config = MagicMock()
+    mock_config.get_setting.return_value = "test_key"
+
+    mock_annotator.annotate.return_value = {
+        "matchhash001": {"gpt-4o-mini": MagicMock(error=None)},
+    }
+
+    image_records = [
+        {"id": 10, "phash": "matchhash001", "stored_image_path": str(image_files[0])},
+    ]
+
+    mock_container.annotation_save_service.save_annotation_results.return_value = AnnotationSaveResult(
+        success_count=1, skip_count=0, error_count=0, total_count=1
+    )
+    mock_container.image_repository.get_images_by_filter.return_value = (image_records, 1)
+    mock_container.annotator_library = mock_annotator
+    mock_container.config_service = mock_config
+    mock_get_container.return_value = mock_container
+
+    result = runner.invoke(
+        app,
+        ["annotate", "run", "--project", "test_dataset", "--model", "gpt-4o-mini"],
+    )
+
+    assert result.exit_code == 0
+    assert "Saved to DB" in result.stdout
+    assert "Skipped" in result.stdout
+    # 完了メッセージに保存件数が含まれる
+    assert "saved to DB" in result.stdout
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+@patch("lorairo.cli.commands.annotate.get_service_container")
+def test_annotate_run_db_save_error_shows_warning(
+    mock_get_container: MagicMock,
+    test_project_with_images: tuple[Path, list[Path]],
+) -> None:
+    """Test: annotate run - DB保存エラー時はWarningを表示して処理継続。"""
+    _project_dir, image_files = test_project_with_images
+
+    mock_container = MagicMock()
+    mock_annotator = MagicMock()
+    mock_config = MagicMock()
+    mock_config.get_setting.return_value = "test_key"
+
+    mock_annotator.annotate.return_value = {
+        "saveerrhash001": {"gpt-4o-mini": MagicMock(error=None)},
+    }
+
+    image_records = [
+        {"id": 5, "phash": "saveerrhash001", "stored_image_path": str(image_files[0])},
+    ]
+
+    mock_container.annotation_save_service.save_annotation_results.return_value = AnnotationSaveResult(
+        success_count=0,
+        skip_count=0,
+        error_count=1,
+        total_count=1,
+        error_details=["phash=saveerrh...: DB write error"],
+    )
+    mock_container.image_repository.get_images_by_filter.return_value = (image_records, 1)
+    mock_container.annotator_library = mock_annotator
+    mock_container.config_service = mock_config
+    mock_get_container.return_value = mock_container
+
+    result = runner.invoke(
+        app,
+        ["annotate", "run", "--project", "test_dataset", "--model", "gpt-4o-mini"],
+    )
+
+    # 保存エラーがあっても exit_code=0 で継続
+    assert result.exit_code == 0
+    assert "Warning" in result.stdout
+    # 保存件数は0
+    assert "Saved to DB" in result.stdout
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+@patch("lorairo.cli.commands.annotate.get_service_container")
+def test_annotate_run_phash_mismatch_skips_gracefully(
+    mock_get_container: MagicMock,
+    test_project_with_images: tuple[Path, list[Path]],
+) -> None:
+    """Test: annotate run - phashが不一致の場合はスキップして処理継続。"""
+    _project_dir, image_files = test_project_with_images
+
+    mock_container = MagicMock()
+    mock_annotator = MagicMock()
+    mock_config = MagicMock()
+    mock_config.get_setting.return_value = "test_key"
+
+    # アノテーション結果のphashがDB記録と不一致
+    mock_annotator.annotate.return_value = {
+        "completely_different_hash": {"gpt-4o-mini": MagicMock(error=None)},
+    }
+
+    image_records = [
+        {"id": 1, "phash": "db_stored_hash_001", "stored_image_path": str(image_files[0])},
+    ]
+
+    mock_container.annotation_save_service.save_annotation_results.return_value = AnnotationSaveResult(
+        success_count=0, skip_count=1, error_count=0, total_count=1
+    )
+    mock_container.image_repository.get_images_by_filter.return_value = (image_records, 1)
+    mock_container.annotator_library = mock_annotator
+    mock_container.config_service = mock_config
+    mock_get_container.return_value = mock_container
+
+    result = runner.invoke(
+        app,
+        ["annotate", "run", "--project", "test_dataset", "--model", "gpt-4o-mini"],
+    )
+
+    assert result.exit_code == 0
+    # スキップされてもエラーにならない
+    assert "Saved to DB" in result.stdout

--- a/tests/unit/services/test_annotation_save_service.py
+++ b/tests/unit/services/test_annotation_save_service.py
@@ -1,0 +1,154 @@
+"""AnnotationSaveService ユニットテスト。"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from lorairo.services.annotation_save_service import AnnotationSaveResult, AnnotationSaveService
+
+
+@pytest.fixture
+def mock_repository() -> MagicMock:
+    """モック ImageRepository。"""
+    repo = MagicMock()
+    repo.find_image_ids_by_phashes.return_value = {}
+    repo.get_models_by_names.return_value = {}
+    repo.batch_resolve_tag_ids.return_value = {}
+    return repo
+
+
+@pytest.fixture
+def service(mock_repository: MagicMock) -> AnnotationSaveService:
+    """テスト対象サービス。"""
+    return AnnotationSaveService(mock_repository)
+
+
+def _make_success_result(
+    tags: list[str] | None = None,
+    captions: list[str] | None = None,
+    scores: dict | None = None,
+) -> MagicMock:
+    """正常系 UnifiedAnnotationResult モックを生成する。"""
+    result = MagicMock()
+    result.error = None
+    result.tags = tags or []
+    result.captions = captions or []
+    result.scores = scores
+    result.ratings = None
+    result.formatted_output = None
+    return result
+
+
+@pytest.mark.unit
+def test_save_annotation_results_with_empty_results_returns_zeros(
+    service: AnnotationSaveService,
+) -> None:
+    """空の結果を渡した場合、すべてゼロの AnnotationSaveResult を返す。"""
+    result = service.save_annotation_results({})
+
+    assert result.success_count == 0
+    assert result.skip_count == 0
+    assert result.error_count == 0
+    assert result.total_count == 0
+    assert result.error_details == []
+
+
+@pytest.mark.unit
+def test_save_annotation_results_with_known_phashes_saves_all(
+    service: AnnotationSaveService,
+    mock_repository: MagicMock,
+) -> None:
+    """DBに存在するphashのアノテーションを全件保存する。"""
+    mock_model = MagicMock()
+    mock_model.id = 10
+
+    mock_repository.find_image_ids_by_phashes.return_value = {"phash001": 1, "phash002": 2}
+    mock_repository.get_models_by_names.return_value = {"wdtagger": mock_model}
+    mock_repository.batch_resolve_tag_ids.return_value = {}
+
+    results = {
+        "phash001": {"wdtagger": _make_success_result(tags=["tag1", "tag2"])},
+        "phash002": {"wdtagger": _make_success_result(tags=["tag1"])},
+    }
+
+    result = service.save_annotation_results(results)
+
+    assert result.success_count == 2
+    assert result.skip_count == 0
+    assert result.error_count == 0
+    assert result.total_count == 2
+    assert mock_repository.save_annotations.call_count == 2
+
+
+@pytest.mark.unit
+def test_save_annotation_results_with_unknown_phash_skips_silently(
+    service: AnnotationSaveService,
+    mock_repository: MagicMock,
+) -> None:
+    """DBに存在しないphashはスキップして処理を継続する。"""
+    mock_repository.find_image_ids_by_phashes.return_value = {}
+
+    results = {
+        "unknown_phash": {"wdtagger": _make_success_result(tags=["tag1"])},
+    }
+
+    result = service.save_annotation_results(results)
+
+    assert result.success_count == 0
+    assert result.skip_count == 1
+    assert result.error_count == 0
+    assert result.total_count == 1
+    mock_repository.save_annotations.assert_not_called()
+
+
+@pytest.mark.unit
+def test_save_annotation_results_handles_partial_save_failure(
+    service: AnnotationSaveService,
+    mock_repository: MagicMock,
+) -> None:
+    """save_annotations 例外発生時はエラー件数に集計して処理を継続する。"""
+    mock_model = MagicMock()
+    mock_model.id = 1
+    mock_repository.find_image_ids_by_phashes.return_value = {"phash001": 1}
+    mock_repository.get_models_by_names.return_value = {"wdtagger": mock_model}
+    mock_repository.save_annotations.side_effect = RuntimeError("DB write error")
+
+    results = {
+        "phash001": {"wdtagger": _make_success_result(tags=["tag1"])},
+    }
+
+    result = service.save_annotation_results(results)
+
+    assert result.success_count == 0
+    assert result.error_count == 1
+    assert result.skip_count == 0
+    assert len(result.error_details) == 1
+    assert "phash001" in result.error_details[0]
+
+
+@pytest.mark.unit
+def test_save_annotation_results_uses_batch_resolution(
+    service: AnnotationSaveService,
+    mock_repository: MagicMock,
+) -> None:
+    """N+1を避けるため、find_image_ids_by_phashesとget_models_by_namesを各1回のみ呼ぶ。"""
+    mock_model = MagicMock()
+    mock_model.id = 1
+    mock_repository.find_image_ids_by_phashes.return_value = {
+        "phash001": 1,
+        "phash002": 2,
+        "phash003": 3,
+    }
+    mock_repository.get_models_by_names.return_value = {"wdtagger": mock_model}
+    mock_repository.batch_resolve_tag_ids.return_value = {}
+
+    results = {
+        "phash001": {"wdtagger": _make_success_result(tags=["tag1"])},
+        "phash002": {"wdtagger": _make_success_result(tags=["tag2"])},
+        "phash003": {"wdtagger": _make_success_result(tags=["tag3"])},
+    }
+
+    service.save_annotation_results(results)
+
+    mock_repository.find_image_ids_by_phashes.assert_called_once()
+    mock_repository.get_models_by_names.assert_called_once()


### PR DESCRIPTION
## Summary

- `AnnotationSaveService` を新設し、`annotate run` のアノテーション結果DB保存ロジックを移管
- `ServiceContainer` に `annotation_save_service` プロパティを追加（lazy init）
- `annotate.py` のインライン9ヘルパー関数を削除し、`container.annotation_save_service.save_annotation_results()` 呼び出しに変更
- `_load_images_from_db` の戻り値から `phash_to_image_id` を除去（Service内部で `find_image_ids_by_phashes()` を使用）
- Summary テーブルに「Saved to DB」「Skipped」件数を表示
- 保存エラー時に Warning を表示

## Changed Files

| File | Change |
|------|--------|
| `src/lorairo/services/annotation_save_service.py` | 新規作成（`AnnotationSaveResult` dataclass + `AnnotationSaveService` クラス） |
| `src/lorairo/services/service_container.py` | `annotation_save_service` プロパティ追加 |
| `src/lorairo/cli/commands/annotate.py` | 9インライン関数削除 → Service呼び出しに変更 |
| `tests/unit/services/test_annotation_save_service.py` | 新規作成（5テスト） |
| `tests/unit/cli/test_commands_annotate.py` | DB保存テスト4件を新Service経由に更新 |

## Architecture

```
CLI (annotate run)
  └─ ServiceContainer.annotation_save_service
       └─ AnnotationSaveService.save_annotation_results(results)
            ├─ find_image_ids_by_phashes()   # N+1回避、バッチ取得
            ├─ get_models_by_names()         # バッチ取得
            ├─ _resolve_tag_ids()            # batch_resolve_tag_ids()
            └─ save_annotations()            # 各画像に保存
```

`AnnotationSaveService` は Qt-free で CLI・GUI・API の3経路で共有可能。

## Test Plan

- [x] `uv run pytest tests/unit/services/test_annotation_save_service.py -v` — 5件全PASS
- [x] `uv run pytest tests/unit/cli/test_commands_annotate.py -v` — 21件全PASS
- [x] `uv run pytest -m unit --timeout=30` — 全ユニットテスト PASS
- [x] `uv run ruff check src/lorairo/services/annotation_save_service.py` — エラーなし
- [x] `uv run mypy src/lorairo/services/annotation_save_service.py` — エラーなし

## Notes

- Sub-Issue B (#190): `AnnotationWorker._save_results_to_database()` を `AnnotationSaveService` に移管（別PR、本PRマージ後に rebase）
- Sub-Issue C (#191): 3経路統合テスト（B マージ後）
- Closes #168 の一部（Sub-Issue A のみ）

🤖 Generated with [Claude Code](https://claude.com/claude-code)