### PR TITLE
feat: image-annotator-lib Issue #2 対応で互換コード削除 + ADR 0022 + CLI/upscaler 修正

### DIFF
--- a/.claude/commands/test.md
+++ b/.claude/commands/test.md
@@ -41,6 +41,12 @@ uv run mypy -p lorairo --pretty
 uv run pytest --cov=src --cov-report=term-missing -v
 ```
 
+**待機パターン**:
+- デフォルトでは `Bash` 同期実行（約83秒、Bashタイムアウト83分なので問題なし）
+- 並行作業が必要な場合のみ `run_in_background: true` で実行し、完了通知を待つ
+- **禁止**: `sleep N && tail -K output` のような chain（ランタイムがブロック）
+- 詳細: `.claude/rules/testing.md` の「長時間実行テストの待機パターン」
+
 ### 出力形式
 ```markdown
 # Quick Verification Report

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -115,6 +115,76 @@ QT_QPA_PLATFORM=offscreen uv run pytest -m gui
 uv run pytest -m gui
 ```
 
+## 長時間実行テストの待機パターン
+
+LoRAIroの全テスト実行は約83秒。テストは長時間ジョブとなりやすく、待機方法を誤ると `sleep + tail` ループがランタイムによってブロックされる。以下のパターンに従うこと。
+
+### 禁止パターン
+
+```bash
+# ❌ ブロックされる: sleep を含むコマンドの後に追加の処理を chain
+sleep 30 && tail -15 /tmp/.../task.output
+
+# ❌ ブロックされる: 複数 sleep の連鎖でポーリング代替
+for i in 1 2 3; do sleep 10; tail log; done
+
+# ❌ 意味がない: 自分で時間を当てる方法
+qtbot.wait(1000)  # 固定時間待機（テスト内でも禁止）
+```
+
+ランタイムは「先頭に長い `sleep` がある」「`sleep` の後に別コマンドが続く」を検知してブロックする。回避のために sleep を 5 個に分割しても同様にブロックされる（チェーンも検知される）。
+
+### 推奨パターン1: 同期実行（デフォルト）
+
+`Bash` ツールは既定で約83分タイムアウト。テストスイート全体（83秒）であれば同期実行で十分。
+
+```python
+# Claude Code の Bash ツール呼び出し
+Bash(command="uv run pytest --cov=src", description="Run full test suite")
+# 完了までブロック → 完了後に stdout/stderr が直接返る
+```
+
+**利点**: 追加の待機ロジック不要。出力が即座に context に入る。
+**使う場面**: テスト結果が次のステップに必要な場合（殆どのケース）。
+
+### 推奨パターン2: バックグラウンド実行 + 完了通知
+
+他の独立した作業と並行したい場合のみ使用。`run_in_background: true` を設定すると、ランタイムが完了時に自動通知する。
+
+```python
+Bash(command="uv run pytest -v", run_in_background=True, description="Run tests in background")
+# → タスクIDが返る。Claude は他作業を継続。
+# → 完了時に system-reminder で通知。出力ファイルを Read で読む。
+```
+
+**重要**: 通知が来る前に自分で `sleep` してポーリングしない。ランタイムに任せる。
+
+### 推奨パターン3: 条件待機（Monitor + until ループ）
+
+特定の条件成立を待ちたい場合のみ使用。`Monitor` ツールを `ToolSearch` で取り出し、`until` ループの脱出を待つ。
+
+```bash
+# ✓ 許可されているパターン: until ループ内の sleep
+until grep -q "PASSED" /tmp/results.log; do sleep 2; done
+```
+
+このパターンは Bash の単発 `sleep && next` と異なり、条件成立時に脱出する明示的な待機なので許可されている。
+
+### 判断フロー
+
+| 状況 | 使うパターン |
+|------|------------|
+| テスト結果がすぐ必要 | パターン1（同期実行） |
+| 並行して他作業を進めたい | パターン2（バックグラウンド + 通知） |
+| 特定ログ出力を待ちたい | パターン3（Monitor + until） |
+| ジョブ完了を `sleep` で待ちたい | **どれも該当しない → 設計を見直す** |
+
+### よくある間違い
+
+- 「タスク開始から30秒経ったら結果を見る」と決め打ちで `sleep 30` する → 完了通知を待つべき
+- バックグラウンド実行後に `tail` で進捗を確認したくなる → 完了通知が来てから `Read` する
+- 短い `sleep` を複数回挟んで回避を試みる → ランタイムが検知してブロックする
+
 ## BDD テスト（pytest-bdd）
 
 BDDはE2Eに限定せず「振る舞い仕様の表現形式」としてService層以上に適用する。

--- a/docs/decisions/0022-aesthetic-score-predictor-survey.md
+++ b/docs/decisions/0022-aesthetic-score-predictor-survey.md
@@ -1,0 +1,162 @@
+# ADR 0022: Aesthetic Score Predictor Model Survey
+
+- **日付**: 2025-02-06
+- **ステータス**: Accepted
+- **ソース**: [美的評価モデル比較：Aesthetic ShadowとVisionRewardの選択 (NEXTAltair, 2025-02-06)](https://nextaltair.hatenablog.com/entry/2025/02/06/Aesthetic_Score_Predictor)
+- **関連 ADR**: [0004 Annotator-Lib Architecture](0004-annotator-lib-architecture.md)
+- **関連実装**:
+  - `local_packages/image-annotator-lib/src/image_annotator_lib/model_class/pipeline_scorers.py` (Aesthetic Shadow / Cafe Aesthetic)
+  - `local_packages/image-annotator-lib/src/image_annotator_lib/model_class/scorer_clip.py` (ImprovedAesthetic / WaifuAesthetic)
+
+## Context
+
+LoRAIro の品質スコアリング機能において、生成画像の美的評価を数値化するモデルを選定する必要があった。
+Stable Diffusion 等で生成した画像のデータセット品質管理・生成パラメータ最適化に活用するため、
+複数の Aesthetic Score Predictor モデルを比較調査した。
+
+評価対象は以下の観点:
+
+- **対応領域**: アニメ特化 / 実写対応 / 汎用
+- **処理速度**: バッチサイズ・スループット
+- **入力解像度**: モデル固有の制約
+- **出力スケール**: スコアの範囲・正規化方式
+- **入手性**: 公式配布の継続性、ライセンス
+- **計算コスト**: ローカル実行可能性
+
+## Decision
+
+`image-annotator-lib` で **以下 4 モデルを採用**し、用途に応じて使い分ける:
+
+| モデル | 採用クラス | フレームワーク | 用途 |
+|--------|----------|-------------|------|
+| Aesthetic Shadow v1 | `AestheticShadow` (`pipeline_scorers.py`) | HF Pipeline | アニメ画像の高精度評価 |
+| Aesthetic Shadow v2 | `AestheticShadow` (`pipeline_scorers.py`) | HF Pipeline | アニメ画像の 4 段階評価 |
+| Cafe Aesthetic | `CafePredictor` (`pipeline_scorers.py`) | HF Pipeline | 実写・アニメ両対応、バッチ高速処理 |
+| ImprovedAesthetic | `ImprovedAesthetic` (`scorer_clip.py`) | CLIP+MLP | 汎用・軽量 |
+| WaifuAesthetic | `WaifuAesthetic` (`scorer_clip.py`) | CLIP+MLP | アニメ特化 (CLIP ベース) |
+
+**保留中候補**: VisionReward (THUDM)・ImageReward (THUDM) は将来導入候補とし、
+本 ADR では未採用とする。
+
+## Rationale
+
+### モデル比較表
+
+| モデル | 開発元 | 専門領域 | パラメータ | 入力解像度 | 出力 | 速度 (A100) | ライセンス |
+|--------|-------|---------|----------|----------|------|------------|----------|
+| Aesthetic Shadow v1 | shadowlilac | アニメ | 約11億 (1.1B) | 1024×1024 | hq / lq の 2 値 | ~200ms/枚 | 利用可能 |
+| Aesthetic Shadow v2 | shadowlilac | アニメ | 約11億 | 1024×1024 | very aesthetic / aesthetic / displeasing / very displeasing の 4 段階 | ~120ms/枚 | **2024 年末に公式リポジトリでの公開停止、ミラー使用** |
+| Cafe Aesthetic | cafeai | 実写・アニメ両対応 | 約8600万 (BEiT-base) | 384×384 | 公式は `aesthetic` / `not_aesthetic` の 2 クラス分類。記事/実装側で `math.floor(aesthetic_score * 10)` で 0-10 化 | ~150ms/枚 (BS=32) | 利用可能 |
+| CLIP+MLP | C. Schuhmann | 汎用 | 約5000万 | 記載なし | 1-10 | 記載なし | 利用可能 |
+| Waifu-Diffusion Aesthetic | WD チーム | アニメ | 非公表 | 224×224 | 0-10 | - | 手動 DL 必須・サポート対象外 |
+| **VisionReward** | THUDM (清華大学) | 多次元評価・動画対応 | 非公表 | 記載なし | チェックリスト形式 | - | Apache-2.0 |
+| **ImageReward** | THUDM (清華大学) | テキスト-画像生成評価 | 非公表 | 224×224 | 標準正規分布 (μ=0.167, σ=1.033) | - | 利用可能 |
+
+### スコア解釈の差異 (重要)
+
+各モデルで **評価スケールが異なる** ため、スコア間の直接比較は不可:
+
+- **Aesthetic Shadow v1**: hq / lq の独立した確率値 (合計 1.0 にならない)
+- **Aesthetic Shadow v2**: 4 カテゴリの独立した確率値
+- **Cafe Aesthetic**: `floor(raw_score × 10)` で 0-10 の整数化
+- **CLIP+MLP / WaifuAesthetic**: 1-10 の連続値
+- **ImageReward**: 標準正規分布に従う実数値 (`μ=0.167, σ=1.033`)
+- **VisionReward**: 多次元のチェックリスト評価（コンテンツの豊かさ、細部の現実性、構図、色彩調和など）
+
+LoRAIro の `UnifiedAnnotationResult.scores` フィールドはモデル横断で `dict[str, float]` を保持するが、
+**スコア値の意味はモデル固有** であり、品質フィルタ等で複数モデルのスコアを混在させる場合は
+モデル別に閾値を設定する必要がある。
+
+### モデル別の採用根拠
+
+#### Aesthetic Shadow v1 / v2 (採用)
+- **長所**: アニメ画像で最高精度。v2 は 4 段階評価で粒度高い
+- **短所**: v2 は公式配布停止のためミラーリポジトリ依存
+- **採用理由**: アニメ画像主体の LoRA 学習データセット品質管理に必須
+
+#### Cafe Aesthetic (採用)
+- **長所**: バッチサイズ 32 対応で高スループット、実写・アニメ両対応、低品質線画の自動識別
+- **短所**: 384×384 入力に限定
+- **採用理由**: 大規模データセットの一次フィルタリングに最適
+- **補足 (一次ソース)**: 公式モデルは `microsoft/beit-base-patch16-384` を 3.5K 程度の実写/アニメ画像でファインチューニングした **2 クラス分類器** (`aesthetic` / `not_aesthetic`)。0-10 スケール化は記事/`pipeline_scorers.py` 側の二次処理
+
+#### ImprovedAesthetic / CLIP+MLP (採用)
+- **長所**: CLIP エンベディング + MLP の軽量構成、汎用性が高い
+- **短所**: モデル自体が古い (1 年以上前)、最新の生成画像傾向に追従しない
+- **採用理由**: ベースライン比較用、軽量実行環境向けフォールバック
+
+#### WaifuAesthetic (採用)
+- **長所**: CLIP+3 層 NN でアニメ特化
+- **短所**: 手動ダウンロード必須、サポート対象外
+- **採用理由**: 既存 LoRA データセット作成ワークフローとの互換維持
+
+#### VisionReward (未採用、将来候補)
+- **長所**: 多次元評価（コンテンツの豊かさ Rich content / 細部の現実性 Details realistic / 構図のバランス / 色彩の調和）、解釈可能なチェックリスト形式、画像および動画に対応、Apache-2.0
+- **短所**: 計算コストが比較的高い
+- **未採用理由**: 単一スコアではない多次元評価のため、LoRAIro の `scores: dict[str, float]` への
+  マッピング方針が未確定。GUI 表示・フィルタリング UX も再設計が必要
+- **補足 (一次ソース)**: アノテーションは画像 48K に対し質問 3M、動画 33K に対し質問 2M。
+  Video Preference Test Set で Tau=64.0 / Diff=72.1 を達成し VideoScore を 17.2% 上回る SOTA。
+  Multi-objective Preference Optimization (MPO) で複数軸を同時最適化可能
+
+#### ImageReward (未採用、将来候補)
+- **長所**: ImageRewardDB (137K+ エキスパート評価) で学習、CLIP より 38.6% / Aesthetic より 39.6% / BLIP より 31.6% 高い精度。
+  BLIP + MLP ベース、5 層 MLP による最終的なスコア予測、クロスアテンションによるテキストと画像の特徴融合
+- **短所**: テキスト-画像ペアの評価モデルでありプロンプト入力前提
+- **未採用理由**: LoRAIro は画像単体評価が主用途で、プロンプトを伴うフローが現状未整備
+- **補足 (一次ソース)**: 学習データは [DiffusionDB](https://github.com/poloclub/diffusiondb) のテキストプロンプトと
+  対応する生成画像から構築 (137K pairs of expert comparisons)。NeurIPS 2023 採択論文
+  (arXiv:2304.05977)。Backbone は ViT-L 画像エンコーダ + Transformer テキスト特徴量をクロスアテンションで統合し、
+  MLP head でスカラー報酬を出力
+
+## Consequences
+
+### 良い点
+
+- 5 種類の採用モデルで「アニメ特化 (高精度)」「実写対応」「軽量汎用」の用途を網羅
+- `image-annotator-lib` の Pipeline / CLIP 抽象化により、新規スコアラー追加が容易
+- スコア意味論を ADR で明文化したため、モデル横断の閾値設定方針が明確化
+
+### 悪い点・制約
+
+- **Aesthetic Shadow v2 はミラー依存**: 公式配布停止のため、ミラーリポジトリの可用性に依存。
+  別のミラー消失時に代替手段の確保が課題
+- **スコア値の不均一性**: モデル間で出力スケールが異なるため、品質フィルタ実装時には
+  モデル別閾値設定が必要 (UI で閾値スライダーを単一にできない)
+- **VisionReward / ImageReward 未採用**: 多次元評価・テキスト連動評価のニーズが高まれば
+  別途 ADR で導入判断が必要
+
+### 未解決の論点
+
+1. **Aesthetic Shadow v2 ミラー消失時の代替**: 候補モデルのバックアップ戦略
+2. **マルチモデル評価の集約方針**: 複数スコアラーの結果を「総合スコア」として集約するロジック
+   (現状: 各モデル独立のスコアを `scores: dict[str, float]` に保持)
+3. **VisionReward 統合時の `UnifiedAnnotationResult` 拡張**: 多次元評価を保持する `aspects: dict[str, float]`
+   フィールド追加の要否 (現時点では `raw_output` 任意辞書で対応可能)
+
+## References
+
+### 元記事
+- [元ブログ記事: 美的評価モデル比較 (NEXTAltair, 2025-02-06)](https://nextaltair.hatenablog.com/entry/2025/02/06/Aesthetic_Score_Predictor)
+
+### 採用モデルの一次ソース
+- [shadowlilac/aesthetic-shadow (HuggingFace)](https://huggingface.co/shadowlilac/aesthetic-shadow)
+- [shadowlilac/aesthetic-shadow-v2 (HuggingFace)](https://huggingface.co/shadowlilac/aesthetic-shadow-v2) — 公式配布停止
+- [NeoChen1024/aesthetic-shadow-v2-backup (HuggingFace)](https://huggingface.co/NeoChen1024/aesthetic-shadow-v2-backup) — v2 ミラー
+- [cafeai/cafe_aesthetic (HuggingFace)](https://huggingface.co/cafeai/cafe_aesthetic)
+- [improved-aesthetic-predictor (LAION)](https://github.com/christophschuhmann/improved-aesthetic-predictor)
+
+### 将来候補モデルの一次ソース
+- [THUDM/ImageReward (GitHub)](https://github.com/THUDM/ImageReward)
+- [THUDM/ImageRewardDB (HuggingFace Dataset)](https://huggingface.co/datasets/THUDM/ImageRewardDB)
+- [ImageReward 論文 (arXiv 2304.05977)](https://arxiv.org/html/2304.05977v4) — NeurIPS 2023
+- [THUDM/VisionReward (GitHub)](https://github.com/THUDM/VisionReward)
+- [THUDM/VisionReward-Image (HuggingFace)](https://huggingface.co/THUDM/VisionReward-Image)
+- [THUDM/VisionReward-Video (HuggingFace)](https://huggingface.co/THUDM/VisionReward-Video)
+- [VisionReward 論文 (arXiv 2412.21059)](https://arxiv.org/html/2412.21059v1)
+
+### 検証メモ
+本 ADR は元ブログ記事を一次資料とし、2026-04-29 時点で各モデルの公式リポジトリ・論文と
+クロスチェック済み。**入力解像度・パラメータ数・精度比較数値は一次ソースで裏取り完了**。
+ブログ記事に含まれていた「VisionReward の入力 224×224 固定 / テキスト 35 トークン以下制約」
+「CLIP+MLP の入力解像度 可変」は一次ソースで確認できなかったため本 ADR からは除外している。

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -25,6 +25,7 @@ LoRAIro の重要な設計判断を記録するドキュメント群。
 | [0019](0019-export-filter-required-design.md) | Export Filter Required Design | 2026-04-22 | Implemented |
 | [0020](0020-cli-message-language-policy.md) | CLI Message Language Policy | 2026-04-27 | Accepted |
 | [0021](0021-litellm-driven-model-registry.md) | LiteLLM-Driven WebAPI Model Registry | 2026-04-28 | Proposed |
+| [0022](0022-aesthetic-score-predictor-survey.md) | Aesthetic Score Predictor Model Survey | 2025-02-06 | Accepted |
 
 ## ADR テンプレート
 

--- a/src/lorairo/cli/commands/annotate.py
+++ b/src/lorairo/cli/commands/annotate.py
@@ -192,6 +192,11 @@ def run(
     """Run annotation on project images.
 
     プロジェクトの画像に対してアノテーションを実行します。
+    使用可能なモデル名は 'lorairo-cli models list' で確認してください。
+
+    Examples:
+        lorairo-cli annotate run --project myproject --model gpt-4o
+        lorairo-cli annotate run --project myproject --model gpt-4o --model claude-3-5-sonnet-20241022
     """
     try:
         # API層経由でプロジェクト確認 & DB 接続切り替え
@@ -366,7 +371,7 @@ def _display_batch_import_result(result: BatchImportResult, *, dry_run: bool) ->
 def import_batch(
     jsonl_dir: Path = typer.Argument(
         ...,
-        help="Directory containing JSONL result files from OpenAI Batch API\nOpenAI Batch API結果のJSONLファイルが格納されたディレクトリ",
+        help="JSONL files directory (OpenAI Batch API results)",
         exists=True,
         file_okay=False,
         dir_okay=True,
@@ -399,8 +404,8 @@ def import_batch(
     アノテーション結果をインポートします。
 
     Examples:
-        lorairo annotate import-batch jsonl/ -p main_dataset_20250707_001
-        lorairo annotate import-batch jsonl/ -p my_project --dry-run
+        lorairo-cli annotate import-batch jsonl/ -p main_dataset_20250707_001
+        lorairo-cli annotate import-batch jsonl/ -p my_project --dry-run
     """
     try:
         get_service_container().set_active_project(project)

--- a/src/lorairo/cli/commands/export.py
+++ b/src/lorairo/cli/commands/export.py
@@ -235,8 +235,14 @@ def create(
     """Create a dataset export from project.
 
     プロジェクトからデータセットをエクスポートします。
-    最低1つのフィルタ条件（--tags, --caption, --manual-rating, --ai-rating,
-    --score-min, --score-max）を指定する必要があります。
+
+    [必須] --tags / --caption / --manual-rating / --ai-rating /
+           --score-min / --score-max のいずれかを最低1つ指定してください。
+
+    Examples:
+        lorairo-cli export create --project myproject --tags cat --output /tmp/out
+        lorairo-cli export create --project myproject --tags "cat,dog" --manual-rating PG --output /tmp/out
+        lorairo-cli export create --project myproject --score-min 6.0 --output /tmp/out --format json
     """
     try:
         # API層経由でプロジェクト確認

--- a/src/lorairo/cli/commands/images.py
+++ b/src/lorairo/cli/commands/images.py
@@ -180,7 +180,8 @@ def list_images(
         None,
         "--limit",
         "-l",
-        help="Maximum number of images to display",
+        min=1,
+        help="Maximum number of images to display (>= 1)",
     ),
 ) -> None:
     """List images in a project.
@@ -258,10 +259,14 @@ def update(
         help="Target specific image by ID",
     ),
 ) -> None:
-    """Update image metadata.
+    """Add tags to images in a project.
 
     プロジェクト内の画像にタグを追加します。
     --image-id を指定すると特定の1枚のみ更新します。
+    指定しない場合はプロジェクト全画像が対象です。
+
+    Example:
+        lorairo-cli images update --project myproject --tags "cat,dog"
     """
     if not tags:
         console.print("[red]Error:[/red] At least one update operation is required.")

--- a/src/lorairo/cli/main.py
+++ b/src/lorairo/cli/main.py
@@ -22,7 +22,15 @@ if TYPE_CHECKING:
 # Typer app 定義
 app = typer.Typer(
     name="lorairo",
-    help="LoRAIro - AI-powered image annotation and dataset management",
+    help=(
+        "LoRAIro - AI-powered image annotation and dataset management\n\n"
+        "Typical workflow:\n\n"
+        "  1. lorairo-cli project create <name>\n\n"
+        "  2. lorairo-cli images register <dir> --project <name>\n\n"
+        "  3. lorairo-cli models list  (confirm model names)\n\n"
+        "  4. lorairo-cli annotate run --project <name> --model <model>\n\n"
+        "  5. lorairo-cli export create --project <name> --tags <tag> --output <dir>"
+    ),
     add_completion=True,
     no_args_is_help=True,
 )

--- a/src/lorairo/editor/image_processor.py
+++ b/src/lorairo/editor/image_processor.py
@@ -147,6 +147,9 @@ class ImageProcessingManager:
             metadata["was_upscaled"] = True
             metadata["upscaler_used"] = upscaler
             return upscaled
+        except FileNotFoundError:
+            metadata["upscale_skipped_reason"] = "model_not_found"
+            return img
         except Exception as e:
             metadata["upscale_skipped_reason"] = "upscale_failed"
             logger.warning(f"アップスケール失敗、元サイズのまま処理を続行: {image_path}, Error: {e}")

--- a/src/lorairo/editor/upscaler.py
+++ b/src/lorairo/editor/upscaler.py
@@ -68,6 +68,9 @@ class Upscaler:
 
             return self._upscale(img, model, scale)
 
+        except FileNotFoundError:
+            # モデル未配置は呼び出し元 (_try_upscale) で「想定内のスキップ」として扱うため再 raise
+            raise
         except Exception as e:
             logger.error(f"アップスケーリング中のエラー: {e}")
             return img

--- a/src/lorairo/editor/upscaler.py
+++ b/src/lorairo/editor/upscaler.py
@@ -65,6 +65,9 @@ class Upscaler:
 
             # モデル読み込み（キャッシュ使用）。モデル未配置時は FileNotFoundError を送出
             model = self._get_or_load_model(model_name, model_config)
+            if model is None:
+                logger.debug(f"モデル '{model_name}' が利用不可のためアップスケールをスキップ")
+                return img
 
             return self._upscale(img, model, scale)
 

--- a/src/lorairo/editor/upscaler.py
+++ b/src/lorairo/editor/upscaler.py
@@ -63,11 +63,8 @@ class Upscaler:
             # スケール決定
             scale = scale or model_config.get("scale", 4.0)
 
-            # モデル読み込み（キャッシュ使用）
+            # モデル読み込み（キャッシュ使用）。モデル未配置時は FileNotFoundError を送出
             model = self._get_or_load_model(model_name, model_config)
-            if model is None:
-                logger.debug(f"モデル '{model_name}' が利用不可のためアップスケールをスキップ")
-                return img
 
             return self._upscale(img, model, scale)
 
@@ -92,7 +89,7 @@ class Upscaler:
                 self._model_not_found_warned.add(model_name)
             else:
                 logger.debug(f"モデルファイルが見つかりません（スキップ）: {model_name}")
-            return None
+            raise FileNotFoundError(model_path)
 
         try:
             model = self._load_model(model_path)

--- a/src/lorairo/services/annotation_save_service.py
+++ b/src/lorairo/services/annotation_save_service.py
@@ -7,7 +7,7 @@ CLI・GUI・API の3経路で共有する Qt-free サービス。
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any, cast  # cast: _extract_scores_from_formatted_outputで使用
+from typing import TYPE_CHECKING, Any
 
 from lorairo.database.db_repository import ImageRepository
 from lorairo.utils.log import logger
@@ -56,31 +56,6 @@ class AnnotationSaveService:
         if isinstance(result, dict):
             return result.get(field_name)
         return getattr(result, field_name, None)
-
-    @staticmethod
-    def _extract_scores_from_formatted_output(formatted_output: Any) -> dict[str, float] | None:
-        """formatted_outputからスコア辞書を抽出する。
-
-        Pipeline/CLIPモデルはscoresではなくformatted_outputにスコアを格納するため変換する。
-        FIXME: image-annotator-libのUnifiedAnnotationResultスコアフィールド統一後に削除
-        """
-        if formatted_output is None:
-            return None
-
-        if hasattr(formatted_output, "scores") and isinstance(
-            getattr(formatted_output, "scores", None), dict
-        ):
-            return cast("dict[str, float]", formatted_output.scores)
-
-        if isinstance(formatted_output, dict) and "hq" in formatted_output:
-            hq_value = formatted_output.get("hq")
-            if isinstance(hq_value, (int, float)):
-                return {"aesthetic": float(hq_value)}
-
-        if isinstance(formatted_output, (int, float)):
-            return {"aesthetic": float(formatted_output)}
-
-        return None
 
     def _append_model_result(
         self,
@@ -146,15 +121,9 @@ class AnnotationSaveService:
             logger.warning(f"モデル '{model_name}' がDB未登録")
             return
 
-        scores = self._extract_field(unified_result, "scores")
-        if scores is None:
-            scores = self._extract_scores_from_formatted_output(
-                self._extract_field(unified_result, "formatted_output")
-            )
-
         self._append_model_result(
             model.id,
-            scores,
+            self._extract_field(unified_result, "scores"),
             self._extract_field(unified_result, "tags"),
             self._extract_field(unified_result, "captions"),
             self._extract_field(unified_result, "ratings"),

--- a/tests/integration/services/test_annotation_save_three_paths.py
+++ b/tests/integration/services/test_annotation_save_three_paths.py
@@ -200,7 +200,6 @@ class TestAnnotationSaveThreePaths:
                     "scores": None,
                     "ratings": None,
                     "error": None,
-                    "formatted_output": None,
                 }
             }
         }
@@ -258,7 +257,6 @@ class TestAnnotationSaveThreePaths:
                     "scores": None,
                     "ratings": None,
                     "error": None,
-                    "formatted_output": None,
                 }
             }
         }

--- a/tests/unit/cli/test_commands_images.py
+++ b/tests/unit/cli/test_commands_images.py
@@ -371,7 +371,7 @@ def test_images_update_help() -> None:
     result = runner.invoke(app, ["images", "update", "--help"])
 
     assert result.exit_code == 0
-    assert "Update image" in result.stdout
+    assert "Add tags to images" in result.stdout
 
 
 @pytest.mark.unit

--- a/tests/unit/services/test_annotation_save_service.py
+++ b/tests/unit/services/test_annotation_save_service.py
@@ -35,7 +35,6 @@ def _make_success_result(
     result.captions = captions or []
     result.scores = scores
     result.ratings = None
-    result.formatted_output = None
     return result
 
 

--- a/tests/unit/test_image_processor.py
+++ b/tests/unit/test_image_processor.py
@@ -13,6 +13,7 @@ import pytest
 from PIL import Image
 
 from lorairo.editor.image_processor import ImageProcessingManager, ImageProcessor
+from lorairo.editor.upscaler import Upscaler
 from lorairo.storage.file_system import FileSystemManager
 
 
@@ -304,6 +305,30 @@ class TestImageProcessingManager:
                     preferred_resolutions=[(512, 512)],
                     config_service=self.mock_config_service,
                 )
+
+
+class TestUpscaler:
+    """Test cases for Upscaler class"""
+
+    def test_upscale_image_returns_original_when_model_load_returns_none(self):
+        """Model load failure should skip without calling _upscale with None."""
+        mock_config_service = Mock()
+        mock_config_service.validate_upscaler_config.return_value = True
+        mock_config_service.get_upscaler_model_by_name.return_value = {
+            "path": "models/missing-or-invalid.pth",
+            "scale": 4.0,
+        }
+        upscaler = Upscaler(mock_config_service)
+        img = Image.new("RGB", (64, 64), color="blue")
+
+        with (
+            patch.object(upscaler, "_get_or_load_model", return_value=None),
+            patch.object(upscaler, "_upscale") as mock_upscale,
+        ):
+            result = upscaler.upscale_image(img, "InvalidModel")
+
+        assert result is img
+        mock_upscale.assert_not_called()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

複数スコープを束ねた PR。中心は image-annotator-lib Issue #2 (UnifiedAnnotationResult 統一) への追従修正。

### 1. image-annotator-lib Issue #2 対応 (主目的)

- `_extract_scores_from_formatted_output()` を削除（lib 側で `UnifiedAnnotationResult.scores` が確実に設定されるため不要）
- `_process_model_result` の `formatted_output` フォールバック呼び出しを削除し `scores` 直接参照に簡略化
- 関連テストの `formatted_output` モック設定を削除
- image-annotator-lib submodule を Issue #2 修正コミットに更新

関連: [image-annotator-lib#18](https://github.com/NEXTAltair/image-annotator-lib/pull/18)

### 2. ADR 0022: 美的評価モデル調査記録

- NEXTAltair ブログ (2025-02-06) を一次資料とし、HuggingFace モデルカード・arxiv 論文・GitHub README とクロスチェック済み
- 採用済み 5 モデル (Aesthetic Shadow v1/v2, Cafe Aesthetic, ImprovedAesthetic, WaifuAesthetic) の選定根拠を整理
- 未採用候補 (VisionReward, ImageReward) の保留理由を記録

### 3. CLI ヘルプ改善 / upscaler エラーハンドリング

- main.py: トップレベルヘルプに 5 ステップワークフローを追加
- annotate run / export create / images update のヘルプ強化と Examples 追加
- list `--limit` に `min=1` バリデーション (#204)
- import-batch docstring の `lorairo` → `lorairo-cli` 修正 (#205, #207)
- upscaler: モデル不在時に `FileNotFoundError` 送出、`_try_upscale` で重複ログ回避 (#202)

## Test plan

- [x] `uv run pytest tests/unit/services/test_annotation_save_service.py` (4 件 pass)
- [x] `uv run pytest tests/integration/services/test_annotation_save_three_paths.py` (5 件 pass)
- [x] `uv run mypy src/lorairo/services/annotation_save_service.py` (issues なし)
- [x] image-annotator-lib 側ユニットテスト 41 件 pass
- [ ] 実機モデル E2E (annotate run コマンド経由) — マージ後手動

## Notes

- submodule pointer は `image-annotator-lib#18` のマージコミットに後で更新する必要あり (現在は feature branch コミットを指している)
- `00`, `ONBOARDING.md`, `.claude/settings.local.json` は意図不明のため未コミットのまま残置

🤖 Generated with [Claude Code](https://claude.com/claude-code)