### PR TITLE
fix(#201): RealESRGAN 未配置時の過剰 ERROR ログを初回 WARNING のみに抑制

### DIFF
--- a/src/lorairo/editor/upscaler.py
+++ b/src/lorairo/editor/upscaler.py
@@ -29,6 +29,7 @@ class Upscaler:
         """
         self.config_service = config_service
         self._loaded_models: dict[str, Any] = {}
+        self._model_not_found_warned: set[str] = set()
 
         # 設定の妥当性チェック
         if not self.config_service.validate_upscaler_config():
@@ -54,7 +55,9 @@ class Upscaler:
             # モデル設定取得
             model_config = self.config_service.get_upscaler_model_by_name(model_name)
             if not model_config:
-                logger.error(f"アップスケーラーモデル '{model_name}' が見つかりません")
+                logger.warning(
+                    f"アップスケーラーモデル設定 '{model_name}' が見つかりません。スキップします"
+                )
                 return img
 
             # スケール決定
@@ -63,7 +66,7 @@ class Upscaler:
             # モデル読み込み（キャッシュ使用）
             model = self._get_or_load_model(model_name, model_config)
             if model is None:
-                logger.error(f"モデル '{model_name}' の読み込みに失敗しました")
+                logger.debug(f"モデル '{model_name}' が利用不可のためアップスケールをスキップ")
                 return img
 
             return self._upscale(img, model, scale)
@@ -84,7 +87,11 @@ class Upscaler:
             model_path = project_root / model_path
 
         if not model_path.exists():
-            logger.error(f"モデルファイルが見つかりません: {model_path}")
+            if model_name not in self._model_not_found_warned:
+                logger.warning(f"モデルファイルが見つかりません（アップスケールをスキップ）: {model_path}")
+                self._model_not_found_warned.add(model_name)
+            else:
+                logger.debug(f"モデルファイルが見つかりません（スキップ）: {model_name}")
             return None
 
         try:


### PR DESCRIPTION
## Summary

- モデルファイルが存在しない場合、画像1枚ごとに2行 ERROR が出力される問題を修正
- `_get_or_load_model`: 初回のみ `WARNING`、2回目以降は `DEBUG` に降格（`_model_not_found_warned` セットで管理）
- `upscale_image`: モデル不可時の重複ログを `ERROR` → `DEBUG` に変更（`_get_or_load_model` 側で記録済みのため）
- モデル設定が見つからない場合も `ERROR` → `WARNING` に降格

**修正前:** 画像 N 枚で N×2 行の ERROR  
**修正後:** 初回のみ WARNING 1 行、以降は DEBUG

Closes #201

## Test plan

- [ ] 既存の integration テストがパスすること (`uv run pytest tests/integration/test_upscaler_database_integration.py`)
- [ ] `models/RealESRGAN/RealESRGAN_x4plus.pth` が存在しない状態で `images register` を実行し、WARNING が1回だけ出力されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)