### PR TITLE
fix(#247): image-annotator-lib#57 修正取込み + --deselect 撤去

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -291,13 +291,9 @@ jobs:
         run: uv sync --dev
 
       - name: Run image-annotator-lib tests
-        # --deselect: image-annotator-lib#57 (test_toriigate_tagger_format_with_assistant_prefix
-        # が _format_predictions の戻り値型変更に追従していない既存バグ) を暫定回避。
-        # lib 側修正 + submodule pin 更新後に撤去する。
         run: |
           uv run pytest \
             -m "not real_api and not heavy and not system_integration" \
-            --deselect tests/unit/model_class/test_tagger_transformers.py::test_toriigate_tagger_format_with_assistant_prefix \
             --cov=image_annotator_lib \
             --cov-report=xml:coverage-image-annotator-lib.xml \
             --cov-report=term-missing \


### PR DESCRIPTION
## Summary

PR #251 で暫定回避していた lib 側テストバグ ([image-annotator-lib#57](https://github.com/NEXTAltair/image-annotator-lib/issues/57)) の修正を取り込み、CI の暫定 `--deselect` 行を撤去する。

**Depends on**: [image-annotator-lib#58](https://github.com/NEXTAltair/image-annotator-lib/pull/58) (lib 側 PR の merge を待ってから本 PR の submodule pin を merge commit に再更新する)

## 変更

### submodule pin 更新

- `local_packages/image-annotator-lib`: `45b27a71ac1d2293c317ffda5b27583b0d28e2f9` -> `ae3716305fe1cd75720e6de83b09be4bc27e7ca1`
- pin 先 commit は image-annotator-lib PR #58 の branch HEAD (`fix/issue-57-toriigate-test-result-type`)
- PR #58 merge 後に本 PR の pin を merge commit に再更新する

### ci.yml: `--deselect` 行と暫定コメント撤去

`.github/workflows/ci.yml` の `test-image-annotator-lib` job:

\`\`\`diff
       - name: Run image-annotator-lib tests
-        # --deselect: image-annotator-lib#57 (test_toriigate_tagger_format_with_assistant_prefix
-        # が _format_predictions の戻り値型変更に追従していない既存バグ) を暫定回避。
-        # lib 側修正 + submodule pin 更新後に撤去する。
         run: |
           uv run pytest \
             -m "not real_api and not heavy and not system_integration" \
-            --deselect tests/unit/model_class/test_tagger_transformers.py::test_toriigate_tagger_format_with_assistant_prefix \
             --cov=image_annotator_lib \
\`\`\`

## ローカル検証 (LoRAIro 本体)

\`\`\`text
$ uv run pytest --cov=src --cov-report=term -q
Required test coverage of 75.0% reached. Total coverage: 77.59%
2233 passed, 2 skipped, 45 warnings in 71.80s (0:01:11)

$ uv run ruff check src/ tests/
All checks passed!

$ uv run ruff format src/ tests/ --check
291 files already formatted

$ uv run mypy -p lorairo
Success: no issues found in 142 source files
\`\`\`

## Test plan

- [ ] image-annotator-lib#58 を merge する
- [ ] 本 PR の submodule pin を image-annotator-lib main の merge commit に更新する
- [ ] LoRAIro CI で全 5 test job が green
  - [ ] **特に `test-image-annotator-lib` job が `--deselect` なし で 0 failed**
- [ ] coverage-gate が ≥ 75% 維持

## 関連

- LoRAIro PR #251 (Issue #247、本 PR の前提): https://github.com/NEXTAltair/LoRAIro/pull/251
- image-annotator-lib PR #58 (本 PR の依存): https://github.com/NEXTAltair/image-annotator-lib/pull/58
- image-annotator-lib Issue #57: https://github.com/NEXTAltair/image-annotator-lib/issues/57

🤖 Generated with [Claude Code](https://claude.com/claude-code)