### PR TITLE
fix(#208): images register で単一ファイルパスを受け付けるよう拡張

### DIFF
--- a/src/lorairo/api/images.py
+++ b/src/lorairo/api/images.py
@@ -44,11 +44,10 @@ def register_images(
     container = ServiceContainer()
 
     if project_name:
-        # P2: register_images() と同じパスバリデーションを project ブランチにも適用
         if not directory_path.exists():
-            raise ImageRegistrationError(f"ディレクトリが見つかりません: {directory_path}", 0)
-        if not directory_path.is_dir():
-            raise ImageRegistrationError(f"ディレクトリではありません: {directory_path}", 0)
+            raise ImageRegistrationError(f"パスが見つかりません: {directory_path}", 0)
+        if not directory_path.is_file() and not directory_path.is_dir():
+            raise ImageRegistrationError(f"ファイルまたはディレクトリではありません: {directory_path}", 0)
 
         # プロジェクト指定時: プロジェクトを自己解決してから DB 登録を行う
         container.set_active_project(project_name)
@@ -57,6 +56,8 @@ def register_images(
         image_files = scan_service.get_image_files(directory_path)
 
         if not image_files:
+            if directory_path.is_file():
+                raise ImageRegistrationError(f"サポートされていない画像形式: {directory_path}", 0)
             return RegistrationResult(total=0, successful=0, failed=0, skipped=0)
 
         db_manager = container.db_manager

--- a/src/lorairo/cli/commands/images.py
+++ b/src/lorairo/cli/commands/images.py
@@ -107,9 +107,9 @@ def _print_update_summary(
 
 @app.command("register")
 def register(
-    directory: str = typer.Argument(
+    path: str = typer.Argument(
         ...,
-        help="Image directory path",
+        help="Image file or directory path",
     ),
     project: str = typer.Option(
         ...,
@@ -123,21 +123,21 @@ def register(
         help="Skip duplicate images (detected by pHash)",
     ),
 ) -> None:
-    """Register images from directory to project.
+    """Register images from file or directory to project.
 
-    画像ディレクトリからプロジェクトへ画像を登録します。
+    画像ファイルまたはディレクトリからプロジェクトへ画像を登録します。
     pHashを計算して重複検出を行います。
     """
     try:
-        dir_path = Path(directory).resolve()
+        input_path = Path(path).resolve()
 
-        # ディレクトリ存在確認
-        if not dir_path.exists():
-            console.print(f"[red]Error:[/red] Directory not found: {directory}")
+        # パス存在確認
+        if not input_path.exists():
+            console.print(f"[red]Error:[/red] Path not found: {path}")
             raise typer.Exit(code=1)
 
-        if not dir_path.is_dir():
-            console.print(f"[red]Error:[/red] Not a directory: {directory}")
+        if not input_path.is_file() and not input_path.is_dir():
+            console.print(f"[red]Error:[/red] Not a file or directory: {path}")
             raise typer.Exit(code=1)
 
         # プロジェクト存在確認 & DB 接続切り替え
@@ -150,10 +150,10 @@ def register(
         get_service_container().set_active_project(project)
 
         # API層経由で画像登録（プロジェクトコンテキスト付き）
-        result = api_register_images(dir_path, skip_duplicates, project_name=project)
+        result = api_register_images(input_path, skip_duplicates, project_name=project)
 
         if result.total == 0:
-            console.print(f"[yellow]Warning:[/yellow] No image files found in {directory}")
+            console.print(f"[yellow]Warning:[/yellow] No image files found in {path}")
             raise typer.Exit(code=0)
 
         _print_registration_summary(result, project)

--- a/src/lorairo/services/image_registration_service.py
+++ b/src/lorairo/services/image_registration_service.py
@@ -43,14 +43,14 @@ class ImageRegistrationService:
 
     def register_images(
         self,
-        directory: Path,
+        source: Path,
         skip_duplicates: bool = True,
         project_dir: Path | None = None,
     ) -> RegistrationResult:
-        """ディレクトリから画像を登録。
+        """ファイルまたはディレクトリから画像を登録。
 
         Args:
-            directory: 画像ファイルのソースディレクトリ。
+            source: 画像ファイルまたはソースディレクトリのパス。
             skip_duplicates: 重複画像をスキップするか。
             project_dir: プロジェクトディレクトリ。指定時は
                         image_dataset/original_images/ にコピー。
@@ -59,13 +59,14 @@ class ImageRegistrationService:
             RegistrationResult: 登録結果。
 
         Raises:
-            ImageRegistrationError: ディレクトリが見つからない場合。
+            ImageRegistrationError: パスが見つからない、または非対応形式の場合。
         """
-        if not directory.exists():
-            raise ImageRegistrationError(f"ディレクトリが見つかりません: {directory}", 0)
+        if not source.exists():
+            raise ImageRegistrationError(f"パスが見つかりません: {source}", 0)
+        if source.is_file() and source.suffix not in self.SUPPORTED_EXTENSIONS:
+            raise ImageRegistrationError(f"サポートされていない画像形式: {source}", 0)
 
-        if not directory.is_dir():
-            raise ImageRegistrationError(f"ディレクトリではありません: {directory}", 0)
+        image_files = self.get_image_files(source)
 
         # プロジェクトの画像格納先を準備
         dest_dir: Path | None = None
@@ -73,8 +74,6 @@ class ImageRegistrationService:
             dest_dir = project_dir / "image_dataset" / "original_images"
             dest_dir.mkdir(parents=True, exist_ok=True)
 
-        # 画像ファイルをスキャン
-        image_files = self._get_image_files(directory)
         logger.info(f"スキャン完了: {len(image_files)}個の画像ファイル")
 
         # 登録処理
@@ -176,16 +175,20 @@ class ImageRegistrationService:
 
         return duplicates
 
-    def get_image_files(self, directory: Path) -> list[Path]:
-        """ディレクトリから画像ファイルを取得（公開API）。
+    def get_image_files(self, source: Path) -> list[Path]:
+        """ファイルまたはディレクトリから画像ファイルを取得（公開API）。
 
         Args:
-            directory: 検索対象ディレクトリ。
+            source: 画像ファイルまたは検索対象ディレクトリ。
 
         Returns:
             list[Path]: 画像ファイルパスのリスト（ソート済み）。
         """
-        return self._get_image_files(directory)
+        if source.is_file():
+            if source.suffix in self.SUPPORTED_EXTENSIONS:
+                return [source]
+            return []
+        return self._get_image_files(source)
 
     # ==================== プライベートメソッド ====================
 

--- a/tests/unit/api/test_images_api.py
+++ b/tests/unit/api/test_images_api.py
@@ -118,6 +118,26 @@ class TestRegisterImages:
         result = register_images(d)
         assert result.total >= 3
 
+    def test_single_file_registration(self, tmp_path: Path) -> None:
+        """単一ファイルパスで登録が成功する。"""
+        img = Image.new("RGB", (100, 100), color=(100, 100, 100))
+        img_path = tmp_path / "test.jpg"
+        img.save(img_path)
+
+        result = register_images(img_path)
+
+        assert result.total == 1
+        assert result.successful == 1
+        assert result.failed == 0
+
+    def test_single_file_unsupported_format_raises_error(self, tmp_path: Path) -> None:
+        """サポート外形式の単一ファイルはImageRegistrationError。"""
+        txt_file = tmp_path / "test.txt"
+        txt_file.write_text("not an image")
+
+        with pytest.raises(ImageRegistrationError):
+            register_images(txt_file)
+
 
 @pytest.mark.unit
 @pytest.mark.usefixtures("_reset_service_container")

--- a/tests/unit/cli/test_commands_images.py
+++ b/tests/unit/cli/test_commands_images.py
@@ -526,3 +526,33 @@ def test_images_register_no_directory_arg() -> None:
     result = runner.invoke(app, ["images", "register", "--project", "test"])
 
     assert result.exit_code == 2  # 必須引数欠落
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+def test_images_register_single_file_success(mock_projects_dir: Path, tmp_path: Path) -> None:
+    """Test: images register - 単一ファイルパスで登録が成功する。"""
+    runner.invoke(app, ["project", "create", "test-project"])
+
+    img = Image.new("RGB", (100, 100), color=(100, 100, 100))
+    img_path = tmp_path / "test.jpg"
+    img.save(img_path)
+
+    result = runner.invoke(app, ["images", "register", str(img_path), "--project", "test-project"])
+
+    assert result.exit_code == 0
+    assert "Registration Summary" in result.stdout
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+def test_images_register_unsupported_file_format(mock_projects_dir: Path, tmp_path: Path) -> None:
+    """Test: images register - サポート外形式のファイルはエラー。"""
+    runner.invoke(app, ["project", "create", "test-project"])
+
+    txt_path = tmp_path / "test.txt"
+    txt_path.write_text("not an image")
+
+    result = runner.invoke(app, ["images", "register", str(txt_path), "--project", "test-project"])
+
+    assert result.exit_code == 1


### PR DESCRIPTION
## Summary

- `lorairo-cli images register <file.jpg>` が "Error: Not a directory" で弾かれていた問題を修正
- Service / API / CLI の 3 層すべてでファイルパスとディレクトリパスを両対応に変更

## 変更内容

### Service層 (`image_registration_service.py`)
- `register_images(source)`: 引数名を `directory` → `source` に変更し、ファイルパスの場合にサポート形式チェック後 `[source]` のリストで処理
- `get_image_files(source)`: ファイルパスを渡した場合にサポート形式なら `[source]`、非対応なら `[]` を返すよう拡張

### API層 (`api/images.py`)
- `project_name` 指定時のバリデーション: `is_dir()` 必須 → `is_file() or is_dir()` に変更
- サポート外形式のファイルが指定された場合は `ImageRegistrationError` を上げる

### CLI層 (`cli/commands/images.py`)
- 引数名: `directory` → `path`（位置引数なので CLI インターフェースは同一）
- ヘルプ: "Image directory path" → "Image file or directory path"
- バリデーション: `is_dir()` チェック → `is_file() or is_dir()` チェックに変更

## テスト

新規 4 テスト追加 (all PASSED):
- `test_single_file_registration` — 単一ファイルパスで登録成功
- `test_single_file_unsupported_format_raises_error` — サポート外形式のファイルはエラー
- `test_images_register_single_file_success` — CLI 単一ファイル登録成功
- `test_images_register_unsupported_file_format` — CLI サポート外形式エラー

既存 327 テスト全 PASSED（リグレッションなし）

Closes #208

🤖 Generated with [Claude Code](https://claude.com/claude-code)