### PR TITLE
fix(#254): Windows console code page を UTF-8 化して mojibake 解消

### DIFF
--- a/src/lorairo/cli/main.py
+++ b/src/lorairo/cli/main.py
@@ -115,15 +115,18 @@ def status() -> None:
 
 
 def _ensure_stdout_utf8() -> None:
-    """Issue #254: Windows cp932 等の非 UTF-8 環境で stdout/stderr を UTF-8 に切り替える。
+    """Issue #254: cp932 環境で stdout/stderr UTF-8 化 + Windows console code page 切替。
 
-    ``✓`` (U+2713) / ``✗`` (U+2717) 等の cp932 で encode 不能な文字を CLI 出力に
-    含む際 ``UnicodeEncodeError`` で起動失敗するのを防ぐ。Python 3.7+ の
-    ``io.TextIOWrapper.reconfigure`` を使う。
+    2 段階対策:
 
-    既に UTF-8 環境 (Linux / macOS / Windows Terminal の標準) では no-op。
-    cmd.exe 等のレガシー Windows ターミナルでは ``errors="replace"`` で encode 不能
-    文字を ``?`` に置換し、CLI 起動失敗より優先する。
+    1. Python ``sys.stdout`` / ``sys.stderr`` の ``TextIOWrapper`` を UTF-8 に
+       reconfigure し ``UnicodeEncodeError`` 例外を防ぐ。
+    2. Windows console output/input code page を 65001 (UTF-8) に切り替え、
+       Python が UTF-8 bytes を console に書き込んだ際に active code page (cp932 等)
+       として bytes が解釈されて mojibake する問題を防ぐ。
+
+    Step 2 は ``sys.platform == "win32"`` でのみ実行。atexit で元の code page を
+    復元し parent shell の状態を変更しない。
 
     Rich ``Console`` は ``sys.stdout`` を出力時に lazy 参照するため、module-level
     で生成済の Console 群に対しても本関数を ``main()`` 冒頭で呼べば反映される。
@@ -139,6 +142,53 @@ def _ensure_stdout_utf8() -> None:
             # 想定外の stream 種別 (pytest capture 等) は skip
             continue
         reconfigure(encoding="utf-8", errors="replace")
+
+    if sys.platform == "win32":
+        _set_windows_console_utf8()
+
+
+def _set_windows_console_utf8() -> None:
+    """Issue #254: Windows console output/input code page を UTF-8 (65001) に切替。
+
+    cp932 等の非 UTF-8 active code page で Python が UTF-8 bytes を console に
+    書き込むと、bytes が active code page として解釈され mojibake する。Win32
+    ``SetConsoleOutputCP`` / ``SetConsoleCP`` を ctypes 経由で呼び、console 自体の
+    code page を UTF-8 に切り替えてこれを解消する。
+
+    atexit で元の code page を復元することで、parent shell (PowerShell / cmd.exe) の
+    code page 状態を CLI 終了後も変更しないようにする。
+
+    Should be called only when ``sys.platform == "win32"``. console 不在 (redirect 中等)
+    で ``SetConsoleOutputCP`` が失敗した場合は silent skip し、本来の出力経路に任せる。
+    """
+    import sys
+
+    if sys.platform != "win32":
+        return
+
+    import atexit
+    import ctypes
+
+    kernel32 = ctypes.windll.kernel32
+    utf8_cp = 65001
+
+    original_output_cp = kernel32.GetConsoleOutputCP()
+    original_input_cp = kernel32.GetConsoleCP()
+
+    if original_output_cp == utf8_cp and original_input_cp == utf8_cp:
+        # 既に UTF-8 (Windows Terminal の utf-8 default 等)
+        return
+
+    if not kernel32.SetConsoleOutputCP(utf8_cp):
+        # console 不在で失敗 → 何もせず復元 hook も登録しない
+        return
+    kernel32.SetConsoleCP(utf8_cp)
+
+    def _restore_console_cp() -> None:
+        kernel32.SetConsoleOutputCP(original_output_cp)
+        kernel32.SetConsoleCP(original_input_cp)
+
+    atexit.register(_restore_console_cp)
 
 
 def main() -> None:

--- a/tests/unit/cli/test_main.py
+++ b/tests/unit/cli/test_main.py
@@ -250,3 +250,167 @@ def test_ensure_stdout_utf8_handles_missing_reconfigure(monkeypatch: pytest.Monk
 
     # 例外で落ちないこと (reconfigure 不在をハンドル)
     _ensure_stdout_utf8()
+
+
+# --- Issue #254 (reopen): Windows console code page 切替 ---
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+def test_ensure_stdout_utf8_skips_console_cp_on_linux(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Issue #254: 非 Windows 環境では console code page 切替を呼ばない。"""
+    import sys
+
+    import lorairo.cli.main as cli_main
+
+    monkeypatch.setattr(sys, "platform", "linux")
+    called: list[None] = []
+    monkeypatch.setattr(cli_main, "_set_windows_console_utf8", lambda: called.append(None))
+
+    cli_main._ensure_stdout_utf8()
+
+    assert called == []
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+def test_ensure_stdout_utf8_invokes_console_cp_on_windows(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Issue #254: Windows 環境では console code page 切替が呼ばれる。"""
+    import sys
+
+    import lorairo.cli.main as cli_main
+
+    monkeypatch.setattr(sys, "platform", "win32")
+    called: list[None] = []
+    monkeypatch.setattr(cli_main, "_set_windows_console_utf8", lambda: called.append(None))
+
+    cli_main._ensure_stdout_utf8()
+
+    assert called == [None]
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+def test_set_windows_console_utf8_calls_set_console_output_cp(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Issue #254: cp932 console で SetConsoleOutputCP(65001) と SetConsoleCP(65001) が呼ばれる。"""
+    import ctypes
+    import sys
+
+    monkeypatch.setattr(sys, "platform", "win32")
+
+    kernel32 = MagicMock()
+    kernel32.GetConsoleOutputCP.return_value = 932
+    kernel32.GetConsoleCP.return_value = 932
+    kernel32.SetConsoleOutputCP.return_value = 1  # 成功 (non-zero)
+
+    windll = MagicMock()
+    windll.kernel32 = kernel32
+    monkeypatch.setattr(ctypes, "windll", windll, raising=False)
+
+    registered: list = []
+    monkeypatch.setattr("atexit.register", lambda f: registered.append(f))
+
+    from lorairo.cli.main import _set_windows_console_utf8
+
+    _set_windows_console_utf8()
+
+    kernel32.SetConsoleOutputCP.assert_called_once_with(65001)
+    kernel32.SetConsoleCP.assert_called_once_with(65001)
+    assert len(registered) == 1  # 復元 callback が atexit に登録される
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+def test_set_windows_console_utf8_noop_when_already_utf8(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Issue #254: 既に code page 65001 の console では SetConsoleOutputCP を呼ばない。"""
+    import ctypes
+    import sys
+
+    monkeypatch.setattr(sys, "platform", "win32")
+
+    kernel32 = MagicMock()
+    kernel32.GetConsoleOutputCP.return_value = 65001
+    kernel32.GetConsoleCP.return_value = 65001
+
+    windll = MagicMock()
+    windll.kernel32 = kernel32
+    monkeypatch.setattr(ctypes, "windll", windll, raising=False)
+
+    registered: list = []
+    monkeypatch.setattr("atexit.register", lambda f: registered.append(f))
+
+    from lorairo.cli.main import _set_windows_console_utf8
+
+    _set_windows_console_utf8()
+
+    kernel32.SetConsoleOutputCP.assert_not_called()
+    kernel32.SetConsoleCP.assert_not_called()
+    assert registered == []
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+def test_set_windows_console_utf8_skips_on_set_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Issue #254: SetConsoleOutputCP が 0 (失敗) を返す場合は atexit 復元を登録しない。"""
+    import ctypes
+    import sys
+
+    monkeypatch.setattr(sys, "platform", "win32")
+
+    kernel32 = MagicMock()
+    kernel32.GetConsoleOutputCP.return_value = 932
+    kernel32.GetConsoleCP.return_value = 932
+    kernel32.SetConsoleOutputCP.return_value = 0  # 失敗 (console 不在等)
+
+    windll = MagicMock()
+    windll.kernel32 = kernel32
+    monkeypatch.setattr(ctypes, "windll", windll, raising=False)
+
+    registered: list = []
+    monkeypatch.setattr("atexit.register", lambda f: registered.append(f))
+
+    from lorairo.cli.main import _set_windows_console_utf8
+
+    _set_windows_console_utf8()
+
+    kernel32.SetConsoleOutputCP.assert_called_once_with(65001)
+    kernel32.SetConsoleCP.assert_not_called()  # output 失敗時は input も呼ばない
+    assert registered == []  # 復元 callback も登録しない
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+def test_set_windows_console_utf8_restores_original_on_exit(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Issue #254: atexit hook が元の code page を SetConsoleOutputCP / SetConsoleCP で復元する。"""
+    import ctypes
+    import sys
+
+    monkeypatch.setattr(sys, "platform", "win32")
+
+    kernel32 = MagicMock()
+    kernel32.GetConsoleOutputCP.return_value = 932
+    kernel32.GetConsoleCP.return_value = 850  # 異なる initial CP
+    kernel32.SetConsoleOutputCP.return_value = 1
+
+    windll = MagicMock()
+    windll.kernel32 = kernel32
+    monkeypatch.setattr(ctypes, "windll", windll, raising=False)
+
+    registered: list = []
+    monkeypatch.setattr("atexit.register", lambda f: registered.append(f))
+
+    from lorairo.cli.main import _set_windows_console_utf8
+
+    _set_windows_console_utf8()
+
+    # 切替直後: SetConsoleOutputCP(65001), SetConsoleCP(65001)
+    assert kernel32.SetConsoleOutputCP.call_args_list == [((65001,),)]
+    assert kernel32.SetConsoleCP.call_args_list == [((65001,),)]
+
+    # 登録された atexit callback を実行 → 元の code page に戻る
+    assert len(registered) == 1
+    registered[0]()
+
+    # SetConsoleOutputCP / SetConsoleCP の最終呼び出しが original
+    kernel32.SetConsoleOutputCP.assert_called_with(932)
+    kernel32.SetConsoleCP.assert_called_with(850)


### PR DESCRIPTION
## Summary

PR #259 (Issue #254 初版 fix) は `sys.stdout.reconfigure(encoding="utf-8")` で `UnicodeEncodeError` 例外を防いだが、Windows console (active code page 932) は依然として bytes を cp932 として解釈するため**視覚的 mojibake が残っていた**。本 PR は `SetConsoleOutputCP(65001)` を ctypes 経由で呼び、console 自体を UTF-8 化することで mojibake を解消する。

## 観測された mojibake (user 報告)

```text
2026-05-16 00:29:31.310 | INFO | image_annotator_lib.core.config:load - Ý'èƒtƒ@ƒCƒ‹‚Ì"Ç‚Ýž‚Ý‚ªŠ®—¹‚µ‚Ü‚µ‚½B
2026-05-16 00:29:31.324 | INFO | image_annotator_lib.core.registry:register_annotators - ƒAƒmƒe[ƒ^‚Ì"o˜^‚ªŠ®—¹‚µ‚Ü‚µ‚½B
```

元文字列:
- 「設定ファイルの読み込みが完了しました。」
- 「アノテータの登録が完了しました。」

UTF-8 bytes を cp932 として解釈した典型パターン。出力源は image-annotator-lib の loguru ログ (stderr) で、PR #259 の修正範囲外。

## 原因分析

| 要素 | PR #259 後の状態 |
|---|---|
| `sys.stdout` encoding | `utf-8` ✓ (reconfigure 済) |
| Windows console active code page | `932` (cp932) のまま ✗ |
| Python の出力 | UTF-8 bytes |
| Console の解釈 | cp932 として bytes を表示 → mojibake |

`reconfigure` は Python 側 `TextIOWrapper` を変えるだけで、Win32 console の active code page (`GetConsoleOutputCP()`) は変えない。

## 修正内容

`_set_windows_console_utf8()` を新設し、`_ensure_stdout_utf8()` から `sys.platform == "win32"` でのみ呼ぶ:

- ctypes 経由で `kernel32.SetConsoleOutputCP(65001)` / `SetConsoleCP(65001)` を呼び console を UTF-8 化
- atexit で元の code page を復元 (parent shell の状態を変更しない)
- `SetConsoleOutputCP` 失敗 (console 不在等) は silent skip
- 既に 65001 の場合は no-op
- Linux / macOS では `sys.platform == "win32"` で early return

## 検証

- 新規 unit test 6 件 (`tests/unit/cli/test_main.py`):
  - `test_ensure_stdout_utf8_skips_console_cp_on_linux`
  - `test_ensure_stdout_utf8_invokes_console_cp_on_windows`
  - `test_set_windows_console_utf8_calls_set_console_output_cp`
  - `test_set_windows_console_utf8_noop_when_already_utf8`
  - `test_set_windows_console_utf8_skips_on_set_failure`
  - `test_set_windows_console_utf8_restores_original_on_exit`
- 既存 4 件 (PR #259 由来) は全て pass を維持
- CI-equivalent filter (`-m "not gui_show and not real_api and not slow"`):
  **2246 passed, 2 skipped** (regression なし)
- `ruff check` / `mypy -p lorairo.cli.main`: clean
- 実機確認 (Windows + PowerShell + 日本語環境) は user 環境で要確認

## Test plan

- [ ] Windows + PowerShell (cp932) で `lorairo-cli annotate run` 等を実行し、image-annotator-lib の loguru 日本語ログが mojibake せず表示されることを確認
- [ ] CLI 終了後に parent PowerShell の `chcp` が元の値 (932) に戻ることを確認 (atexit 復元動作)
- [ ] Windows Terminal (UTF-8 default) で no-op として動作することを確認
- [ ] Linux / Codespace で既存通り動作することを確認 (CI で検証済)

Reopens #254 (補完)

🤖 Generated with [Claude Code](https://claude.com/claude-code)