### PR TITLE
docs(adr-0023): 同期 wrapper のサポート対象実行環境スコープを明記

### DIFF
--- a/docs/decisions/0023-pydanticai-litellm-webapi-inference-boundary.md
+++ b/docs/decisions/0023-pydanticai-litellm-webapi-inference-boundary.md
@@ -381,6 +381,35 @@ resolved_at IS NULL
 - running loop を検出した場合は thread fallback せず、async API 利用を促す明示エラーを返す
 - 将来問題が出た場合は、呼び出し側の async 化または worker 実行方式を別 issue で調整する
 
+#### サポート対象実行環境とスコープ
+
+`image-annotator-lib` は **LoRAIro 専用 submodule** として運用される前提で設計されている。
+LoRAIro は WebAPI annotation を Qt worker (`QRunnable` on `QThreadPool`,
+`src/lorairo/gui/workers/`) で実行し、Qt event loop は asyncio とは別系統のため
+worker thread には running asyncio loop が存在しない。本 ADR の sync wrapper は
+この想定のもと `asyncio.run()` 経由で動作する。
+
+サポート対象の実行環境:
+
+- LoRAIro の Qt worker (`QRunnable` / `QThreadPool`)
+- 通常の Python CLI / script (`python -m image_annotator_lib...`)
+- pytest 同期テスト (asyncio loop なし)
+
+サポート対象外の実行環境:
+
+- Jupyter notebook / IPython kernel (kernel が asyncio loop を保持する)
+- FastAPI handler / asyncio web framework の handler 内
+- 既に `asyncio.run()` 内の任意の async コンテキスト
+
+これらの環境で `image_annotator_lib.annotate()` を呼ぶと sync wrapper の running
+loop 検出ロジックにより `InferenceError` が raise される。本ライブラリを直接利用する
+外部コードがこの制約を超える要件を持った場合は、別 issue で公開 `annotate_async()` の
+追加または `nest_asyncio` 等の代替を再評価する。
+
+[Codex review on PR #38](https://github.com/NEXTAltair/image-annotator-lib/pull/38#discussion_r3204194306)
+で同問題が指摘されたが、上記の実行環境スコープに基づき現状の `InferenceError`
+fail-fast を維持する判断とした。
+
 ### 実行経路 (確定版)
 
 1. LiteLLM 同梱 DB を起動時に読み、`SUPPORTED_PROVIDERS` と capability で filter して registry を構築


### PR DESCRIPTION
## Summary

ADR [0023](docs/decisions/0023-pydanticai-litellm-webapi-inference-boundary.md) の `Async execution` セクションに sub-section 「サポート対象実行環境とスコープ」を追加し、image-annotator-lib の sync wrapper がサポートする実行環境と対象外環境を明示する。

## Context

[Codex review on image-annotator-lib#38 (discussion_r3204194306)](https://github.com/NEXTAltair/image-annotator-lib/pull/38#discussion_r3204194306) で、新 sync wrapper が running asyncio loop 内では `InferenceError` を raise する点を regression として指摘された。しかし image-annotator-lib は LoRAIro 専用 submodule として運用され、LoRAIro 側は Qt worker (`QRunnable` on `QThreadPool`) から `annotate()` を呼ぶ。Qt event loop は asyncio とは別系統で worker thread には running asyncio loop が存在しないため、現状の sync wrapper でも問題なく動作する。

本 PR では「LoRAIro 専用利用想定」を ADR で明示し、Jupyter / FastAPI / asyncio web framework 等の実行環境はサポート対象外として fail-fast を維持する判断を文書化する。

## What changed

`docs/decisions/0023-pydanticai-litellm-webapi-inference-boundary.md` の `### Async execution` セクションに以下を追加:

- **サポート対象**: LoRAIro Qt worker / 通常 Python CLI・script / pytest 同期テスト
- **サポート対象外**: Jupyter notebook / FastAPI handler / 既に `asyncio.run()` 内の async コンテキスト
- Codex review への参照と、現状の fail-fast 維持判断の根拠

## Test plan

- [x] ADR 編集のみ (コード変更なし)
- [x] markdown rendering 確認

## Related

- Codex review: [image-annotator-lib#38 discussion_r3204194306](https://github.com/NEXTAltair/image-annotator-lib/pull/38#discussion_r3204194306)
- Phase 1 実装 PR: [image-annotator-lib#38](https://github.com/NEXTAltair/image-annotator-lib/pull/38)

🤖 Generated with [Claude Code](https://claude.com/claude-code)