### PR TITLE
feat(#220): models list にローカルモデル表示と type/category フィルタを追加

### DIFF
--- a/src/lorairo/annotations/annotator_adapter.py
+++ b/src/lorairo/annotations/annotator_adapter.py
@@ -41,14 +41,32 @@ class AnnotatorLibraryAdapter:
         self.config_service = config_service
         logger.info("AnnotatorLibraryAdapter初期化完了（実ライブラリ統合モード）")
 
+    def list_annotator_info(self) -> list[AnnotatorInfo]:
+        """利用可能アノテーターの型安全メタデータ一覧を取得する。
+
+        image-annotator-lib の ``list_annotator_info()`` 公開 API を委譲呼び出しで返す。
+        ローカル ML モデルと WebAPI モデル、PydanticAI 直接モデルを統合した完全リストを
+        ``list[AnnotatorInfo]`` で返却する (ソート: name 昇順)。
+
+        Returns:
+            list[AnnotatorInfo]: 型安全なアノテーター情報のリスト
+        """
+        try:
+            infos = list_annotator_info()
+            logger.debug(f"image-annotator-lib から AnnotatorInfo を {len(infos)} 件取得")
+            return infos
+        except Exception:
+            logger.error("image-annotator-lib AnnotatorInfo 取得エラー", exc_info=True)
+            raise
+
     def get_available_models_with_metadata(self) -> list[dict[str, Any]]:
-        """利用可能アノテーターのメタデータ付き一覧を取得
+        """利用可能アノテーターのメタデータ付き一覧を取得 (dict 互換 API)。
 
         image-annotator-lib の型安全 API ``list_annotator_info()`` を呼び出し、
-        上位層が期待する dict 形式に変換する。
+        上位層 (ModelSyncService 等) が期待する dict 形式に変換する。
 
-        ※ Issue #220 でこの dict 変換は除去し、Protocol/worker/sync_service を
-           ``list[AnnotatorInfo]`` に揃える予定。
+        ※ 後続 Issue で Protocol/sync_service を ``list[AnnotatorInfo]`` に揃え、
+           ``provider`` 等は config_registry 経由で取得する想定 (Phase 2)。
 
         Returns:
             list[dict[str, Any]]: モデルメタデータリスト
@@ -72,7 +90,7 @@ class AnnotatorLibraryAdapter:
         """モデル名からプロバイダーを推論する。
 
         AnnotatorInfo に provider フィールドが存在しないため、モデル名のキーワードから推論する。
-        Issue #220 で config_registry 経由の正式取得に置き換える予定。
+        Phase 2 (Issue #19/#220 follow-up) で config_registry 経由の正式取得に置き換える予定。
 
         Args:
             info: アノテーター情報
@@ -101,7 +119,8 @@ class AnnotatorLibraryAdapter:
         Note:
             ``class`` / ``api_model_id`` / ``estimated_size_gb`` / ``discontinued_at`` /
             ``max_output_tokens`` は AnnotatorInfo に含まれないため None で埋める。
-            Issue #220 で ``list[AnnotatorInfo]`` への migration と同時に config_registry 経由で取得する。
+            Phase 2 (Issue #19/#220 follow-up) で ``list[AnnotatorInfo]`` への migration と
+            同時に config_registry 経由で取得する。
             ``provider`` はモデル名からの推論で補完する (暫定対処)。
         """
         provider = AnnotatorLibraryAdapter._infer_provider(info)

--- a/src/lorairo/annotations/annotator_adapter.py
+++ b/src/lorairo/annotations/annotator_adapter.py
@@ -68,6 +68,30 @@ class AnnotatorLibraryAdapter:
             raise
 
     @staticmethod
+    def _infer_provider(info: AnnotatorInfo) -> str | None:
+        """モデル名からプロバイダーを推論する。
+
+        AnnotatorInfo に provider フィールドが存在しないため、モデル名のキーワードから推論する。
+        Issue #220 で config_registry 経由の正式取得に置き換える予定。
+
+        Args:
+            info: アノテーター情報
+
+        Returns:
+            str | None: プロバイダー名。ローカルモデルまたは推論不能の場合は None。
+        """
+        if not info.is_api:
+            return None
+        name_lower = info.name.lower()
+        if any(k in name_lower for k in ("claude", "anthropic")):
+            return "anthropic"
+        if any(k in name_lower for k in ("gpt", "openai", "o1-", "o3-", "o4-")):
+            return "openai"
+        if any(k in name_lower for k in ("gemini", "google")):
+            return "google"
+        return None
+
+    @staticmethod
     def _annotator_info_to_dict(info: AnnotatorInfo) -> dict[str, Any]:
         """AnnotatorInfo を上位層の dict 形式に変換する。
 
@@ -75,11 +99,12 @@ class AnnotatorLibraryAdapter:
         新規の型安全フィールド (is_local/is_api/device) も追加する。
 
         Note:
-            旧形式に存在した ``class`` / ``provider`` / ``api_model_id`` / ``estimated_size_gb`` /
-            ``discontinued_at`` / ``max_output_tokens`` は AnnotatorInfo には含まれないため
-            None で埋める。これらが必要な箇所がある場合は Issue #220 で正式に
-            ``list[AnnotatorInfo]`` への migration と同時に config_registry 経由で取得する。
+            ``class`` / ``api_model_id`` / ``estimated_size_gb`` / ``discontinued_at`` /
+            ``max_output_tokens`` は AnnotatorInfo に含まれないため None で埋める。
+            Issue #220 で ``list[AnnotatorInfo]`` への migration と同時に config_registry 経由で取得する。
+            ``provider`` はモデル名からの推論で補完する (暫定対処)。
         """
+        provider = AnnotatorLibraryAdapter._infer_provider(info)
         return {
             "name": info.name,
             "model_name": info.name,
@@ -89,9 +114,9 @@ class AnnotatorLibraryAdapter:
             "is_api": info.is_api,
             "device": info.device,
             "requires_api_key": info.is_api,
-            # 旧 dict 互換キー (現状は AnnotatorInfo には含めず None)
+            # 旧 dict 互換キー
             "class": None,
-            "provider": None,
+            "provider": provider,
             "api_model_id": None,
             "estimated_size_gb": None,
             "discontinued_at": None,

--- a/src/lorairo/cli/commands/models.py
+++ b/src/lorairo/cli/commands/models.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from enum import StrEnum
+
 import typer
 from rich.console import Console
 from rich.table import Table
@@ -11,6 +13,24 @@ from lorairo.utils.log import logger
 
 app = typer.Typer(help="Model registry commands")
 console = Console()
+
+
+class ModelTypeFilter(StrEnum):
+    """`models list` の `--type` フィルタ値。"""
+
+    all = "all"
+    webapi = "webapi"
+    local = "local"
+
+
+class ModelCategoryFilter(StrEnum):
+    """`models list` の `--category` フィルタ値 (AnnotatorInfo.model_type に対応)。"""
+
+    all = "all"
+    tagger = "tagger"
+    scorer = "scorer"
+    captioner = "captioner"
+    vision = "vision"
 
 
 @app.command("refresh")
@@ -53,31 +73,64 @@ def list_models(
     include_deprecated: bool = typer.Option(
         False,
         "--include-deprecated",
-        help="Include deprecated models",
+        help="Include deprecated WebAPI models",
+    ),
+    type_filter: ModelTypeFilter = typer.Option(
+        ModelTypeFilter.all,
+        "--type",
+        case_sensitive=False,
+        help="Filter by execution type (all / webapi / local)",
+    ),
+    category: ModelCategoryFilter = typer.Option(
+        ModelCategoryFilter.all,
+        "--category",
+        case_sensitive=False,
+        help="Filter by model category (all / tagger / scorer / captioner / vision)",
     ),
 ) -> None:
-    """List available WebAPI models."""
+    """List available annotator models (WebAPI + local)."""
     try:
         container = get_service_container()
         annotator = container.annotator_library
-        models = annotator.list_available_models(include_deprecated=include_deprecated)
+        infos = annotator.list_annotator_info()
 
-        table = Table(title="Available API Models")
-        table.add_column("Model", style="cyan")
-        table.add_column("Status", style="green")
+        rows: list[tuple[str, str, str, bool]] = []
+        for info in infos:
+            if type_filter is ModelTypeFilter.webapi and not info.is_api:
+                continue
+            if type_filter is ModelTypeFilter.local and not info.is_local:
+                continue
+            if category is not ModelCategoryFilter.all and info.model_type != category.value:
+                continue
 
-        for model in models:
             try:
-                deprecated = annotator.is_model_deprecated(model)
+                deprecated = annotator.is_model_deprecated(info.name)
             except Exception as e:
-                logger.warning(f"Deprecated check failed for {model}: {e}")
+                logger.warning(f"Deprecated check failed for {info.name}: {e}")
                 deprecated = False
+
             if deprecated and not include_deprecated:
                 continue
-            table.add_row(model, "[yellow]deprecated[/yellow]" if deprecated else "active")
+
+            type_label = "webapi" if info.is_api else "local"
+            rows.append((info.name, type_label, info.model_type, deprecated))
+
+        table = Table(title="Available Models")
+        table.add_column("Model", style="cyan", no_wrap=True)
+        table.add_column("Type", style="magenta")
+        table.add_column("Category", style="blue")
+        table.add_column("Status", style="green")
+
+        for name, type_label, model_category, deprecated in rows:
+            table.add_row(
+                name,
+                type_label,
+                model_category,
+                "[yellow]deprecated[/yellow]" if deprecated else "active",
+            )
 
         console.print(table)
-        console.print(f"[dim]{len(models)} model(s)[/dim]")
+        console.print(f"[dim]{len(rows)} model(s)[/dim]")
     except Exception as e:
         console.print(f"[red]Error:[/red] Failed to list models: {e}")
         logger.error(f"Model list command failed: {e}", exc_info=True)

--- a/src/lorairo/cli/commands/models.py
+++ b/src/lorairo/cli/commands/models.py
@@ -115,11 +115,15 @@ def list_models(
             type_label = "webapi" if info.is_api else "local"
             rows.append((info.name, type_label, info.model_type, deprecated))
 
+        # 長いモデル名 (例: "vercel_ai_gateway/openai/o1") で固定幅未指定のままだと
+        # Rich Table が Type/Category/Status を 0 幅に collapse させて Issue #220 の
+        # 主要機能 (Type 列で local/webapi 区別) が視認できなくなる。各カラムに
+        # min_width を指定し、Model カラムは折返し許容で長さに対応する。
         table = Table(title="Available Models")
-        table.add_column("Model", style="cyan", no_wrap=True)
-        table.add_column("Type", style="magenta")
-        table.add_column("Category", style="blue")
-        table.add_column("Status", style="green")
+        table.add_column("Model", style="cyan", overflow="fold", min_width=20)
+        table.add_column("Type", style="magenta", min_width=6, no_wrap=True)
+        table.add_column("Category", style="blue", min_width=9, no_wrap=True)
+        table.add_column("Status", style="green", min_width=10, no_wrap=True)
 
         for name, type_label, model_category, deprecated in rows:
             table.add_row(

--- a/src/lorairo/services/model_sync_service.py
+++ b/src/lorairo/services/model_sync_service.py
@@ -192,7 +192,7 @@ class ModelSyncService:
             else:
                 return ["captioner"]
 
-        elif library_model_type == "score":
+        elif library_model_type in ("score", "scorer"):
             return ["score"]
 
         elif library_model_type == "tagger":

--- a/tests/unit/cli/test_commands_models.py
+++ b/tests/unit/cli/test_commands_models.py
@@ -1,5 +1,6 @@
 """models CLI command tests."""
 
+from dataclasses import dataclass, field
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -8,6 +9,35 @@ from typer.testing import CliRunner
 from lorairo.cli.main import app
 
 runner = CliRunner()
+
+
+@dataclass(frozen=True)
+class _FakeAnnotatorInfo:
+    """テスト用 AnnotatorInfo ダミー (実体と同等のフィールドを持つ frozen dataclass)。"""
+
+    name: str
+    model_type: str
+    is_local: bool
+    is_api: bool
+    capabilities: frozenset = field(default_factory=frozenset)
+    device: str | None = None
+
+
+def _make_infos() -> list[_FakeAnnotatorInfo]:
+    """ローカル / WebAPI / 各 model_type を網羅したテスト用モデル群。"""
+    return [
+        _FakeAnnotatorInfo(
+            name="wd-v1-4-tagger", model_type="tagger", is_local=True, is_api=False, device="cuda"
+        ),
+        _FakeAnnotatorInfo(
+            name="aesthetic-predictor", model_type="scorer", is_local=True, is_api=False, device="cuda"
+        ),
+        _FakeAnnotatorInfo(
+            name="blip-large", model_type="captioner", is_local=True, is_api=False, device="cpu"
+        ),
+        _FakeAnnotatorInfo(name="gpt-4o", model_type="vision", is_local=False, is_api=True),
+        _FakeAnnotatorInfo(name="claude-3-5-sonnet", model_type="vision", is_local=False, is_api=True),
+    ]
 
 
 @pytest.mark.unit
@@ -60,19 +90,129 @@ def test_models_refresh_fails_when_db_sync_reports_errors(mock_get_container) ->
 @pytest.mark.unit
 @pytest.mark.cli
 @patch("lorairo.cli.commands.models.get_service_container")
-def test_models_list_excludes_deprecated_by_default(mock_get_container) -> None:
-    """models list はデフォルトで active モデルだけを表示する。"""
+def test_models_list_shows_local_and_webapi_with_type_column(mock_get_container) -> None:
+    """models list はローカルと WebAPI 両方を表示し、Type カラムで区別する (Issue #220)."""
     mock_container = MagicMock()
-    mock_container.annotator_library.list_available_models.return_value = ["openai/gpt-4.1-mini"]
+    mock_container.annotator_library.list_annotator_info.return_value = _make_infos()
     mock_container.annotator_library.is_model_deprecated.return_value = False
     mock_get_container.return_value = mock_container
 
     result = runner.invoke(app, ["models", "list"])
 
     assert result.exit_code == 0
-    mock_container.annotator_library.list_available_models.assert_called_once_with(include_deprecated=False)
-    assert "openai/gpt-4.1-mini" in result.stdout
-    assert "active" in result.stdout
+    mock_container.annotator_library.list_annotator_info.assert_called_once_with()
+    # ローカルモデルが表示されること (Issue #220 の主要要求)
+    assert "wd-v1-4-tagger" in result.stdout
+    assert "aesthetic-predictor" in result.stdout
+    # WebAPI モデルも表示されること
+    assert "gpt-4o" in result.stdout
+    assert "claude-3-5-sonnet" in result.stdout
+    # Type カラムの値
+    assert "local" in result.stdout
+    assert "webapi" in result.stdout
+    # 件数
+    assert "5 model(s)" in result.stdout
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+@patch("lorairo.cli.commands.models.get_service_container")
+def test_models_list_filter_type_local_only(mock_get_container) -> None:
+    """--type local はローカルモデルのみ表示する。"""
+    mock_container = MagicMock()
+    mock_container.annotator_library.list_annotator_info.return_value = _make_infos()
+    mock_container.annotator_library.is_model_deprecated.return_value = False
+    mock_get_container.return_value = mock_container
+
+    result = runner.invoke(app, ["models", "list", "--type", "local"])
+
+    assert result.exit_code == 0
+    assert "wd-v1-4-tagger" in result.stdout
+    assert "aesthetic-predictor" in result.stdout
+    assert "blip-large" in result.stdout
+    assert "gpt-4o" not in result.stdout
+    assert "claude-3-5-sonnet" not in result.stdout
+    assert "3 model(s)" in result.stdout
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+@patch("lorairo.cli.commands.models.get_service_container")
+def test_models_list_filter_type_webapi_only(mock_get_container) -> None:
+    """--type webapi は WebAPI モデルのみ表示する。"""
+    mock_container = MagicMock()
+    mock_container.annotator_library.list_annotator_info.return_value = _make_infos()
+    mock_container.annotator_library.is_model_deprecated.return_value = False
+    mock_get_container.return_value = mock_container
+
+    result = runner.invoke(app, ["models", "list", "--type", "webapi"])
+
+    assert result.exit_code == 0
+    assert "gpt-4o" in result.stdout
+    assert "claude-3-5-sonnet" in result.stdout
+    assert "wd-v1-4-tagger" not in result.stdout
+    assert "2 model(s)" in result.stdout
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+@patch("lorairo.cli.commands.models.get_service_container")
+def test_models_list_filter_category_tagger(mock_get_container) -> None:
+    """--category tagger は tagger モデルのみ表示する。"""
+    mock_container = MagicMock()
+    mock_container.annotator_library.list_annotator_info.return_value = _make_infos()
+    mock_container.annotator_library.is_model_deprecated.return_value = False
+    mock_get_container.return_value = mock_container
+
+    result = runner.invoke(app, ["models", "list", "--category", "tagger"])
+
+    assert result.exit_code == 0
+    assert "wd-v1-4-tagger" in result.stdout
+    assert "aesthetic-predictor" not in result.stdout
+    assert "gpt-4o" not in result.stdout
+    assert "1 model(s)" in result.stdout
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+@patch("lorairo.cli.commands.models.get_service_container")
+def test_models_list_filter_combines_type_and_category(mock_get_container) -> None:
+    """--type local --category scorer はローカル scorer のみ表示する。"""
+    mock_container = MagicMock()
+    mock_container.annotator_library.list_annotator_info.return_value = _make_infos()
+    mock_container.annotator_library.is_model_deprecated.return_value = False
+    mock_get_container.return_value = mock_container
+
+    result = runner.invoke(app, ["models", "list", "--type", "local", "--category", "scorer"])
+
+    assert result.exit_code == 0
+    assert "aesthetic-predictor" in result.stdout
+    assert "wd-v1-4-tagger" not in result.stdout
+    assert "gpt-4o" not in result.stdout
+    assert "1 model(s)" in result.stdout
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+@patch("lorairo.cli.commands.models.get_service_container")
+def test_models_list_excludes_deprecated_by_default(mock_get_container) -> None:
+    """デフォルトでは deprecated モデルを除外する。"""
+    mock_container = MagicMock()
+    mock_container.annotator_library.list_annotator_info.return_value = [
+        _FakeAnnotatorInfo(name="gpt-4o", model_type="vision", is_local=False, is_api=True),
+        _FakeAnnotatorInfo(name="gpt-4-vision-preview", model_type="vision", is_local=False, is_api=True),
+    ]
+    mock_container.annotator_library.is_model_deprecated.side_effect = lambda model_name: (
+        model_name == "gpt-4-vision-preview"
+    )
+    mock_get_container.return_value = mock_container
+
+    result = runner.invoke(app, ["models", "list"])
+
+    assert result.exit_code == 0
+    assert "gpt-4o" in result.stdout
+    assert "gpt-4-vision-preview" not in result.stdout
+    assert "1 model(s)" in result.stdout
 
 
 @pytest.mark.unit
@@ -81,18 +221,67 @@ def test_models_list_excludes_deprecated_by_default(mock_get_container) -> None:
 def test_models_list_include_deprecated_shows_status(mock_get_container) -> None:
     """--include-deprecated は廃止済みモデルも表示する。"""
     mock_container = MagicMock()
-    mock_container.annotator_library.list_available_models.return_value = [
-        "openai/gpt-4.1-mini",
-        "openai/gpt-4-vision-preview",
+    mock_container.annotator_library.list_annotator_info.return_value = [
+        _FakeAnnotatorInfo(name="gpt-4o", model_type="vision", is_local=False, is_api=True),
+        _FakeAnnotatorInfo(name="gpt-4-vision-preview", model_type="vision", is_local=False, is_api=True),
     ]
     mock_container.annotator_library.is_model_deprecated.side_effect = lambda model_name: (
-        model_name == "openai/gpt-4-vision-preview"
+        model_name == "gpt-4-vision-preview"
     )
     mock_get_container.return_value = mock_container
 
     result = runner.invoke(app, ["models", "list", "--include-deprecated"])
 
     assert result.exit_code == 0
-    mock_container.annotator_library.list_available_models.assert_called_once_with(include_deprecated=True)
-    assert "openai/gpt-4-vision-preview" in result.stdout
+    assert "gpt-4o" in result.stdout
+    assert "gpt-4-vision-preview" in result.stdout
     assert "deprecated" in result.stdout
+    assert "2 model(s)" in result.stdout
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+@patch("lorairo.cli.commands.models.get_service_container")
+def test_models_list_invalid_type_exits_with_error(mock_get_container) -> None:
+    """--type に不正値を指定すると typer が exit_code=2 で拒否する。"""
+    mock_get_container.return_value = MagicMock()
+
+    result = runner.invoke(app, ["models", "list", "--type", "bogus"])
+
+    assert result.exit_code == 2
+    mock_get_container.return_value.annotator_library.list_annotator_info.assert_not_called()
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+@patch("lorairo.cli.commands.models.get_service_container")
+def test_models_list_handles_deprecated_check_failure(mock_get_container) -> None:
+    """is_model_deprecated 例外時は deprecated=False として継続する。"""
+    mock_container = MagicMock()
+    mock_container.annotator_library.list_annotator_info.return_value = [
+        _FakeAnnotatorInfo(name="gpt-4o", model_type="vision", is_local=False, is_api=True),
+    ]
+    mock_container.annotator_library.is_model_deprecated.side_effect = RuntimeError("network down")
+    mock_get_container.return_value = mock_container
+
+    result = runner.invoke(app, ["models", "list"])
+
+    assert result.exit_code == 0
+    assert "gpt-4o" in result.stdout
+    assert "active" in result.stdout
+    assert "1 model(s)" in result.stdout
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+@patch("lorairo.cli.commands.models.get_service_container")
+def test_models_list_empty_registry_returns_zero(mock_get_container) -> None:
+    """registry が空のとき 0件で正常終了する。"""
+    mock_container = MagicMock()
+    mock_container.annotator_library.list_annotator_info.return_value = []
+    mock_get_container.return_value = mock_container
+
+    result = runner.invoke(app, ["models", "list"])
+
+    assert result.exit_code == 0
+    assert "0 model(s)" in result.stdout

--- a/tests/unit/cli/test_commands_models.py
+++ b/tests/unit/cli/test_commands_models.py
@@ -285,3 +285,42 @@ def test_models_list_empty_registry_returns_zero(mock_get_container) -> None:
 
     assert result.exit_code == 0
     assert "0 model(s)" in result.stdout
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+@patch("lorairo.cli.commands.models.get_service_container")
+def test_models_list_long_model_names_keep_columns_visible(mock_get_container) -> None:
+    """長いモデル名でも Type/Category/Status カラムが collapse されない (Issue #220 表示バグ regression)."""
+    long_infos = [
+        _FakeAnnotatorInfo(
+            name="vercel_ai_gateway/openai/o1-very-long-model-name-2025-04-16",
+            model_type="vision",
+            is_local=False,
+            is_api=True,
+        ),
+        _FakeAnnotatorInfo(
+            name="some/very/deep/namespace/local-tagger-with-extremely-long-identifier-v3.5.2",
+            model_type="tagger",
+            is_local=True,
+            is_api=False,
+            device="cuda",
+        ),
+    ]
+    mock_container = MagicMock()
+    mock_container.annotator_library.list_annotator_info.return_value = long_infos
+    mock_container.annotator_library.is_model_deprecated.return_value = False
+    mock_get_container.return_value = mock_container
+
+    result = runner.invoke(app, ["models", "list"])
+
+    assert result.exit_code == 0
+    # Type 値 (webapi/local) が空 collapse せずに描画されること
+    assert "webapi" in result.stdout
+    assert "local" in result.stdout
+    # Category 値 (vision/tagger) が空 collapse せずに描画されること
+    assert "vision" in result.stdout
+    assert "tagger" in result.stdout
+    # Status 値 (active) が空 collapse せずに描画されること
+    assert "active" in result.stdout
+    assert "2 model(s)" in result.stdout

--- a/tests/unit/test_annotator_adapter_model_registry.py
+++ b/tests/unit/test_annotator_adapter_model_registry.py
@@ -1,10 +1,47 @@
 """AnnotatorLibraryAdapter model registry tests."""
 
+from dataclasses import dataclass
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 from lorairo.annotations.annotator_adapter import AnnotatorLibraryAdapter
+
+# --- _infer_provider のテスト用ダミー ---
+
+
+@dataclass(frozen=True)
+class _FakeAnnotatorInfo:
+    name: str
+    is_api: bool
+
+
+@pytest.mark.unit
+class TestInferProvider:
+    """_infer_provider がモデル名からプロバイダーを推論することを検証する (P1修正)。"""
+
+    def _make(self, name: str, is_api: bool) -> _FakeAnnotatorInfo:
+        return _FakeAnnotatorInfo(name=name, is_api=is_api)
+
+    def test_local_model_returns_none(self):
+        info = self._make("wd-v1-4-tagger", is_api=False)
+        assert AnnotatorLibraryAdapter._infer_provider(info) is None  # type: ignore[arg-type]
+
+    def test_claude_returns_anthropic(self):
+        info = self._make("Claude-3-Opus", is_api=True)
+        assert AnnotatorLibraryAdapter._infer_provider(info) == "anthropic"  # type: ignore[arg-type]
+
+    def test_gpt_returns_openai(self):
+        info = self._make("GPT-4o", is_api=True)
+        assert AnnotatorLibraryAdapter._infer_provider(info) == "openai"  # type: ignore[arg-type]
+
+    def test_gemini_returns_google(self):
+        info = self._make("gemini-2.5-pro", is_api=True)
+        assert AnnotatorLibraryAdapter._infer_provider(info) == "google"  # type: ignore[arg-type]
+
+    def test_unknown_api_model_returns_none(self):
+        info = self._make("unknown-cloud-model", is_api=True)
+        assert AnnotatorLibraryAdapter._infer_provider(info) is None  # type: ignore[arg-type]
 
 
 @pytest.mark.unit

--- a/tests/unit/test_annotator_adapter_model_registry.py
+++ b/tests/unit/test_annotator_adapter_model_registry.py
@@ -80,3 +80,35 @@ def test_list_available_models_switches_active_and_all() -> None:
     ):
         assert adapter.list_available_models() == ["active"]
         assert adapter.list_available_models(include_deprecated=True) == ["active", "old"]
+
+
+@pytest.mark.unit
+def test_list_annotator_info_passes_through_library_result() -> None:
+    """adapter.list_annotator_info() がライブラリ戻り値をそのまま返すことを検証する (Issue #220)."""
+    adapter = AnnotatorLibraryAdapter(MagicMock())
+    fake_infos = [
+        _FakeAnnotatorInfo(name="wd-v1-4-tagger", is_api=False),
+        _FakeAnnotatorInfo(name="gpt-4o", is_api=True),
+    ]
+
+    with patch(
+        "lorairo.annotations.annotator_adapter.list_annotator_info",
+        return_value=fake_infos,
+    ) as mock_lib:
+        result = adapter.list_annotator_info()
+
+    assert result == fake_infos
+    mock_lib.assert_called_once_with()
+
+
+@pytest.mark.unit
+def test_list_annotator_info_propagates_library_exception() -> None:
+    """ライブラリ例外は呼び出し元に伝播することを検証する (Issue #220)."""
+    adapter = AnnotatorLibraryAdapter(MagicMock())
+
+    with patch(
+        "lorairo.annotations.annotator_adapter.list_annotator_info",
+        side_effect=RuntimeError("registry not initialized"),
+    ):
+        with pytest.raises(RuntimeError, match="registry not initialized"):
+            adapter.list_annotator_info()

--- a/tests/unit/test_model_sync_service.py
+++ b/tests/unit/test_model_sync_service.py
@@ -149,6 +149,13 @@ class TestModelTypeMapping:
         result = service_with_mock._map_library_model_type_to_db("score", "aesthetic", "AestheticPredictor")
         assert result == ["score"]
 
+    def test_map_scorer_to_score(self, service_with_mock):
+        """scorerタイプ (Issue #19 の新値) をscoreにマッピング (P1修正: #scorer != #score 不一致)"""
+        result = service_with_mock._map_library_model_type_to_db(
+            "scorer", "cafe-aesthetic", "CafeAesthetic"
+        )
+        assert result == ["score"]
+
     def test_map_tagger_to_tagger(self, service_with_mock):
         """taggerタイプをtaggerにマッピング"""
         result = service_with_mock._map_library_model_type_to_db("tagger", "wd-tagger", "WDTagger")


### PR DESCRIPTION
## Summary

- Issue #220: `lorairo-cli models list` が WebAPI モデルのみ表示していた問題を修正
- `AnnotatorLibraryAdapter.list_annotator_info()` pass-through メソッドを新設し、CLI 経路を型安全な `AnnotatorInfo` で貫通
- `--type {webapi,local}` / `--category {tagger,scorer,captioner,vision}` フィルタオプションを実装、Type / Category 列を追加
- 同梱: PR #223 の Codex P1 フィードバック対応 (provider 推論 / scorer マッピング修正) を `fix(#19):` コミットとして含める

## 変更コミット

1. `849794e4 fix(#19): adapter の provider 推論と sync_service の scorer マップ追加`
   - `_infer_provider` 追加 (provider None ハードコードの実害回避)
   - `_map_library_model_type_to_db` を `"score"`/`"scorer"` 両対応に
2. `4b0cfa1a feat(#220): models list にローカルモデル表示と type/category フィルタを追加`
   - adapter: `list_annotator_info()` pass-through 追加
   - CLI: `list_models()` 刷新、フィルタ・列追加
   - adapter docstring の TODO を Phase 2 (Issue #19/#220 follow-up) へ移動

## CLI 仕様

\`\`\`bash
lorairo-cli models list                                    # 全モデル active
lorairo-cli models list --type webapi                      # WebAPI のみ
lorairo-cli models list --type local                       # ローカルのみ
lorairo-cli models list --category tagger                  # tagger のみ
lorairo-cli models list --type local --category scorer     # 組み合わせ
lorairo-cli models list --include-deprecated               # 廃止含む (既存)
\`\`\`

## Test plan

- [x] `uv run pytest tests/` で **2129 passed** (新規 +10 件、回帰なし)
- [x] `uv run ruff format` / `ruff check` クリア
- [x] `uv run mypy src/lorairo/cli/commands/models.py src/lorairo/annotations/annotator_adapter.py` クリア
- [ ] 手動確認: `uv run lorairo-cli models list` 各オプション (レビュー時に確認推奨)

## 残タスク (別 Issue として起票予定)

Phase 2: `AnnotatorLibraryProtocol` を `list[AnnotatorInfo]` に migrate
- `model_sync_service.AnnotatorLibraryProtocol` のシグネチャ変更
- `MockAnnotatorLibrary` 更新
- `provider`/`api_model_id`/`class`/`estimated_size_gb`/`discontinued_at` の取得元を `config_registry` 経由に統一
- `_infer_provider` の名前ベース推論を削除
- `get_available_models_with_metadata()` (dict 互換) の廃止
- ADR 0021 (LiteLLM 駆動 registry) との整合確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)