### PR TITLE
feat(#281): iam-lib submodule pin を a609589 に更新 (ADR 0002 / SCORE_LABELS)

### DIFF
--- a/src/lorairo/annotations/annotator_adapter.py
+++ b/src/lorairo/annotations/annotator_adapter.py
@@ -32,10 +32,12 @@ if TYPE_CHECKING:
 
 # AnnotatorInfo.capabilities (frozenset[TaskCapability]) → ModelInfo.capabilities (list[str])
 # の変換テーブル。TaskCapability.value をそのまま採用する。
+# iam-lib ADR 0002: SCORE_LABELS は canonical scorer (aesthetic_shadow / cafe) が宣言する。
 _CAPABILITY_VALUES: dict[TaskCapability, str] = {
     TaskCapability.TAGS: "tags",
     TaskCapability.CAPTIONS: "captions",
     TaskCapability.SCORES: "scores",
+    TaskCapability.SCORE_LABELS: "score_labels",
 }
 
 __all__ = ["AnnotatorLibraryAdapter"]


### PR DESCRIPTION
## Summary

- image-annotator-lib PR #68 (ADR 0002 implementation: `SCORE_LABELS` capability + `score_labels` field) を取り込む submodule pin 更新
- `annotator_adapter.py:_CAPABILITY_VALUES` 辞書に `TaskCapability.SCORE_LABELS` を hot-fix で追加 (この追加なしでは canonical scorer の `AnnotatorInfo.capabilities` 列挙時に `KeyError` 発生)
- `score_labels` の DB 保存経路、整数 bin tag (`[CAFE]score_N` 等) の consumer inventory 等は **Issue #281 で追跡**

## 取り込む内容 (iam-lib #66 / ADR 0002)

| Model | capabilities | scores | score_labels |
|---|---|---|---|
| `aesthetic_shadow_v1/v2` | `["scores", "score_labels"]` | `{hq, lq}` (0-1, sum=1) | 4-tier 閾値 (`["very aesthetic"]` 等) |
| `cafe_aesthetic` | `["scores", "score_labels"]` | `{aesthetic, not_aesthetic}` (0-1, sum=1) | argmax (`["aesthetic"]` or `["not_aesthetic"]`) |
| `ImprovedAesthetic` | `["scores"]` | `{aesthetic}` (1-10) | `None` |
| `WaifuAesthetic` | `["scores"]` | `{aesthetic}` (0-1) | `None` |

全 scorer で `tags=None` (content tag は WDTagger 等専用に純化)。

## Test plan

CI-EQUIV-TESTED

- [x] LoRAIro CI-equivalent filter (`uv run pytest -m "not gui_show and not real_api and not slow"`): **2260 passed, 2 skipped** (既知), 45 warnings
- [x] hot-fix 直接確認: `python -c "from lorairo.annotations.annotator_adapter import _CAPABILITY_VALUES; print(_CAPABILITY_VALUES)"` → 4 enum 値 (TAGS / CAPTIONS / SCORES / SCORE_LABELS) を含む
- [x] iam-lib CI-equivalent filter (PR #68 で確認済): 634 passed, 18 skipped (skip は iam-lib #269 既知)

## Out of scope (Issue #281 で追跡)

- `score_labels` の DB 保存経路 (`annotation_save_service.py` + `AnnotationsDict` schema) は未対応 — canonical scorer の `score_labels` は silent drop される
- 整数 bin tag (`[CAFE]score_N` 等) の consumer inventory + 必要なら派生実装

## Refs

- Issue: #281 (本 PR は hot-fix のみ、残課題は同 issue で追跡)
- iam-lib Issue: NEXTAltair/image-annotator-lib#66 (closed)
- iam-lib PR: NEXTAltair/image-annotator-lib#67 (ADR), #68 (implementation)
- iam-lib ADR: `docs/decisions/0002-score-model-output-contract.md`
- LoRAIro 起源 issue: #273 (closed/migrated)
- LoRAIro ADR: `docs/decisions/0026-on-demand-runtime-validation-strategy.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)