### PR TITLE
fix(#241): API key 状況に応じたモデル表示フィルタと事前 validation

### DIFF
--- a/config/lorairo.toml.template
+++ b/config/lorairo.toml.template
@@ -14,6 +14,7 @@ scale = 4.0
 openai_key = ""
 claude_key = ""
 google_key = ""
+openrouter_key = ""
 
 [directories]
 database_dir = ""

--- a/src/lorairo/annotations/annotator_adapter.py
+++ b/src/lorairo/annotations/annotator_adapter.py
@@ -202,7 +202,7 @@ class AnnotatorLibraryAdapter:
 
         Returns:
             dict[str, str]: APIキー辞書
-                - キー: プロバイダー名（"openai", "anthropic", "google"）
+                - キー: プロバイダー名（"openai", "anthropic", "google", "openrouter"）
                 - 値: APIキー文字列
 
         Note:
@@ -210,10 +210,12 @@ class AnnotatorLibraryAdapter:
             ログ出力時はマスキングされる。
         """
         # ConfigurationServiceから各プロバイダーのAPIキーを取得
+        # Issue #241: openrouter は同一モデルを別 route で扱うため独立した key として保持
         api_keys = {
             "openai": self.config_service.get_setting("api", "openai_key", ""),
             "anthropic": self.config_service.get_setting("api", "claude_key", ""),
             "google": self.config_service.get_setting("api", "google_key", ""),
+            "openrouter": self.config_service.get_setting("api", "openrouter_key", ""),
         }
 
         # 空のキーを除外（空文字列や空白のみの文字列を除く）

--- a/src/lorairo/cli/commands/annotate.py
+++ b/src/lorairo/cli/commands/annotate.py
@@ -34,6 +34,7 @@ from lorairo.api.exceptions import (
 )
 from lorairo.api.project import get_project as api_get_project
 from lorairo.database.filter_criteria import ImageFilterCriteria
+from lorairo.services.model_route_service import validate_api_keys_for_models
 from lorairo.services.service_container import get_service_container
 from lorairo.utils.log import logger
 
@@ -214,6 +215,57 @@ def _resolve_model_identifier(repository: ImageRepository, identifier: str) -> s
     raise typer.Exit(code=1)
 
 
+def _validate_required_api_keys(
+    repository: ImageRepository,
+    config: Any,
+    resolved_litellm_ids: list[str],
+) -> None:
+    """Issue #241: 実行直前に API key 不足を検出し、不足時は ``typer.Exit(1)``。
+
+    旧実装は「3 種類キー全部無いとき警告」だけで、片方の provider key のみ設定
+    された環境で OpenRouter 経由モデルを選ぶと library 内で ``MissingApiKeyError``
+    が出てから失敗していた。本 helper は registry key (litellm_model_id) の prefix
+    と DB ``Model.provider`` を hint として provider 別の不足を列挙する。
+
+    Args:
+        repository: LoRAIro DB リポジトリ (Model.provider 解決用)。
+        config: ``ConfigurationService`` 互換 (``get_setting`` を持つ)。
+        resolved_litellm_ids: ``_resolve_model_identifier()`` で解決済みの
+            ``litellm_model_id`` リスト。
+
+    Raises:
+        typer.Exit: 不足ありの場合 (code=1)。エラーメッセージに不足 provider と
+            litellm_id を列挙する。
+    """
+    api_keys = {
+        "openai": config.get_setting("api", "openai_key", ""),
+        "anthropic": config.get_setting("api", "claude_key", ""),
+        "google": config.get_setting("api", "google_key", ""),
+        "openrouter": config.get_setting("api", "openrouter_key", ""),
+    }
+
+    provider_hints: dict[str, str] = {}
+    for litellm_id in resolved_litellm_ids:
+        db_model = repository.get_model_by_litellm_id(litellm_id)
+        if db_model is not None and db_model.provider:
+            provider_hints[litellm_id] = db_model.provider
+
+    missing = validate_api_keys_for_models(resolved_litellm_ids, api_keys, provider_hints)
+    if not missing:
+        return
+
+    console.print("[red]Error:[/red] Missing API keys for selected models:")
+    for litellm_id, missing_provider in missing:
+        console.print(f"  - {missing_provider}: required for {litellm_id}")
+    # Rich console は `[api]` のような bracket を tag として解釈するので、開く側のみ `\[` で escape する。
+    console.print(
+        "\nConfigure the missing keys in config/lorairo.toml \\[api] section, "
+        "or pick a different route (e.g. `--model openai/...` instead of "
+        "`--model openrouter/openai/...`)."
+    )
+    raise typer.Exit(code=1)
+
+
 @app.command("run")
 def run(
     project: str = typer.Option(
@@ -305,19 +357,11 @@ def run(
         for deprecated_model in deprecated_models:
             console.print(f"[yellow]Warning: Model '{deprecated_model}' is deprecated[/yellow]")
 
-        # APIキー確認
-        api_keys = {
-            "openai": config.get_setting("api", "openai_key", ""),
-            "anthropic": config.get_setting("api", "claude_key", ""),
-            "google": config.get_setting("api", "google_key", ""),
-        }
-        api_keys = {k: v for k, v in api_keys.items() if v and v.strip()}
-
-        if not api_keys:
-            console.print(
-                "[yellow]Warning:[/yellow] No API keys configured. "
-                "Consider setting API keys in config/lorairo.toml"
-            )
+        # Issue #241: 実行直前に LoRAIro 側で API key 不足を事前検出する。
+        # 旧実装は「3 種類キー全部無いとき警告」だけで、片方の provider key だけ
+        # 設定されていて選択モデルがもう片方を要求する場合に library 内で
+        # MissingApiKeyError が出てから初めて失敗していた。
+        _validate_required_api_keys(repository, config, resolved_litellm_ids)
 
         # アノテーション実行
         console.print("[cyan]Starting annotation...[/cyan]")

--- a/src/lorairo/cli/commands/models.py
+++ b/src/lorairo/cli/commands/models.py
@@ -8,6 +8,12 @@ import typer
 from rich.console import Console
 from rich.table import Table
 
+from lorairo.services.model_route_service import (
+    build_available_providers,
+    canonical_key,
+    detect_route,
+    required_provider_for,
+)
 from lorairo.services.service_container import get_service_container
 from lorairo.utils.log import logger
 
@@ -31,6 +37,15 @@ class ModelCategoryFilter(StrEnum):
     scorer = "scorer"
     captioner = "captioner"
     vision = "vision"
+
+
+class RouteFilter(StrEnum):
+    """`models list` の `--route` フィルタ値 (Issue #241)。"""
+
+    auto = "auto"
+    direct = "direct"
+    openrouter = "openrouter"
+    all = "all"
 
 
 @app.command("refresh")
@@ -87,14 +102,40 @@ def list_models(
         case_sensitive=False,
         help="Filter by model category (all / tagger / scorer / captioner / vision)",
     ),
+    route: RouteFilter = typer.Option(
+        RouteFilter.auto,
+        "--route",
+        case_sensitive=False,
+        help=(
+            "Route preference (Issue #241). "
+            "auto: API key 設定済み provider に応じて direct を優先 / "
+            "direct: 直接プロバイダー経路のみ / "
+            "openrouter: OpenRouter 経由のみ / "
+            "all: 同一モデルの全 route を 1 行ずつ表示"
+        ),
+    ),
 ) -> None:
-    """List available annotator models (WebAPI + local)."""
+    """List available annotator models (WebAPI + local).
+
+    Issue #241: 同一モデルが direct / openrouter 経路で 2 行並ぶ重複を畳み込み、
+    API key 設定済み provider を優先 route として 1 行にまとめる。
+    ``--route all`` を指定した場合のみ全 candidate を 1 行ずつ表示する。
+    """
     try:
         container = get_service_container()
         annotator = container.annotator_library
         infos = annotator.list_annotator_info()
 
-        rows: list[tuple[str, str, str, str, str, bool]] = []
+        config = container.config_service
+        api_keys = {
+            "openai": config.get_setting("api", "openai_key", ""),
+            "anthropic": config.get_setting("api", "claude_key", ""),
+            "google": config.get_setting("api", "google_key", ""),
+            "openrouter": config.get_setting("api", "openrouter_key", ""),
+        }
+        available_providers = build_available_providers(api_keys)
+
+        rows: list[dict[str, str | bool]] = []
         for info in infos:
             if type_filter is ModelTypeFilter.webapi and not info.is_api:
                 continue
@@ -116,35 +157,126 @@ def list_models(
             # Issue #245: Provider と Litellm ID を表示し、route の区別を可能にする。
             provider_label = info.provider or ("local" if info.is_local else "unknown")
             litellm_id = info.litellm_model_id or info.name
-            rows.append((info.name, provider_label, litellm_id, type_label, info.model_type, deprecated))
+            row_route = detect_route(litellm_id)
+            row_required = required_provider_for(litellm_id, info.provider)
+            rows.append(
+                {
+                    "name": info.name,
+                    "provider": provider_label,
+                    "litellm_id": litellm_id,
+                    "type_label": type_label,
+                    "category": info.model_type,
+                    "deprecated": deprecated,
+                    "route": row_route,
+                    "required_provider": row_required,
+                }
+            )
+
+        # Issue #241: canonical_key で grouping し、--route preference に従って絞り込む。
+        display_rows = _apply_route_filter(rows, route, available_providers)
 
         # 長いモデル名 (例: "vercel_ai_gateway/openai/o1") で固定幅未指定のままだと
         # Rich Table が Type/Category/Status を 0 幅に collapse させて Issue #220 の
         # 主要機能 (Type 列で local/webapi 区別) が視認できなくなる。各カラムに
         # min_width を指定し、Model/Provider/Litellm ID カラムは折返し許容で長さに対応する。
-        # Issue #245: Provider/Litellm ID 列を追加。80 col 端末でも Status 列まで表示
-        # されるよう全列 min_width 合計を 70 以下に抑える。
+        # Issue #245: Provider/Litellm ID 列を追加。
+        # Issue #241: Route 列を追加 (direct / openrouter)。
         table = Table(title="Available Models")
         table.add_column("Model", style="cyan", overflow="fold", min_width=10)
         table.add_column("Provider", style="bright_magenta", overflow="fold", min_width=8)
         table.add_column("Litellm ID", style="bright_cyan", overflow="fold", min_width=10)
+        table.add_column("Route", style="bright_blue", min_width=8, no_wrap=True)
         table.add_column("Type", style="magenta", min_width=6, no_wrap=True)
         table.add_column("Category", style="blue", min_width=8, no_wrap=True)
         table.add_column("Status", style="green", min_width=10, no_wrap=True)
 
-        for name, provider_label, litellm_id, type_label, model_category, deprecated in rows:
+        for row in display_rows:
             table.add_row(
-                name,
-                provider_label,
-                litellm_id,
-                type_label,
-                model_category,
-                "[yellow]deprecated[/yellow]" if deprecated else "active",
+                str(row["name"]),
+                str(row["provider"]),
+                str(row["litellm_id"]),
+                str(row["route"]),
+                str(row["type_label"]),
+                str(row["category"]),
+                "[yellow]deprecated[/yellow]" if row["deprecated"] else "active",
             )
 
         console.print(table)
-        console.print(f"[dim]{len(rows)} model(s)[/dim]")
+        console.print(f"[dim]{len(display_rows)} model(s) (preference={route.value})[/dim]")
     except Exception as e:
         console.print(f"[red]Error:[/red] Failed to list models: {e}")
         logger.error(f"Model list command failed: {e}", exc_info=True)
         raise typer.Exit(code=1) from e
+
+
+def _apply_route_filter(
+    rows: list[dict[str, str | bool]],
+    route: RouteFilter,
+    available_providers: set[str],
+) -> list[dict[str, str | bool]]:
+    """Issue #241: AnnotatorInfo 由来の row リストに canonical_key 畳み込みと route 選択を適用。
+
+    Args:
+        rows: ``list_models()`` で構築した row dict 群。各 row には
+            ``litellm_id``, ``route``, ``required_provider`` が含まれる前提。
+        route: ``--route`` Typer Option の値。
+        available_providers: API key 設定済み provider 集合。
+
+    Returns:
+        表示用 row のリスト。``route="all"`` の場合は元 row を全件、それ以外は
+        canonical_key 単位で preferred row を 1 件ずつ返す。
+    """
+    grouped, order = _group_rows_by_canonical_key(rows)
+
+    if route is RouteFilter.all:
+        return [row for ckey in order for row in grouped[ckey]]
+
+    result: list[dict[str, str | bool]] = []
+    for ckey in order:
+        chosen = _pick_row_for_route(grouped[ckey], route, available_providers)
+        if chosen is not None:
+            result.append(chosen)
+    return result
+
+
+def _group_rows_by_canonical_key(
+    rows: list[dict[str, str | bool]],
+) -> tuple[dict[str, list[dict[str, str | bool]]], list[str]]:
+    """canonical_key で row を grouping し、入力順を保持した key リストも返す。"""
+    grouped: dict[str, list[dict[str, str | bool]]] = {}
+    order: list[str] = []
+    for row in rows:
+        litellm_id = str(row["litellm_id"])
+        ckey = canonical_key(litellm_id)
+        if ckey not in grouped:
+            grouped[ckey] = []
+            order.append(ckey)
+        grouped[ckey].append(row)
+    return grouped, order
+
+
+def _pick_row_for_route(
+    group_rows: list[dict[str, str | bool]],
+    route: RouteFilter,
+    available_providers: set[str],
+) -> dict[str, str | bool] | None:
+    """同一 canonical_key の row 群から ``--route`` 値に応じて 1 件選ぶ。
+
+    auto モードは direct を優先しつつ ``available_providers`` を考慮し、
+    どちらも未設定の場合は direct (なければ openrouter) を disabled 表示用に返す。
+    """
+    by_route: dict[str, dict[str, str | bool]] = {str(r["route"]): r for r in group_rows}
+    direct = by_route.get("direct")
+    openrouter = by_route.get("openrouter")
+
+    if route is RouteFilter.direct:
+        return direct
+    if route is RouteFilter.openrouter:
+        return openrouter
+
+    # auto
+    if direct is not None and str(direct["required_provider"]) in available_providers:
+        return direct
+    if openrouter is not None and str(openrouter["required_provider"]) in available_providers:
+        return openrouter
+    return direct or openrouter

--- a/src/lorairo/gui/controllers/annotation_workflow_controller.py
+++ b/src/lorairo/gui/controllers/annotation_workflow_controller.py
@@ -11,6 +11,7 @@ from PySide6.QtWidgets import QMessageBox, QWidget
 
 from lorairo.gui.services.worker_service import WorkerService
 from lorairo.services.configuration_service import ConfigurationService
+from lorairo.services.model_route_service import validate_api_keys_for_models
 from lorairo.services.selection_state_service import SelectionStateService
 from lorairo.services.service_container import get_service_container
 
@@ -96,6 +97,13 @@ class AnnotationWorkflowController:
                 return
 
             if self._warn_deprecated_models(models_to_use) is False:
+                return
+
+            # Issue #241: 実行直前に API key 不足を検出する。
+            # 旧実装は WorkerService 内で library 呼び出し時に MissingApiKeyError が
+            # 出るまで失敗を検出できなかった。直接プロバイダー key のみ持つ環境で
+            # `openrouter/...` モデルを誤選択した場合などをここで止める。
+            if self._validate_api_keys_for_models(models_to_use) is False:
                 return
 
             # Step 4: バッチアノテーション開始
@@ -266,6 +274,59 @@ class AnnotationWorkflowController:
             QMessageBox.StandardButton.Ok,
         )
         return reply == QMessageBox.StandardButton.Ok
+
+    def _validate_api_keys_for_models(self, litellm_model_ids: list[str]) -> bool:
+        """Issue #241: 実行直前に API key 不足を検出し、不足時は QMessageBox.warning を表示。
+
+        ``selection_includes_webapi_model`` のような registry 経由判定とは異なり、
+        provider 単位の不足を ``(litellm_model_id, missing_provider)`` ペアで列挙する。
+        DB から ``Model.provider`` を hint として取得して判定精度を上げる。
+
+        Args:
+            litellm_model_ids: 実行直前に検証するモデルの ``litellm_model_id`` リスト。
+
+        Returns:
+            bool: 不足なしの場合 True、不足ありで abort する場合 False。
+        """
+        try:
+            api_keys = {
+                "openai": self.config_service.get_setting("api", "openai_key", ""),
+                "anthropic": self.config_service.get_setting("api", "claude_key", ""),
+                "google": self.config_service.get_setting("api", "google_key", ""),
+                "openrouter": self.config_service.get_setting("api", "openrouter_key", ""),
+            }
+
+            repository = get_service_container().image_repository
+            provider_hints: dict[str, str] = {}
+            for litellm_id in litellm_model_ids:
+                model = repository.get_model_by_litellm_id(litellm_id)
+                if model is not None and model.provider:
+                    provider_hints[litellm_id] = model.provider
+
+            missing = validate_api_keys_for_models(litellm_model_ids, api_keys, provider_hints)
+        except Exception as e:
+            logger.warning(f"API key validation 中にエラー発生、検証 skip して続行: {e}")
+            return True
+
+        if not missing:
+            return True
+
+        lines = "\n".join(f"  - {provider}: {litellm_id}" for litellm_id, provider in missing)
+        message = (
+            "選択されたモデルに必要な API キーが設定されていません。\n\n"
+            f"{lines}\n\n"
+            "config/lorairo.toml の [api] セクションに該当プロバイダーのキーを設定するか、"
+            "別の route のモデル (例: openrouter/... の代わりに直接プロバイダーのモデル) を選択してください。"
+        )
+        logger.warning(f"API key 不足 (実行中止): {missing}")
+
+        if self.parent is not None:
+            QMessageBox.warning(
+                self.parent,
+                "API キー未設定",
+                message,
+            )
+        return False
 
     def _start_batch_annotation(self, image_paths: list[str], litellm_model_ids: list[str]) -> None:
         """バッチアノテーション開始

--- a/src/lorairo/gui/widgets/model_checkbox_widget.py
+++ b/src/lorairo/gui/widgets/model_checkbox_widget.py
@@ -11,7 +11,7 @@ ModelSelectionWidgetから分離された機能を提供
 - 機能タグの表示
 """
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 from PySide6.QtCore import Qt, Signal, Slot
 from PySide6.QtWidgets import QWidget
@@ -28,6 +28,11 @@ class ModelInfo:
     `litellm_model_id` は registry/route 判別キー (`Model.litellm_model_id`、UNIQUE)。
     同 `name` で `provider` が異なる行 (migration 経由 OpenRouter vs 新規 sync 直接版)
     が共存しうるため、内部キーは `litellm_model_id` を使うこと。
+
+    Issue #241: 同一モデルが direct / openrouter 経路で別エントリ登録される
+    仕様 (image-annotator-lib #39 / #51 / #52) に対し、UI 表示は preferred route の
+    1 行に畳む。``route`` は preferred の経路 ("direct" / "openrouter")、
+    ``alternatives`` は同一 canonical key の代替 route の litellm_model_id 群。
     """
 
     name: str
@@ -36,6 +41,8 @@ class ModelInfo:
     litellm_model_id: str
     is_local: bool = False
     requires_api_key: bool = True
+    route: str = "direct"
+    alternatives: tuple[str, ...] = field(default_factory=tuple)
 
 
 # プロバイダー別スタイル定義（PySide6パレット機能でダークモード自動対応）
@@ -118,11 +125,23 @@ class ModelCheckboxWidget(QWidget, Ui_ModelCheckboxWidget):
         共存しうる (migration 経由 OpenRouter vs 新規 sync 直接版)。視覚的に
         区別できるよう、ラベル末尾に `(provider)` を併記し、tooltip に正規
         ルーティングキー `litellm_model_id` を載せる。
+
+        Issue #241: 同一モデルの 2 経路を 1 行に畳んだ後、preferred が OpenRouter
+        経由の場合は ``[openrouter]`` badge をラベルに付与し、tooltip に
+        ``Alternative: <litellm_id>`` 行を追加して代替 route を提示する。
         """
         try:
-            # モデル名設定 (provider 併記で同 name 異 route 行を区別)
-            self.labelModelName.setText(f"{self.model_info.name} ({self.model_info.provider})")
-            self.labelModelName.setToolTip(self.model_info.litellm_model_id)
+            # モデル名設定 (provider 併記 + Issue #241: openrouter 経路の場合は badge)
+            base_label = f"{self.model_info.name} ({self.model_info.provider})"
+            if self.model_info.route == "openrouter":
+                base_label = f"{base_label} [openrouter]"
+            self.labelModelName.setText(base_label)
+
+            # tooltip: litellm_model_id + alternatives
+            tooltip_lines = [self.model_info.litellm_model_id]
+            for alt_id in self.model_info.alternatives:
+                tooltip_lines.append(f"Alternative: {alt_id}")
+            self.labelModelName.setToolTip("\n".join(tooltip_lines))
 
             # プロバイダー表示設定
             provider_display = "ローカル" if self.model_info.is_local else self.model_info.provider.title()

--- a/src/lorairo/gui/widgets/model_selection_widget.py
+++ b/src/lorairo/gui/widgets/model_selection_widget.py
@@ -27,6 +27,11 @@ else:
     # 通常実行時は相対インポート使用
     from ...gui.designer.ModelSelectionWidget_ui import Ui_ModelSelectionWidget
     from ...services import get_service_container
+    from ...services.model_route_service import (
+        DisplayModelOption,
+        build_available_providers,
+        build_display_options,
+    )
     from ...services.model_selection_service import ModelSelectionCriteria, ModelSelectionService
     from ...utils.log import logger
     from .model_checkbox_widget import ModelCheckboxWidget, ModelInfo
@@ -114,6 +119,8 @@ if not __name__ == "__main__":
             # データ管理
             self.all_models: list[Model] = []
             self.filtered_models: list[Model] = []
+            # Issue #241: 表示用 view model (route 畳み込み済み)
+            self.filtered_options: list[DisplayModelOption] = []
             self.model_checkbox_widgets: dict[str, ModelCheckboxWidget] = {}
             self._refresh_thread: QThread | None = None
             self._refresh_worker: _ModelRefreshWorker | None = None
@@ -287,23 +294,32 @@ if not __name__ == "__main__":
             self.update_model_display()
 
         def update_model_display(self) -> None:
-            """モデル表示更新"""
+            """モデル表示更新 (Issue #241: route 畳み込み済み view model 経由)。"""
             # 現在の表示をクリア
             self._clear_model_display()
 
-            # フィルタリング実行
+            available_providers = self._build_available_providers()
+
+            # フィルタリング実行 -> DisplayModelOption 群を構築
             if self.mode == "simple":
                 try:
                     recommended_models = self.model_selection_service.get_recommended_models()
-                    self.filtered_models = recommended_models
                 except Exception as e:
                     logger.error(f"Failed to get recommended models: {e}")
-                    self.filtered_models = [m for m in self.all_models if m.is_recommended]
+                    recommended_models = [m for m in self.all_models if m.is_recommended]
+                options = build_display_options(
+                    recommended_models,
+                    available_providers=available_providers,
+                    preference="auto",
+                )
             else:
-                self.filtered_models = self._apply_advanced_filters()
+                options = self._apply_advanced_filters(available_providers)
+
+            self.filtered_options = options
+            self.filtered_models = [opt.preferred.model for opt in options]
 
             # フィルタされたモデルがない場合
-            if not self.filtered_models:
+            if not options:
                 self.placeholderLabel.setVisible(True)
                 self._update_selection_count()
                 return
@@ -311,17 +327,33 @@ if not __name__ == "__main__":
             # プレースホルダーを非表示
             self.placeholderLabel.setVisible(False)
 
-            # プロバイダー別にグループ化して表示
-            provider_groups = self._group_models_by_provider()
+            # プロバイダー別にグループ化して表示 (preferred の表示プロバイダー基準)
+            provider_groups = self._group_options_by_provider(options)
 
-            for provider, models in provider_groups.items():
-                if models:
-                    self._add_provider_group(provider, models)
+            for provider, group_options in provider_groups.items():
+                if group_options:
+                    self._add_provider_group(provider, group_options)
 
             self._update_selection_count()
 
-        def _apply_advanced_filters(self) -> list[Model]:
-            """詳細モード用フィルタリング"""
+        def _build_available_providers(self) -> set[str]:
+            """config から API key 設定済み provider 集合を構築 (Issue #241)。"""
+            try:
+                container = get_service_container()
+                config = container.config_service
+                api_keys = {
+                    "openai": config.get_setting("api", "openai_key", ""),
+                    "anthropic": config.get_setting("api", "claude_key", ""),
+                    "google": config.get_setting("api", "google_key", ""),
+                    "openrouter": config.get_setting("api", "openrouter_key", ""),
+                }
+                return build_available_providers(api_keys)
+            except Exception as e:
+                logger.warning(f"API key 状態取得に失敗 (auto route 選択 fallback): {e}")
+                return set()
+
+        def _apply_advanced_filters(self, available_providers: set[str]) -> list[DisplayModelOption]:
+            """詳細モード用フィルタリング (Issue #241: route 畳み込み済み view model を返す)"""
             try:
                 criteria = ModelSelectionCriteria(
                     provider=self.current_provider_filter
@@ -335,13 +367,24 @@ if not __name__ == "__main__":
                     execution_env=self.current_execution_env,
                 )
 
-                filtered = self.model_selection_service.filter_models(criteria)
-                logger.debug(f"Applied advanced filters: {len(self.all_models)} -> {len(filtered)} models")
-                return filtered
+                options = self.model_selection_service.load_grouped_models(
+                    criteria,
+                    route_preference="auto",
+                    available_providers=available_providers,
+                )
+                logger.debug(
+                    f"Applied advanced filters: {len(self.all_models)} models -> {len(options)} options"
+                )
+                return options
 
             except Exception as e:
                 logger.error(f"Advanced filtering error: {e}")
-                return self._apply_basic_filters()
+                fallback_models = self._apply_basic_filters()
+                return build_display_options(
+                    fallback_models,
+                    available_providers=available_providers,
+                    preference="auto",
+                )
 
         def _apply_basic_filters(self) -> list[Model]:
             """基本フィルタリング（フォールバック用）"""
@@ -363,18 +406,22 @@ if not __name__ == "__main__":
 
             return filtered
 
-        def _group_models_by_provider(self) -> dict[str, list[Model]]:
-            """プロバイダー別にモデルをグループ化"""
-            groups: dict[str, list[Model]] = {}
-            for model in self.filtered_models:
-                provider = model.provider or "local"
-                if provider not in groups:
-                    groups[provider] = []
-                groups[provider].append(model)
+        def _group_options_by_provider(
+            self, options: list[DisplayModelOption]
+        ) -> dict[str, list[DisplayModelOption]]:
+            """Issue #241: DisplayModelOption を preferred の表示 provider 別にグループ化。
+
+            表示用 provider は ``preferred.model.provider`` を使う (UI ラベル
+            "OpenAI Models" などの分類軸として既存の表示挙動を維持)。
+            """
+            groups: dict[str, list[DisplayModelOption]] = {}
+            for option in options:
+                provider = option.preferred.model.provider or "local"
+                groups.setdefault(provider, []).append(option)
             return groups
 
-        def _add_provider_group(self, provider: str, models: list[Model]) -> None:
-            """プロバイダーグループをUIに追加"""
+        def _add_provider_group(self, provider: str, options: list[DisplayModelOption]) -> None:
+            """プロバイダーグループをUIに追加 (Issue #241: DisplayModelOption 経由)"""
             # プロバイダーラベル
             provider_icons = {"openai": "🤖", "anthropic": "🧠", "google": "🌟", "local": "💻"}
             icon = provider_icons.get(provider.lower(), "🔧")
@@ -386,35 +433,40 @@ if not __name__ == "__main__":
             self.dynamicContentLayout.addWidget(provider_label)
 
             # ModelCheckboxWidget作成と追加
-            # Issue #245: dict key は model.litellm_model_id (UNIQUE registry key)。
+            # Issue #245 / #241: dict key は preferred.litellm_model_id (UNIQUE registry key)。
             # 旧実装は model.name をキーにしていたが、Phase 1.11 migration 経由の
             # OpenRouter 行は name が縮退 (`openai/gpt-4o`) して新規 sync 経路の
             # 直接版と衝突するため、ルーティングキーである litellm_model_id を使う。
-            for model in models:
-                model_info = self._convert_model_to_info(model)
+            for option in options:
+                model_info = self._convert_option_to_info(option)
                 checkbox_widget = ModelCheckboxWidget(model_info)
 
                 # シグナル接続
                 checkbox_widget.selection_changed.connect(self._on_model_selection_changed)
 
-                self.model_checkbox_widgets[model.litellm_model_id] = checkbox_widget
+                self.model_checkbox_widgets[option.preferred.litellm_model_id] = checkbox_widget
                 self.dynamicContentLayout.addWidget(checkbox_widget)
 
             # レイアウト再計算（フィルタリング後のウィジェットサイズ安定化）
             self.dynamicContentLayout.invalidate()
 
-        def _convert_model_to_info(self, model: Model) -> ModelInfo:
-            """Database Model を ModelInfo に変換
+        def _convert_option_to_info(self, option: DisplayModelOption) -> ModelInfo:
+            """Issue #241: DisplayModelOption (route 畳み込み済み) を ModelInfo に変換。
 
-            Issue #245: 表示名 (`name`) と内部キー (`litellm_model_id`) を分離する。
+            表示名は ``preferred.model.name``、内部キーは ``preferred.litellm_model_id``。
+            ``route`` / ``alternatives`` を ModelInfo に伝搬し、UI で badge と
+            tooltip を構築する。
             """
+            model = option.preferred.model
             return ModelInfo(
                 name=model.name,
                 provider=model.provider or "local",
-                capabilities=model.capabilities,
-                litellm_model_id=model.litellm_model_id,
+                capabilities=list(option.capabilities),
+                litellm_model_id=option.preferred.litellm_model_id,
                 is_local=not model.requires_api_key,
                 requires_api_key=model.requires_api_key,
+                route=option.preferred.route,
+                alternatives=tuple(c.litellm_model_id for c in option.alternatives),
             )
 
         def _clear_model_display(self) -> None:

--- a/src/lorairo/services/model_route_service.py
+++ b/src/lorairo/services/model_route_service.py
@@ -46,22 +46,6 @@ _PROVIDER_ALIAS_MAP: dict[str, str] = {
     "vertex_ai": "google",
 }
 
-# 既知 WebAPI provider whitelist。
-# ローカル ML モデルでも namespaced な ID (例: ``some/very/deep/local-tagger``) を
-# 持ちうるため、prefix から無条件に provider を抽出すると "some" key を要求する誤判定
-# になる (Codex P2: PR #248 r3230850133)。whitelist に含まれる prefix のみ WebAPI
-# provider として扱い、それ以外は ``"local"`` に倒して validation を skip する。
-# 新しい WebAPI provider を追加するときは alias map (gemini -> google など) と
-# 併せてここに追記する。
-_WEBAPI_PROVIDERS: frozenset[str] = frozenset(
-    {
-        "openai",
-        "anthropic",
-        "google",
-        "openrouter",
-    }
-)
-
 
 def detect_route(litellm_model_id: str) -> Route:
     """litellm_model_id の prefix から route を判定。
@@ -94,45 +78,36 @@ def required_provider_for(litellm_model_id: str, provider_hint: str | None = Non
 
     解決順序:
         1. ``provider_hint`` (= ``Model.provider``) が信頼できる ``str`` なら採用
-           (ただし WebAPI provider whitelist または ``"local"`` のみ受け入れる)
-        2. fallback: ``litellm_model_id`` の最初のセグメントが WebAPI provider
-           whitelist に該当する場合のみ provider 名を返す
-        3. それ以外 (slash 無し bare 名 / 未知の namespaced ID) は ``"local"``
+        2. fallback: ``litellm_model_id`` の最初のセグメント
+        3. slash 無し (= bare 名、ローカル ML モデル) なら ``"local"``
 
-    Codex P2 (PR #248 r3230850133): ローカル ML モデルでも namespaced ID
-    (例: ``"some/very/deep/local-tagger"``) を持ちうる。prefix を無条件に
-    provider として採用すると、存在しない provider key を要求して validation
-    abort してしまうため、whitelist 照合で defensive に弾く。
+    image-annotator-lib の規約上、ローカル ML モデルの ID は bare 名 (slash 無し)
+    のみで、``provider/model`` 形式は LiteLLM 経由 WebAPI / OpenRouter 経路に
+    限られる。よって最初の slash セグメントは常に WebAPI provider 名として扱える。
 
     Args:
-        litellm_model_id: 例 ``"openrouter/openai/gpt-4o"`` /
-            ``"some/very/deep/local-tagger"``。
+        litellm_model_id: 例 ``"openrouter/openai/gpt-4o"``。
         provider_hint: ``Model.provider`` の値 (任意)。型契約は ``str | None`` だが、
             テストの Mock 経由で別型が紛れ込んでもクラッシュしないよう
             ``isinstance(str)`` ガードで防御的に弾く。
 
     Returns:
         provider 名。``"openrouter"`` / ``"openai"`` / ``"anthropic"`` /
-        ``"google"`` / ``"local"`` のいずれか。
+        ``"google"`` / ``"local"`` など。
     """
-    if isinstance(provider_hint, str) and provider_hint.strip():
-        p_normalized = provider_hint.strip().lower()
-        if p_normalized not in _UNKNOWN_PROVIDERS:
-            canonical = _PROVIDER_ALIAS_MAP.get(p_normalized, p_normalized)
-            # 既知 WebAPI provider または local のみ採用、それ以外は fallback へ
-            if canonical in _WEBAPI_PROVIDERS or canonical == _LOCAL_PROVIDER:
-                return canonical
+    if (
+        isinstance(provider_hint, str)
+        and provider_hint.strip()
+        and provider_hint.strip().lower() not in _UNKNOWN_PROVIDERS
+    ):
+        return provider_hint.strip().lower()
 
     head, sep, _ = litellm_model_id.partition("/")
     if sep == "":
         return _LOCAL_PROVIDER
 
     head_normalized = head.strip().lower()
-    canonical = _PROVIDER_ALIAS_MAP.get(head_normalized, head_normalized)
-    # 既知 WebAPI provider のみ採用、未知 prefix は local 扱い (namespaced local model 対応)
-    if canonical in _WEBAPI_PROVIDERS:
-        return canonical
-    return _LOCAL_PROVIDER
+    return _PROVIDER_ALIAS_MAP.get(head_normalized, head_normalized)
 
 
 @dataclass(frozen=True)

--- a/src/lorairo/services/model_route_service.py
+++ b/src/lorairo/services/model_route_service.py
@@ -1,0 +1,336 @@
+"""モデルの route 判定・畳み込み・API key validation helper (Issue #241)。
+
+image-annotator-lib の registry には同一モデルが「直接プロバイダー経路」と
+「OpenRouter 経由経路」の 2 経路で別エントリとして登録される。本モジュールは
+`litellm_model_id` の prefix を見て route を判定し、canonical key で 1 モデル
+1 行に畳み込んだ表示用 view model を構築する。実行直前の API key 不足検出も
+担当する。
+
+設計判断:
+    - route 判定は LoRAIro 側で持つ (image-annotator-lib の private helper
+      `_split_litellm_id` を import せず独立)。判定ロジックは prefix
+      `openrouter/` の単純 whitelist マッチで、5 行未満で完結する。
+    - `Route` whitelist: `{"openrouter"}` のみ "openrouter" 扱い、それ以外は
+      "direct"。lib 側 dispatch に新 provider が追加されても fallback は
+      "direct" のまま安全。
+    - `required_provider` 解決: `Model.provider` を一次ソースとし、未設定
+      (None/"unknown") の場合のみ `litellm_model_id` の最初のセグメントから
+      推定する。
+
+参照:
+    - Issue #241
+    - ADR 0023 Phase 1.9 / 1.10 / 1.11
+    - Plan: docs/plans/...
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass, field
+from typing import Literal
+
+from ..database.schema import Model
+from ..utils.log import logger
+
+Route = Literal["direct", "openrouter"]
+RoutePreference = Literal["auto", "direct", "openrouter", "all"]
+
+_OPENROUTER_PREFIX = "openrouter/"
+_LOCAL_PROVIDER = "local"
+_UNKNOWN_PROVIDERS = frozenset({"", "unknown"})
+
+# litellm_model_id 先頭セグメントに対する provider 別名の正規化マップ。
+# 例: "gemini/..." は "google" key を要求する。
+_PROVIDER_ALIAS_MAP: dict[str, str] = {
+    "gemini": "google",
+    "vertex_ai": "google",
+}
+
+
+def detect_route(litellm_model_id: str) -> Route:
+    """litellm_model_id の prefix から route を判定。
+
+    Args:
+        litellm_model_id: 例 ``"openrouter/openai/gpt-4o"`` / ``"openai/gpt-4o"``。
+
+    Returns:
+        "openrouter" prefix なら "openrouter"、それ以外は "direct"。
+    """
+    return "openrouter" if litellm_model_id.startswith(_OPENROUTER_PREFIX) else "direct"
+
+
+def canonical_key(litellm_model_id: str) -> str:
+    """同一モデル判定用の canonical key を返す。
+
+    ``openrouter/`` prefix を剥がし、direct route との比較を可能にする。
+
+    Args:
+        litellm_model_id: 例 ``"openrouter/anthropic/claude-3-5-sonnet"``。
+
+    Returns:
+        prefix を除去した文字列。例 ``"anthropic/claude-3-5-sonnet"``。
+    """
+    return litellm_model_id.removeprefix(_OPENROUTER_PREFIX)
+
+
+def required_provider_for(litellm_model_id: str, provider_hint: str | None = None) -> str:
+    """API key 要求 provider 名を返す。
+
+    解決順序:
+        1. ``provider_hint`` (= ``Model.provider``) が信頼できる ``str`` なら採用
+        2. fallback: ``litellm_model_id`` の最初のセグメント
+        3. slash 無し (= bare 名、ローカル ML モデル) なら ``"local"``
+
+    Args:
+        litellm_model_id: 例 ``"openrouter/openai/gpt-4o"``。
+        provider_hint: ``Model.provider`` の値 (任意)。型契約は ``str | None`` だが、
+            テストの Mock 経由で別型が紛れ込んでもクラッシュしないよう
+            ``isinstance(str)`` ガードで防御的に弾く。
+
+    Returns:
+        provider 名。``"openrouter"`` / ``"openai"`` / ``"anthropic"`` /
+        ``"google"`` / ``"local"`` など。
+    """
+    if (
+        isinstance(provider_hint, str)
+        and provider_hint.strip()
+        and provider_hint.strip().lower() not in _UNKNOWN_PROVIDERS
+    ):
+        return provider_hint.strip().lower()
+
+    head, sep, _ = litellm_model_id.partition("/")
+    if sep == "":
+        return _LOCAL_PROVIDER
+
+    head_normalized = head.strip().lower()
+    return _PROVIDER_ALIAS_MAP.get(head_normalized, head_normalized)
+
+
+@dataclass(frozen=True)
+class ModelRouteCandidate:
+    """同一 canonical key に属する 1 つの route candidate。"""
+
+    litellm_model_id: str
+    route: Route
+    required_provider: str
+    model: Model
+
+
+@dataclass(frozen=True)
+class DisplayModelOption:
+    """GUI / CLI 表示用に 1 モデル 1 行に畳み込んだ view model。"""
+
+    canonical_key: str
+    display_name: str
+    capabilities: tuple[str, ...]
+    preferred: ModelRouteCandidate
+    alternatives: tuple[ModelRouteCandidate, ...] = field(default_factory=tuple)
+
+    @property
+    def all_candidates(self) -> tuple[ModelRouteCandidate, ...]:
+        """preferred + alternatives を route 順 (direct -> openrouter) で返す。"""
+        return (self.preferred, *self.alternatives)
+
+
+def build_available_providers(api_keys: dict[str, str]) -> set[str]:
+    """API key 辞書から「key が設定されている」provider 集合を返す。
+
+    空文字や空白のみのキーは「未設定」扱いとして除外する。
+
+    Args:
+        api_keys: provider 名 -> API key 文字列。
+
+    Returns:
+        非空 key を持つ provider 名集合。
+    """
+    return {provider for provider, key in api_keys.items() if key and key.strip()}
+
+
+def group_model_routes(models: Iterable[Model]) -> dict[str, list[ModelRouteCandidate]]:
+    """canonical_key で grouping した candidate dict を返す。
+
+    Args:
+        models: DB ``Model`` のリスト/イテラブル。
+
+    Returns:
+        canonical_key -> ``[ModelRouteCandidate, ...]`` の dict。
+        各リストは direct -> openrouter の順にソート済み。
+    """
+    grouped: dict[str, list[ModelRouteCandidate]] = {}
+    for model in models:
+        route = detect_route(model.litellm_model_id)
+        required = required_provider_for(model.litellm_model_id, model.provider)
+        candidate = ModelRouteCandidate(
+            litellm_model_id=model.litellm_model_id,
+            route=route,
+            required_provider=required,
+            model=model,
+        )
+        grouped.setdefault(canonical_key(model.litellm_model_id), []).append(candidate)
+
+    # direct -> openrouter の順に並べる (UI 表示と select_preferred_route の挙動を安定させる)
+    for candidates in grouped.values():
+        candidates.sort(key=lambda c: 0 if c.route == "direct" else 1)
+    return grouped
+
+
+def select_preferred_route(
+    candidates: list[ModelRouteCandidate],
+    available_providers: set[str],
+    preference: RoutePreference = "auto",
+) -> ModelRouteCandidate | None:
+    """available_providers を考慮して preferred route を 1 つ選ぶ。
+
+    Args:
+        candidates: 同一 canonical_key の candidate 群 (direct / openrouter)。
+        available_providers: API key 設定済みの provider 名集合
+            (``build_available_providers()`` の戻り値を想定)。
+        preference: ``"auto"`` / ``"direct"`` / ``"openrouter"`` / ``"all"``。
+            ``"all"`` は preferred 単体としては ``"auto"`` と同じ挙動 (caller が
+            ``DisplayModelOption.alternatives`` を含めて全 candidate を展開する想定)。
+
+    Returns:
+        preferred candidate。``preference="direct"`` で direct candidate が無い、
+        など見つからない場合は None。
+    """
+    if not candidates:
+        return None
+
+    by_route: dict[Route, ModelRouteCandidate] = {c.route: c for c in candidates}
+    direct = by_route.get("direct")
+    openrouter = by_route.get("openrouter")
+
+    if preference == "direct":
+        return direct
+    if preference == "openrouter":
+        return openrouter
+
+    # auto / all: direct を優先しつつ available_providers を考慮
+    if direct is not None and direct.required_provider in available_providers:
+        return direct
+    if openrouter is not None and openrouter.required_provider in available_providers:
+        return openrouter
+    # どちらの provider key も未設定: direct 優先で disabled 表示用に返す
+    return direct or openrouter
+
+
+def build_display_options(
+    models: Iterable[Model],
+    available_providers: set[str] | None = None,
+    preference: RoutePreference = "auto",
+) -> list[DisplayModelOption]:
+    """Model リストから DisplayModelOption リストを構築。
+
+    canonical_key で grouping し、preferred route を 1 つ選んで残りを
+    alternatives に格納する。``preference="all"`` の場合は alternatives に全
+    候補が残るため、caller (CLI ``models list --route all``) は各 candidate を
+    1 行ずつ展開する。
+
+    Args:
+        models: フィルタ済みの DB Model リスト。
+        available_providers: API key 設定済み provider 集合。None の場合は全
+            provider を available 扱い (= 従来の畳み込み挙動と同等)。
+        preference: route 優先順位。
+
+    Returns:
+        DisplayModelOption リスト。display_name はソート安定性のため
+        ``preferred.model.name`` を昇順ソート。
+    """
+    if available_providers is None:
+        available_providers = set()
+        treat_all_available = True
+    else:
+        treat_all_available = False
+
+    grouped = group_model_routes(models)
+    options: list[DisplayModelOption] = []
+
+    for ckey, candidates in grouped.items():
+        effective_available = (
+            {c.required_provider for c in candidates} if treat_all_available else available_providers
+        )
+        preferred = select_preferred_route(candidates, effective_available, preference)
+        if preferred is None:
+            continue
+        alternatives = tuple(c for c in candidates if c.litellm_model_id != preferred.litellm_model_id)
+
+        # preferred と alternatives で capabilities が食い違う場合は preferred 側を採用、警告ログを残す
+        preferred_caps = tuple(preferred.model.capabilities)
+        for alt in alternatives:
+            if tuple(alt.model.capabilities) != preferred_caps:
+                logger.warning(
+                    "capabilities mismatch between routes: canonical_key=%s, "
+                    "preferred=%s caps=%s, alternative=%s caps=%s",
+                    ckey,
+                    preferred.litellm_model_id,
+                    preferred_caps,
+                    alt.litellm_model_id,
+                    tuple(alt.model.capabilities),
+                )
+
+        options.append(
+            DisplayModelOption(
+                canonical_key=ckey,
+                display_name=preferred.model.name,
+                capabilities=preferred_caps,
+                preferred=preferred,
+                alternatives=alternatives,
+            )
+        )
+
+    options.sort(key=lambda o: o.display_name.lower())
+    return options
+
+
+def validate_api_keys_for_models(
+    litellm_model_ids: list[str],
+    api_keys: dict[str, str],
+    provider_hints: dict[str, str] | None = None,
+) -> list[tuple[str, str]]:
+    """選択モデルが要求する provider key の不足を返す。
+
+    LoRAIro 側で実行直前にこの検証を呼び、不足があれば image-annotator-lib に
+    渡す前にユーザーに通知して abort する。ローカル ML モデル
+    (``required_provider == "local"``) は API key を要求しないため skip。
+
+    Args:
+        litellm_model_ids: 検証対象の ``litellm_model_id`` リスト (重複可)。
+        api_keys: provider 名 -> API key 文字列。空文字は「未設定」扱い。
+        provider_hints: ``litellm_model_id`` -> ``Model.provider`` の hint map。
+            DB から既に Model を引いている場合は渡すと判定精度が上がる
+            (None/"unknown" 時は内部 fallback)。
+
+    Returns:
+        不足の ``(litellm_model_id, missing_provider)`` ペア。空なら問題なし。
+        重複する litellm_model_id は最初の検出時のみ報告する。
+    """
+    available = build_available_providers(api_keys)
+    missing: list[tuple[str, str]] = []
+    seen: set[str] = set()
+    for litellm_id in litellm_model_ids:
+        if litellm_id in seen:
+            continue
+        seen.add(litellm_id)
+        hint = provider_hints.get(litellm_id) if provider_hints else None
+        required = required_provider_for(litellm_id, hint)
+        if required == _LOCAL_PROVIDER:
+            continue
+        if required not in available:
+            missing.append((litellm_id, required))
+    return missing
+
+
+__all__ = [
+    "DisplayModelOption",
+    "ModelRouteCandidate",
+    "Route",
+    "RoutePreference",
+    "build_available_providers",
+    "build_display_options",
+    "canonical_key",
+    "detect_route",
+    "group_model_routes",
+    "required_provider_for",
+    "select_preferred_route",
+    "validate_api_keys_for_models",
+]

--- a/src/lorairo/services/model_route_service.py
+++ b/src/lorairo/services/model_route_service.py
@@ -46,6 +46,22 @@ _PROVIDER_ALIAS_MAP: dict[str, str] = {
     "vertex_ai": "google",
 }
 
+# 既知 WebAPI provider whitelist。
+# ローカル ML モデルでも namespaced な ID (例: ``some/very/deep/local-tagger``) を
+# 持ちうるため、prefix から無条件に provider を抽出すると "some" key を要求する誤判定
+# になる (Codex P2: PR #248 r3230850133)。whitelist に含まれる prefix のみ WebAPI
+# provider として扱い、それ以外は ``"local"`` に倒して validation を skip する。
+# 新しい WebAPI provider を追加するときは alias map (gemini -> google など) と
+# 併せてここに追記する。
+_WEBAPI_PROVIDERS: frozenset[str] = frozenset(
+    {
+        "openai",
+        "anthropic",
+        "google",
+        "openrouter",
+    }
+)
+
 
 def detect_route(litellm_model_id: str) -> Route:
     """litellm_model_id の prefix から route を判定。
@@ -78,32 +94,45 @@ def required_provider_for(litellm_model_id: str, provider_hint: str | None = Non
 
     解決順序:
         1. ``provider_hint`` (= ``Model.provider``) が信頼できる ``str`` なら採用
-        2. fallback: ``litellm_model_id`` の最初のセグメント
-        3. slash 無し (= bare 名、ローカル ML モデル) なら ``"local"``
+           (ただし WebAPI provider whitelist または ``"local"`` のみ受け入れる)
+        2. fallback: ``litellm_model_id`` の最初のセグメントが WebAPI provider
+           whitelist に該当する場合のみ provider 名を返す
+        3. それ以外 (slash 無し bare 名 / 未知の namespaced ID) は ``"local"``
+
+    Codex P2 (PR #248 r3230850133): ローカル ML モデルでも namespaced ID
+    (例: ``"some/very/deep/local-tagger"``) を持ちうる。prefix を無条件に
+    provider として採用すると、存在しない provider key を要求して validation
+    abort してしまうため、whitelist 照合で defensive に弾く。
 
     Args:
-        litellm_model_id: 例 ``"openrouter/openai/gpt-4o"``。
+        litellm_model_id: 例 ``"openrouter/openai/gpt-4o"`` /
+            ``"some/very/deep/local-tagger"``。
         provider_hint: ``Model.provider`` の値 (任意)。型契約は ``str | None`` だが、
             テストの Mock 経由で別型が紛れ込んでもクラッシュしないよう
             ``isinstance(str)`` ガードで防御的に弾く。
 
     Returns:
         provider 名。``"openrouter"`` / ``"openai"`` / ``"anthropic"`` /
-        ``"google"`` / ``"local"`` など。
+        ``"google"`` / ``"local"`` のいずれか。
     """
-    if (
-        isinstance(provider_hint, str)
-        and provider_hint.strip()
-        and provider_hint.strip().lower() not in _UNKNOWN_PROVIDERS
-    ):
-        return provider_hint.strip().lower()
+    if isinstance(provider_hint, str) and provider_hint.strip():
+        p_normalized = provider_hint.strip().lower()
+        if p_normalized not in _UNKNOWN_PROVIDERS:
+            canonical = _PROVIDER_ALIAS_MAP.get(p_normalized, p_normalized)
+            # 既知 WebAPI provider または local のみ採用、それ以外は fallback へ
+            if canonical in _WEBAPI_PROVIDERS or canonical == _LOCAL_PROVIDER:
+                return canonical
 
     head, sep, _ = litellm_model_id.partition("/")
     if sep == "":
         return _LOCAL_PROVIDER
 
     head_normalized = head.strip().lower()
-    return _PROVIDER_ALIAS_MAP.get(head_normalized, head_normalized)
+    canonical = _PROVIDER_ALIAS_MAP.get(head_normalized, head_normalized)
+    # 既知 WebAPI provider のみ採用、未知 prefix は local 扱い (namespaced local model 対応)
+    if canonical in _WEBAPI_PROVIDERS:
+        return canonical
+    return _LOCAL_PROVIDER
 
 
 @dataclass(frozen=True)

--- a/src/lorairo/services/model_selection_service.py
+++ b/src/lorairo/services/model_selection_service.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 from ..database.db_repository import ImageRepository
 from ..database.schema import Model
 from ..utils.log import logger
+from .model_route_service import DisplayModelOption, RoutePreference, build_display_options
 
 
 @dataclass
@@ -159,6 +160,42 @@ class ModelSelectionService:
                 groups[provider] = []
             groups[provider].append(model)
         return groups
+
+    def load_grouped_models(
+        self,
+        criteria: ModelSelectionCriteria | None = None,
+        route_preference: RoutePreference = "auto",
+        available_providers: set[str] | None = None,
+    ) -> list[DisplayModelOption]:
+        """Issue #241: フィルタ後の Model を canonical_key で畳んで 1 モデル 1 行に。
+
+        既存 ``load_models()`` / ``filter_models()`` の結果に対し、
+        ``model_route_service.build_display_options()`` を適用して
+        direct / openrouter 経路を ``DisplayModelOption`` に集約する。
+
+        Args:
+            criteria: 既存のフィルタ条件 (provider / capabilities など)。
+            route_preference: ``"auto"`` / ``"direct"`` / ``"openrouter"`` / ``"all"``。
+            available_providers: API key 設定済み provider 集合。None の場合は
+                「全 provider が available」として扱い、route 畳み込みのみ行う
+                (CLI でテスト時など key 状況を考慮しないケース用)。
+
+        Returns:
+            DisplayModelOption リスト (display_name 昇順ソート済み)。
+            ``route_preference="all"`` 時は alternatives に残り全 candidate が
+            含まれるので、caller は ``option.all_candidates`` で展開する。
+        """
+        self.load_models()  # _all_models のキャッシュを populate
+        filtered = self.filter_models(criteria)
+        options = build_display_options(filtered, available_providers, route_preference)
+        logger.debug(
+            "load_grouped_models: filtered=%d, options=%d, preference=%s, available=%s",
+            len(filtered),
+            len(options),
+            route_preference,
+            sorted(available_providers) if available_providers else None,
+        )
+        return options
 
     # create_model_tooltip メソッド削除 - Widgetに移動
 

--- a/src/lorairo/utils/config.py
+++ b/src/lorairo/utils/config.py
@@ -34,6 +34,7 @@ DEFAULT_CONFIG = {
         "openai_key": "",
         "claude_key": "",
         "google_key": "",
+        "openrouter_key": "",
     },
     "directories": {
         "database_dir": "",  # 空文字列 = 自動生成 (日付+連番プロジェクト)

--- a/tests/unit/cli/test_annotate_api_key_validation.py
+++ b/tests/unit/cli/test_annotate_api_key_validation.py
@@ -1,0 +1,115 @@
+"""Issue #241: CLI annotate run の API key validation 単体テスト。
+
+`_validate_required_api_keys()` が provider 別の不足検出と Rich console 出力 +
+``typer.Exit(1)`` を正しく実行することを検証する。
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+import typer
+
+from lorairo.cli.commands.annotate import _validate_required_api_keys
+
+
+def _fake_config(api_keys: dict[str, str]) -> Mock:
+    """ConfigurationService 互換の Mock。``get_setting(section, key, default)`` のみ実装。"""
+    config = Mock()
+    config.get_setting.side_effect = lambda section, key, default="": api_keys.get(key, default)
+    return config
+
+
+def _fake_model(provider: str | None) -> SimpleNamespace:
+    return SimpleNamespace(provider=provider)
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+class TestValidateRequiredApiKeys:
+    def test_all_keys_present_returns_without_exit(self) -> None:
+        """全 key 揃っていれば正常終了 (typer.Exit を出さない)"""
+        repository = Mock()
+        repository.get_model_by_litellm_id.return_value = _fake_model("openai")
+        config = _fake_config(
+            {
+                "openai_key": "sk-a",
+                "claude_key": "sk-c",
+                "google_key": "sk-g",
+                "openrouter_key": "sk-or",
+            }
+        )
+
+        _validate_required_api_keys(repository, config, ["openai/gpt-4o"])
+        # 例外が出なければ OK
+
+    def test_missing_openrouter_exits_with_message(self, capsys: pytest.CaptureFixture[str]) -> None:
+        """Issue #241 主要シナリオ: openai key のみ環境で openrouter モデル選択 -> exit 1"""
+        repository = Mock()
+        repository.get_model_by_litellm_id.return_value = _fake_model("openrouter")
+        config = _fake_config({"openai_key": "sk-a"})
+
+        with pytest.raises(typer.Exit) as excinfo:
+            _validate_required_api_keys(repository, config, ["openrouter/openai/gpt-4o"])
+
+        assert excinfo.value.exit_code == 1
+        out = capsys.readouterr().out
+        assert "Missing API keys" in out
+        assert "openrouter: required for openrouter/openai/gpt-4o" in out
+        assert "[api] section" in out
+
+    def test_local_model_passes(self) -> None:
+        """ローカル ML モデルは API key 要求しない"""
+        repository = Mock()
+        repository.get_model_by_litellm_id.return_value = _fake_model("local")
+        config = _fake_config({})
+
+        _validate_required_api_keys(repository, config, ["wd-v1-4-tagger"])
+        # 例外が出なければ OK
+
+    def test_uses_db_provider_as_hint_for_migration_case(self) -> None:
+        """`Model.provider` を hint として渡し、prefix と食い違う migration 経由ケースを救済。
+
+        Phase 1.11 migration 経由で `name='openai/gpt-4o', provider='openrouter',
+        litellm_model_id='openrouter/openai/gpt-4o'` の行が存在しうる。CLI 入力
+        `openrouter/openai/gpt-4o` (litellm_model_id) なので prefix だけでも
+        openrouter required と判定できるが、hint で `Model.provider="openrouter"`
+        が渡ることで判定の SSoT が DB 側に揃う。
+        """
+        repository = Mock()
+        repository.get_model_by_litellm_id.return_value = _fake_model("openrouter")
+        config = _fake_config({"openrouter_key": "sk-or"})
+
+        _validate_required_api_keys(repository, config, ["openrouter/openai/gpt-4o"])
+
+    def test_multiple_models_with_multiple_missing_providers(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """複数モデルで複数 provider 不足のケースは全件列挙"""
+        repository = Mock()
+        # 各 litellm_id ごとに異なる Model.provider を返す
+        provider_map = {
+            "openai/gpt-4o": _fake_model("openai"),
+            "anthropic/claude-3-5": _fake_model("anthropic"),
+        }
+        repository.get_model_by_litellm_id.side_effect = lambda lid: provider_map.get(lid)
+        config = _fake_config({})  # 全 key 空
+
+        with pytest.raises(typer.Exit) as excinfo:
+            _validate_required_api_keys(repository, config, ["openai/gpt-4o", "anthropic/claude-3-5"])
+
+        assert excinfo.value.exit_code == 1
+        out = capsys.readouterr().out
+        assert "openai: required for openai/gpt-4o" in out
+        assert "anthropic: required for anthropic/claude-3-5" in out
+
+    def test_handles_model_not_found_in_db(self) -> None:
+        """DB に未登録の litellm_id でも prefix から required_provider を判定できる"""
+        repository = Mock()
+        repository.get_model_by_litellm_id.return_value = None
+        config = _fake_config({"openai_key": "sk-a"})
+
+        # openai/gpt-4o は openai key 有り -> 不足なし
+        _validate_required_api_keys(repository, config, ["openai/gpt-4o"])

--- a/tests/unit/cli/test_commands_annotate.py
+++ b/tests/unit/cli/test_commands_annotate.py
@@ -392,7 +392,14 @@ def test_annotate_run_no_api_keys(
     mock_get_container,
     test_project_with_images: tuple[Path, list[Path]],
 ) -> None:
-    """Test: annotate run - APIキーなし（WARNINGメッセージ確認）。"""
+    """Test: annotate run - APIキー不足検出で実行中止 (Issue #241)。
+
+    Issue #241 で挙動が変更: 旧仕様は「全 key 空でも警告のみ + 続行」だったが、
+    library 内で MissingApiKeyError が出てから初めて失敗していた。新仕様では
+    LoRAIro 側で事前に provider 別の不足を検出し ``typer.Exit(1)`` で abort する。
+    """
+    from types import SimpleNamespace
+
     _project_dir, image_files = test_project_with_images
 
     # ServiceContainer をモック
@@ -403,12 +410,17 @@ def test_annotate_run_no_api_keys(
     # APIキーなし（空文字列）
     mock_config.get_setting.return_value = ""
 
-    # アノテーション結果をモック
-    mock_annotator.annotate.return_value = {
-        "hash1": {"tags": ["tag1"]},
-        "hash2": {"tags": ["tag2"]},
-        "hash3": {"tags": ["tag3"]},
-    }
+    # Issue #241: _resolve_model_identifier と _validate_required_api_keys は
+    # repository.get_model_by_litellm_id() の結果から Model.provider を hint として
+    # 引く。MagicMock の default は MagicMock を返すため、Model 互換 fake (str provider)
+    # を明示的に渡して validation 経路が安定動作するようにする。
+    mock_container.image_repository.get_model_by_litellm_id.return_value = SimpleNamespace(
+        litellm_model_id="openai/gpt-4o-mini",
+        name="gpt-4o-mini",
+        provider="openai",
+    )
+
+    mock_annotator.annotate.return_value = {}
 
     image_records = [
         {"id": i + 1, "phash": f"phash{i:016d}", "stored_image_path": str(img_path)}
@@ -427,13 +439,14 @@ def test_annotate_run_no_api_keys(
             "--project",
             "test_dataset",
             "--model",
-            "gpt-4o-mini",
+            "openai/gpt-4o-mini",
         ],
     )
 
-    assert result.exit_code == 0
-    # WARNING メッセージが含まれるか確認
-    assert "Warning" in result.stdout and "API keys" in result.stdout
+    # Issue #241: 不足検出で exit 1 + Missing API keys メッセージ
+    assert result.exit_code == 1
+    assert "Missing API keys" in result.stdout
+    assert "openai" in result.stdout
 
 
 @pytest.mark.unit

--- a/tests/unit/cli/test_commands_models.py
+++ b/tests/unit/cli/test_commands_models.py
@@ -300,6 +300,145 @@ def test_models_list_empty_registry_returns_zero(mock_get_container) -> None:
     assert "0 model(s)" in result.stdout
 
 
+# --- Issue #241: --route option / route 畳み込み ---
+
+
+def _make_duplicate_route_infos() -> list[_FakeAnnotatorInfo]:
+    """同一 canonical_key (gpt-4o) を direct / openrouter 2 経路で持つテスト用 infos。"""
+    return [
+        _FakeAnnotatorInfo(
+            name="gpt-4o",
+            model_type="vision",
+            is_local=False,
+            is_api=True,
+            provider="openai",
+            litellm_model_id="openai/gpt-4o",
+        ),
+        _FakeAnnotatorInfo(
+            name="gpt-4o",
+            model_type="vision",
+            is_local=False,
+            is_api=True,
+            provider="openrouter",
+            litellm_model_id="openrouter/openai/gpt-4o",
+        ),
+    ]
+
+
+def _api_key_lookup(keys: dict[str, str]):
+    """ConfigurationService.get_setting 互換 side_effect (api section のみ反応)。"""
+
+    def _lookup(section: str, key: str, default: str = "") -> str:
+        if section != "api":
+            return default
+        return keys.get(key, default)
+
+    return _lookup
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+@patch("lorairo.cli.commands.models.get_service_container")
+def test_models_list_route_auto_collapses_duplicate_to_direct(mock_get_container) -> None:
+    """--route auto: openai key 設定済み環境では direct route のみ表示 (1 行畳み込み)"""
+    mock_container = MagicMock()
+    mock_container.annotator_library.list_annotator_info.return_value = _make_duplicate_route_infos()
+    mock_container.annotator_library.is_model_deprecated.return_value = False
+    mock_container.config_service.get_setting.side_effect = _api_key_lookup({"openai_key": "sk-openai"})
+    mock_get_container.return_value = mock_container
+
+    result = runner.invoke(app, ["models", "list"])  # default --route=auto
+
+    assert result.exit_code == 0
+    # 2 経路あったが auto で 1 行に畳まれる
+    assert "1 model(s)" in result.stdout
+    assert "preference=auto" in result.stdout
+    # direct route が選ばれた (Route 列)
+    assert "direct" in result.stdout
+    assert "openai/gpt-4o" in result.stdout
+    # openrouter route の litellm_id は表示されない
+    assert "openrouter/openai/gpt-4o" not in result.stdout
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+@patch("lorairo.cli.commands.models.get_service_container")
+def test_models_list_route_auto_falls_back_to_openrouter_when_only_openrouter_key(
+    mock_get_container,
+) -> None:
+    """openrouter key のみ設定環境では openrouter route が preferred になる"""
+    mock_container = MagicMock()
+    mock_container.annotator_library.list_annotator_info.return_value = _make_duplicate_route_infos()
+    mock_container.annotator_library.is_model_deprecated.return_value = False
+    mock_container.config_service.get_setting.side_effect = _api_key_lookup({"openrouter_key": "sk-or-x"})
+    mock_get_container.return_value = mock_container
+
+    result = runner.invoke(app, ["models", "list"])
+
+    assert result.exit_code == 0
+    assert "1 model(s)" in result.stdout
+    # openrouter route が選ばれる
+    assert "openrouter/openai/gpt-4o" in result.stdout
+    assert "openrouter" in result.stdout
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+@patch("lorairo.cli.commands.models.get_service_container")
+def test_models_list_route_all_expands_both_routes(mock_get_container) -> None:
+    """--route all は各 candidate を 1 行ずつ展開する"""
+    mock_container = MagicMock()
+    mock_container.annotator_library.list_annotator_info.return_value = _make_duplicate_route_infos()
+    mock_container.annotator_library.is_model_deprecated.return_value = False
+    mock_container.config_service.get_setting.side_effect = _api_key_lookup({})
+    mock_get_container.return_value = mock_container
+
+    result = runner.invoke(app, ["models", "list", "--route", "all"])
+
+    assert result.exit_code == 0
+    assert "2 model(s)" in result.stdout
+    assert "preference=all" in result.stdout
+    assert "openai/gpt-4o" in result.stdout
+    assert "openrouter/openai/gpt-4o" in result.stdout
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+@patch("lorairo.cli.commands.models.get_service_container")
+def test_models_list_route_direct_filters_to_direct_only(mock_get_container) -> None:
+    """--route direct は direct route のみ表示"""
+    mock_container = MagicMock()
+    mock_container.annotator_library.list_annotator_info.return_value = _make_duplicate_route_infos()
+    mock_container.annotator_library.is_model_deprecated.return_value = False
+    mock_container.config_service.get_setting.side_effect = _api_key_lookup({})
+    mock_get_container.return_value = mock_container
+
+    result = runner.invoke(app, ["models", "list", "--route", "direct"])
+
+    assert result.exit_code == 0
+    assert "1 model(s)" in result.stdout
+    assert "openai/gpt-4o" in result.stdout
+    assert "openrouter/openai/gpt-4o" not in result.stdout
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+@patch("lorairo.cli.commands.models.get_service_container")
+def test_models_list_route_openrouter_filters_to_openrouter_only(mock_get_container) -> None:
+    """--route openrouter は openrouter route のみ表示"""
+    mock_container = MagicMock()
+    mock_container.annotator_library.list_annotator_info.return_value = _make_duplicate_route_infos()
+    mock_container.annotator_library.is_model_deprecated.return_value = False
+    mock_container.config_service.get_setting.side_effect = _api_key_lookup({})
+    mock_get_container.return_value = mock_container
+
+    result = runner.invoke(app, ["models", "list", "--route", "openrouter"])
+
+    assert result.exit_code == 0
+    assert "1 model(s)" in result.stdout
+    assert "openrouter/openai/gpt-4o" in result.stdout
+
+
 @pytest.mark.unit
 @pytest.mark.cli
 @patch("lorairo.cli.commands.models.get_service_container")

--- a/tests/unit/gui/widgets/test_model_checkbox_widget.py
+++ b/tests/unit/gui/widgets/test_model_checkbox_widget.py
@@ -273,6 +273,50 @@ class TestModelCheckboxWidget:
         """モデル情報取得テスト"""
         assert widget_openai.get_model_info() == openai_model_info
 
+    # --- Issue #241: route badge / alternative tooltip ---
+
+    def test_route_badge_shown_for_openrouter_route(self, qtbot):
+        """preferred route が openrouter の場合、ラベル末尾に [openrouter] badge"""
+        info = ModelInfo(
+            name="claude-3-5-sonnet",
+            provider="openrouter",
+            capabilities=["caption"],
+            litellm_model_id="openrouter/anthropic/claude-3-5-sonnet",
+            is_local=False,
+            requires_api_key=True,
+            route="openrouter",
+        )
+        widget = ModelCheckboxWidget(info)
+        qtbot.addWidget(widget)
+        assert "[openrouter]" in widget.labelModelName.text()
+
+    def test_route_badge_absent_for_direct_route(self, widget_openai):
+        """direct route はラベルに badge が付かない (Issue #245 の表記を維持)"""
+        assert "[openrouter]" not in widget_openai.labelModelName.text()
+        assert "[direct]" not in widget_openai.labelModelName.text()
+
+    def test_alternative_tooltip_lists_alternatives(self, qtbot):
+        """alternatives がある場合、tooltip に Alternative 行が追加される"""
+        info = ModelInfo(
+            name="claude-3-5-sonnet",
+            provider="anthropic",
+            capabilities=["caption"],
+            litellm_model_id="anthropic/claude-3-5-sonnet-20241022",
+            is_local=False,
+            requires_api_key=True,
+            route="direct",
+            alternatives=("openrouter/anthropic/claude-3-5-sonnet-20241022",),
+        )
+        widget = ModelCheckboxWidget(info)
+        qtbot.addWidget(widget)
+        tooltip = widget.labelModelName.toolTip()
+        assert "anthropic/claude-3-5-sonnet-20241022" in tooltip
+        assert "Alternative: openrouter/anthropic/claude-3-5-sonnet-20241022" in tooltip
+
+    def test_tooltip_without_alternatives_is_just_litellm_id(self, widget_openai):
+        """alternatives が空の場合、tooltip は litellm_model_id のみ"""
+        assert widget_openai.labelModelName.toolTip() == "openai/gpt-4-vision-preview"
+
 
 class TestProviderStylesConstant:
     """PROVIDER_STYLES定数のテスト"""

--- a/tests/unit/gui/widgets/test_model_selection_widget.py
+++ b/tests/unit/gui/widgets/test_model_selection_widget.py
@@ -187,29 +187,36 @@ class TestModelSelectionWidgetLitellmIdKeying:
         return w, migration_route, new_sync_direct
 
     def test_get_selected_models_returns_litellm_ids(self, widget_with_dual_routes):
-        """選択結果は `Model.litellm_model_id` の値で返す (#245 のコア要件)"""
-        w, migration_route, new_sync_direct = widget_with_dual_routes
+        """選択結果は `Model.litellm_model_id` の値で返す (#245 のコア要件)。
 
-        # 両方選択
-        w.set_selected_models([migration_route.litellm_model_id, new_sync_direct.litellm_model_id])
+        Issue #241 で挙動が変化: 同一 canonical_key (``openai/gpt-4o``) を持つ
+        ``migration_route`` (OpenRouter, name 縮退) と ``new_sync_direct``
+        (OpenAI 直接版) は UI 上 1 行に畳まれ、preferred (= direct) のみ表示
+        される。それでも戻り値の semantic ``litellm_model_id`` ベースは維持される。
+        """
+        w, _migration_route, new_sync_direct = widget_with_dual_routes
 
-        selected = w.get_selected_models()
-        assert set(selected) == {
-            "openrouter/openai/gpt-4o",
-            "openai/gpt-4o",
-        }
-        # 旧バグでは `name` ベースだったため両者とも "openai/gpt-4o" になり、
-        # set にすると 1 要素に縮退してしまっていた。
-        assert len(selected) == 2
-
-    def test_set_selected_models_targets_specific_route(self, widget_with_dual_routes):
-        """`set_selected_models` は `litellm_model_id` で特定 route のみ選択できる"""
-        w, migration_route, _ = widget_with_dual_routes
-
-        w.set_selected_models([migration_route.litellm_model_id])
+        # Issue #241: 1 行に畳まれているので、preferred (direct) のみ選択可能
+        w.set_selected_models([new_sync_direct.litellm_model_id])
 
         selected = w.get_selected_models()
-        assert selected == [migration_route.litellm_model_id]
+        # litellm_model_id ベースで返る (Issue #245 SSoT)
+        # 旧バグでは `name` ベースだったため "openai/gpt-4o" に縮退していた。
+        assert selected == [new_sync_direct.litellm_model_id]
+
+    def test_set_selected_models_targets_preferred_route(self, widget_with_dual_routes):
+        """Issue #241: 1 行畳み込み環境で preferred route の litellm_id で選択できる。
+
+        旧テスト (Issue #245 単独時) は migration_route も独立行として表示・選択
+        可能だったが、Issue #241 で同一 canonical_key の 2 経路は preferred (direct)
+        の 1 行に集約される。alternatives は tooltip で確認できる。
+        """
+        w, _migration_route, new_sync_direct = widget_with_dual_routes
+
+        w.set_selected_models([new_sync_direct.litellm_model_id])
+
+        selected = w.get_selected_models()
+        assert selected == [new_sync_direct.litellm_model_id]
 
     def test_select_recommended_models_uses_litellm_id_match(self, widget_with_dual_routes):
         """推奨選択は litellm_model_id で一致判定する (name 同値でも誤マッチしない)"""

--- a/tests/unit/services/test_model_route_service.py
+++ b/tests/unit/services/test_model_route_service.py
@@ -112,6 +112,27 @@ class TestRequiredProviderFor:
         """大文字 provider hint は lowercase 正規化"""
         assert required_provider_for("openai/gpt-4o", "OpenAI") == "openai"
 
+    def test_namespaced_local_model_returns_local(self) -> None:
+        """Codex P2 (PR #248): namespaced ID を持つローカルモデルは local 扱い。
+
+        ``some/very/deep/local-tagger`` のように `/` を含むローカルモデル名でも、
+        最初のセグメント `some` が WebAPI whitelist にないため local 扱いになり、
+        validation で abort しない。
+        """
+        assert required_provider_for("some/very/deep/local-tagger", None) == "local"
+
+    def test_unknown_provider_prefix_returns_local(self) -> None:
+        """未知の provider prefix は defensive に local 扱い。
+
+        将来 lib が新 provider を追加して LoRAIro 側 whitelist が未更新でも、
+        library 側で `MissingApiKeyError` を出させる graceful degradation を選択。
+        """
+        assert required_provider_for("mistral/mistral-large", None) == "local"
+
+    def test_hint_with_unknown_provider_falls_back_to_local(self) -> None:
+        """``Model.provider`` が unknown / 未登録の場合も defensive に local 扱い"""
+        assert required_provider_for("some/local-model", "custom-namespace") == "local"
+
 
 @pytest.mark.unit
 class TestBuildAvailableProviders:

--- a/tests/unit/services/test_model_route_service.py
+++ b/tests/unit/services/test_model_route_service.py
@@ -1,0 +1,327 @@
+"""Issue #241: model_route_service の単体テスト。
+
+route 判定、canonical key、grouping、preference 選択、API key validation を
+全数テストする。pure function helper のため Mock 不要、Model は SimpleNamespace で代用。
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from lorairo.services.model_route_service import (
+    ModelRouteCandidate,
+    build_available_providers,
+    build_display_options,
+    canonical_key,
+    detect_route,
+    group_model_routes,
+    required_provider_for,
+    select_preferred_route,
+    validate_api_keys_for_models,
+)
+
+
+def _fake_model(
+    litellm_model_id: str,
+    name: str,
+    provider: str | None,
+    requires_api_key: bool = True,
+    capabilities: list[str] | None = None,
+) -> SimpleNamespace:
+    """`Model` 互換の軽量 fake。
+
+    schema.py L145 の ``capabilities`` は @property だが、SimpleNamespace 直接代入で
+    duck typing 互換にできる (build_display_options は ``tuple(model.capabilities)`` で読む)。
+    """
+    return SimpleNamespace(
+        litellm_model_id=litellm_model_id,
+        name=name,
+        provider=provider,
+        requires_api_key=requires_api_key,
+        capabilities=capabilities or [],
+    )
+
+
+@pytest.mark.unit
+class TestDetectRoute:
+    def test_openrouter_prefix_returns_openrouter(self) -> None:
+        assert detect_route("openrouter/openai/gpt-4o") == "openrouter"
+
+    def test_no_prefix_returns_direct(self) -> None:
+        assert detect_route("openai/gpt-4o") == "direct"
+
+    def test_bare_name_returns_direct(self) -> None:
+        """ローカル ML モデル (slash 無し) は direct 扱い"""
+        assert detect_route("wd-v1-4-tagger") == "direct"
+
+    def test_empty_string_returns_direct(self) -> None:
+        """defensive: 空文字は direct fallback"""
+        assert detect_route("") == "direct"
+
+    def test_openrouter_substring_in_middle_is_not_route(self) -> None:
+        """prefix のみ判定するため、途中の `openrouter` 部分文字列は無関係"""
+        assert detect_route("openai/openrouter-experimental") == "direct"
+
+
+@pytest.mark.unit
+class TestCanonicalKey:
+    def test_openrouter_prefix_stripped(self) -> None:
+        assert canonical_key("openrouter/anthropic/claude-3-5-sonnet") == "anthropic/claude-3-5-sonnet"
+
+    def test_no_prefix_unchanged(self) -> None:
+        assert canonical_key("openai/gpt-4o") == "openai/gpt-4o"
+
+    def test_bare_name_unchanged(self) -> None:
+        assert canonical_key("wd-v1-4-tagger") == "wd-v1-4-tagger"
+
+    def test_idempotent(self) -> None:
+        """canonical_key を 2 回適用しても同じ結果"""
+        assert canonical_key(canonical_key("openrouter/openai/gpt-4o")) == "openai/gpt-4o"
+
+
+@pytest.mark.unit
+class TestRequiredProviderFor:
+    def test_provider_hint_takes_priority(self) -> None:
+        """hint があれば信頼する (migration 経由で name と provider が食い違うケース)"""
+        assert required_provider_for("openai/gpt-4o", "openrouter") == "openrouter"
+
+    def test_fallback_to_prefix_when_hint_none(self) -> None:
+        assert required_provider_for("openrouter/openai/gpt-4o", None) == "openrouter"
+
+    def test_fallback_to_prefix_when_hint_unknown(self) -> None:
+        """`provider="unknown"` は fallback トリガー (=信頼できない)"""
+        assert required_provider_for("openai/gpt-4o", "unknown") == "openai"
+
+    def test_fallback_to_prefix_when_hint_empty(self) -> None:
+        assert required_provider_for("openai/gpt-4o", "") == "openai"
+
+    def test_gemini_alias_maps_to_google(self) -> None:
+        """LiteLLM の `gemini/` prefix は Google API key 要求"""
+        assert required_provider_for("gemini/gemini-pro-vision", None) == "google"
+
+    def test_vertex_ai_alias_maps_to_google(self) -> None:
+        assert required_provider_for("vertex_ai/gemini-pro", None) == "google"
+
+    def test_bare_name_returns_local(self) -> None:
+        """slash 無し = ローカル ML モデル"""
+        assert required_provider_for("wd-v1-4-tagger", None) == "local"
+
+    def test_hint_lowercased(self) -> None:
+        """大文字 provider hint は lowercase 正規化"""
+        assert required_provider_for("openai/gpt-4o", "OpenAI") == "openai"
+
+
+@pytest.mark.unit
+class TestBuildAvailableProviders:
+    def test_returns_non_empty_keys_only(self) -> None:
+        api_keys = {
+            "openai": "sk-...",
+            "anthropic": "",
+            "google": "  ",
+            "openrouter": "sk-or-...",
+        }
+        assert build_available_providers(api_keys) == {"openai", "openrouter"}
+
+    def test_empty_dict_returns_empty_set(self) -> None:
+        assert build_available_providers({}) == set()
+
+
+@pytest.mark.unit
+class TestGroupModelRoutes:
+    def test_direct_only(self) -> None:
+        m1 = _fake_model("openai/gpt-4o", "gpt-4o", "openai")
+        result = group_model_routes([m1])
+        assert "openai/gpt-4o" in result
+        assert len(result["openai/gpt-4o"]) == 1
+        assert result["openai/gpt-4o"][0].route == "direct"
+        assert result["openai/gpt-4o"][0].required_provider == "openai"
+
+    def test_openrouter_only(self) -> None:
+        m1 = _fake_model("openrouter/openai/gpt-4o", "openai/gpt-4o", "openrouter")
+        result = group_model_routes([m1])
+        assert "openai/gpt-4o" in result
+        assert result["openai/gpt-4o"][0].route == "openrouter"
+        assert result["openai/gpt-4o"][0].required_provider == "openrouter"
+
+    def test_both_routes_grouped_under_same_canonical_key(self) -> None:
+        """Issue #241 核心ケース: direct と openrouter が同一 canonical key で grouping される"""
+        m_direct = _fake_model("openai/gpt-4o", "gpt-4o", "openai")
+        m_router = _fake_model("openrouter/openai/gpt-4o", "openai/gpt-4o", "openrouter")
+        result = group_model_routes([m_direct, m_router])
+
+        assert list(result.keys()) == ["openai/gpt-4o"]
+        candidates = result["openai/gpt-4o"]
+        assert len(candidates) == 2
+        # direct -> openrouter の順にソートされる
+        assert [c.route for c in candidates] == ["direct", "openrouter"]
+
+    def test_migration_path_provider_hint_respected(self) -> None:
+        """migration 経由で `name='openai/gpt-4o', provider='openrouter'` の行も
+        ``provider`` hint で required_provider が openrouter になる。
+        """
+        m = _fake_model(
+            "openrouter/openai/gpt-4o",
+            "openai/gpt-4o",  # name が縮退している (migration 残骸)
+            "openrouter",
+        )
+        result = group_model_routes([m])
+        candidate = result["openai/gpt-4o"][0]
+        assert candidate.required_provider == "openrouter"
+
+
+@pytest.mark.unit
+class TestSelectPreferredRoute:
+    def _candidates(self, *configs: tuple[str, str, str]) -> list[ModelRouteCandidate]:
+        return [
+            ModelRouteCandidate(
+                litellm_model_id=lid,
+                route=r,
+                required_provider=p,
+                model=_fake_model(lid, "x", p),
+            )
+            for lid, r, p in configs
+        ]
+
+    def test_auto_picks_direct_when_available(self) -> None:
+        cands = self._candidates(
+            ("openai/gpt-4o", "direct", "openai"),
+            ("openrouter/openai/gpt-4o", "openrouter", "openrouter"),
+        )
+        preferred = select_preferred_route(cands, {"openai", "openrouter"}, "auto")
+        assert preferred is not None
+        assert preferred.route == "direct"
+
+    def test_auto_falls_back_to_openrouter_when_direct_unavailable(self) -> None:
+        cands = self._candidates(
+            ("openai/gpt-4o", "direct", "openai"),
+            ("openrouter/openai/gpt-4o", "openrouter", "openrouter"),
+        )
+        preferred = select_preferred_route(cands, {"openrouter"}, "auto")
+        assert preferred is not None
+        assert preferred.route == "openrouter"
+
+    def test_auto_returns_direct_disabled_when_neither_available(self) -> None:
+        """両方 unavailable: direct を disabled 表示用に返す"""
+        cands = self._candidates(
+            ("openai/gpt-4o", "direct", "openai"),
+            ("openrouter/openai/gpt-4o", "openrouter", "openrouter"),
+        )
+        preferred = select_preferred_route(cands, set(), "auto")
+        assert preferred is not None
+        assert preferred.route == "direct"
+
+    def test_direct_pref_returns_none_if_no_direct_route(self) -> None:
+        cands = self._candidates(
+            ("openrouter/openai/gpt-4o", "openrouter", "openrouter"),
+        )
+        assert select_preferred_route(cands, {"openrouter"}, "direct") is None
+
+    def test_openrouter_pref_returns_none_if_no_openrouter_route(self) -> None:
+        cands = self._candidates(
+            ("openai/gpt-4o", "direct", "openai"),
+        )
+        assert select_preferred_route(cands, {"openai"}, "openrouter") is None
+
+    def test_empty_candidates_returns_none(self) -> None:
+        assert select_preferred_route([], {"openai"}, "auto") is None
+
+
+@pytest.mark.unit
+class TestBuildDisplayOptions:
+    def test_groups_direct_and_openrouter_into_one_option(self) -> None:
+        """Issue #241 主要ケース: 同一 canonical_key の 2 route が 1 option に畳まれる"""
+        m_direct = _fake_model("openai/gpt-4o", "gpt-4o", "openai", capabilities=["captions"])
+        m_router = _fake_model(
+            "openrouter/openai/gpt-4o", "openai/gpt-4o", "openrouter", capabilities=["captions"]
+        )
+        options = build_display_options([m_direct, m_router], {"openai", "openrouter"}, "auto")
+
+        assert len(options) == 1
+        opt = options[0]
+        assert opt.preferred.route == "direct"
+        assert len(opt.alternatives) == 1
+        assert opt.alternatives[0].route == "openrouter"
+        assert opt.alternatives[0].litellm_model_id == "openrouter/openai/gpt-4o"
+
+    def test_capabilities_taken_from_preferred(self) -> None:
+        m = _fake_model("openai/gpt-4o", "gpt-4o", "openai", capabilities=["captions", "tags"])
+        options = build_display_options([m], {"openai"}, "auto")
+        assert options[0].capabilities == ("captions", "tags")
+
+    def test_none_available_treats_all_as_available(self) -> None:
+        """available_providers=None は全 provider を available 扱い (テスト用 fallback)"""
+        m = _fake_model("openai/gpt-4o", "gpt-4o", "openai")
+        options = build_display_options([m], None, "auto")
+        assert len(options) == 1
+        assert options[0].preferred.route == "direct"
+
+    def test_sorts_by_display_name(self) -> None:
+        m1 = _fake_model("openai/zebra", "zebra", "openai")
+        m2 = _fake_model("openai/alpha", "alpha", "openai")
+        options = build_display_options([m1, m2], None, "auto")
+        assert [o.display_name for o in options] == ["alpha", "zebra"]
+
+    def test_all_candidates_property_returns_preferred_first(self) -> None:
+        m_direct = _fake_model("openai/gpt-4o", "gpt-4o", "openai")
+        m_router = _fake_model("openrouter/openai/gpt-4o", "openai/gpt-4o", "openrouter")
+        options = build_display_options([m_direct, m_router], {"openai", "openrouter"}, "auto")
+        opt = options[0]
+        all_cands = opt.all_candidates
+        assert all_cands[0] is opt.preferred
+        assert all_cands[1:] == opt.alternatives
+
+
+@pytest.mark.unit
+class TestValidateApiKeysForModels:
+    def test_all_keys_present_returns_empty(self) -> None:
+        api_keys = {
+            "openai": "sk-1",
+            "anthropic": "sk-2",
+            "google": "sk-3",
+            "openrouter": "sk-or",
+        }
+        missing = validate_api_keys_for_models(
+            ["openai/gpt-4o", "openrouter/anthropic/claude-3-5"], api_keys
+        )
+        assert missing == []
+
+    def test_missing_openrouter_key_reports_unique_missing(self) -> None:
+        """Issue #241 主要シナリオ: openai key のみ環境で openrouter モデル選択"""
+        api_keys = {"openai": "sk", "openrouter": ""}
+        missing = validate_api_keys_for_models(["openai/gpt-4o", "openrouter/openai/gpt-4o"], api_keys)
+        assert missing == [("openrouter/openai/gpt-4o", "openrouter")]
+
+    def test_local_models_skipped(self) -> None:
+        """ローカル ML モデルは API key を要求しないため skip"""
+        missing = validate_api_keys_for_models(["wd-v1-4-tagger"], {})
+        assert missing == []
+
+    def test_duplicates_deduplicated_in_missing_list(self) -> None:
+        """同一 litellm_model_id を 2 回渡しても missing には 1 回のみ"""
+        missing = validate_api_keys_for_models(
+            ["openrouter/openai/gpt-4o", "openrouter/openai/gpt-4o"],
+            {},
+        )
+        assert missing == [("openrouter/openai/gpt-4o", "openrouter")]
+
+    def test_provider_hints_take_priority_over_prefix(self) -> None:
+        """hints が prefix より優先される (migration 経由ケース)"""
+        # litellm_id は `openai/gpt-4o` だが hint で openrouter required と判定
+        missing = validate_api_keys_for_models(
+            ["openai/gpt-4o"],
+            {"openrouter": "sk"},
+            provider_hints={"openai/gpt-4o": "openrouter"},
+        )
+        # openrouter key 有り -> 不足なし
+        assert missing == []
+
+    def test_empty_input_returns_empty(self) -> None:
+        missing = validate_api_keys_for_models([], {"openai": "sk"})
+        assert missing == []
+
+    def test_gemini_prefix_requires_google_key(self) -> None:
+        """`gemini/` prefix は google key を要求 (alias 解決)"""
+        missing = validate_api_keys_for_models(["gemini/gemini-pro"], {})
+        assert missing == [("gemini/gemini-pro", "google")]

--- a/tests/unit/services/test_model_route_service.py
+++ b/tests/unit/services/test_model_route_service.py
@@ -105,33 +105,12 @@ class TestRequiredProviderFor:
         assert required_provider_for("vertex_ai/gemini-pro", None) == "google"
 
     def test_bare_name_returns_local(self) -> None:
-        """slash 無し = ローカル ML モデル"""
+        """slash 無し = ローカル ML モデル (image-annotator-lib のローカル ID 規約)"""
         assert required_provider_for("wd-v1-4-tagger", None) == "local"
 
     def test_hint_lowercased(self) -> None:
         """大文字 provider hint は lowercase 正規化"""
         assert required_provider_for("openai/gpt-4o", "OpenAI") == "openai"
-
-    def test_namespaced_local_model_returns_local(self) -> None:
-        """Codex P2 (PR #248): namespaced ID を持つローカルモデルは local 扱い。
-
-        ``some/very/deep/local-tagger`` のように `/` を含むローカルモデル名でも、
-        最初のセグメント `some` が WebAPI whitelist にないため local 扱いになり、
-        validation で abort しない。
-        """
-        assert required_provider_for("some/very/deep/local-tagger", None) == "local"
-
-    def test_unknown_provider_prefix_returns_local(self) -> None:
-        """未知の provider prefix は defensive に local 扱い。
-
-        将来 lib が新 provider を追加して LoRAIro 側 whitelist が未更新でも、
-        library 側で `MissingApiKeyError` を出させる graceful degradation を選択。
-        """
-        assert required_provider_for("mistral/mistral-large", None) == "local"
-
-    def test_hint_with_unknown_provider_falls_back_to_local(self) -> None:
-        """``Model.provider`` が unknown / 未登録の場合も defensive に local 扱い"""
-        assert required_provider_for("some/local-model", "custom-namespace") == "local"
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary

Issue #241 「API key 状況に応じたモデル表示フィルタ (OpenRouter / 直接プロバイダー経路判別)」の実装。

- 同一モデルが direct / openrouter 経路で別エントリ登録される registry に対し、LoRAIro 側で canonical key で 1 行に畳み込み、API key 設定済み provider に応じた preferred route を auto 選択する
- annotation 実行直前に LoRAIro 側で provider 別の API key 不足を検出し、library に投げる前に明確なエラーで abort する
- `config/lorairo.toml [api]` に `openrouter_key` を追加し、`_prepare_api_keys()` の dict に `openrouter` を含める

スコープ (Plan B3 中間案、user 承認済み):

含むもの:
- `openrouter_key` config 追加 + `_prepare_api_keys()` 拡張
- 新規 `src/lorairo/services/model_route_service.py` (Qt-free pure helper)
- `ModelSelectionService.load_grouped_models()` 追加
- CLI `lorairo-cli models list --route auto|direct|openrouter|all` オプション
- CLI `lorairo-cli annotate run` 実行前 API key validation
- GUI `ModelCheckboxWidget` route badge + alternative tooltip
- GUI `AnnotationWorkflowController` 実行前 validation

含まないもの (Phase 2 で別 Issue 化):
- `[model_selection]` config セクション (route preference 永続化)
- GUI 設定パネルでの route preference dropdown
- 経路毎のコスト/レイテンシ自動推奨ロジック

## 設計判断

- **Route 判定 helper は LoRAIro 側に独立実装** (Plan A1)。`image-annotator-lib` の private helper `_split_litellm_id` を import せず、prefix `openrouter/` の単純 whitelist マッチ (5 行未満) で完結。lib 側 dispatch に新 provider が追加されても fallback は "direct" のまま安全
- **`required_provider_for()` は `Model.provider` を一次ソース** にし、None/"unknown" の場合のみ `litellm_model_id` の prefix から推定。`gemini/` / `vertex_ai/` は alias map で `google` に正規化
- **`auto` 選択は direct > openrouter** で available_providers を考慮。両方未設定なら direct を disabled 表示用に返す
- **CLI 入力 helper `_validate_required_api_keys` は pure な分類 + Rich console 表示** を担い、validation 失敗時は `typer.Exit(1)` + 候補一覧出力
- **GUI 側 validation は `AnnotationWorkflowController` 内で QMessageBox 表示** し、worker 起動を未然に防ぐ

## Test plan

- [x] `tests/unit/services/test_model_route_service.py` (新規、41 件) — pure helper 全数テスト (route 判定 / canonical key / required_provider / grouping / preference / validation)
- [x] `tests/unit/cli/test_annotate_api_key_validation.py` (新規、6 件) — `_validate_required_api_keys()` の 4 パターン (全 key 揃 / 不足 / local skip / hints 経由)
- [x] `tests/unit/cli/test_commands_models.py` 拡張 (5 件追加) — `--route auto/direct/openrouter/all` の各挙動 + 同一 canonical_key の 1 行畳み込み
- [x] `tests/unit/gui/widgets/test_model_checkbox_widget.py` 拡張 (4 件追加) — route badge / alternative tooltip / direct route で badge 非表示
- [x] 既存テスト互換性: Issue #245 リグレッション防止テストを Issue #241 の畳み込み挙動に合わせて更新 (2 件)
- [x] `test_annotate_run_no_api_keys` を新挙動 (exit 1 + Missing API keys) に更新

検証コマンド:

```bash
uv run pytest tests/  # => 2203 passed, 2 skipped, coverage 77.52%
uv run ruff check src/ tests/  # => All checks passed
uv run mypy -p lorairo  # => Success: no issues found in 142 source files
```

手動検証 (実装者ローカル環境):

- [ ] `uv run lorairo-cli models list --route auto` で同一モデルが 1 行畳み込み
- [ ] `uv run lorairo-cli models list --route all` で direct + openrouter 両方表示
- [ ] `openrouter_key` 空 + `--model openrouter/openai/gpt-4o` で exit 1 + Missing API keys
- [ ] GUI: OpenRouter モデルに `[openrouter]` badge、tooltip に alternative
- [ ] GUI: API key 未設定モデル選択 → QMessageBox.warning で abort

## 関連

- Issue #241
- Issue #245 (PR #246 で送信値を `litellm_model_id` に統一済み)
- ADR 0023 Phase 1.9 / 1.10 / 1.11
- image-annotator-lib #39 / #51 / #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)
