### PR TITLE
fix(#253): models list 0 件時の中立 hint と DEBUG diagnostic を追加

### DIFF
--- a/src/lorairo/cli/commands/models.py
+++ b/src/lorairo/cli/commands/models.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from enum import StrEnum
+from pathlib import Path
 from typing import Any
 
 import typer
@@ -167,11 +168,13 @@ def list_models(
         )
 
         # Issue #241: canonical_key で grouping し、--route preference に従って絞り込む。
-        display_rows = _apply_route_filter(rows, route, available_providers)
+        display_rows_pre_unavailable = _apply_route_filter(rows, route, available_providers)
 
         # Issue #249: --show-unavailable 未指定時は available 行のみに絞る。
         if not show_unavailable:
-            display_rows = [r for r in display_rows if r.get("available", True)]
+            display_rows = [r for r in display_rows_pre_unavailable if r.get("available", True)]
+        else:
+            display_rows = display_rows_pre_unavailable
 
         # 長いモデル名 (例: "vercel_ai_gateway/openai/o1") で固定幅未指定のままだと
         # Rich Table が Type/Category/Status を 0 幅に collapse させて Issue #220 の
@@ -214,6 +217,26 @@ def list_models(
             f"[dim]{len(display_rows)} model(s) "
             f"(preference={route.value} from {preference_source}{unavailable_suffix})[/dim]"
         )
+
+        # Issue #253: silent 0 件問題の切り分けのため DEBUG 診断を出し、
+        # 0 件のときは原因に応じた hint を画面に表示する。
+        _log_models_list_diagnostic(
+            container=container,
+            api_keys=api_keys,
+            available_providers=available_providers,
+            infos=infos,
+            rows_count=len(rows),
+            display_rows_pre_unavailable_count=len(display_rows_pre_unavailable),
+            display_rows_count=len(display_rows),
+            route=route,
+            preference_source=preference_source,
+        )
+        if not display_rows:
+            _emit_zero_count_hint(
+                console=console,
+                api_keys_configured=bool(available_providers),
+                show_unavailable=show_unavailable,
+            )
     except Exception as e:
         console.print(f"[red]Error:[/red] Failed to list models: {e}")
         logger.error(f"Model list command failed: {e}", exc_info=True)
@@ -350,3 +373,111 @@ def _pick_row_for_route(
     if openrouter is not None and str(openrouter["required_provider"]) in available_providers:
         return openrouter
     return direct or openrouter
+
+
+def _resolve_active_config_path(container: Any) -> str:
+    """Issue #253: 実際に読まれている config file の absolute path を返す。
+
+    ``ConfigurationService.__init__`` は ``config_path`` 引数を ``self._config_path``
+    に保持している。本番経路は引数なしで ``DEFAULT_CONFIG_PATH`` 固定だが、テストの
+    ``MagicMock`` 等で属性が無い場合は ``DEFAULT_CONFIG_PATH`` への直 fallback で
+    ``<default: ...>`` ラベル付き表示にする (実 path とは限らないことを明示する)。
+    """
+    config_service = container.config_service
+    config_path = getattr(config_service, "_config_path", None)
+    if config_path is not None:
+        try:
+            return str(Path(config_path).resolve())
+        except (OSError, TypeError):
+            pass
+    try:
+        from lorairo.utils.config import DEFAULT_CONFIG_PATH
+
+        return f"<default: {DEFAULT_CONFIG_PATH.resolve()}>"
+    except ImportError:
+        return "<unknown>"
+
+
+def _log_models_list_diagnostic(
+    *,
+    container: Any,
+    api_keys: dict[str, str],
+    available_providers: set[str],
+    infos: list[Any],
+    rows_count: int,
+    display_rows_pre_unavailable_count: int,
+    display_rows_count: int,
+    route: RouteFilter,
+    preference_source: str,
+) -> None:
+    """Issue #253: ``models list`` の切り分け用 DEBUG diagnostic を 1 行で出す。
+
+    key 値は出さず ``*_loaded`` boolean のみ。
+    ``--log-level DEBUG`` 起動時のみ表示。
+    """
+    config_path = _resolve_active_config_path(container)
+    api_key_status = {
+        "openai_key_loaded": bool(api_keys.get("openai") and api_keys["openai"].strip()),
+        "claude_key_loaded": bool(api_keys.get("anthropic") and api_keys["anthropic"].strip()),
+        "google_key_loaded": bool(api_keys.get("google") and api_keys["google"].strip()),
+        "openrouter_key_loaded": bool(api_keys.get("openrouter") and api_keys["openrouter"].strip()),
+    }
+    is_api_count = sum(1 for i in infos if getattr(i, "is_api", False))
+    is_local_count = sum(1 for i in infos if getattr(i, "is_local", False))
+    logger.debug(
+        f"models list diagnostic: "
+        f"config_path={config_path}, "
+        f"api_key_status={api_key_status}, "
+        f"available_providers={sorted(available_providers) or 'NONE'}, "
+        f"total_infos={len(infos)}, "
+        f"is_api_count={is_api_count}, is_local_count={is_local_count}, "
+        f"rows_after_type_filter={rows_count}, "
+        f"rows_after_route_filter={display_rows_pre_unavailable_count}, "
+        f"rows_after_show_unavailable_filter={display_rows_count}, "
+        f"preference={route.value} from {preference_source}"
+    )
+
+
+def _emit_zero_count_hint(
+    *,
+    console: Console,
+    api_keys_configured: bool,
+    show_unavailable: bool,
+) -> None:
+    """Issue #253: 0 件表示時に原因と次の手を提示する hint。
+
+    ADR 0020 英日併記 (英 1 行目 / 日 2 行目)。Rich ``[yellow]`` スタイル、
+    exit code は 0 維持。``--log-level DEBUG`` 案内は含めず 2 行に収める。
+    """
+    if not api_keys_configured and not show_unavailable:
+        # シナリオ A: API key が 1 つも読み込まれていない (未設定 or 読まれていない)
+        console.print(
+            "[yellow]Hint: No API keys were loaded from config. "
+            "Either no keys are set, or the config file is not being read. "
+            "Pass --show-unavailable to list all registered models regardless.[/yellow]"
+        )
+        console.print(
+            "[yellow]ヒント: config から API キーを 1 つも読み込めませんでした。"
+            "未設定か、config ファイルが読まれていない可能性があります。"
+            "--show-unavailable で登録済みの全モデルを表示できます。[/yellow]"
+        )
+    elif not show_unavailable:
+        # シナリオ B: API key は読み込めているが filter で全件消えた
+        console.print(
+            "[yellow]Hint: No models matched the current filters. "
+            "Try --show-unavailable, --type all, or --route all.[/yellow]"
+        )
+        console.print(
+            "[yellow]ヒント: 現在のフィルタ条件に一致するモデルがありません。"
+            "--show-unavailable / --type all / --route all を試してください。[/yellow]"
+        )
+    else:
+        # シナリオ C: --show-unavailable 付きでも 0 件 = registry 自体が空
+        console.print(
+            "[yellow]Hint: No entries in the registry match --type/--category. "
+            "Run 'lorairo-cli models refresh' to update the model registry.[/yellow]"
+        )
+        console.print(
+            "[yellow]ヒント: --type / --category 条件に一致するモデルが registry に"
+            "ありません。'lorairo-cli models refresh' で registry を更新してください。[/yellow]"
+        )

--- a/tests/unit/cli/test_commands_models.py
+++ b/tests/unit/cli/test_commands_models.py
@@ -616,3 +616,103 @@ def test_models_list_long_model_names_keep_columns_visible(mock_get_container) -
     # ローカルモデルは常に available なため active (webapi は disabled で表示される)
     assert "active" in result.stdout
     assert "2 model(s)" in result.stdout
+
+
+# --- Issue #253: 0 件 hint + DEBUG diagnostic ---
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+@patch("lorairo.cli.commands.models.get_service_container")
+def test_models_list_zero_count_hint_when_no_api_keys_loaded(mock_get_container) -> None:
+    """Issue #253 シナリオ A: API key 全空 + show_unavailable 無で 0 件 → 中立 hint を出す."""
+    mock_container = MagicMock()
+    mock_container.annotator_library.list_annotator_info.return_value = _make_duplicate_route_infos()
+    mock_container.annotator_library.is_model_deprecated.return_value = False
+    mock_container.config_service.get_setting.side_effect = _api_key_lookup({})
+    mock_get_container.return_value = mock_container
+
+    result = runner.invoke(app, ["models", "list", "--type", "webapi", "--route", "auto"])
+
+    assert result.exit_code == 0
+    assert "0 model(s)" in result.stdout
+    # 中立的な文言: "No API keys are configured" のような断定ではない
+    assert "No API keys were loaded from config" in result.stdout
+    assert "--show-unavailable" in result.stdout
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+@patch("lorairo.cli.commands.models.get_service_container")
+def test_models_list_zero_count_hint_when_filters_eliminate_all(mock_get_container) -> None:
+    """Issue #253 シナリオ B: API key 設定済みだが filter で 0 件 → 'No models matched' hint."""
+    # ローカルモデルのみ。--type webapi で 0 件
+    mock_container = MagicMock()
+    mock_container.annotator_library.list_annotator_info.return_value = [
+        _FakeAnnotatorInfo(
+            name="wd-v1-4-tagger", model_type="tagger", is_local=True, is_api=False, device="cuda"
+        ),
+    ]
+    mock_container.annotator_library.is_model_deprecated.return_value = False
+    mock_container.config_service.get_setting.side_effect = _api_key_lookup({"openai_key": "sk-openai"})
+    mock_get_container.return_value = mock_container
+
+    result = runner.invoke(app, ["models", "list", "--type", "webapi"])
+
+    assert result.exit_code == 0
+    assert "0 model(s)" in result.stdout
+    assert "No models matched the current filters" in result.stdout
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+@patch("lorairo.cli.commands.models.get_service_container")
+def test_models_list_zero_count_hint_with_show_unavailable_empty_registry(mock_get_container) -> None:
+    """Issue #253 シナリオ C: show_unavailable=True でも 0 件 → 'No entries in registry' hint."""
+    mock_container = MagicMock()
+    mock_container.annotator_library.list_annotator_info.return_value = []
+    mock_get_container.return_value = mock_container
+
+    result = runner.invoke(app, ["models", "list", "--show-unavailable"])
+
+    assert result.exit_code == 0
+    assert "0 model(s)" in result.stdout
+    assert "No entries in the registry" in result.stdout
+    assert "models refresh" in result.stdout
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+@patch("lorairo.cli.commands.models.get_service_container")
+def test_models_list_diagnostic_log_includes_config_and_key_status(mock_get_container) -> None:
+    """Issue #253: DEBUG diagnostic に config_path + per-provider key loaded 状況が含まれる.
+
+    loguru sink を StringIO に追加して capture する (conftest にブリッジ helper が
+    無いため、本 test 内で自己完結する方式を採用)。
+    """
+    from io import StringIO
+
+    from loguru import logger as loguru_logger
+
+    mock_container = MagicMock()
+    mock_container.annotator_library.list_annotator_info.return_value = _make_duplicate_route_infos()
+    mock_container.annotator_library.is_model_deprecated.return_value = False
+    mock_container.config_service.get_setting.side_effect = _api_key_lookup({"openai_key": "sk-openai"})
+    # MagicMock では _config_path が無いので DEFAULT_CONFIG_PATH fallback (<default: ...>) になる前提
+    mock_get_container.return_value = mock_container
+
+    buffer = StringIO()
+    handler_id = loguru_logger.add(buffer, format="{message}", level="DEBUG")
+    try:
+        result = runner.invoke(app, ["models", "list", "--show-unavailable"])
+    finally:
+        loguru_logger.remove(handler_id)
+
+    assert result.exit_code == 0
+    log_output = buffer.getvalue()
+    assert "models list diagnostic" in log_output
+    assert "config_path=" in log_output
+    assert "openai_key_loaded': True" in log_output or "openai_key_loaded=True" in log_output
+    assert "claude_key_loaded': False" in log_output or "claude_key_loaded=False" in log_output
+    # key 値そのものは出ていないこと (security 要件)
+    assert "sk-openai" not in log_output


### PR DESCRIPTION
## Summary

`lorairo-cli models list --type webapi --route auto` が **silent に 0 件** を表示する UX 問題 (Issue #253) を解消する。Windows 環境で lib 側 90 件 register 済み・CLI 側 0 件という落差から「lib bug?」と誤認されていた。

挙動・default は変えず、**hint と DEBUG diagnostic で原因を user に通知する**方針 (本 PR 着手前にユーザーと合意済)。

## 90 → 0 になる経路と本 PR の補強ポイント

| 段階 | 件数 | 補強 |
|---|---|---|
| `list_annotator_info()` | 90 | DEBUG: `total_infos`, `is_api_count`, `is_local_count` |
| type/category/deprecated filter | 90 | DEBUG: `rows_after_type_filter` |
| `available` フラグ付与 (API key 未設定で全 False) | 90 | DEBUG: `api_key_status` (per-provider boolean), `available_providers` |
| route 畳み込み | 45 | DEBUG: `rows_after_route_filter` |
| `--show-unavailable` 未指定で全 hide | **0** | DEBUG: `rows_after_show_unavailable_filter` + 0 件 hint |

## 受け入れ条件 (Plan より)

- [x] 0 件のときに 3 シナリオ別 hint (A: API key 全空 / B: filter で 0 / C: registry 空)
- [x] DEBUG diagnostic で config_path / per-provider key loaded / 各 filter 後件数 / preference 出力
- [x] 既存挙動・default は不変 (回帰なし)
- [x] hint は ADR 0020 準拠の英日併記、`--log-level DEBUG` 案内は hint に含めない
- [x] **API key 値そのものは log/hint いずれにも出さない** (boolean のみ)
- [x] 新規 unit test 4 件追加 (シナリオ A/B/C hint 3 件 + diagnostic 内容 1 件)
- [x] Ruff format / check / mypy パス
- [x] `pytest -m unit` 1983 passed (regression なし)

## Before / After

**Before** (Windows, API key 未読み込み):
```
Available Models
... empty table ...
0 model(s) (preference=auto from explicit)
```
→ user は理由が一切わからない。lib 側 90 件のログとの落差で「lib bug?」誤認。

**After**:
```
Available Models
... empty table ...
0 model(s) (preference=auto from explicit)
Hint: No API keys were loaded from config. Either no keys are set, or the config file is not being read. Pass --show-unavailable to list all registered models regardless.
ヒント: config から API キーを 1 つも読み込めませんでした。未設定か、config ファイルが読まれていない可能性があります。--show-unavailable で登録済みの全モデルを表示できます。
```

## DEBUG diagnostic サンプル (key 値は含まれない)

```
2026-05-14 11:42:36.232 | DEBUG | lorairo.cli.commands.models:_log_models_list_diagnostic:429 -
  models list diagnostic: config_path=/path/to/lorairo.toml,
  api_key_status={'openai_key_loaded': False, 'claude_key_loaded': False, 'google_key_loaded': False, 'openrouter_key_loaded': False},
  available_providers=NONE, total_infos=2, is_api_count=2, is_local_count=0,
  rows_after_type_filter=2, rows_after_route_filter=1, rows_after_show_unavailable_filter=0,
  preference=auto from explicit
```

これにより user は仮説 A (key 未設定) / B (config path がズレている = #255 連動) / C (key 名 / encoding 問題) を切り分け可能。

## 関連

- 親 Issue: image-annotator-lib#59 (Windows 動作確認から派生)
- 関連 (本 PR の scope 外): #254 (cp932 UnicodeEncodeError), #255 (uv run torch 再 download)

Closes #253

🤖 Generated with [Claude Code](https://claude.com/claude-code)