### PR TITLE
[codex] Fix webapi model list display

### DIFF
--- a/src/lorairo/cli/commands/models.py
+++ b/src/lorairo/cli/commands/models.py
@@ -180,39 +180,13 @@ def list_models(
         else:
             display_rows = display_rows_pre_unavailable
 
-        # 長いモデル名 (例: "vercel_ai_gateway/openai/o1") で固定幅未指定のままだと
-        # Rich Table が Type/Category/Status を 0 幅に collapse させて Issue #220 の
-        # 主要機能 (Type 列で local/webapi 区別) が視認できなくなる。各カラムに
-        # min_width を指定し、Model/Provider/Litellm ID カラムは折返し許容で長さに対応する。
-        # Issue #245: Provider/Litellm ID 列を追加。
-        # Issue #241: Route 列を追加 (direct / openrouter)。
-        table = Table(title="Available Models")
-        table.add_column("Model", style="cyan", overflow="fold", min_width=10)
-        table.add_column("Provider", style="bright_magenta", overflow="fold", min_width=8)
-        table.add_column("Litellm ID", style="bright_cyan", overflow="fold", min_width=10)
-        table.add_column("Route", style="bright_blue", min_width=8, no_wrap=True)
-        table.add_column("Type", style="magenta", min_width=6, no_wrap=True)
-        table.add_column("Category", style="blue", min_width=8, no_wrap=True)
-        table.add_column("Status", style="green", min_width=10, no_wrap=True)
-
-        for row in display_rows:
-            # Issue #249: available=False は deprecated より優先して disabled 表示。
-            if not row.get("available", True):
-                status_label = "[red]disabled[/red]"
-            elif row["deprecated"]:
-                status_label = "[yellow]deprecated[/yellow]"
-            else:
-                status_label = "active"
-            table.add_row(
-                str(row["name"]),
-                str(row["provider"]),
-                str(row["litellm_id"]),
-                str(row["route"]),
-                str(row["type_label"]),
-                str(row["category"]),
-                status_label,
-            )
-
+        table = _build_available_models_table(
+            display_rows=display_rows,
+            type_filter=type_filter,
+            category=category,
+            show_unavailable=show_unavailable,
+            include_deprecated=include_deprecated,
+        )
         console.print(table)
         # Issue #249: preference の取得元と unavailable 件数も表示
         unavailable_count = sum(1 for r in display_rows if not r.get("available", True))
@@ -245,6 +219,61 @@ def list_models(
         console.print(f"[red]Error:[/red] Failed to list models: {e}")
         logger.error(f"Model list command failed: {e}", exc_info=True)
         raise typer.Exit(code=1) from e
+
+
+def _build_available_models_table(
+    *,
+    display_rows: list[dict[str, str | bool]],
+    type_filter: ModelTypeFilter,
+    category: ModelCategoryFilter,
+    show_unavailable: bool,
+    include_deprecated: bool,
+) -> Table:
+    """models list の表示用 Rich table を構築する。"""
+    table = Table(title="Available Models")
+    table.add_column("Provider", style="bright_magenta", min_width=8, no_wrap=True)
+    table.add_column("Route", style="bright_blue", min_width=8, no_wrap=True)
+    table.add_column("Model ID", style="bright_cyan", overflow="fold", min_width=32, ratio=1)
+
+    show_type_column = type_filter is ModelTypeFilter.all
+    show_category_column = type_filter is ModelTypeFilter.all and category is ModelCategoryFilter.all
+    show_availability_column = show_unavailable or include_deprecated
+
+    if show_type_column:
+        table.add_column("Type", style="magenta", min_width=6, no_wrap=True)
+    if show_category_column:
+        table.add_column("Category", style="blue", min_width=8, no_wrap=True)
+    if show_availability_column:
+        table.add_column("Availability", style="green", min_width=12, no_wrap=True)
+
+    for row in display_rows:
+        table_row = [
+            str(row["provider"]),
+            str(row["route"]),
+            str(row["litellm_id"]),
+        ]
+        if show_type_column:
+            table_row.append(str(row["type_label"]))
+        if show_category_column:
+            table_row.append(str(row["category"]))
+        if show_availability_column:
+            table_row.append(_format_availability(row))
+        table.add_row(*table_row)
+
+    return table
+
+
+def _format_availability(row: dict[str, str | bool]) -> str:
+    """ユーザー向けの利用可否ラベルを返す。
+
+    ``models list`` の default は利用可能な行だけを表示するため、この列は
+    ``--show-unavailable`` や ``--include-deprecated`` のときだけ表示する。
+    """
+    if not row.get("available", True):
+        return "[red]missing_key[/red]"
+    if row["deprecated"]:
+        return "[yellow]deprecated[/yellow]"
+    return "ready"
 
 
 def _apply_route_filter(
@@ -326,11 +355,11 @@ def _build_rows_from_infos(
             continue
 
         type_label = "webapi" if info.is_api else "local"
-        # Issue #245: Provider と Litellm ID を表示し、route の区別を可能にする。
-        provider_label = info.provider or ("local" if info.is_local else "unknown")
         litellm_id = info.litellm_model_id or info.name
         row_route = detect_route(litellm_id)
         row_required = required_provider_for(litellm_id, info.provider)
+        # Provider 列は LiteLLM の raw prefix ではなく、実際に必要な API key provider を表示する。
+        provider_label = "local" if info.is_local else row_required
         # Issue #249: ローカル ML モデルは API key 不要のため常に available。
         # info.is_local も加味する: provider 未設定 + slash 入り bare ID のローカルモデル
         # (例: "some/local-tagger") は required_provider_for だと "some" になるため、

--- a/src/lorairo/services/model_route_service.py
+++ b/src/lorairo/services/model_route_service.py
@@ -102,7 +102,8 @@ def required_provider_for(litellm_model_id: str, provider_hint: str | None = Non
         and provider_hint.strip()
         and provider_hint.strip().lower() not in _UNKNOWN_PROVIDERS
     ):
-        return provider_hint.strip().lower()
+        provider_normalized = provider_hint.strip().lower()
+        return _PROVIDER_ALIAS_MAP.get(provider_normalized, provider_normalized)
 
     head, sep, _ = litellm_model_id.partition("/")
     if sep == "":

--- a/tests/unit/cli/test_commands_models.py
+++ b/tests/unit/cli/test_commands_models.py
@@ -12,7 +12,7 @@ from lorairo.cli.main import app
 @pytest.fixture(autouse=True)
 def _wide_terminal(monkeypatch: pytest.MonkeyPatch) -> None:
     """Issue #245: Rich Table が Provider/Litellm ID 列を加えても全列が描画される
-    十分な幅を CLI テスト環境で確保する。デフォルト 80 col では Status 列が
+    十分な幅を CLI テスト環境で確保する。デフォルト 80 col では表示列が
     truncate される or Model 列が改行を挿入して substring 検証が壊れる。
     """
     monkeypatch.setenv("COLUMNS", "200")
@@ -121,8 +121,12 @@ def test_models_list_shows_local_and_webapi_with_type_column(mock_get_container)
     assert "gpt-4o" in result.stdout
     assert "claude-3-5-sonnet" in result.stdout
     # Type カラムの値
+    assert "Type" in result.stdout
     assert "local" in result.stdout
     assert "webapi" in result.stdout
+    # Issue #270: default では active だけの Status 列を出さない
+    assert "Status" not in result.stdout
+    assert "active" not in result.stdout
     # 件数
     assert "5 model(s)" in result.stdout
 
@@ -152,7 +156,7 @@ def test_models_list_filter_type_local_only(mock_get_container) -> None:
 @pytest.mark.cli
 @patch("lorairo.cli.commands.models.get_service_container")
 def test_models_list_filter_type_webapi_only(mock_get_container) -> None:
-    """--type webapi は WebAPI モデルのみ表示する。"""
+    """--type webapi は WebAPI モデルのみを簡潔な列で表示する。"""
     mock_container = MagicMock()
     mock_container.annotator_library.list_annotator_info.return_value = _make_infos()
     mock_container.annotator_library.is_model_deprecated.return_value = False
@@ -164,7 +168,48 @@ def test_models_list_filter_type_webapi_only(mock_get_container) -> None:
     assert "gpt-4o" in result.stdout
     assert "claude-3-5-sonnet" in result.stdout
     assert "wd-v1-4-tagger" not in result.stdout
+    assert "Model ID" in result.stdout
+    assert "Type" not in result.stdout
+    assert "Category" not in result.stdout
+    assert "Status" not in result.stdout
     assert "2 model(s)" in result.stdout
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+@patch("lorairo.cli.commands.models.get_service_container")
+def test_models_list_webapi_shows_gemini_when_google_key_configured(mock_get_container) -> None:
+    """LiteLLM discovery の provider=Gemini は google key 設定済みなら表示する。"""
+    mock_container = MagicMock()
+    mock_container.annotator_library.list_annotator_info.return_value = [
+        _FakeAnnotatorInfo(
+            name="gemini/gemini-2.5-pro",
+            model_type="vision",
+            is_local=False,
+            is_api=True,
+            provider="Gemini",
+            litellm_model_id="gemini/gemini-2.5-pro",
+        ),
+    ]
+    mock_container.annotator_library.is_model_deprecated.return_value = False
+
+    def get_setting(section: str, key: str, default: str = "") -> str:
+        values = {
+            ("api", "google_key"): "configured-google-key",
+            ("model_selection", "route_preference"): "auto",
+        }
+        return values.get((section, key), default)
+
+    mock_container.config_service.get_setting.side_effect = get_setting
+    mock_get_container.return_value = mock_container
+
+    result = runner.invoke(app, ["models", "list", "--type", "webapi"])
+
+    assert result.exit_code == 0
+    assert "google" in result.stdout
+    assert "gemini/gemini-2.5-pro" in result.stdout
+    assert "missing_key" not in result.stdout
+    assert "1 model(s)" in result.stdout
 
 
 @pytest.mark.unit
@@ -231,7 +276,7 @@ def test_models_list_excludes_deprecated_by_default(mock_get_container) -> None:
 @pytest.mark.unit
 @pytest.mark.cli
 @patch("lorairo.cli.commands.models.get_service_container")
-def test_models_list_include_deprecated_shows_status(mock_get_container) -> None:
+def test_models_list_include_deprecated_shows_availability(mock_get_container) -> None:
     """--include-deprecated は廃止済みモデルも表示する。"""
     mock_container = MagicMock()
     mock_container.annotator_library.list_annotator_info.return_value = [
@@ -246,6 +291,7 @@ def test_models_list_include_deprecated_shows_status(mock_get_container) -> None
     result = runner.invoke(app, ["models", "list", "--include-deprecated"])
 
     assert result.exit_code == 0
+    assert "Availability" in result.stdout
     assert "gpt-4o" in result.stdout
     assert "gpt-4-vision-preview" in result.stdout
     assert "deprecated" in result.stdout
@@ -281,7 +327,7 @@ def test_models_list_handles_deprecated_check_failure(mock_get_container) -> Non
 
     assert result.exit_code == 0
     assert "gpt-4o" in result.stdout
-    assert "active" in result.stdout
+    assert "active" not in result.stdout
     assert "1 model(s)" in result.stdout
 
 
@@ -472,8 +518,8 @@ def test_models_list_route_openrouter_filters_to_openrouter_only(mock_get_contai
 @pytest.mark.unit
 @pytest.mark.cli
 @patch("lorairo.cli.commands.models.get_service_container")
-def test_models_list_show_unavailable_displays_disabled_rows(mock_get_container) -> None:
-    """--show-unavailable は API key 未設定の行を 'disabled' Status で表示する"""
+def test_models_list_show_unavailable_displays_missing_key_rows(mock_get_container) -> None:
+    """--show-unavailable は API key 未設定の行を Availability で表示する"""
     mock_container = MagicMock()
     mock_container.annotator_library.list_annotator_info.return_value = _make_duplicate_route_infos()
     mock_container.annotator_library.is_model_deprecated.return_value = False
@@ -485,7 +531,8 @@ def test_models_list_show_unavailable_displays_disabled_rows(mock_get_container)
     assert result.exit_code == 0
     # 全 row が disabled でも表示される
     assert "1 model(s)" in result.stdout
-    assert "disabled" in result.stdout
+    assert "Availability" in result.stdout
+    assert "missing_key" in result.stdout
     assert "unavailable=1" in result.stdout
 
 
@@ -493,7 +540,7 @@ def test_models_list_show_unavailable_displays_disabled_rows(mock_get_container)
 @pytest.mark.cli
 @patch("lorairo.cli.commands.models.get_service_container")
 def test_models_list_show_unavailable_with_route_all(mock_get_container) -> None:
-    """--show-unavailable + --route all で全 candidate を disabled 状態で表示"""
+    """--show-unavailable + --route all で全 candidate を missing_key 状態で表示"""
     mock_container = MagicMock()
     mock_container.annotator_library.list_annotator_info.return_value = _make_duplicate_route_infos()
     mock_container.annotator_library.is_model_deprecated.return_value = False
@@ -504,7 +551,7 @@ def test_models_list_show_unavailable_with_route_all(mock_get_container) -> None
 
     assert result.exit_code == 0
     assert "2 model(s)" in result.stdout
-    assert "disabled" in result.stdout
+    assert "missing_key" in result.stdout
     assert "openai/gpt-4o" in result.stdout
     assert "openrouter/openai/gpt-4o" in result.stdout
 
@@ -580,7 +627,7 @@ def test_models_list_route_invalid_config_falls_back_to_auto(mock_get_container)
 @pytest.mark.cli
 @patch("lorairo.cli.commands.models.get_service_container")
 def test_models_list_long_model_names_keep_columns_visible(mock_get_container) -> None:
-    """長いモデル名でも Type/Category/Status カラムが collapse されない (Issue #220 表示バグ regression)."""
+    """長いモデル ID でも主要カラムが collapse されない (Issue #220/#270 regression)."""
     long_infos = [
         _FakeAnnotatorInfo(
             name="vercel_ai_gateway/openai/o1-very-long-model-name-2025-04-16",
@@ -607,14 +654,20 @@ def test_models_list_long_model_names_keep_columns_visible(mock_get_container) -
     result = runner.invoke(app, ["models", "list", "--show-unavailable"])
 
     assert result.exit_code == 0
+    # 主要列が空 collapse せずに描画されること
+    assert "Provider" in result.stdout
+    assert "Route" in result.stdout
+    assert "Model ID" in result.stdout
+    assert "Availability" in result.stdout
     # Type 値 (webapi/local) が空 collapse せずに描画されること
     assert "webapi" in result.stdout
     assert "local" in result.stdout
     # Category 値 (vision/tagger) が空 collapse せずに描画されること
     assert "vision" in result.stdout
     assert "tagger" in result.stdout
-    # ローカルモデルは常に available なため active (webapi は disabled で表示される)
-    assert "active" in result.stdout
+    # ローカルモデルは ready、webapi は key 未設定で missing_key 表示
+    assert "ready" in result.stdout
+    assert "missing_key" in result.stdout
     assert "2 model(s)" in result.stdout
 
 

--- a/tests/unit/services/test_model_route_service.py
+++ b/tests/unit/services/test_model_route_service.py
@@ -103,6 +103,10 @@ class TestRequiredProviderFor:
         """LiteLLM の `gemini/` prefix は Google API key 要求"""
         assert required_provider_for("gemini/gemini-pro-vision", None) == "google"
 
+    def test_gemini_provider_hint_alias_maps_to_google(self) -> None:
+        """LiteLLM discovery の `provider=Gemini` も Google API key 要求として扱う。"""
+        assert required_provider_for("gemini/gemini-2.5-pro", "Gemini") == "google"
+
     def test_vertex_ai_alias_maps_to_google(self) -> None:
         assert required_provider_for("vertex_ai/gemini-pro", None) == "google"
 


### PR DESCRIPTION
## Summary

- Simplify `lorairo-cli models list --type webapi` to show the practical columns: Provider, Route, and Model ID.
- Hide the old always-active Status column by default and show Availability only when unavailable/deprecated rows are requested.
- Normalize Gemini provider hints to the Google API key provider so direct Gemini models are listed when `google_key` is configured.

## Root Cause

LiteLLM discovery can report Gemini direct models with `provider=Gemini` and model IDs such as `gemini/gemini-2.5-pro`. LoRAIro already mapped the `gemini/` prefix to the Google key provider, but provider hints were returned before alias normalization. That made Gemini rows require a non-existent `gemini` key instead of the configured `google` key, so they were filtered from the normal webapi list.

The table also exposed internal categories/status values that were not useful for the webapi-only list.

## Validation

- `.venv\Scripts\python.exe -m pytest tests\unit\services\test_model_route_service.py tests\unit\cli\test_commands_models.py` -> 85 passed
- `uv run lorairo-cli models list --type webapi | Select-String -Pattern "gemini-2.5-pro"` shows `google direct gemini/gemini-2.5-pro`