### PR TITLE
fix(#199): CLI 実行時の loguru DEBUG/INFO ログ流出を修正する

### DIFF
--- a/src/lorairo/cli/main.py
+++ b/src/lorairo/cli/main.py
@@ -14,6 +14,7 @@ from rich.table import Table
 from lorairo.cli.commands import annotate, export, images, project
 from lorairo.services.service_container import get_service_container
 from lorairo.utils.config import DEFAULT_CONFIG_PATH
+from lorairo.utils.log import initialize_logging
 
 if TYPE_CHECKING:
     from lorairo.services.service_container import ServiceContainer
@@ -113,6 +114,7 @@ def main() -> None:
     import os
 
     os.environ.setdefault("LORAIRO_CLI_MODE", "true")
+    initialize_logging({"level": "WARNING"})  # CLI モード: DEBUG/INFO を抑制
     app()
 
 

--- a/tests/unit/cli/test_main.py
+++ b/tests/unit/cli/test_main.py
@@ -154,3 +154,16 @@ def test_project_help() -> None:
     assert "create" in result.stdout
     assert "list" in result.stdout
     assert "delete" in result.stdout
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+def test_main_configures_logging_warning_level() -> None:
+    """Test: main() が CLI モードで loguru を WARNING レベルに設定する。"""
+    with patch("lorairo.cli.main.initialize_logging") as mock_init_log, patch("lorairo.cli.main.app"):
+        from lorairo.cli.main import main
+
+        main()
+    mock_init_log.assert_called_once()
+    config_arg = mock_init_log.call_args[0][0]
+    assert config_arg["level"] == "WARNING"


### PR DESCRIPTION
## Summary

- `lorairo-cli` 実行時、loguru のデフォルトハンドラ (stderr, DEBUG レベル) が残存し DEBUG/INFO ログが Rich 出力に混入していた
- CLI エントリポイント `main()` に `initialize_logging({"level": "WARNING"})` を追加し、WARNING 以上のみ表示するよう修正
- GUI `main.py` が同関数を呼ぶ既存パターンと対称性を保つ最小変更

## Test plan

- [x] `uv run pytest tests/unit/cli/test_main.py -v -m unit` — 8件すべてパス
- [x] `uv run ruff check src/lorairo/cli/main.py tests/unit/cli/test_main.py` — クリーン
- [x] `uv run mypy src/lorairo/cli/main.py` — エラーなし
- [ ] 手動確認: `lorairo-cli project list` で DEBUG/INFO ログが消えることを確認

Closes #199

🤖 Generated with [Claude Code](https://claude.com/claude-code)