### PR TITLE
fix(#267): transformers v4.50+ 対応 (AutoModelForVision2Seq → AutoModelForImageTextToText)

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -1476,7 +1476,7 @@ requires-dist = [
     { name = "torch", specifier = ">=2.6.0" },
     { name = "torchvision", specifier = ">=0.21.0" },
     { name = "tqdm", specifier = ">=4.66.0" },
-    { name = "transformers", specifier = ">=4.27.4" },
+    { name = "transformers", specifier = ">=4.50.0" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
## Summary

transformers v4.50+ で `AutoModelForVision2Seq` が `AutoModelForImageTextToText` に統合・改名された。LoRAIro の `.venv` (transformers 4.57.1) では import 不能となり、BLIP / BLIP2 / GIT / ToriiGate annotator (計 10 モデル) が ImportError で動作不能だった。

## Changes

- **submodule pin**: `image-annotator-lib` を NEXTAltair/image-annotator-lib#64 マージ済 commit (1a67b87) に更新
- **uv.lock**: transformers 制約引き上げ (>=4.27.4 → >=4.50.0) に同期

詳細変更は image-annotator-lib#64 を参照。

## Test plan

- [x] CI-equivalent filter (LoRAIro 本体): 2260 passed, 2 skipped, 0 failed
- [x] CI-equivalent filter (image-annotator-lib): 631 passed (修正前は test_model_factory_v2 で 5 failed)

CI-EQUIV-TESTED

Closes #267

🤖 Generated with [Claude Code](https://claude.com/claude-code)