### PR TITLE
feat(#169): images list コマンドを実装する

### DIFF
--- a/src/lorairo/cli/commands/images.py
+++ b/src/lorairo/cli/commands/images.py
@@ -14,6 +14,7 @@ from lorairo.api.exceptions import ImageRegistrationError, ProjectNotFoundError
 from lorairo.api.images import register_images as api_register_images
 from lorairo.api.project import get_project as api_get_project
 from lorairo.api.types import RegistrationResult
+from lorairo.database.filter_criteria import ImageFilterCriteria
 from lorairo.services.service_container import get_service_container
 
 # サブコマンドアプリ定義
@@ -127,10 +128,52 @@ def list_images(
 ) -> None:
     """List images in a project.
 
-    プロジェクト内の画像一覧を表示します（将来実装）。
+    プロジェクトに登録されている画像の一覧をテーブル形式で表示します。
     """
-    console.print("[yellow]Note:[/yellow] images list is not yet implemented")
-    console.print("This will show registered images in the project.")
+    try:
+        try:
+            api_get_project(project)
+        except ProjectNotFoundError as e:
+            console.print(f"[red]Error:[/red] Project not found: {project}")
+            raise typer.Exit(code=1) from e
+
+        container = get_service_container()
+        container.set_active_project(project)
+
+        repository = container.image_repository
+        criteria = ImageFilterCriteria(include_nsfw=True)
+        image_records, total_count = repository.get_images_by_filter(criteria)
+
+        if not image_records:
+            console.print(f"No images found in project: {project}")
+            return
+
+        display_records = image_records[:limit] if limit else image_records
+
+        console.print(f"Images in project: {project}")
+        table = Table()
+        table.add_column("ID", style="cyan")
+        table.add_column("Filename")
+        table.add_column("Tags", style="green")
+        table.add_column("Annotated", style="yellow")
+
+        for record in display_records:
+            image_id = str(record.get("id", ""))
+            filename = Path(record.get("stored_image_path", "")).name or str(record.get("filename", ""))
+            tag_count = str(record.get("tag_count", 0))
+            annotated = "Yes" if record.get("tag_count", 0) > 0 else "No"
+            table.add_row(image_id, filename, tag_count, annotated)
+
+        console.print(table)
+
+        if limit and total_count > limit:
+            console.print(f"Showing {limit} of {total_count} images.")
+
+    except typer.Exit:
+        raise
+    except Exception as e:
+        console.print(f"[red]Error:[/red] {e}")
+        raise typer.Exit(code=1) from e
 
 
 @app.command("update")

--- a/tests/unit/cli/test_commands_images.py
+++ b/tests/unit/cli/test_commands_images.py
@@ -1,6 +1,7 @@
 """Image management commands テスト。"""
 
 from pathlib import Path
+from unittest.mock import MagicMock, patch
 
 import pytest
 from PIL import Image
@@ -195,18 +196,62 @@ def test_images_list_help() -> None:
 
 @pytest.mark.unit
 @pytest.mark.cli
-def test_images_list_not_implemented(mock_projects_dir: Path) -> None:
-    """Test: images list - 未実装通知。"""
-    # プロジェクト作成
+def test_images_list_shows_registered_images(mock_projects_dir: Path, test_images_dir: Path) -> None:
+    """Test: images list - 登録済み画像をテーブル表示する。"""
     runner.invoke(app, ["project", "create", "test-project"])
+    runner.invoke(app, ["images", "register", str(test_images_dir), "--project", "test-project"])
 
-    result = runner.invoke(
-        app,
-        ["images", "list", "--project", "test-project"],
-    )
+    result = runner.invoke(app, ["images", "list", "--project", "test-project"])
 
     assert result.exit_code == 0
-    assert "not yet implemented" in result.stdout
+    assert "Images in project: test-project" in result.stdout
+    assert "ID" in result.stdout
+    assert "Filename" in result.stdout
+    assert "Tags" in result.stdout
+    assert "Annotated" in result.stdout
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+def test_images_list_no_images_shows_message(mock_projects_dir: Path) -> None:
+    """Test: images list - 画像未登録時は適切なメッセージを表示する。"""
+    runner.invoke(app, ["project", "create", "test-project"])
+
+    result = runner.invoke(app, ["images", "list", "--project", "test-project"])
+
+    assert result.exit_code == 0
+    assert "No images found" in result.stdout
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+def test_images_list_with_limit(mock_projects_dir: Path) -> None:
+    """Test: images list --limit - 件数を制限して表示する。"""
+    runner.invoke(app, ["project", "create", "test-project"])
+
+    fake_records = [
+        {"id": i, "stored_image_path": f"/path/image{i}.jpg", "tag_count": 0} for i in range(1, 4)
+    ]
+    with patch("lorairo.cli.commands.images.get_service_container") as mock_get_container:
+        mock_container = MagicMock()
+        mock_container.image_repository.get_images_by_filter.return_value = (fake_records, 3)
+        mock_get_container.return_value = mock_container
+
+        result = runner.invoke(app, ["images", "list", "--project", "test-project", "--limit", "1"])
+
+    assert result.exit_code == 0
+    assert "Images in project: test-project" in result.stdout
+    assert "Showing 1 of 3" in result.stdout
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+def test_images_list_nonexistent_project(mock_projects_dir: Path) -> None:
+    """Test: images list - 存在しないプロジェクトはエラー。"""
+    result = runner.invoke(app, ["images", "list", "--project", "nonexistent"])
+
+    assert result.exit_code == 1
+    assert "Project not found" in result.stdout
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary

- `lorairo-cli images list --project <name>` のスタブ実装を本実装に置換
- `annotate run` と同一パターン（`api_get_project` → `set_active_project` → `get_images_by_filter`）で画像一覧を取得
- Rich Table で ID / Filename / Tags / Annotated を表示

## Changes

### `src/lorairo/cli/commands/images.py`
- `list_images()` を実装（スタブ2行 → 実装約40行）
- `ImageFilterCriteria` import 追加
- `--limit` オプション: 表示件数制限 + "Showing X of Y" メッセージ
- 0件時は `"No images found in project: {project}"` を表示

### `tests/unit/cli/test_commands_images.py`
- `test_images_list_not_implemented` を削除（スタブ確認テスト）
- 4テスト追加:
  - `test_images_list_shows_registered_images` — テーブルヘッダー表示
  - `test_images_list_no_images_shows_message` — 0件メッセージ
  - `test_images_list_with_limit` — --limit で件数制限
  - `test_images_list_nonexistent_project` — 未存在プロジェクトエラー

## Test plan

- [x] `uv run pytest tests/unit/cli/test_commands_images.py -v` — 16テスト全件パス
- [x] `uv run pytest tests/ -m unit` — 1843テスト全件パス（リグレッションなし）
- [x] `uv run ruff check` / `uv run mypy` — エラーなし

Closes #169

🤖 Generated with [Claude Code](https://claude.com/claude-code)