### PR TITLE
fix(#200): image_processor の raw print を logger.warning に変更

### DIFF
--- a/src/lorairo/editor/image_processor.py
+++ b/src/lorairo/editor/image_processor.py
@@ -213,8 +213,9 @@ class ImageProcessor:
             Optional[tuple[int, int]]: 同じアスペクト比の解像度のタプル
         """
         if original_width < self.target_resolution and original_height < self.target_resolution:
-            print(
-                f"find_matching_resolution Error: 意図しない小さな画像を受け取った: {original_width}x{original_height}"
+            logger.warning(
+                f"target_resolution ({self.target_resolution}) より小さな画像を受け取りました: "
+                f"{original_width}x{original_height}"
             )
             return None
 


### PR DESCRIPTION
## Summary

- `src/lorairo/editor/image_processor.py` の `_find_matching_resolution` で `target_resolution` より小さな画像を受け取った際に `print()` で stdout に直接出力していたのを `logger.warning()` に変更
- メッセージ内容も「Error」表現から「Warning」に修正（`return None` でフォールバック処理されるため）

Closes #200

## Test plan

- [ ] 既存の unit テストがパスすること (`uv run pytest -m unit`)
- [ ] `target_resolution` より小さな画像を登録した際に stdout ではなくログに出力されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)