### PR TITLE
feat(#36): ADR 0023 Phase 1 - image-annotator-lib submodule pointer 更新と adapter 追従

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -135,14 +135,22 @@ graph TD
 
 ### AI Integration Architecture
 
-**Multi-Provider Support**: OpenAI, Anthropic, Google, Local ML models via `image-annotator-lib`
+**Multi-Provider Support**: OpenAI, Anthropic, Google, OpenRouter, Local ML models via `image-annotator-lib`
 
 **Key Integration**:
 - **AnnotationWorker**: Primary AI coordination
 - **image-annotator-lib**: Unified provider interface
 - **Local Models**: CLIP, DeepDanbooru, ONNX/TensorFlow support
 
-**Design decisions**: `docs/decisions/0003-annotator-config-management.md`, `docs/decisions/0004-annotator-lib-architecture.md`
+**WebAPI 推論経路の責務分離 (ADR 0023 Phase 1)**:
+- **discovery / capability metadata**: LiteLLM 同梱 DB を runtime SSoT (`available_api_models.toml` キャッシュ廃止)
+- **推論実行 / multimodal input / structured output / output retry**: PydanticAI native provider/model
+- **LiteLLM ID と PydanticAI 実行 descriptor mapping**: `image-annotator-lib/core/model_id.py`
+- **API key 注入**: provider object への明示注入のみ (`os.environ` mutate 全廃)
+- **Agent / Provider / Model**: 推論呼び出しごとに新規作成 (キャッシュなし)
+- **対応 provider**: OpenAI / Anthropic / Google / OpenRouter (Phase 1 スコープ)
+
+**Design decisions**: `docs/decisions/0003-annotator-config-management.md`, `docs/decisions/0004-annotator-lib-architecture.md`, `docs/decisions/0023-pydanticai-litellm-webapi-inference-boundary.md`
 
 ### Storage Architecture
 

--- a/src/lorairo/annotations/annotator_adapter.py
+++ b/src/lorairo/annotations/annotator_adapter.py
@@ -105,19 +105,20 @@ class AnnotatorLibraryAdapter:
             estimated_size_gb=info.estimated_size_gb,
         )
 
-    def refresh_available_models(self, force_refresh: bool = True) -> list[str]:
-        """WebAPIモデル一覧を強制更新し、利用可能なモデルIDを返す。"""
-        try:
-            logger.info("image-annotator-libモデル一覧の手動更新を開始")
-            result = discover_available_vision_models(force_refresh=force_refresh)
-            if "error" in result:
-                raise RuntimeError(result["error"])
+    def refresh_available_models(self) -> list[str]:
+        """WebAPIモデル一覧を取得し、利用可能なモデルIDを返す。
 
+        ADR 0023 Phase 1 で `force_refresh` 引数は廃止された。LiteLLM 同梱 DB を
+        runtime SSoT として直接参照するため、refresh 概念が消失している。
+        """
+        try:
+            logger.info("image-annotator-libモデル一覧の取得を開始")
+            result = discover_available_vision_models()
             models = cast(list[str], result.get("models", []))
-            logger.info(f"image-annotator-libモデル一覧更新完了: {len(models)}件")
+            logger.info(f"image-annotator-libモデル一覧取得完了: {len(models)}件")
             return models
         except Exception:
-            logger.error("image-annotator-libモデル一覧更新エラー", exc_info=True)
+            logger.error("image-annotator-libモデル一覧取得エラー", exc_info=True)
             raise
 
     def list_available_models(self, include_deprecated: bool = False) -> list[str]:

--- a/src/lorairo/cli/commands/models.py
+++ b/src/lorairo/cli/commands/models.py
@@ -48,7 +48,7 @@ def refresh(
         if project is not None:
             container.set_active_project(project)
         console.print("[cyan]Refreshing model registry...[/cyan]")
-        models = container.annotator_library.refresh_available_models(force_refresh=True)
+        models = container.annotator_library.refresh_available_models()
         sync_result = container.model_sync_service.sync_available_models()
 
         if sync_result.errors:

--- a/src/lorairo/gui/widgets/model_selection_widget.py
+++ b/src/lorairo/gui/widgets/model_selection_widget.py
@@ -50,7 +50,7 @@ if not __name__ == "__main__":
         def run(self) -> None:
             try:
                 service_container = get_service_container()
-                models = service_container.annotator_library.refresh_available_models(force_refresh=True)
+                models = service_container.annotator_library.refresh_available_models()
                 sync_result = service_container.model_sync_service.sync_available_models()
 
                 if sync_result.errors:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -71,7 +71,7 @@ _ial_mock.config_registry = unittest.mock.MagicMock()
 _ial_mock.config_registry.get = unittest.mock.MagicMock(side_effect=lambda name, key, default=None: default)
 _ial_mock.init_logger = unittest.mock.MagicMock()
 _ial_mock.discover_available_vision_models = unittest.mock.MagicMock(
-    return_value={"models": [], "toml_data": {}}
+    return_value={"models": [], "metadata": {}}
 )
 _ial_mock.list_all_models = unittest.mock.MagicMock(return_value=[])
 _ial_mock.is_model_deprecated = unittest.mock.MagicMock(return_value=False)

--- a/tests/unit/cli/test_commands_models.py
+++ b/tests/unit/cli/test_commands_models.py
@@ -59,7 +59,7 @@ def test_models_refresh_updates_registry(mock_get_container) -> None:
     result = runner.invoke(app, ["models", "refresh"])
 
     assert result.exit_code == 0
-    mock_container.annotator_library.refresh_available_models.assert_called_once_with(force_refresh=True)
+    mock_container.annotator_library.refresh_available_models.assert_called_once_with()
     mock_container.model_sync_service.sync_available_models.assert_called_once()
     assert "Model registry refreshed" in result.stdout
 

--- a/tests/unit/test_annotator_adapter_model_registry.py
+++ b/tests/unit/test_annotator_adapter_model_registry.py
@@ -38,24 +38,29 @@ def test_refresh_available_models_returns_discovered_models() -> None:
 
     with patch(
         "lorairo.annotations.annotator_adapter.discover_available_vision_models",
-        return_value={"models": ["openai/gpt-4.1-mini"], "toml_data": {}},
+        return_value={"models": ["openai/gpt-4.1-mini"], "metadata": {}},
     ) as mock_discover:
-        result = adapter.refresh_available_models(force_refresh=True)
+        result = adapter.refresh_available_models()
 
     assert result == ["openai/gpt-4.1-mini"]
-    mock_discover.assert_called_once_with(force_refresh=True)
+    mock_discover.assert_called_once_with()
 
 
 @pytest.mark.unit
 def test_refresh_available_models_raises_on_discovery_error() -> None:
+    """ADR 0023 Phase 1: 旧 API の `{"error": ...}` 戻り値経路は廃止された。
+
+    新 `discover_available_vision_models()` は例外を内部で catch せず raise するため、
+    adapter の `except Exception:` で受け再 raise されることを検証する。
+    """
     adapter = AnnotatorLibraryAdapter(MagicMock())
 
     with patch(
         "lorairo.annotations.annotator_adapter.discover_available_vision_models",
-        return_value={"error": "network unavailable"},
+        side_effect=RuntimeError("network unavailable"),
     ):
         with pytest.raises(RuntimeError, match="network unavailable"):
-            adapter.refresh_available_models(force_refresh=True)
+            adapter.refresh_available_models()
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary

Phase 1 完了 ([image-annotator-lib PR #38](https://github.com/NEXTAltair/image-annotator-lib/pull/38)) に追従するための LoRAIro 親側変更。submodule pointer を進め、新 API に合わせて `AnnotatorLibraryAdapter` と関連 caller / テスト / ドキュメントを更新する。

ADR [0023](docs/decisions/0023-pydanticai-litellm-webapi-inference-boundary.md) に基づき、`image-annotator-lib` の WebAPI 推論経路は LiteLLM 同梱 DB を runtime SSoT として、PydanticAI native provider/model で推論する 1 ルート構成に統一された。本 PR ではその後方互換のない API 変更を LoRAIro 側で受ける。

## What changed

### submodule pointer
- `local_packages/image-annotator-lib`: `0281240` → `a9861bd` (PR #38 merge commit)

### `src/lorairo/annotations/annotator_adapter.py` 改修
- `refresh_available_models()` の `force_refresh` 引数を廃止 (新 API では runtime LiteLLM call のみで refresh 概念が消失)
- `discover_available_vision_models()` 戻り値の `toml_data` キー参照を削除 (新 schema は `metadata` キー、LoRAIro 側は `models` キーしか参照していないため動作への影響なし)
- 旧 API の `{"error": ...}` 戻り値経路は廃止 (新 API は raise) のため `if "error" in result` の defensive チェックを削除

### caller 追従 (signature 変更)
- `src/lorairo/cli/commands/models.py`
- `src/lorairo/gui/widgets/model_selection_widget.py`

### テスト追従
- `tests/conftest.py`: `discover_available_vision_models` mock 戻り値を `{"models": [], "metadata": {}}` に変更
- `tests/unit/test_annotator_adapter_model_registry.py`: `force_refresh=True` の渡し / アサート箇所を削除、error 経路テストを `side_effect=RuntimeError(...)` ベースに書換
- `tests/unit/cli/test_commands_models.py`: `assert_called_once_with(force_refresh=True)` → `assert_called_once_with()`

### ドキュメント
- `docs/architecture.md` の AI Integration Architecture セクションに ADR 0023 Phase 1 の責務分離 (LiteLLM SSoT, PydanticAI 推論実行, `model_id` mapping, API key 明示注入, Agent キャッシュなし, Phase 1 対応 4 provider) を追記

## Test plan

- [x] `uv run pytest tests/unit/test_annotator_adapter_model_registry.py tests/unit/cli/test_commands_models.py` — 21/21 PASS
- [x] `ruff format` / `ruff check` クリア
- [ ] `uv run pytest -m unit` — full unit test (CI で確認)
- [ ] `uv run pytest -m integration` — full integration test (CI で確認)
- [ ] `uv run mypy -p lorairo` — type 検証 (CI で確認)
- [ ] GUI ヘッドレス起動 (`QT_QPA_PLATFORM=offscreen uv run lorairo`) で WebAPI モデル一覧表示確認 (手動検証)

## Out of scope (別 Issue として後続)

- SafetyRefusalError / ContentPolicyRefusalError と `AnnotationSaveService.error_records` 統合 (Phase 1.5)
- [Issue image-annotator-lib#35](https://github.com/NEXTAltair/image-annotator-lib/issues/35): WebAPI 経路で `determine_effective_device` 呼び出し削除
- [Issue image-annotator-lib#39](https://github.com/NEXTAltair/image-annotator-lib/issues/39): OpenRouter と直接プロバイダーの選択ロジック設計

## Related

- ADR 0023: `docs/decisions/0023-pydanticai-litellm-webapi-inference-boundary.md`
- ADR 0023 注記追記: PR #229 (merged)
- image-annotator-lib Phase 1 実装: [PR #38](https://github.com/NEXTAltair/image-annotator-lib/pull/38) (merged)
- Closes #36 (LoRAIro 側で対応する場合のリファレンス。Issue は image-annotator-lib 側のため自動 close 不可)

🤖 Generated with [Claude Code](https://claude.com/claude-code)