### PR TITLE
feat(#249): モデル route preference の永続化と GUI 設定 (Phase 2)

### DIFF
--- a/config/lorairo.toml.template
+++ b/config/lorairo.toml.template
@@ -38,7 +38,9 @@ file_path = ""
 rotation = "25 MB"
 
 [model_selection]
-# Issue #249: モデル経路の優先設定 (auto | direct | openrouter | all)
+# Issue #249: モデル経路の優先設定。
+# auto | direct | openrouter (GUI 設定 dropdown で選択可)
+# all は CLI 専用: lorairo-cli models list --route all
 route_preference = "auto"
 
 [qt]

--- a/config/lorairo.toml.template
+++ b/config/lorairo.toml.template
@@ -37,6 +37,10 @@ level = "DEBUG"
 file_path = ""
 rotation = "25 MB"
 
+[model_selection]
+# Issue #249: モデル経路の優先設定 (auto | direct | openrouter | all)
+route_preference = "auto"
+
 [qt]
 font_size = 10
 suppress_warnings = true

--- a/src/lorairo/cli/commands/models.py
+++ b/src/lorairo/cli/commands/models.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from enum import StrEnum
+from typing import Any
 
 import typer
 from rich.console import Console
@@ -12,6 +13,7 @@ from lorairo.services.model_route_service import (
     build_available_providers,
     canonical_key,
     detect_route,
+    parse_route_preference,
     required_provider_for,
 )
 from lorairo.services.service_container import get_service_container
@@ -102,8 +104,8 @@ def list_models(
         case_sensitive=False,
         help="Filter by model category (all / tagger / scorer / captioner / vision)",
     ),
-    route: RouteFilter = typer.Option(
-        RouteFilter.auto,
+    route: RouteFilter | None = typer.Option(
+        None,
         "--route",
         case_sensitive=False,
         help=(
@@ -111,7 +113,16 @@ def list_models(
             "auto: API key 設定済み provider に応じて direct を優先 / "
             "direct: 直接プロバイダー経路のみ / "
             "openrouter: OpenRouter 経由のみ / "
-            "all: 同一モデルの全 route を 1 行ずつ表示"
+            "all: 同一モデルの全 route を 1 行ずつ表示。"
+            "未指定時は config の [model_selection].route_preference を使う (Issue #249)。"
+        ),
+    ),
+    show_unavailable: bool = typer.Option(
+        False,
+        "--show-unavailable",
+        help=(
+            "API key 未設定で利用不可な行も表示する (Issue #249)。"
+            "default は available な行のみ。ローカル ML モデルは常に available 扱い。"
         ),
     ),
 ) -> None:
@@ -120,6 +131,9 @@ def list_models(
     Issue #241: 同一モデルが direct / openrouter 経路で 2 行並ぶ重複を畳み込み、
     API key 設定済み provider を優先 route として 1 行にまとめる。
     ``--route all`` を指定した場合のみ全 candidate を 1 行ずつ表示する。
+
+    Issue #249: ``--route`` 未指定時は config の ``[model_selection].route_preference``
+    を default として読み込み、``--show-unavailable`` で API key 未設定の行も表示する。
     """
     try:
         container = get_service_container()
@@ -135,45 +149,29 @@ def list_models(
         }
         available_providers = build_available_providers(api_keys)
 
-        rows: list[dict[str, str | bool]] = []
-        for info in infos:
-            if type_filter is ModelTypeFilter.webapi and not info.is_api:
-                continue
-            if type_filter is ModelTypeFilter.local and not info.is_local:
-                continue
-            if category is not ModelCategoryFilter.all and info.model_type != category.value:
-                continue
+        # Issue #249: --route 未指定時は config 値を使う。明示指定は config 上書き。
+        if route is None:
+            raw_preference = config.get_setting("model_selection", "route_preference", "auto")
+            route = RouteFilter(parse_route_preference(raw_preference))
+            preference_source = "config"
+        else:
+            preference_source = "explicit"
 
-            try:
-                deprecated = annotator.is_model_deprecated(info.name)
-            except Exception as e:
-                logger.warning(f"Deprecated check failed for {info.name}: {e}")
-                deprecated = False
-
-            if deprecated and not include_deprecated:
-                continue
-
-            type_label = "webapi" if info.is_api else "local"
-            # Issue #245: Provider と Litellm ID を表示し、route の区別を可能にする。
-            provider_label = info.provider or ("local" if info.is_local else "unknown")
-            litellm_id = info.litellm_model_id or info.name
-            row_route = detect_route(litellm_id)
-            row_required = required_provider_for(litellm_id, info.provider)
-            rows.append(
-                {
-                    "name": info.name,
-                    "provider": provider_label,
-                    "litellm_id": litellm_id,
-                    "type_label": type_label,
-                    "category": info.model_type,
-                    "deprecated": deprecated,
-                    "route": row_route,
-                    "required_provider": row_required,
-                }
-            )
+        rows = _build_rows_from_infos(
+            infos=infos,
+            type_filter=type_filter,
+            category=category,
+            include_deprecated=include_deprecated,
+            annotator=annotator,
+            available_providers=available_providers,
+        )
 
         # Issue #241: canonical_key で grouping し、--route preference に従って絞り込む。
         display_rows = _apply_route_filter(rows, route, available_providers)
+
+        # Issue #249: --show-unavailable 未指定時は available 行のみに絞る。
+        if not show_unavailable:
+            display_rows = [r for r in display_rows if r.get("available", True)]
 
         # 長いモデル名 (例: "vercel_ai_gateway/openai/o1") で固定幅未指定のままだと
         # Rich Table が Type/Category/Status を 0 幅に collapse させて Issue #220 の
@@ -191,6 +189,13 @@ def list_models(
         table.add_column("Status", style="green", min_width=10, no_wrap=True)
 
         for row in display_rows:
+            # Issue #249: available=False は deprecated より優先して disabled 表示。
+            if not row.get("available", True):
+                status_label = "[red]disabled[/red]"
+            elif row["deprecated"]:
+                status_label = "[yellow]deprecated[/yellow]"
+            else:
+                status_label = "active"
             table.add_row(
                 str(row["name"]),
                 str(row["provider"]),
@@ -198,11 +203,17 @@ def list_models(
                 str(row["route"]),
                 str(row["type_label"]),
                 str(row["category"]),
-                "[yellow]deprecated[/yellow]" if row["deprecated"] else "active",
+                status_label,
             )
 
         console.print(table)
-        console.print(f"[dim]{len(display_rows)} model(s) (preference={route.value})[/dim]")
+        # Issue #249: preference の取得元と unavailable 件数も表示
+        unavailable_count = sum(1 for r in display_rows if not r.get("available", True))
+        unavailable_suffix = f", unavailable={unavailable_count}" if unavailable_count > 0 else ""
+        console.print(
+            f"[dim]{len(display_rows)} model(s) "
+            f"(preference={route.value} from {preference_source}{unavailable_suffix})[/dim]"
+        )
     except Exception as e:
         console.print(f"[red]Error:[/red] Failed to list models: {e}")
         logger.error(f"Model list command failed: {e}", exc_info=True)
@@ -253,6 +264,65 @@ def _group_rows_by_canonical_key(
             order.append(ckey)
         grouped[ckey].append(row)
     return grouped, order
+
+
+def _build_rows_from_infos(
+    *,
+    infos: list[Any],
+    type_filter: ModelTypeFilter,
+    category: ModelCategoryFilter,
+    include_deprecated: bool,
+    annotator: Any,
+    available_providers: set[str],
+) -> list[dict[str, str | bool]]:
+    """AnnotatorInfo リストから表示用 row dict 群を構築する。
+
+    Issue #249: ``list_models`` の cyclomatic complexity を下げるための切り出し。
+    type/category/deprecated フィルタ + provider / route / available 判定までを担当。
+    """
+    rows: list[dict[str, str | bool]] = []
+    for info in infos:
+        if type_filter is ModelTypeFilter.webapi and not info.is_api:
+            continue
+        if type_filter is ModelTypeFilter.local and not info.is_local:
+            continue
+        if category is not ModelCategoryFilter.all and info.model_type != category.value:
+            continue
+
+        try:
+            deprecated = annotator.is_model_deprecated(info.name)
+        except Exception as e:
+            logger.warning(f"Deprecated check failed for {info.name}: {e}")
+            deprecated = False
+
+        if deprecated and not include_deprecated:
+            continue
+
+        type_label = "webapi" if info.is_api else "local"
+        # Issue #245: Provider と Litellm ID を表示し、route の区別を可能にする。
+        provider_label = info.provider or ("local" if info.is_local else "unknown")
+        litellm_id = info.litellm_model_id or info.name
+        row_route = detect_route(litellm_id)
+        row_required = required_provider_for(litellm_id, info.provider)
+        # Issue #249: ローカル ML モデルは API key 不要のため常に available。
+        # info.is_local も加味する: provider 未設定 + slash 入り bare ID のローカルモデル
+        # (例: "some/local-tagger") は required_provider_for だと "some" になるため、
+        # info.is_local フラグを優先して available 判定する。
+        row_available = info.is_local or row_required == "local" or row_required in available_providers
+        rows.append(
+            {
+                "name": info.name,
+                "provider": provider_label,
+                "litellm_id": litellm_id,
+                "type_label": type_label,
+                "category": info.model_type,
+                "deprecated": deprecated,
+                "route": row_route,
+                "required_provider": row_required,
+                "available": row_available,
+            }
+        )
+    return rows
 
 
 def _pick_row_for_route(

--- a/src/lorairo/gui/controllers/settings_controller.py
+++ b/src/lorairo/gui/controllers/settings_controller.py
@@ -53,16 +53,22 @@ class SettingsController:
 
         return True
 
-    def open_settings_dialog(self) -> None:
+    def open_settings_dialog(self) -> bool:
         """設定ダイアログを開く
 
         ConfigurationServiceを使用して設定ダイアログを表示します。
+
+        Returns:
+            bool: ユーザーが OK で確定し設定が保存された場合 True、
+                Cancel・ImportError・例外で確定しなかった場合 False。
+                Issue #249: 呼び出し元 (MainWindow) が True 時に依存ウィジェット
+                (ModelSelectionWidget 等) を reload するための戻り値。
         """
         logger.info("設定ダイアログを開きます")
 
         # Step 1: サービス検証
         if not self._validate_services():
-            return
+            return False
 
         try:
             # ConfigurationWindow実装を使用
@@ -75,12 +81,14 @@ class SettingsController:
 
             if result == QDialog.DialogCode.Accepted:
                 logger.info("設定が保存されました")
-            else:
-                logger.info("設定ダイアログがキャンセルされました")
+                return True
+            logger.info("設定ダイアログがキャンセルされました")
+            return False
 
         except ImportError:
             logger.warning("ConfigurationWindowが見つかりません - 代替実装を使用します")
             self._show_simple_settings_dialog()
+            return False
         except Exception as e:
             logger.error(f"設定ダイアログの表示に失敗しました: {e}", exc_info=True)
             from PySide6.QtWidgets import QMessageBox
@@ -88,6 +96,7 @@ class SettingsController:
             QMessageBox.critical(
                 self.parent, "エラー", f"設定ダイアログの表示中にエラーが発生しました:\n\n{e}"
             )
+            return False
 
     def _show_simple_settings_dialog(self) -> None:
         """シンプルな設定ダイアログを表示（フォールバック）

--- a/src/lorairo/gui/widgets/model_selection_widget.py
+++ b/src/lorairo/gui/widgets/model_selection_widget.py
@@ -29,8 +29,10 @@ else:
     from ...services import get_service_container
     from ...services.model_route_service import (
         DisplayModelOption,
+        RoutePreference,
         build_available_providers,
         build_display_options,
+        parse_route_preference,
     )
     from ...services.model_selection_service import ModelSelectionCriteria, ModelSelectionService
     from ...utils.log import logger
@@ -294,11 +296,16 @@ if not __name__ == "__main__":
             self.update_model_display()
 
         def update_model_display(self) -> None:
-            """モデル表示更新 (Issue #241: route 畳み込み済み view model 経由)。"""
+            """モデル表示更新 (Issue #241: route 畳み込み済み view model 経由)。
+
+            Issue #249: ``route_preference`` を config から読み込み、永続化された
+            ユーザー設定を反映する (旧実装は ``"auto"`` ハードコード)。
+            """
             # 現在の表示をクリア
             self._clear_model_display()
 
             available_providers = self._build_available_providers()
+            route_preference = self._get_route_preference()
 
             # フィルタリング実行 -> DisplayModelOption 群を構築
             if self.mode == "simple":
@@ -310,10 +317,10 @@ if not __name__ == "__main__":
                 options = build_display_options(
                     recommended_models,
                     available_providers=available_providers,
-                    preference="auto",
+                    preference=route_preference,
                 )
             else:
-                options = self._apply_advanced_filters(available_providers)
+                options = self._apply_advanced_filters(available_providers, route_preference)
 
             self.filtered_options = options
             self.filtered_models = [opt.preferred.model for opt in options]
@@ -352,7 +359,26 @@ if not __name__ == "__main__":
                 logger.warning(f"API key 状態取得に失敗 (auto route 選択 fallback): {e}")
                 return set()
 
-        def _apply_advanced_filters(self, available_providers: set[str]) -> list[DisplayModelOption]:
+        def _get_route_preference(self) -> RoutePreference:
+            """config から route_preference を取得 (Issue #249)。
+
+            不正値・取得失敗時は ``parse_route_preference`` 経由で
+            ``"auto"`` に安全 fallback する。
+            """
+            try:
+                container = get_service_container()
+                config = container.config_service
+                raw = config.get_setting("model_selection", "route_preference", "auto")
+                return parse_route_preference(raw)
+            except Exception as e:
+                logger.warning(f"route_preference 取得失敗、auto fallback: {e}")
+                return "auto"
+
+        def _apply_advanced_filters(
+            self,
+            available_providers: set[str],
+            route_preference: RoutePreference = "auto",
+        ) -> list[DisplayModelOption]:
             """詳細モード用フィルタリング (Issue #241: route 畳み込み済み view model を返す)"""
             try:
                 criteria = ModelSelectionCriteria(
@@ -369,7 +395,7 @@ if not __name__ == "__main__":
 
                 options = self.model_selection_service.load_grouped_models(
                     criteria,
-                    route_preference="auto",
+                    route_preference=route_preference,
                     available_providers=available_providers,
                 )
                 logger.debug(
@@ -383,7 +409,7 @@ if not __name__ == "__main__":
                 return build_display_options(
                     fallback_models,
                     available_providers=available_providers,
-                    preference="auto",
+                    preference=route_preference,
                 )
 
         def _apply_basic_filters(self) -> list[Model]:

--- a/src/lorairo/gui/window/configuration_window.py
+++ b/src/lorairo/gui/window/configuration_window.py
@@ -21,11 +21,14 @@ from PySide6.QtWidgets import (
 )
 
 from ...services.configuration_service import ConfigurationService
+from ...services.model_route_service import parse_route_preference
 from ...utils.log import initialize_logging, logger
 from ..widgets.directory_picker import DirectoryPickerWidget
 
 # ログレベル選択肢
 _LOG_LEVELS = ["DEBUG", "INFO", "WARNING", "ERROR"]
+# Issue #249: モデル経路の優先設定値域 (RoutePreference Literal と完全一致)
+_ROUTE_PREFERENCES = ["auto", "direct", "openrouter", "all"]
 
 
 class ConfigurationWindow(QDialog):
@@ -160,6 +163,22 @@ class ConfigurationWindow(QDialog):
 
         tab_layout.addWidget(image_group)
 
+        # モデル選択設定 (Issue #249)
+        model_group = QGroupBox("モデル選択")
+        model_layout = QFormLayout(model_group)
+
+        self._combo_box_route_preference = QComboBox()
+        self._combo_box_route_preference.setObjectName("comboBoxRoutePreference")
+        self._combo_box_route_preference.addItems(_ROUTE_PREFERENCES)
+        self._combo_box_route_preference.setToolTip(
+            "モデル経路の優先設定。auto: API key 状況に応じて direct を優先 / "
+            "direct: 直接プロバイダー経路のみ / openrouter: OpenRouter 経由のみ / "
+            "all: 全 route を表示"
+        )
+        model_layout.addRow("経路の優先設定:", self._combo_box_route_preference)
+
+        tab_layout.addWidget(model_group)
+
         # プロンプト設定
         prompt_group = QGroupBox("プロンプト")
         prompt_layout = QVBoxLayout(prompt_group)
@@ -210,6 +229,13 @@ class ConfigurationWindow(QDialog):
         if idx >= 0:
             self._combo_box_upscaler.setCurrentIndex(idx)
 
+        # モデル選択設定 (Issue #249): 不正値・None・空文字は parse_route_preference で auto fallback
+        model_selection = config.get("model_selection", {})
+        normalized_preference = parse_route_preference(model_selection.get("route_preference"))
+        idx = self._combo_box_route_preference.findText(normalized_preference)
+        if idx >= 0:
+            self._combo_box_route_preference.setCurrentIndex(idx)
+
         # プロンプト設定
         prompts = config.get("prompts", {})
         self._text_edit_prompt.setPlainText(prompts.get("additional", ""))
@@ -237,6 +263,11 @@ class ConfigurationWindow(QDialog):
             },
             "image_processing": {
                 "upscaler": self._combo_box_upscaler.currentText(),
+            },
+            "model_selection": {
+                # Issue #249: ComboBox の値域は _ROUTE_PREFERENCES なので
+                # parse_route_preference を通さなくても常に valid だが、防御的に正規化。
+                "route_preference": parse_route_preference(self._combo_box_route_preference.currentText()),
             },
             "prompts": {
                 "additional": self._text_edit_prompt.toPlainText(),

--- a/src/lorairo/gui/window/configuration_window.py
+++ b/src/lorairo/gui/window/configuration_window.py
@@ -27,8 +27,12 @@ from ..widgets.directory_picker import DirectoryPickerWidget
 
 # ログレベル選択肢
 _LOG_LEVELS = ["DEBUG", "INFO", "WARNING", "ERROR"]
-# Issue #249: モデル経路の優先設定値域 (RoutePreference Literal と完全一致)
-_ROUTE_PREFERENCES = ["auto", "direct", "openrouter", "all"]
+# Issue #249: モデル経路の優先設定値域 (GUI 公開分)。
+# "all" は CLI 専用 (--route all): 同一モデルの全 candidate を 1 行ずつ展開する用途で、
+# GUI checkbox UI では preferred のみ描画する設計と整合しないため、GUI dropdown からは除外。
+# CLI 経路 (--route all) と config 手動編集 ("all") の値は parse_route_preference で
+# 受理し続けるが、GUI から保存できる値は auto / direct / openrouter のみ。
+_ROUTE_PREFERENCES = ["auto", "direct", "openrouter"]
 
 
 class ConfigurationWindow(QDialog):
@@ -172,8 +176,8 @@ class ConfigurationWindow(QDialog):
         self._combo_box_route_preference.addItems(_ROUTE_PREFERENCES)
         self._combo_box_route_preference.setToolTip(
             "モデル経路の優先設定。auto: API key 状況に応じて direct を優先 / "
-            "direct: 直接プロバイダー経路のみ / openrouter: OpenRouter 経由のみ / "
-            "all: 全 route を表示"
+            "direct: 直接プロバイダー経路のみ / openrouter: OpenRouter 経由のみ。"
+            "全 route 一覧表示は CLI 専用 (lorairo-cli models list --route all)。"
         )
         model_layout.addRow("経路の優先設定:", self._combo_box_route_preference)
 
@@ -229,12 +233,23 @@ class ConfigurationWindow(QDialog):
         if idx >= 0:
             self._combo_box_upscaler.setCurrentIndex(idx)
 
-        # モデル選択設定 (Issue #249): 不正値・None・空文字は parse_route_preference で auto fallback
+        # モデル選択設定 (Issue #249): 不正値・None・空文字は parse_route_preference で auto fallback。
+        # "all" は CLI 専用のため GUI ComboBox には項目が無い → findText が -1 を返す。
+        # その場合 auto にフォールバックして警告ログを残す (silently overwrite を避けるための明示通知)。
         model_selection = config.get("model_selection", {})
         normalized_preference = parse_route_preference(model_selection.get("route_preference"))
         idx = self._combo_box_route_preference.findText(normalized_preference)
         if idx >= 0:
             self._combo_box_route_preference.setCurrentIndex(idx)
+        else:
+            logger.warning(
+                "route_preference=%r は GUI 設定では選択できないため auto にフォールバック表示します "
+                "(OK 押下時に auto で上書き保存)。CLI でのみ利用する場合は GUI で変更しないでください。",
+                normalized_preference,
+            )
+            auto_idx = self._combo_box_route_preference.findText("auto")
+            if auto_idx >= 0:
+                self._combo_box_route_preference.setCurrentIndex(auto_idx)
 
         # プロンプト設定
         prompts = config.get("prompts", {})

--- a/src/lorairo/gui/window/main_window.py
+++ b/src/lorairo/gui/window/main_window.py
@@ -1392,7 +1392,16 @@ class MainWindow(QMainWindow, Ui_MainWindow):
     def open_settings(self) -> None:
         """設定ウィンドウを開く（SettingsControllerに委譲）"""
         if self.settings_controller:
-            self.settings_controller.open_settings_dialog()
+            settings_applied = self.settings_controller.open_settings_dialog()
+            # Issue #249: route_preference 等の保存値を ModelSelectionWidget に即時反映
+            if settings_applied:
+                batch_widget = getattr(self, "batchModelSelection", None)
+                if batch_widget is not None:
+                    try:
+                        batch_widget.update_model_display()
+                        logger.debug("設定変更を反映してモデル選択ウィジェットを更新しました")
+                    except Exception as e:
+                        logger.warning(f"モデル選択ウィジェットの更新に失敗 (継続可): {e}")
         else:
             logger.error("SettingsControllerが初期化されていません")
             QMessageBox.warning(

--- a/src/lorairo/services/model_route_service.py
+++ b/src/lorairo/services/model_route_service.py
@@ -27,7 +27,7 @@ from __future__ import annotations
 
 from collections.abc import Iterable
 from dataclasses import dataclass, field
-from typing import Literal
+from typing import Literal, cast, get_args
 
 from ..database.schema import Model
 from ..utils.log import logger
@@ -38,6 +38,8 @@ RoutePreference = Literal["auto", "direct", "openrouter", "all"]
 _OPENROUTER_PREFIX = "openrouter/"
 _LOCAL_PROVIDER = "local"
 _UNKNOWN_PROVIDERS = frozenset({"", "unknown"})
+# Issue #249: parse_route_preference の validation 集合 (Literal 値域と完全一致)
+_VALID_ROUTE_PREFERENCES: frozenset[str] = frozenset(get_args(RoutePreference))
 
 # litellm_model_id 先頭セグメントに対する provider 別名の正規化マップ。
 # 例: "gemini/..." は "google" key を要求する。
@@ -129,6 +131,10 @@ class DisplayModelOption:
     capabilities: tuple[str, ...]
     preferred: ModelRouteCandidate
     alternatives: tuple[ModelRouteCandidate, ...] = field(default_factory=tuple)
+    # Issue #249: preferred の required_provider が API key 未設定で disabled
+    # fallback として返された場合は False。CLI `--show-unavailable` で活用。
+    # default True は既存呼び出し元 (preference="all" や key 状況非考慮) の後方互換。
+    available: bool = True
 
     @property
     def all_candidates(self) -> tuple[ModelRouteCandidate, ...]:
@@ -272,6 +278,15 @@ def build_display_options(
                     tuple(alt.model.capabilities),
                 )
 
+        # Issue #249: preferred の required_provider が API key 設定済みかで available 判定。
+        # ローカル ML モデルは API key 不要のため常に available。
+        # caller が available_providers を渡さない場合 (= treat_all_available)
+        # は全 candidate を available 扱い (従来挙動と同等)。
+        if treat_all_available or preferred.required_provider == _LOCAL_PROVIDER:
+            is_available = True
+        else:
+            is_available = preferred.required_provider in available_providers
+
         options.append(
             DisplayModelOption(
                 canonical_key=ckey,
@@ -279,11 +294,42 @@ def build_display_options(
                 capabilities=preferred_caps,
                 preferred=preferred,
                 alternatives=alternatives,
+                available=is_available,
             )
         )
 
     options.sort(key=lambda o: o.display_name.lower())
     return options
+
+
+def parse_route_preference(raw: str | None) -> RoutePreference:
+    """config から取得した raw 値を ``RoutePreference`` Literal に正規化。
+
+    Issue #249: GUI / CLI の双方が config 由来 default を扱うため、不正値・None・
+    空文字を ``"auto"`` に安全 fallback する共通 helper。不正値は warning log。
+
+    Args:
+        raw: ``ConfigurationService.get_setting("model_selection", "route_preference", ...)``
+            の戻り値。型契約は ``str | None`` だが、Mock 経由など想定外の型が
+            紛れ込んでもクラッシュしないよう ``isinstance(str)`` ガードで弾く。
+
+    Returns:
+        正規化された ``RoutePreference``。値域は
+        ``Literal["auto", "direct", "openrouter", "all"]`` と完全一致。
+    """
+    if not isinstance(raw, str):
+        return "auto"
+    normalized = raw.strip().lower()
+    if normalized == "":
+        return "auto"
+    if normalized in _VALID_ROUTE_PREFERENCES:
+        return cast(RoutePreference, normalized)
+    logger.warning(
+        "Invalid route_preference value %r, falling back to 'auto'. Valid values: %s",
+        raw,
+        sorted(_VALID_ROUTE_PREFERENCES),
+    )
+    return "auto"
 
 
 def validate_api_keys_for_models(
@@ -334,6 +380,7 @@ __all__ = [
     "canonical_key",
     "detect_route",
     "group_model_routes",
+    "parse_route_preference",
     "required_provider_for",
     "select_preferred_route",
     "validate_api_keys_for_models",

--- a/src/lorairo/utils/config.py
+++ b/src/lorairo/utils/config.py
@@ -105,7 +105,11 @@ DEFAULT_CONFIG = {
     },
     "log": {"level": "INFO", "file_path": str(DEFAULT_LOG_PATH), "rotation": "25 MB", "levels": {}},
     "model_selection": {
-        # Issue #249: route preference の永続化。auto | direct | openrouter | all
+        # Issue #249: route preference の永続化。
+        # auto | direct | openrouter (GUI dropdown で選択可)
+        # all は CLI 専用 (--route all): GUI checkbox UI は preferred 1 行のみ描画する設計と
+        # 整合しないため GUI dropdown では未提供。手動で "all" を書いた場合 GUI 起動時に
+        # warning log + auto 表示にフォールバックする (configuration_window.py 参照)。
         "route_preference": "auto",
     },
 }

--- a/src/lorairo/utils/config.py
+++ b/src/lorairo/utils/config.py
@@ -104,6 +104,10 @@ DEFAULT_CONFIG = {
         # Tag databases are now managed via genai-tag-db-tools public API (initialize_databases)
     },
     "log": {"level": "INFO", "file_path": str(DEFAULT_LOG_PATH), "rotation": "25 MB", "levels": {}},
+    "model_selection": {
+        # Issue #249: route preference の永続化。auto | direct | openrouter | all
+        "route_preference": "auto",
+    },
 }
 
 

--- a/tests/unit/cli/test_commands_models.py
+++ b/tests/unit/cli/test_commands_models.py
@@ -336,6 +336,19 @@ def _api_key_lookup(keys: dict[str, str]):
     return _lookup
 
 
+def _config_lookup(api_keys: dict[str, str], route_preference: str = "auto"):
+    """Issue #249: api section + model_selection section の両方に反応する side_effect。"""
+
+    def _lookup(section: str, key: str, default: str = "") -> str:
+        if section == "api":
+            return api_keys.get(key, default)
+        if section == "model_selection" and key == "route_preference":
+            return route_preference
+        return default
+
+    return _lookup
+
+
 @pytest.mark.unit
 @pytest.mark.cli
 @patch("lorairo.cli.commands.models.get_service_container")
@@ -386,11 +399,17 @@ def test_models_list_route_auto_falls_back_to_openrouter_when_only_openrouter_ke
 @pytest.mark.cli
 @patch("lorairo.cli.commands.models.get_service_container")
 def test_models_list_route_all_expands_both_routes(mock_get_container) -> None:
-    """--route all は各 candidate を 1 行ずつ展開する"""
+    """--route all は各 candidate を 1 行ずつ展開する。
+
+    Issue #249: 両方の key が設定済みでなければ available=False で filter される。
+    本テストでは route 展開挙動のみ検証するため両 key を mock に持たせる。
+    """
     mock_container = MagicMock()
     mock_container.annotator_library.list_annotator_info.return_value = _make_duplicate_route_infos()
     mock_container.annotator_library.is_model_deprecated.return_value = False
-    mock_container.config_service.get_setting.side_effect = _api_key_lookup({})
+    mock_container.config_service.get_setting.side_effect = _api_key_lookup(
+        {"openai_key": "sk-1", "openrouter_key": "sk-or"}
+    )
     mock_get_container.return_value = mock_container
 
     result = runner.invoke(app, ["models", "list", "--route", "all"])
@@ -406,11 +425,15 @@ def test_models_list_route_all_expands_both_routes(mock_get_container) -> None:
 @pytest.mark.cli
 @patch("lorairo.cli.commands.models.get_service_container")
 def test_models_list_route_direct_filters_to_direct_only(mock_get_container) -> None:
-    """--route direct は direct route のみ表示"""
+    """--route direct は direct route のみ表示。
+
+    Issue #249: openai_key を設定しないと available=False で行が消えるため、
+    direct route の表示挙動を検証するために key を入れる。
+    """
     mock_container = MagicMock()
     mock_container.annotator_library.list_annotator_info.return_value = _make_duplicate_route_infos()
     mock_container.annotator_library.is_model_deprecated.return_value = False
-    mock_container.config_service.get_setting.side_effect = _api_key_lookup({})
+    mock_container.config_service.get_setting.side_effect = _api_key_lookup({"openai_key": "sk-1"})
     mock_get_container.return_value = mock_container
 
     result = runner.invoke(app, ["models", "list", "--route", "direct"])
@@ -425,11 +448,15 @@ def test_models_list_route_direct_filters_to_direct_only(mock_get_container) -> 
 @pytest.mark.cli
 @patch("lorairo.cli.commands.models.get_service_container")
 def test_models_list_route_openrouter_filters_to_openrouter_only(mock_get_container) -> None:
-    """--route openrouter は openrouter route のみ表示"""
+    """--route openrouter は openrouter route のみ表示。
+
+    Issue #249: openrouter_key を設定しないと available=False で行が消えるため、
+    openrouter route の表示挙動を検証するために key を入れる。
+    """
     mock_container = MagicMock()
     mock_container.annotator_library.list_annotator_info.return_value = _make_duplicate_route_infos()
     mock_container.annotator_library.is_model_deprecated.return_value = False
-    mock_container.config_service.get_setting.side_effect = _api_key_lookup({})
+    mock_container.config_service.get_setting.side_effect = _api_key_lookup({"openrouter_key": "sk-or"})
     mock_get_container.return_value = mock_container
 
     result = runner.invoke(app, ["models", "list", "--route", "openrouter"])
@@ -437,6 +464,116 @@ def test_models_list_route_openrouter_filters_to_openrouter_only(mock_get_contai
     assert result.exit_code == 0
     assert "1 model(s)" in result.stdout
     assert "openrouter/openai/gpt-4o" in result.stdout
+
+
+# --- Issue #249: --show-unavailable / config 由来 default ---
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+@patch("lorairo.cli.commands.models.get_service_container")
+def test_models_list_show_unavailable_displays_disabled_rows(mock_get_container) -> None:
+    """--show-unavailable は API key 未設定の行を 'disabled' Status で表示する"""
+    mock_container = MagicMock()
+    mock_container.annotator_library.list_annotator_info.return_value = _make_duplicate_route_infos()
+    mock_container.annotator_library.is_model_deprecated.return_value = False
+    mock_container.config_service.get_setting.side_effect = _api_key_lookup({})
+    mock_get_container.return_value = mock_container
+
+    result = runner.invoke(app, ["models", "list", "--show-unavailable"])
+
+    assert result.exit_code == 0
+    # 全 row が disabled でも表示される
+    assert "1 model(s)" in result.stdout
+    assert "disabled" in result.stdout
+    assert "unavailable=1" in result.stdout
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+@patch("lorairo.cli.commands.models.get_service_container")
+def test_models_list_show_unavailable_with_route_all(mock_get_container) -> None:
+    """--show-unavailable + --route all で全 candidate を disabled 状態で表示"""
+    mock_container = MagicMock()
+    mock_container.annotator_library.list_annotator_info.return_value = _make_duplicate_route_infos()
+    mock_container.annotator_library.is_model_deprecated.return_value = False
+    mock_container.config_service.get_setting.side_effect = _api_key_lookup({})
+    mock_get_container.return_value = mock_container
+
+    result = runner.invoke(app, ["models", "list", "--route", "all", "--show-unavailable"])
+
+    assert result.exit_code == 0
+    assert "2 model(s)" in result.stdout
+    assert "disabled" in result.stdout
+    assert "openai/gpt-4o" in result.stdout
+    assert "openrouter/openai/gpt-4o" in result.stdout
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+@patch("lorairo.cli.commands.models.get_service_container")
+def test_models_list_route_default_reads_from_config(mock_get_container) -> None:
+    """--route 未指定時は config の model_selection.route_preference を default として使う"""
+    mock_container = MagicMock()
+    mock_container.annotator_library.list_annotator_info.return_value = _make_duplicate_route_infos()
+    mock_container.annotator_library.is_model_deprecated.return_value = False
+    # config に "direct" を入れる、両方の key を available にして filter で消えないようにする
+    mock_container.config_service.get_setting.side_effect = _config_lookup(
+        {"openai_key": "sk-1", "openrouter_key": "sk-or"},
+        route_preference="direct",
+    )
+    mock_get_container.return_value = mock_container
+
+    result = runner.invoke(app, ["models", "list"])  # --route 未指定
+
+    assert result.exit_code == 0
+    # config 値 "direct" が default として効く
+    assert "preference=direct from config" in result.stdout
+    assert "openai/gpt-4o" in result.stdout
+    # openrouter route は preference=direct で除外される
+    assert "openrouter/openai/gpt-4o" not in result.stdout
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+@patch("lorairo.cli.commands.models.get_service_container")
+def test_models_list_explicit_route_overrides_config(mock_get_container) -> None:
+    """--route 明示指定は config 値を上書きする (preference_source=explicit)"""
+    mock_container = MagicMock()
+    mock_container.annotator_library.list_annotator_info.return_value = _make_duplicate_route_infos()
+    mock_container.annotator_library.is_model_deprecated.return_value = False
+    mock_container.config_service.get_setting.side_effect = _config_lookup(
+        {"openai_key": "sk-1"},
+        route_preference="openrouter",  # config では openrouter
+    )
+    mock_get_container.return_value = mock_container
+
+    result = runner.invoke(app, ["models", "list", "--route", "direct"])
+
+    assert result.exit_code == 0
+    # 明示指定 "direct" が config 値 "openrouter" を上書き
+    assert "preference=direct from explicit" in result.stdout
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+@patch("lorairo.cli.commands.models.get_service_container")
+def test_models_list_route_invalid_config_falls_back_to_auto(mock_get_container) -> None:
+    """config の route_preference が不正値の場合 'auto' に fallback"""
+    mock_container = MagicMock()
+    mock_container.annotator_library.list_annotator_info.return_value = _make_duplicate_route_infos()
+    mock_container.annotator_library.is_model_deprecated.return_value = False
+    mock_container.config_service.get_setting.side_effect = _config_lookup(
+        {"openai_key": "sk-1"},
+        route_preference="bogus_value",
+    )
+    mock_get_container.return_value = mock_container
+
+    result = runner.invoke(app, ["models", "list"])
+
+    assert result.exit_code == 0
+    # 不正値は auto fallback
+    assert "preference=auto from config" in result.stdout
 
 
 @pytest.mark.unit
@@ -464,7 +601,10 @@ def test_models_list_long_model_names_keep_columns_visible(mock_get_container) -
     mock_container.annotator_library.is_model_deprecated.return_value = False
     mock_get_container.return_value = mock_container
 
-    result = runner.invoke(app, ["models", "list"])
+    # Issue #249: webapi モデルの provider が None だと available=False で filter される。
+    # 本テストは表示列の collapse 防止 (Issue #220) を検証するため --show-unavailable で
+    # 表示自体を保証する。
+    result = runner.invoke(app, ["models", "list", "--show-unavailable"])
 
     assert result.exit_code == 0
     # Type 値 (webapi/local) が空 collapse せずに描画されること
@@ -473,6 +613,6 @@ def test_models_list_long_model_names_keep_columns_visible(mock_get_container) -
     # Category 値 (vision/tagger) が空 collapse せずに描画されること
     assert "vision" in result.stdout
     assert "tagger" in result.stdout
-    # Status 値 (active) が空 collapse せずに描画されること
+    # ローカルモデルは常に available なため active (webapi は disabled で表示される)
     assert "active" in result.stdout
     assert "2 model(s)" in result.stdout

--- a/tests/unit/gui/widgets/test_model_selection_widget.py
+++ b/tests/unit/gui/widgets/test_model_selection_widget.py
@@ -228,3 +228,55 @@ class TestModelSelectionWidgetLitellmIdKeying:
         # 推奨は new_sync_direct (openai 直接版) のみ
         assert selected == [new_sync_direct.litellm_model_id]
         assert migration_route.litellm_model_id not in selected
+
+
+class TestModelSelectionWidgetRoutePreference:
+    """Issue #249: route_preference を config から読み込む挙動。"""
+
+    def test_get_route_preference_uses_config_value(self, qtbot, mock_model_service, monkeypatch) -> None:
+        """config の model_selection.route_preference が ``_get_route_preference`` に反映される。"""
+        mock_container = Mock()
+        mock_container.config_service.get_setting.return_value = "direct"
+        monkeypatch.setattr(
+            "lorairo.gui.widgets.model_selection_widget.get_service_container",
+            lambda: mock_container,
+        )
+
+        w = ModelSelectionWidget(model_selection_service=mock_model_service)
+        qtbot.addWidget(w)
+
+        assert w._get_route_preference() == "direct"
+
+    def test_get_route_preference_invalid_value_falls_back_to_auto(
+        self, qtbot, mock_model_service, monkeypatch
+    ) -> None:
+        """config 不正値は parse_route_preference 経由で auto fallback。"""
+        mock_container = Mock()
+        mock_container.config_service.get_setting.return_value = "bogus"
+        monkeypatch.setattr(
+            "lorairo.gui.widgets.model_selection_widget.get_service_container",
+            lambda: mock_container,
+        )
+
+        w = ModelSelectionWidget(model_selection_service=mock_model_service)
+        qtbot.addWidget(w)
+
+        assert w._get_route_preference() == "auto"
+
+    def test_get_route_preference_falls_back_on_container_exception(
+        self, qtbot, mock_model_service, monkeypatch
+    ) -> None:
+        """get_service_container が例外を投げた場合は auto に fallback。"""
+
+        def _raise() -> None:
+            raise RuntimeError("container not initialized")
+
+        monkeypatch.setattr(
+            "lorairo.gui.widgets.model_selection_widget.get_service_container",
+            _raise,
+        )
+
+        w = ModelSelectionWidget(model_selection_service=mock_model_service)
+        qtbot.addWidget(w)
+
+        assert w._get_route_preference() == "auto"

--- a/tests/unit/gui/window/test_configuration_window.py
+++ b/tests/unit/gui/window/test_configuration_window.py
@@ -97,9 +97,16 @@ class TestConfigurationWindow:
         assert project_name.text() == "test_project"
 
     def test_collect_settings_returns_all_sections(self, dialog: ConfigurationWindow) -> None:
-        """全セクション含む辞書を返す。"""
+        """全セクション含む辞書を返す (Issue #249 で model_selection を追加)。"""
         settings = dialog._collect_settings()
-        expected_sections = {"api", "directories", "log", "image_processing", "prompts"}
+        expected_sections = {
+            "api",
+            "directories",
+            "log",
+            "image_processing",
+            "prompts",
+            "model_selection",
+        }
         assert set(settings.keys()) == expected_sections
 
     def test_populate_and_collect_roundtrip(self, dialog: ConfigurationWindow) -> None:
@@ -155,3 +162,86 @@ class TestConfigurationWindow:
         items = [upscaler.itemText(i) for i in range(upscaler.count())]
         assert "RealESRGAN_x4plus" in items
         assert "RealESRGAN_x4plus_anime_6B" in items
+
+
+@pytest.mark.gui
+class TestConfigurationWindowRoutePreference:
+    """Issue #249: route_preference ComboBox の populate / collect / fallback。"""
+
+    def test_route_preference_combobox_populated_with_four_values(
+        self, dialog: ConfigurationWindow
+    ) -> None:
+        """ComboBox に auto/direct/openrouter/all の 4 値が並ぶ。"""
+        combo = dialog.findChild(QComboBox, "comboBoxRoutePreference")
+        assert combo is not None
+        items = [combo.itemText(i) for i in range(combo.count())]
+        assert items == ["auto", "direct", "openrouter", "all"]
+
+    def test_route_preference_default_to_auto_when_section_missing(
+        self, dialog: ConfigurationWindow
+    ) -> None:
+        """model_selection section が config に無い場合、auto がセットされる。"""
+        combo = dialog.findChild(QComboBox, "comboBoxRoutePreference")
+        assert combo is not None
+        # _make_mock_config_service は model_selection を返さないため auto fallback
+        assert combo.currentText() == "auto"
+
+    def test_route_preference_populated_from_config(self, qtbot, config_service: MagicMock) -> None:
+        """config の model_selection.route_preference が ComboBox に反映される。"""
+        config_service.get_all_settings.return_value = {
+            "api": {},
+            "directories": {},
+            "log": {"level": "INFO"},
+            "image_processing": {"upscaler": "RealESRGAN_x4plus"},
+            "prompts": {"additional": ""},
+            "model_selection": {"route_preference": "openrouter"},
+        }
+        dlg = ConfigurationWindow(config_service=config_service)
+        qtbot.addWidget(dlg)
+        combo = dlg.findChild(QComboBox, "comboBoxRoutePreference")
+        assert combo is not None
+        assert combo.currentText() == "openrouter"
+
+    def test_route_preference_invalid_config_falls_back_to_auto(
+        self, qtbot, config_service: MagicMock
+    ) -> None:
+        """config の不正値は parse_route_preference 経由で auto に fallback。"""
+        config_service.get_all_settings.return_value = {
+            "api": {},
+            "directories": {},
+            "log": {"level": "INFO"},
+            "image_processing": {"upscaler": "RealESRGAN_x4plus"},
+            "prompts": {"additional": ""},
+            "model_selection": {"route_preference": "bogus"},
+        }
+        dlg = ConfigurationWindow(config_service=config_service)
+        qtbot.addWidget(dlg)
+        combo = dlg.findChild(QComboBox, "comboBoxRoutePreference")
+        assert combo is not None
+        assert combo.currentText() == "auto"
+
+    def test_collect_settings_includes_model_selection(self, dialog: ConfigurationWindow) -> None:
+        """_collect_settings に model_selection.route_preference が含まれる。"""
+        settings = dialog._collect_settings()
+        assert "model_selection" in settings
+        assert settings["model_selection"]["route_preference"] in {
+            "auto",
+            "direct",
+            "openrouter",
+            "all",
+        }
+
+    def test_ok_saves_route_preference(
+        self, dialog: ConfigurationWindow, config_service: MagicMock, qtbot
+    ) -> None:
+        """OK で model_selection.route_preference が update_setting されて save される。"""
+        combo = dialog.findChild(QComboBox, "comboBoxRoutePreference")
+        assert combo is not None
+        combo.setCurrentText("direct")
+        with qtbot.waitSignal(dialog.accepted, timeout=3000):
+            dialog._on_accepted()
+        # update_setting が ("model_selection", "route_preference", "direct") で呼ばれている
+        update_calls = config_service.update_setting.call_args_list
+        assert any(
+            call.args == ("model_selection", "route_preference", "direct") for call in update_calls
+        ), f"expected update_setting('model_selection', 'route_preference', 'direct') in {update_calls}"

--- a/tests/unit/gui/window/test_configuration_window.py
+++ b/tests/unit/gui/window/test_configuration_window.py
@@ -168,14 +168,19 @@ class TestConfigurationWindow:
 class TestConfigurationWindowRoutePreference:
     """Issue #249: route_preference ComboBox の populate / collect / fallback。"""
 
-    def test_route_preference_combobox_populated_with_four_values(
+    def test_route_preference_combobox_populated_with_three_values(
         self, dialog: ConfigurationWindow
     ) -> None:
-        """ComboBox に auto/direct/openrouter/all の 4 値が並ぶ。"""
+        """ComboBox に auto/direct/openrouter の 3 値が並ぶ (Issue #249 PR #250 review)。
+
+        ``all`` は CLI 専用 (--route all)。GUI checkbox UI は preferred 1 行のみ
+        描画する設計と整合しないため、GUI dropdown には含めない。
+        """
         combo = dialog.findChild(QComboBox, "comboBoxRoutePreference")
         assert combo is not None
         items = [combo.itemText(i) for i in range(combo.count())]
-        assert items == ["auto", "direct", "openrouter", "all"]
+        assert items == ["auto", "direct", "openrouter"]
+        assert "all" not in items
 
     def test_route_preference_default_to_auto_when_section_missing(
         self, dialog: ConfigurationWindow
@@ -218,6 +223,30 @@ class TestConfigurationWindowRoutePreference:
         qtbot.addWidget(dlg)
         combo = dlg.findChild(QComboBox, "comboBoxRoutePreference")
         assert combo is not None
+        assert combo.currentText() == "auto"
+
+    def test_route_preference_all_config_falls_back_to_auto_in_gui(
+        self, qtbot, config_service: MagicMock
+    ) -> None:
+        """config に "all" がある場合、GUI ComboBox には項目が無いため auto fallback (PR #250 review)。
+
+        CLI 経路では "all" は valid だが、GUI dropdown には項目が無いため
+        ``findText("all") == -1`` で auto fallback。warning log が出ること自体は
+        loguru 経路で副作用、本テストでは ComboBox の最終状態のみ検証。
+        """
+        config_service.get_all_settings.return_value = {
+            "api": {},
+            "directories": {},
+            "log": {"level": "INFO"},
+            "image_processing": {"upscaler": "RealESRGAN_x4plus"},
+            "prompts": {"additional": ""},
+            "model_selection": {"route_preference": "all"},
+        }
+        dlg = ConfigurationWindow(config_service=config_service)
+        qtbot.addWidget(dlg)
+        combo = dlg.findChild(QComboBox, "comboBoxRoutePreference")
+        assert combo is not None
+        # GUI 上は auto として表示 (CLI 専用値のため)
         assert combo.currentText() == "auto"
 
     def test_collect_settings_includes_model_selection(self, dialog: ConfigurationWindow) -> None:

--- a/tests/unit/services/test_model_route_service.py
+++ b/tests/unit/services/test_model_route_service.py
@@ -11,12 +11,14 @@ from types import SimpleNamespace
 import pytest
 
 from lorairo.services.model_route_service import (
+    DisplayModelOption,
     ModelRouteCandidate,
     build_available_providers,
     build_display_options,
     canonical_key,
     detect_route,
     group_model_routes,
+    parse_route_preference,
     required_provider_for,
     select_preferred_route,
     validate_api_keys_for_models,
@@ -325,3 +327,81 @@ class TestValidateApiKeysForModels:
         """`gemini/` prefix は google key を要求 (alias 解決)"""
         missing = validate_api_keys_for_models(["gemini/gemini-pro"], {})
         assert missing == [("gemini/gemini-pro", "google")]
+
+
+@pytest.mark.unit
+class TestParseRoutePreference:
+    """Issue #249: config から取得した raw 値の正規化 + 不正値フォールバック"""
+
+    @pytest.mark.parametrize("raw", ["auto", "direct", "openrouter", "all"])
+    def test_valid_values_returned_as_is(self, raw: str) -> None:
+        assert parse_route_preference(raw) == raw
+
+    def test_none_falls_back_to_auto(self) -> None:
+        assert parse_route_preference(None) == "auto"
+
+    def test_empty_string_falls_back_to_auto(self) -> None:
+        assert parse_route_preference("") == "auto"
+
+    def test_whitespace_only_falls_back_to_auto(self) -> None:
+        assert parse_route_preference("   ") == "auto"
+
+    def test_invalid_value_falls_back_to_auto(self) -> None:
+        """不正値は 'auto' に fallback (warning log 経路)"""
+        assert parse_route_preference("bogus") == "auto"
+
+    def test_uppercase_normalized(self) -> None:
+        """大文字 / strip も正規化される"""
+        assert parse_route_preference("  DIRECT  ") == "direct"
+
+    def test_non_string_falls_back_to_auto(self) -> None:
+        """isinstance ガードで int / None 以外も safe fallback"""
+        assert parse_route_preference(123) == "auto"  # type: ignore[arg-type]  # 防御テスト
+
+
+@pytest.mark.unit
+class TestDisplayModelOptionAvailable:
+    """Issue #249: DisplayModelOption.available field 動作"""
+
+    def test_default_is_true(self) -> None:
+        """field default は True (既存呼び出し元の後方互換)"""
+        m = _fake_model("openai/gpt-4o", "gpt-4o", "openai")
+        candidate = ModelRouteCandidate(
+            litellm_model_id="openai/gpt-4o",
+            route="direct",
+            required_provider="openai",
+            model=m,
+        )
+        opt = DisplayModelOption(
+            canonical_key="openai/gpt-4o",
+            display_name="gpt-4o",
+            capabilities=(),
+            preferred=candidate,
+        )
+        assert opt.available is True
+
+    def test_build_display_options_marks_available_when_key_present(self) -> None:
+        """API key 設定済み provider の preferred は available=True"""
+        m = _fake_model("openai/gpt-4o", "gpt-4o", "openai")
+        options = build_display_options([m], {"openai"}, "auto")
+        assert options[0].available is True
+
+    def test_build_display_options_marks_unavailable_when_no_key(self) -> None:
+        """API key 未設定環境では preferred (disabled fallback) は available=False"""
+        m = _fake_model("openai/gpt-4o", "gpt-4o", "openai")
+        options = build_display_options([m], set(), "auto")
+        assert len(options) == 1
+        # disabled fallback (auto preference の最後のケース) でも option は返される
+        assert options[0].available is False
+
+    def test_build_display_options_local_model_always_available(self) -> None:
+        """ローカル ML モデル (required_provider == 'local') は API key 不要、常に available"""
+        m = _fake_model("wd-v1-4-tagger", "wd-v1-4-tagger", None, requires_api_key=False)
+        options = build_display_options([m], set(), "auto")
+        assert options[0].available is True
+
+    def test_build_display_options_treat_all_available_when_no_providers_filter(self) -> None:
+        """available_providers=None (= 全 available 扱い) では常に available=True"""
+        m = _fake_model("openai/gpt-4o", "gpt-4o", "openai")
+        options = build_display_options([m], None, "auto")
+        assert options[0].available is True


### PR DESCRIPTION
## Summary

Issue #249 (Phase 2) の実装。PR #248 (Issue #241) でマージされた `model_route_service` のオプショナル項目 3 つを 1 PR で実装。

- **`[model_selection]` config セクション** で `route_preference` を永続化
- **CLI `lorairo-cli models list --show-unavailable`** で API key 未設定行を全件表示
- **GUI 設定パネル (ConfigurationWindow 詳細タブ)** に route preference の ComboBox を追加

## 主要変更

### Service 層
- `model_route_service.parse_route_preference(raw) -> RoutePreference` 新規 helper (不正値・None・空文字は `auto` に warning log + fallback)
- `DisplayModelOption.available: bool = True` field 追加 (default True で既存呼び出し元の後方互換)
- `build_display_options` で `preferred.required_provider in available_providers` を判定して `available` を伝播。ローカルモデルは常に `True`

### CLI (`lorairo-cli models list`)
- `--route` Typer Option default を `None` に変更、未指定時 config の `[model_selection].route_preference` を読み込み
- `--show-unavailable` フラグ追加。未指定時は `available=True` 行のみ、指定時は `[red]disabled[/red]` Status 付きで全件表示
- 出力フッターに `preference={value} from {config|explicit}` と `unavailable={count}` を追加
- 複雑度対策で `_build_rows_from_infos()` helper を切り出し (C901 解消)

### GUI
- `ConfigurationWindow` 詳細タブに「モデル選択 / 経路の優先設定」ComboBox 追加
- `_populate_from_config()` で `parse_route_preference` 経由で安全に読み込み
- `_collect_settings()` に `model_selection.route_preference` を含める
- `SettingsController.open_settings_dialog()` の戻り値を `None` → `bool` (OK 確定で `True`)
- `MainWindow.open_settings()` で accept 後 `batchModelSelection.update_model_display()` を呼んで即時反映
- `ModelSelectionWidget` の `route_preference=\"auto\"` ハードコード (2 箇所) を `_get_route_preference()` 経由の config 読みに置換

### Config 基盤
- `config/lorairo.toml.template` に `[model_selection]` セクション追加
- `DEFAULT_CONFIG` (`utils/config.py`) に `model_selection.route_preference = \"auto\"` 追加

## テスト

| ファイル | 追加件数 | 概要 |
|---|---|---|
| `tests/unit/services/test_model_route_service.py` | 12 件 | `parse_route_preference` 7 件 + `DisplayModelOption.available` 5 件 |
| `tests/unit/cli/test_commands_models.py` | 5 件 + 3 件修正 | `--show-unavailable` 2 件 / config default 2 件 / 不正値 fallback 1 件 + 既存 3 件の mock 更新 |
| `tests/unit/gui/window/test_configuration_window.py` | 6 件 | route_preference ComboBox の populate / collect / fallback |
| `tests/unit/gui/widgets/test_model_selection_widget.py` | 3 件 | `_get_route_preference` の config 読み / 不正値 / 例外時 fallback |

**全 2232 テスト通過 (35.29 秒)**

## 検証手順

```bash
# CLI 動作確認
uv run lorairo-cli models list                              # config default を使う
uv run lorairo-cli models list --route direct               # 明示指定で上書き
uv run lorairo-cli models list --show-unavailable           # disabled 行を表示
grep route_preference config/lorairo.toml                   # GUI 経由で変更後の永続化確認

# 単体テスト
uv run pytest tests/unit/services/test_model_route_service.py \\
              tests/unit/cli/test_commands_models.py \\
              tests/unit/gui/window/test_configuration_window.py \\
              tests/unit/gui/widgets/test_model_selection_widget.py
```

## スコープ外 (再確認)

- `show_route_alternatives` flag (GUI tooltip ON/OFF): Phase 2 で扱わない (要望が出たら別途)
- 経路毎のコスト/レイテンシ自動推奨: 別 Issue 候補

## 関連

- Issue #249 (本 PR でクローズ可)
- Issue #241 (Phase 1、PR #248 マージ済)
- ADR 0023 (Phase 1.9-1.11)

## Test plan

- [x] `parse_route_preference` 正常値 4 ケース + 不正値 5 パターン
- [x] `DisplayModelOption.available` default 値 + disabled fallback + local モデル + treat_all_available
- [x] CLI `--show-unavailable` で disabled 表示 (+ --route all 組合せ)
- [x] CLI `--route` 未指定で config 由来 default が効く
- [x] CLI `--route` 明示指定で config 上書き
- [x] CLI 不正 config 値で auto fallback
- [x] GUI ComboBox 4 値 / 初期値読み / 不正値 auto fallback / collect 含む / OK 保存
- [x] GUI ModelSelectionWidget `_get_route_preference` の config 連携
- [x] ruff format / ruff check / mypy (本 PR 起因エラーなし)
- [x] 全 pytest 通過 (2232 件)

🤖 Generated with [Claude Code](https://claude.com/claude-code)