### PR TITLE
feat(#284): score_labels の GUI compact pill 表示 + JSON export 経路を追加 (ADR 0028)

### DIFF
--- a/src/lorairo/database/db_repository.py
+++ b/src/lorairo/database/db_repository.py
@@ -2450,6 +2450,33 @@ class ImageRepository:
             annotations["scores"] = []
             annotations["score_value"] = 0.0
 
+    def _format_score_labels(self, image: Image, annotations: dict[str, Any]) -> None:
+        """スコアラベル (canonical scorer の categorical 分類) をフォーマットする。
+
+        ADR 0028 に基づき、各 entry は {model, label} ペアで保持し、scalar shorthand
+        は持たない (multi-scorer の集約 / 多数決方式の前提)。
+
+        Args:
+            image: 画像オブジェクト。
+            annotations: フォーマット結果を格納する辞書（直接更新される）。
+
+        """
+        if image.score_labels:
+            annotations["score_labels"] = [
+                {
+                    "id": sl.id,
+                    "label": sl.label,
+                    "model_id": sl.model_id,
+                    "model": sl.model.name if sl.model else "Unknown",
+                    "is_edited_manually": sl.is_edited_manually,
+                    "created_at": sl.created_at,
+                    "updated_at": sl.updated_at,
+                }
+                for sl in image.score_labels
+            ]
+        else:
+            annotations["score_labels"] = []
+
     def _format_ratings(self, image: Image, annotations: dict[str, Any]) -> None:
         """レーティングアノテーション情報をフォーマットする。
 
@@ -2492,12 +2519,14 @@ class ImageRepository:
         self._format_tags(image, annotations)
         self._format_captions(image, annotations)
         self._format_scores(image, annotations)
+        self._format_score_labels(image, annotations)
         self._format_ratings(image, annotations)
 
         logger.debug(
             f"Formatted annotations: tags={len(annotations.get('tags', []))}, "
             f"captions={len(annotations.get('captions', []))}, "
             f"scores={len(annotations.get('scores', []))}, "
+            f"score_labels={len(annotations.get('score_labels', []))}, "
             f"ratings={len(annotations.get('ratings', []))}",
         )
 
@@ -2527,6 +2556,7 @@ class ImageRepository:
                 selectinload(Image.tags).selectinload(Tag.model),
                 selectinload(Image.captions).selectinload(Caption.model),
                 selectinload(Image.scores).selectinload(Score.model),
+                selectinload(Image.score_labels).selectinload(ScoreLabel.model),
                 selectinload(Image.ratings),
             )
         )
@@ -2569,6 +2599,7 @@ class ImageRepository:
                 selectinload(Image.tags).selectinload(Tag.model),
                 selectinload(Image.captions).selectinload(Caption.model),
                 selectinload(Image.scores).selectinload(Score.model),
+                selectinload(Image.score_labels).selectinload(ScoreLabel.model),
                 selectinload(Image.ratings),
             )
         )

--- a/src/lorairo/database/db_repository.py
+++ b/src/lorairo/database/db_repository.py
@@ -1900,8 +1900,32 @@ class ImageRepository:
             "updated_at": rating.updated_at,
         }
 
+    @staticmethod
+    def _format_score_label_annotation(sl: Any) -> dict[str, Any]:
+        """スコアラベルアノテーション (ADR 0028) を dict 形式にフォーマットする。
+
+        ADR 0028 で「常に model 名と組で保持」と決定したため、他 per-item helper と
+        異なり ``model`` (model.name) を含める。``sl.model`` relationship が eager
+        load されている前提 (``joinedload(ScoreLabel.model)`` 等)。
+
+        Args:
+            sl: ScoreLabel ORM オブジェクト。
+
+        Returns:
+            フォーマット済み辞書 (model 含む)。
+        """
+        return {
+            "id": sl.id,
+            "label": sl.label,
+            "model_id": sl.model_id,
+            "model": sl.model.name if sl.model else "Unknown",
+            "is_edited_manually": sl.is_edited_manually,
+            "created_at": sl.created_at,
+            "updated_at": sl.updated_at,
+        }
+
     def get_image_annotations(self, image_id: int) -> dict[str, list[dict[str, Any]]]:
-        """指定された画像IDのアノテーション(タグ、キャプション、スコア、レーティング)を取得する。
+        """指定された画像IDのアノテーション(タグ、キャプション、スコア、スコアラベル、レーティング)を取得する。
 
         Eager Loadingを使用して関連データを効率的に取得する。
 
@@ -1910,7 +1934,7 @@ class ImageRepository:
 
         Returns:
             アノテーションデータを含む辞書。
-            キー: 'tags', 'captions', 'scores', 'ratings'
+            キー: 'tags', 'captions', 'scores', 'score_labels', 'ratings'
             画像が存在しない場合は空のリストを持つ辞書を返す。
 
         Raises:
@@ -1924,6 +1948,7 @@ class ImageRepository:
             "tags": [],
             "captions": [],
             "scores": [],
+            "score_labels": [],
             "ratings": [],
         }
 
@@ -1936,6 +1961,9 @@ class ImageRepository:
                         joinedload(Image.tags),
                         joinedload(Image.captions),
                         joinedload(Image.scores),
+                        # ADR 0028: score_labels は model 名と組で返すため
+                        # ScoreLabel.model も eager load する
+                        joinedload(Image.score_labels).joinedload(ScoreLabel.model),
                         joinedload(Image.ratings),
                         joinedload(Image.processed_images),
                     )
@@ -1952,12 +1980,17 @@ class ImageRepository:
                     annotations["captions"] = [self._format_caption_annotation(c) for c in image.captions]
                 if image.scores:
                     annotations["scores"] = [self._format_score_annotation(s) for s in image.scores]
+                if image.score_labels:
+                    annotations["score_labels"] = [
+                        self._format_score_label_annotation(sl) for sl in image.score_labels
+                    ]
                 if image.ratings:
                     annotations["ratings"] = [self._format_rating_annotation(r) for r in image.ratings]
 
                 logger.info(
                     f"取得したアノテーション数: tags={len(annotations['tags'])}, "
                     f"captions={len(annotations['captions'])}, scores={len(annotations['scores'])}, "
+                    f"score_labels={len(annotations['score_labels'])}, "
                     f"ratings={len(annotations['ratings'])} for image_id={image_id}",
                 )
                 return annotations
@@ -2463,16 +2496,7 @@ class ImageRepository:
         """
         if image.score_labels:
             annotations["score_labels"] = [
-                {
-                    "id": sl.id,
-                    "label": sl.label,
-                    "model_id": sl.model_id,
-                    "model": sl.model.name if sl.model else "Unknown",
-                    "is_edited_manually": sl.is_edited_manually,
-                    "created_at": sl.created_at,
-                    "updated_at": sl.updated_at,
-                }
-                for sl in image.score_labels
+                self._format_score_label_annotation(sl) for sl in image.score_labels
             ]
         else:
             annotations["score_labels"] = []

--- a/src/lorairo/gui/designer/AnnotationDataDisplayWidget.ui
+++ b/src/lorairo/gui/designer/AnnotationDataDisplayWidget.ui
@@ -196,6 +196,37 @@
      </layout>
     </widget>
    </item>
+   <item>
+    <widget class="QGroupBox" name="groupBoxScoreLabels">
+     <property name="title">
+      <string>スコアラベル</string>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayoutScoreLabels">
+      <property name="spacing">
+       <number>4</number>
+      </property>
+      <item>
+       <widget class="QLabel" name="labelScoreLabelsPlaceholder">
+        <property name="text">
+         <string>-</string>
+        </property>
+        <property name="wordWrap">
+         <bool>true</bool>
+        </property>
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="Minimum">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="styleSheet">
+         <string>font-size: 10px; color: palette(text);</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
   </layout>
  </widget>
  <resources />

--- a/src/lorairo/gui/designer/AnnotationDataDisplayWidget_ui.py
+++ b/src/lorairo/gui/designer/AnnotationDataDisplayWidget_ui.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'AnnotationDataDisplayWidget.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.11.0
+## Created by: Qt User Interface Compiler version 6.11.1
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################
@@ -117,6 +117,25 @@ class Ui_AnnotationDataDisplayWidget(object):
 
         self.verticalLayoutMain.addWidget(self.groupBoxScores)
 
+        self.groupBoxScoreLabels = QGroupBox(AnnotationDataDisplayWidget)
+        self.groupBoxScoreLabels.setObjectName(u"groupBoxScoreLabels")
+        self.verticalLayoutScoreLabels = QVBoxLayout(self.groupBoxScoreLabels)
+        self.verticalLayoutScoreLabels.setSpacing(4)
+        self.verticalLayoutScoreLabels.setObjectName(u"verticalLayoutScoreLabels")
+        self.labelScoreLabelsPlaceholder = QLabel(self.groupBoxScoreLabels)
+        self.labelScoreLabelsPlaceholder.setObjectName(u"labelScoreLabelsPlaceholder")
+        self.labelScoreLabelsPlaceholder.setWordWrap(True)
+        sizePolicy2 = QSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum)
+        sizePolicy2.setHorizontalStretch(0)
+        sizePolicy2.setVerticalStretch(0)
+        sizePolicy2.setHeightForWidth(self.labelScoreLabelsPlaceholder.sizePolicy().hasHeightForWidth())
+        self.labelScoreLabelsPlaceholder.setSizePolicy(sizePolicy2)
+
+        self.verticalLayoutScoreLabels.addWidget(self.labelScoreLabelsPlaceholder)
+
+
+        self.verticalLayoutMain.addWidget(self.groupBoxScoreLabels)
+
 
         self.retranslateUi(AnnotationDataDisplayWidget)
 
@@ -153,5 +172,8 @@ class Ui_AnnotationDataDisplayWidget(object):
         self.labelOverallScore.setText(QCoreApplication.translate("AnnotationDataDisplayWidget", u"\u30b9\u30b3\u30a2:", None))
         self.labelOverallValue.setText(QCoreApplication.translate("AnnotationDataDisplayWidget", u"0", None))
         self.labelOverallValue.setStyleSheet(QCoreApplication.translate("AnnotationDataDisplayWidget", u"font-size: 10px; font-weight: bold; color: palette(text);", None))
+        self.groupBoxScoreLabels.setTitle(QCoreApplication.translate("AnnotationDataDisplayWidget", u"\u30b9\u30b3\u30a2\u30e9\u30d9\u30eb", None))
+        self.labelScoreLabelsPlaceholder.setText(QCoreApplication.translate("AnnotationDataDisplayWidget", u"-", None))
+        self.labelScoreLabelsPlaceholder.setStyleSheet(QCoreApplication.translate("AnnotationDataDisplayWidget", u"font-size: 10px; color: palette(text);", None))
     # retranslateUi
 

--- a/src/lorairo/gui/designer/ConfigurationWindow_ui.py
+++ b/src/lorairo/gui/designer/ConfigurationWindow_ui.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'ConfigurationWindow.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.11.0
+## Created by: Qt User Interface Compiler version 6.11.1
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################

--- a/src/lorairo/gui/designer/DatasetExportWidget_ui.py
+++ b/src/lorairo/gui/designer/DatasetExportWidget_ui.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'DatasetExportWidget.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.11.0
+## Created by: Qt User Interface Compiler version 6.11.1
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################

--- a/src/lorairo/gui/designer/DatasetOverviewWidget_ui.py
+++ b/src/lorairo/gui/designer/DatasetOverviewWidget_ui.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'DatasetOverviewWidget.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.11.0
+## Created by: Qt User Interface Compiler version 6.11.1
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################

--- a/src/lorairo/gui/designer/DirectoryPickerWidget_ui.py
+++ b/src/lorairo/gui/designer/DirectoryPickerWidget_ui.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'DirectoryPickerWidget.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.11.0
+## Created by: Qt User Interface Compiler version 6.11.1
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################

--- a/src/lorairo/gui/designer/FilePickerWidget_ui.py
+++ b/src/lorairo/gui/designer/FilePickerWidget_ui.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'FilePickerWidget.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.11.0
+## Created by: Qt User Interface Compiler version 6.11.1
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################

--- a/src/lorairo/gui/designer/FilterSearchPanel_ui.py
+++ b/src/lorairo/gui/designer/FilterSearchPanel_ui.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'FilterSearchPanel.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.11.0
+## Created by: Qt User Interface Compiler version 6.11.1
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################

--- a/src/lorairo/gui/designer/ImageEditWidget_ui.py
+++ b/src/lorairo/gui/designer/ImageEditWidget_ui.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'ImageEditWidget.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.11.0
+## Created by: Qt User Interface Compiler version 6.11.1
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################

--- a/src/lorairo/gui/designer/ImagePreviewWidget_ui.py
+++ b/src/lorairo/gui/designer/ImagePreviewWidget_ui.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'ImagePreviewWidget.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.11.0
+## Created by: Qt User Interface Compiler version 6.11.1
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################

--- a/src/lorairo/gui/designer/MainWindow_ui.py
+++ b/src/lorairo/gui/designer/MainWindow_ui.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'MainWindow.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.11.0
+## Created by: Qt User Interface Compiler version 6.11.1
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################

--- a/src/lorairo/gui/designer/ModelCheckboxWidget_ui.py
+++ b/src/lorairo/gui/designer/ModelCheckboxWidget_ui.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'ModelCheckboxWidget.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.11.0
+## Created by: Qt User Interface Compiler version 6.11.1
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################

--- a/src/lorairo/gui/designer/ModelResultTab_ui.py
+++ b/src/lorairo/gui/designer/ModelResultTab_ui.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'ModelResultTab.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.11.0
+## Created by: Qt User Interface Compiler version 6.11.1
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################

--- a/src/lorairo/gui/designer/ModelSelectionWidget_ui.py
+++ b/src/lorairo/gui/designer/ModelSelectionWidget_ui.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'ModelSelectionWidget.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.11.0
+## Created by: Qt User Interface Compiler version 6.11.1
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################

--- a/src/lorairo/gui/designer/PickerWidget_ui.py
+++ b/src/lorairo/gui/designer/PickerWidget_ui.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'PickerWidget.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.11.0
+## Created by: Qt User Interface Compiler version 6.11.1
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################

--- a/src/lorairo/gui/designer/ProgressWidget_ui.py
+++ b/src/lorairo/gui/designer/ProgressWidget_ui.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'ProgressWidget.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.11.0
+## Created by: Qt User Interface Compiler version 6.11.1
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################

--- a/src/lorairo/gui/designer/SelectedImageDetailsWidget_ui.py
+++ b/src/lorairo/gui/designer/SelectedImageDetailsWidget_ui.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'SelectedImageDetailsWidget.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.11.0
+## Created by: Qt User Interface Compiler version 6.11.1
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################

--- a/src/lorairo/gui/designer/ThumbnailSelectorWidget_ui.py
+++ b/src/lorairo/gui/designer/ThumbnailSelectorWidget_ui.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'ThumbnailSelectorWidget.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.11.0
+## Created by: Qt User Interface Compiler version 6.11.1
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################

--- a/src/lorairo/gui/widgets/annotation_data_display_widget.py
+++ b/src/lorairo/gui/widgets/annotation_data_display_widget.py
@@ -343,6 +343,8 @@ class AnnotationDataDisplayWidget(QWidget, Ui_AnnotationDataDisplayWidget):
             # 既存 pill を削除 (末尾の stretch だけ残す)
             while layout.count() > 1:
                 item = layout.takeAt(0)
+                if item is None:
+                    break
                 pill_widget = item.widget()
                 if pill_widget is not None:
                     pill_widget.deleteLater()

--- a/src/lorairo/gui/widgets/annotation_data_display_widget.py
+++ b/src/lorairo/gui/widgets/annotation_data_display_widget.py
@@ -33,6 +33,8 @@ class AnnotationData:
     aesthetic_score: float | None = None
     overall_score: int = 0
     score_type: str = "Aesthetic"
+    # ADR 0028: canonical scorer の categorical label を {model, label, ...} ペアで保持
+    score_labels: list[dict[str, Any]] = field(default_factory=list)
     # 翻訳データ: {tag_id: {language: translated_text}}
     tag_translations: dict[int, dict[str, str]] = field(default_factory=dict)
     # 利用可能な言語リスト（get_tag_languages()から取得）
@@ -85,6 +87,7 @@ class AnnotationDataDisplayWidget(QWidget, Ui_AnnotationDataDisplayWidget):
         self._setup_widget_properties()
         self._setup_tags_compact_view()
         self._setup_caption_compact_view()
+        self._setup_score_labels_compact_view()
         self._adjust_content_heights()
 
         # 言語コンボボックスのシグナル接続
@@ -130,6 +133,21 @@ class AnnotationDataDisplayWidget(QWidget, Ui_AnnotationDataDisplayWidget):
         self.verticalLayoutCaption.insertWidget(0, self._caption_compact_label)
         self.textEditCaption.setVisible(False)
 
+    def _setup_score_labels_compact_view(self) -> None:
+        """スコアラベル compact pill コンテナの初期化 (ADR 0028)。
+
+        各 scorer model 1 pill で `[model] label` 形式の QLabel を動的に配置する。
+        score_labels が空のときは placeholder ("-") のみ表示し、container を hide する。
+        """
+        self._score_labels_container = QWidget(self.groupBoxScoreLabels)
+        layout = QHBoxLayout(self._score_labels_container)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(4)
+        layout.addStretch(1)  # pill を左寄せするための末尾 stretch
+        self._score_labels_layout = layout
+        self._score_labels_container.setVisible(False)
+        self.verticalLayoutScoreLabels.addWidget(self._score_labels_container)
+
     def update_data(self, data: AnnotationData) -> None:
         """アノテーションデータで表示を更新"""
         try:
@@ -144,10 +162,16 @@ class AnnotationDataDisplayWidget(QWidget, Ui_AnnotationDataDisplayWidget):
             # スコア表示更新
             self._update_scores_display(data.aesthetic_score, data.overall_score, data.score_type)
 
+            # スコアラベル表示更新 (ADR 0028)
+            self._update_score_labels_display(data.score_labels)
+
             self._adjust_content_heights()
 
             self.data_loaded.emit(data)
-            logger.debug(f"Annotation data updated - tags: {len(data.tags)}, caption: {bool(data.caption)}")
+            logger.debug(
+                f"Annotation data updated - tags: {len(data.tags)}, "
+                f"caption: {bool(data.caption)}, score_labels: {len(data.score_labels)}"
+            )
 
         except Exception as e:
             logger.error(f"Error updating annotation data: {e}", exc_info=True)
@@ -303,6 +327,56 @@ class AnnotationDataDisplayWidget(QWidget, Ui_AnnotationDataDisplayWidget):
         except Exception as e:
             logger.error(f"Error updating scores display: {e}")
 
+    def _update_score_labels_display(self, score_labels: list[dict[str, Any]]) -> None:
+        """スコアラベル compact pill 表示を更新する (ADR 0028)。
+
+        各 scorer model 1 pill で ``[model] label`` 形式の QLabel を生成する。
+        ADR 0028 に従い scalar shorthand は持たず、全 scorer を並列に列挙する
+        (UC-C 不一致発見 / UC-A 多数決の前提)。
+
+        Args:
+            score_labels: ``[{"label": str, "model": str, ...}, ...]`` 構造の list。
+                          空 list の場合は placeholder を表示し container を hide する。
+        """
+        try:
+            layout = self._score_labels_layout
+            # 既存 pill を削除 (末尾の stretch だけ残す)
+            while layout.count() > 1:
+                item = layout.takeAt(0)
+                pill_widget = item.widget()
+                if pill_widget is not None:
+                    pill_widget.deleteLater()
+
+            if not score_labels:
+                self.labelScoreLabelsPlaceholder.setVisible(True)
+                self._score_labels_container.setVisible(False)
+                return
+
+            self.labelScoreLabelsPlaceholder.setVisible(False)
+            self._score_labels_container.setVisible(True)
+
+            for entry in score_labels:
+                model = entry.get("model", "Unknown")
+                label = entry.get("label", "-")
+                pill = QLabel(f"[{model}] {label}", self._score_labels_container)
+                pill.setStyleSheet(
+                    "QLabel { "
+                    "background-color: palette(light); "
+                    "border: 1px solid palette(mid); "
+                    "border-radius: 8px; "
+                    "padding: 2px 8px; "
+                    "font-size: 10px; "
+                    "color: palette(text); "
+                    "}"
+                )
+                # stretch の前 (= layout 末尾) に挿入
+                layout.insertWidget(layout.count() - 1, pill)
+
+            logger.debug(f"Updated score_labels display: {len(score_labels)} pills")
+
+        except Exception as e:
+            logger.error(f"Error updating score_labels display: {e}")
+
     @Slot()
     def clear_data(self) -> None:
         """表示データをクリア"""
@@ -319,6 +393,9 @@ class AnnotationDataDisplayWidget(QWidget, Ui_AnnotationDataDisplayWidget):
 
             self.labelScoreTypeValue.setText("-")
             self.labelOverallValue.setText("0")
+
+            # スコアラベル pill もクリア
+            self._update_score_labels_display([])
 
             self._tags_compact_label.setText("-")
             self._adjust_content_heights()
@@ -339,12 +416,17 @@ class AnnotationDataDisplayWidget(QWidget, Ui_AnnotationDataDisplayWidget):
         self.textEditCaption.setReadOnly(read_only)
 
     def set_group_box_visibility(
-        self, tags: bool = True, caption: bool = True, scores: bool = True
+        self,
+        tags: bool = True,
+        caption: bool = True,
+        scores: bool = True,
+        score_labels: bool = True,
     ) -> None:
-        """各グループボックスの表示/非表示制御"""
+        """各グループボックスの表示/非表示制御 (Issue #284 で score_labels を追加)。"""
         self.groupBoxTags.setVisible(tags)
         self.groupBoxCaption.setVisible(caption)
         self.groupBoxScores.setVisible(scores)
+        self.groupBoxScoreLabels.setVisible(score_labels)
 
     def resizeEvent(self, event: QResizeEvent) -> None:
         super().resizeEvent(event)

--- a/src/lorairo/gui/widgets/selected_image_details_widget.py
+++ b/src/lorairo/gui/widgets/selected_image_details_widget.py
@@ -412,6 +412,8 @@ class SelectedImageDetailsWidget(QWidget):
         tags_list = metadata.get("tags", [])
         caption_text = metadata.get("caption_text", "")
         tags_text = metadata.get("tags_text", "")
+        # ADR 0028: canonical scorer の score_labels を AnnotationData に渡す
+        score_labels_list = metadata.get("score_labels", [])
 
         # 翻訳データ取得（N+1回避のためバッチ取得）
         tag_translations: dict[int, dict[str, str]] = {}
@@ -430,6 +432,7 @@ class SelectedImageDetailsWidget(QWidget):
             caption=caption_text,
             aesthetic_score=score_value,
             overall_score=0,  # Rating値は文字列なのでoverall_scoreには使用しない
+            score_labels=score_labels_list,
             tag_translations=tag_translations,
             available_languages=self._available_languages,
         )

--- a/src/lorairo/services/dataset_export_service.py
+++ b/src/lorairo/services/dataset_export_service.py
@@ -203,8 +203,21 @@ class DatasetExportService:
                     if image_data["captions"]
                     else ""
                 )
+                # ADR 0028: score_labels は {model, label} を主とする JSON-safe な形で埋め込む
+                score_labels = [
+                    {
+                        "model": sl.get("model", "Unknown"),
+                        "label": sl.get("label", ""),
+                        "is_edited_manually": bool(sl.get("is_edited_manually")),
+                    }
+                    for sl in image_data.get("score_labels", [])
+                ]
 
-                metadata[str(output_image_path)] = {"tags": tags, "caption": captions}
+                metadata[str(output_image_path)] = {
+                    "tags": tags,
+                    "caption": captions,
+                    "score_labels": score_labels,
+                }
 
                 exported_count += 1
                 logger.debug(f"Exported image {image_id}: {processed_image_path.name}")
@@ -369,6 +382,8 @@ class DatasetExportService:
                 "metadata": metadata,
                 "tags": annotations.get("tags", []),
                 "captions": annotations.get("captions", []),
+                # ADR 0028: canonical scorer の categorical label を {model, label} ペアで保持
+                "score_labels": annotations.get("score_labels", []),
             }
 
         except Exception as e:

--- a/tests/unit/database/test_db_repository_annotations.py
+++ b/tests/unit/database/test_db_repository_annotations.py
@@ -425,6 +425,40 @@ class TestAnnotationFormatters:
         assert result["normalized_rating"] == "pg"
         assert result["confidence_score"] == 0.92
 
+    def test_format_score_label_annotation(self):
+        """スコアラベルアノテーション (ADR 0028) のフォーマット - model 名と組で返ること。"""
+        sl = Mock()
+        sl.id = 5
+        sl.label = "very aesthetic"
+        sl.model_id = 42
+        sl.is_edited_manually = False
+        sl.created_at = datetime(2026, 5, 18)
+        sl.updated_at = datetime(2026, 5, 18)
+        sl.model = Mock()
+        sl.model.name = "aesthetic_shadow_v1"
+
+        result = ImageRepository._format_score_label_annotation(sl)
+        assert result["id"] == 5
+        assert result["label"] == "very aesthetic"
+        assert result["model_id"] == 42
+        # ADR 0028: model 名を常に含める
+        assert result["model"] == "aesthetic_shadow_v1"
+        assert result["is_edited_manually"] is False
+
+    def test_format_score_label_annotation_no_model_relationship(self):
+        """model relationship が None の場合は 'Unknown' が埋まる。"""
+        sl = Mock()
+        sl.id = 6
+        sl.label = "aesthetic"
+        sl.model_id = 99
+        sl.is_edited_manually = False
+        sl.created_at = datetime(2026, 5, 18)
+        sl.updated_at = datetime(2026, 5, 18)
+        sl.model = None
+
+        result = ImageRepository._format_score_label_annotation(sl)
+        assert result["model"] == "Unknown"
+
 
 # ==============================================================================
 # Test _apply_simple_field_updates

--- a/tests/unit/database/test_db_repository_annotations.py
+++ b/tests/unit/database/test_db_repository_annotations.py
@@ -27,6 +27,7 @@ class TestFormatAnnotationsForMetadata:
         image.tags = []
         image.captions = []
         image.scores = []
+        image.score_labels = []
         image.ratings = []
         return image
 
@@ -79,6 +80,7 @@ class TestFormatAnnotationsForMetadata:
         image.tags = [tag1]
         image.captions = [caption1]
         image.scores = [score1]
+        image.score_labels = []
         image.ratings = [rating1]
 
         return image
@@ -94,6 +96,7 @@ class TestFormatAnnotationsForMetadata:
             "caption_text": "",
             "scores": [],
             "score_value": 0.0,
+            "score_labels": [],
             "ratings": [],
             "rating_value": "",  # Issue #4: Rating値は文字列型
         }
@@ -168,6 +171,7 @@ class TestFormatAnnotationsForMetadata:
         image.tags = [tag1]
         image.captions = []
         image.scores = []
+        image.score_labels = []
         image.ratings = []
 
         result = repository._format_annotations_for_metadata(image)
@@ -178,6 +182,7 @@ class TestFormatAnnotationsForMetadata:
         assert result["caption_text"] == ""
         assert len(result["scores"]) == 0
         assert result["score_value"] == 0.0
+        assert len(result["score_labels"]) == 0
         assert len(result["ratings"]) == 0
         assert result["rating_value"] == ""  # Issue #4: Rating値は文字列型
 
@@ -211,6 +216,7 @@ class TestFormatAnnotationsForMetadata:
         image.tags = [tag1, tag2]
         image.captions = []
         image.scores = []
+        image.score_labels = []
         image.ratings = []
 
         result = repository._format_annotations_for_metadata(image)

--- a/tests/unit/database/test_db_repository_score_labels.py
+++ b/tests/unit/database/test_db_repository_score_labels.py
@@ -1,9 +1,12 @@
-"""ImageRepository._save_score_labels のテスト (Issue #281 / ADR 0027).
+"""ImageRepository._save_score_labels / _format_score_labels のテスト (Issue #281, #284 / ADR 0027, 0028).
 
 canonical scorer (aesthetic_shadow_v1/v2 等) の categorical label を保存する
-``_save_score_labels`` メソッドの Upsert 動作を検証する。
+``_save_score_labels`` メソッドの Upsert 動作と、formatting helper ``_format_score_labels``
+(ADR 0028) の挙動を検証する。
 """
 
+import datetime
+from types import SimpleNamespace
 from unittest.mock import MagicMock, Mock
 
 import pytest
@@ -124,3 +127,116 @@ class TestSaveScoreLabels:
 
         added = mock_session.add.call_args[0][0]
         assert added.is_edited_manually is True
+
+
+class TestFormatScoreLabels:
+    """``_format_score_labels`` の formatting 動作テスト (ADR 0028)。
+
+    ADR 0028 で「常に {model, label} ペアで保持」「scalar shorthand 不採用」と決定済み。
+    """
+
+    @pytest.fixture
+    def repository(self) -> ImageRepository:
+        """テスト用 ImageRepository。"""
+        mock_session_factory = Mock()
+        return ImageRepository(session_factory=mock_session_factory)
+
+    def _make_score_label(
+        self,
+        sl_id: int,
+        model_id: int,
+        model_name: str,
+        label: str,
+        is_edited_manually: bool | None = False,
+    ) -> SimpleNamespace:
+        """ScoreLabel ORM ロード相当の SimpleNamespace を組み立てる。"""
+        return SimpleNamespace(
+            id=sl_id,
+            image_id=100,
+            model_id=model_id,
+            label=label,
+            is_edited_manually=is_edited_manually,
+            created_at=datetime.datetime(2026, 5, 18, 10, 0, 0),
+            updated_at=datetime.datetime(2026, 5, 18, 10, 0, 0),
+            model=SimpleNamespace(name=model_name),
+        )
+
+    def test_format_score_labels_empty(self, repository: ImageRepository) -> None:
+        """score_labels 0 件で annotations["score_labels"] = [] となる。"""
+        image = SimpleNamespace(score_labels=[])
+        annotations: dict = {}
+
+        repository._format_score_labels(image, annotations)
+
+        assert annotations["score_labels"] == []
+
+    def test_format_score_labels_single_model(self, repository: ImageRepository) -> None:
+        """1 scorer の場合、{model, label, ...} 構造で 1 entry が組まれる。"""
+        sl = self._make_score_label(1, 42, "aesthetic_shadow_v1", "very aesthetic")
+        image = SimpleNamespace(score_labels=[sl])
+        annotations: dict = {}
+
+        repository._format_score_labels(image, annotations)
+
+        assert len(annotations["score_labels"]) == 1
+        entry = annotations["score_labels"][0]
+        assert entry["label"] == "very aesthetic"
+        assert entry["model"] == "aesthetic_shadow_v1"
+        assert entry["model_id"] == 42
+        assert entry["is_edited_manually"] is False
+        # Scalar shorthand は ADR 0028 で不採用
+        assert "score_label_value" not in annotations
+
+    def test_format_score_labels_multi_models(self, repository: ImageRepository) -> None:
+        """複数 scorer の場合、各 entry が並列に保持される (順序は image.score_labels 順)。"""
+        labels = [
+            self._make_score_label(1, 42, "aesthetic_shadow_v1", "very aesthetic"),
+            self._make_score_label(2, 43, "aesthetic_shadow_v2", "aesthetic"),
+            self._make_score_label(3, 44, "cafe_aesthetic", "very aesthetic"),
+        ]
+        image = SimpleNamespace(score_labels=labels)
+        annotations: dict = {}
+
+        repository._format_score_labels(image, annotations)
+
+        assert len(annotations["score_labels"]) == 3
+        models = [e["model"] for e in annotations["score_labels"]]
+        assert models == ["aesthetic_shadow_v1", "aesthetic_shadow_v2", "cafe_aesthetic"]
+
+    def test_format_score_labels_unknown_model(self, repository: ImageRepository) -> None:
+        """model relationship が None の場合 'Unknown' を埋める (既存 helper と整合)。"""
+        sl = SimpleNamespace(
+            id=1,
+            image_id=100,
+            model_id=42,
+            label="aesthetic",
+            is_edited_manually=False,
+            created_at=datetime.datetime(2026, 5, 18, 10, 0, 0),
+            updated_at=datetime.datetime(2026, 5, 18, 10, 0, 0),
+            model=None,
+        )
+        image = SimpleNamespace(score_labels=[sl])
+        annotations: dict = {}
+
+        repository._format_score_labels(image, annotations)
+
+        assert annotations["score_labels"][0]["model"] == "Unknown"
+
+    def test_format_annotations_for_metadata_includes_score_labels(
+        self, repository: ImageRepository
+    ) -> None:
+        """_format_annotations_for_metadata に score_labels が組み込まれる。"""
+        sl = self._make_score_label(1, 42, "aesthetic_shadow_v1", "very aesthetic")
+        image = SimpleNamespace(
+            tags=[],
+            captions=[],
+            scores=[],
+            ratings=[],
+            score_labels=[sl],
+        )
+
+        annotations = repository._format_annotations_for_metadata(image)
+
+        assert "score_labels" in annotations
+        assert annotations["score_labels"][0]["label"] == "very aesthetic"
+        assert annotations["score_labels"][0]["model"] == "aesthetic_shadow_v1"

--- a/tests/unit/database/test_db_repository_score_labels.py
+++ b/tests/unit/database/test_db_repository_score_labels.py
@@ -240,3 +240,105 @@ class TestFormatScoreLabels:
         assert "score_labels" in annotations
         assert annotations["score_labels"][0]["label"] == "very aesthetic"
         assert annotations["score_labels"][0]["model"] == "aesthetic_shadow_v1"
+
+
+class TestGetImageAnnotationsScoreLabels:
+    """``get_image_annotations`` 経由で score_labels が読まれることを検証する (ADR 0028)。
+
+    PR #286 レビューで指摘された silent バグ防止: 過去 ``get_image_annotations`` は
+    tags/captions/scores/ratings のみ返却で score_labels を silent drop していた。
+    本テストは ``_get_image_export_data`` 等の downstream が score_labels を取得
+    できる経路を保証する。
+    """
+
+    @pytest.fixture
+    def repository(self) -> ImageRepository:
+        """テスト用 ImageRepository。"""
+        mock_session_factory = MagicMock()
+        return ImageRepository(session_factory=mock_session_factory)
+
+    def _setup_session_with_image(
+        self, repository: ImageRepository, image: SimpleNamespace | None
+    ) -> MagicMock:
+        """session_factory を mock してテスト用 Image を返すように設定。"""
+        mock_session = MagicMock()
+        mock_session.__enter__ = Mock(return_value=mock_session)
+        mock_session.__exit__ = Mock(return_value=False)
+
+        mock_result = MagicMock()
+        mock_result.unique.return_value.scalar_one_or_none.return_value = image
+        mock_session.execute.return_value = mock_result
+
+        repository.session_factory = MagicMock(return_value=mock_session)
+        return mock_session
+
+    def test_get_image_annotations_includes_score_labels_key_when_empty(
+        self, repository: ImageRepository
+    ) -> None:
+        """画像なしでも score_labels: [] が返値に含まれる (key 欠落で silent fail しない)。"""
+        self._setup_session_with_image(repository, None)
+
+        annotations = repository.get_image_annotations(image_id=100)
+
+        assert "score_labels" in annotations
+        assert annotations["score_labels"] == []
+
+    def test_get_image_annotations_returns_score_labels_from_db(self, repository: ImageRepository) -> None:
+        """DB に score_labels がある場合、{model, label, ...} 構造で返値に含まれる。"""
+        sl = SimpleNamespace(
+            id=1,
+            image_id=100,
+            model_id=42,
+            label="very aesthetic",
+            is_edited_manually=False,
+            created_at=datetime.datetime(2026, 5, 18, 10, 0, 0),
+            updated_at=datetime.datetime(2026, 5, 18, 10, 0, 0),
+            model=SimpleNamespace(name="aesthetic_shadow_v1"),
+        )
+        image = SimpleNamespace(
+            tags=[],
+            captions=[],
+            scores=[],
+            ratings=[],
+            score_labels=[sl],
+        )
+        self._setup_session_with_image(repository, image)
+
+        annotations = repository.get_image_annotations(image_id=100)
+
+        assert len(annotations["score_labels"]) == 1
+        entry = annotations["score_labels"][0]
+        assert entry["label"] == "very aesthetic"
+        # ADR 0028: model 名と組で保持
+        assert entry["model"] == "aesthetic_shadow_v1"
+        assert entry["model_id"] == 42
+
+    def test_get_image_annotations_multi_scorer_score_labels(self, repository: ImageRepository) -> None:
+        """複数 scorer の score_labels が list 順序で全件返る (UC-A 多数決の前提)。"""
+        labels = [
+            SimpleNamespace(
+                id=i,
+                image_id=100,
+                model_id=40 + i,
+                label=label,
+                is_edited_manually=False,
+                created_at=datetime.datetime(2026, 5, 18, 10, 0, 0),
+                updated_at=datetime.datetime(2026, 5, 18, 10, 0, 0),
+                model=SimpleNamespace(name=model_name),
+            )
+            for i, (model_name, label) in enumerate(
+                [
+                    ("aesthetic_shadow_v1", "very aesthetic"),
+                    ("aesthetic_shadow_v2", "aesthetic"),
+                    ("cafe_aesthetic", "very aesthetic"),
+                ]
+            )
+        ]
+        image = SimpleNamespace(tags=[], captions=[], scores=[], ratings=[], score_labels=labels)
+        self._setup_session_with_image(repository, image)
+
+        annotations = repository.get_image_annotations(image_id=100)
+
+        assert len(annotations["score_labels"]) == 3
+        models = [e["model"] for e in annotations["score_labels"]]
+        assert models == ["aesthetic_shadow_v1", "aesthetic_shadow_v2", "cafe_aesthetic"]

--- a/tests/unit/gui/widgets/test_annotation_data_display_widget.py
+++ b/tests/unit/gui/widgets/test_annotation_data_display_widget.py
@@ -192,3 +192,84 @@ class TestAnnotationDataDisplayWidget:
         widget.update_data(data)
 
         assert "1人の女の子" in widget._tags_compact_label.text()
+
+    # ─── score_labels compact pill display (Issue #284 / ADR 0028) ─────
+
+    @pytest.fixture
+    def sample_score_labels(self):
+        """canonical scorer の score_labels (ADR 0028 のデータ形状)"""
+        return [
+            {
+                "label": "very aesthetic",
+                "model": "aesthetic_shadow_v1",
+                "model_id": 1,
+                "is_edited_manually": False,
+            },
+            {
+                "label": "aesthetic",
+                "model": "cafe_aesthetic",
+                "model_id": 2,
+                "is_edited_manually": False,
+            },
+        ]
+
+    def test_score_labels_empty_shows_placeholder(self, widget):
+        """score_labels 空時、container が hidden で placeholder のみ。"""
+        widget.update_data(AnnotationData(score_labels=[]))
+        # placeholder は visible 設定で残る (qtbot 上は親 invisible だが isHidden() は False)
+        assert not widget.labelScoreLabelsPlaceholder.isHidden()
+        assert widget._score_labels_container.isHidden()
+
+    def test_score_labels_single_pill(self, widget):
+        """1 scorer で 1 pill が描画され、[model] label を含む。"""
+        data = AnnotationData(
+            score_labels=[
+                {
+                    "label": "very aesthetic",
+                    "model": "aesthetic_shadow_v1",
+                    "model_id": 1,
+                    "is_edited_manually": False,
+                }
+            ]
+        )
+        widget.update_data(data)
+
+        # pill (1) + stretch (1)
+        assert widget._score_labels_layout.count() == 2
+        pill = widget._score_labels_layout.itemAt(0).widget()
+        assert pill is not None
+        assert "aesthetic_shadow_v1" in pill.text()
+        assert "very aesthetic" in pill.text()
+        # container は visible 設定、placeholder は hidden 設定
+        assert not widget._score_labels_container.isHidden()
+        assert widget.labelScoreLabelsPlaceholder.isHidden()
+
+    def test_score_labels_multi_pills(self, widget, sample_score_labels):
+        """複数 scorer で複数 pill が描画される。"""
+        widget.update_data(AnnotationData(score_labels=sample_score_labels))
+
+        # 2 pill + 1 stretch
+        assert widget._score_labels_layout.count() == 3
+        pill_texts = [widget._score_labels_layout.itemAt(i).widget().text() for i in range(2)]
+        assert any("aesthetic_shadow_v1" in t for t in pill_texts)
+        assert any("cafe_aesthetic" in t for t in pill_texts)
+
+    def test_score_labels_re_render_clears_previous(self, widget, sample_score_labels):
+        """update_data 再呼出しで前 pill がクリアされて再描画される。"""
+        widget.update_data(AnnotationData(score_labels=sample_score_labels))
+        assert widget._score_labels_layout.count() == 3
+
+        widget.update_data(AnnotationData(score_labels=[sample_score_labels[0]]))
+        # 1 pill + 1 stretch
+        assert widget._score_labels_layout.count() == 2
+
+    def test_set_group_box_visibility_score_labels_false(self, widget):
+        """score_labels=False で groupBoxScoreLabels が hidden になる。"""
+        widget.set_group_box_visibility(score_labels=False)
+        assert widget.groupBoxScoreLabels.isHidden()
+
+    def test_set_group_box_visibility_backward_compatible(self, widget):
+        """score_labels 省略時 (既存 caller) は default True で表示維持。"""
+        widget.set_group_box_visibility(tags=False)
+        # score_labels は default で visible 設定 → isHidden() は False
+        assert not widget.groupBoxScoreLabels.isHidden()

--- a/tests/unit/gui/widgets/test_selected_image_details_widget.py
+++ b/tests/unit/gui/widgets/test_selected_image_details_widget.py
@@ -276,3 +276,55 @@ class TestSelectedImageDetailsWidget:
         mock_reader.get_translations_batch.assert_called_once()
         call_args = mock_reader.get_translations_batch.call_args[0][0]
         assert len(call_args) == 10
+
+    def test_build_metadata_populates_score_labels(self, widget):
+        """metadata の score_labels が AnnotationData に渡されること (ADR 0028)。
+
+        PR #286 Codex 指摘の核: producer 側で score_labels を埋めないと、
+        consumer 側の pill 表示が常に空になる silent バグの回帰防止。
+        """
+        score_labels = [
+            {
+                "label": "very aesthetic",
+                "model": "aesthetic_shadow_v1",
+                "model_id": 1,
+                "is_edited_manually": False,
+            },
+            {
+                "label": "aesthetic",
+                "model": "cafe_aesthetic",
+                "model_id": 2,
+                "is_edited_manually": False,
+            },
+        ]
+        metadata = {
+            "id": 1,
+            "file_path": "/test/img.jpg",
+            "tags": [],
+            "caption_text": "",
+            "tags_text": "",
+            "score_value": 0,
+            "rating_value": "",
+            "score_labels": score_labels,
+        }
+        details = widget._build_image_details_from_metadata(metadata)
+
+        assert details.annotation_data is not None
+        assert details.annotation_data.score_labels == score_labels
+
+    def test_build_metadata_score_labels_missing_defaults_empty(self, widget):
+        """metadata に score_labels key が無い場合は default [] になる (旧データ互換)。"""
+        metadata = {
+            "id": 1,
+            "file_path": "/test/img.jpg",
+            "tags": [],
+            "caption_text": "",
+            "tags_text": "",
+            "score_value": 0,
+            "rating_value": "",
+            # score_labels なし
+        }
+        details = widget._build_image_details_from_metadata(metadata)
+
+        assert details.annotation_data is not None
+        assert details.annotation_data.score_labels == []

--- a/tests/unit/test_dataset_export_service.py
+++ b/tests/unit/test_dataset_export_service.py
@@ -338,6 +338,167 @@ class TestDatasetExportService:
         # Then: Noneが返される
         assert result is None
 
+    # ─── score_labels Export (Issue #284 / ADR 0028) ───────────────────────
+
+    @pytest.fixture
+    def sample_score_labels(self):
+        """canonical scorer の score_labels (ADR 0028 の構造化形式)"""
+        return [
+            {
+                "label": "very aesthetic",
+                "model": "aesthetic_shadow_v1",
+                "model_id": 1,
+                "is_edited_manually": False,
+            },
+            {
+                "label": "aesthetic",
+                "model": "cafe_aesthetic",
+                "model_id": 2,
+                "is_edited_manually": False,
+            },
+        ]
+
+    def test_get_image_export_data_includes_score_labels(
+        self, dataset_export_service, mock_db_manager, sample_image_data, sample_score_labels
+    ):
+        """_get_image_export_data の return に score_labels が含まれる (ADR 0028)。"""
+        mock_db_manager.get_image_metadata.return_value = sample_image_data["metadata"]
+        mock_db_manager.get_image_annotations.return_value = {
+            "tags": sample_image_data["tags"],
+            "captions": sample_image_data["captions"],
+            "score_labels": sample_score_labels,
+        }
+
+        result = dataset_export_service._get_image_export_data(1)
+
+        assert result is not None
+        assert "score_labels" in result
+        assert result["score_labels"] == sample_score_labels
+
+    def test_get_image_export_data_empty_score_labels(
+        self, dataset_export_service, mock_db_manager, sample_image_data
+    ):
+        """annotations に score_labels key がない場合 (旧データ互換) は空 list を返す。"""
+        mock_db_manager.get_image_metadata.return_value = sample_image_data["metadata"]
+        mock_db_manager.get_image_annotations.return_value = {
+            "tags": sample_image_data["tags"],
+            "captions": sample_image_data["captions"],
+            # score_labels なし
+        }
+
+        result = dataset_export_service._get_image_export_data(1)
+
+        assert result is not None
+        assert result["score_labels"] == []
+
+    def test_export_dataset_json_format_includes_score_labels(
+        self,
+        dataset_export_service,
+        mock_file_system_manager,
+        sample_image_data,
+        sample_score_labels,
+    ):
+        """JSON Export の metadata に score_labels が構造化 list で含まれる (ADR 0028)。"""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            output_path = Path(temp_dir) / "export"
+            output_path.mkdir()
+            processed_image_path = Path("/mock/processed/test_project_00001.webp")
+
+            export_data = {**sample_image_data, "score_labels": sample_score_labels}
+            with (
+                patch.object(
+                    dataset_export_service,
+                    "_resolve_processed_image_path",
+                    return_value=processed_image_path,
+                ),
+                patch.object(dataset_export_service, "_get_image_export_data", return_value=export_data),
+            ):
+                dataset_export_service.export_dataset_json_format(
+                    image_ids=[1], output_path=output_path, resolution=512
+                )
+
+            metadata_file = output_path / "metadata.json"
+            with open(metadata_file, encoding="utf-8") as f:
+                metadata = json.load(f)
+            expected_image_path = str(output_path / "test_project_00001.webp")
+            entry = metadata[expected_image_path]
+
+            assert "score_labels" in entry
+            assert len(entry["score_labels"]) == 2
+            # ADR 0028: model 名と label を常に組で保持
+            models = [sl["model"] for sl in entry["score_labels"]]
+            labels = [sl["label"] for sl in entry["score_labels"]]
+            assert "aesthetic_shadow_v1" in models
+            assert "cafe_aesthetic" in models
+            assert "very aesthetic" in labels
+            assert "aesthetic" in labels
+
+    def test_export_dataset_json_format_empty_score_labels(
+        self, dataset_export_service, mock_file_system_manager, sample_image_data
+    ):
+        """JSON Export で score_labels が空の場合、metadata の値は [] となる。"""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            output_path = Path(temp_dir) / "export"
+            output_path.mkdir()
+            processed_image_path = Path("/mock/processed/test_project_00001.webp")
+
+            export_data = {**sample_image_data, "score_labels": []}
+            with (
+                patch.object(
+                    dataset_export_service,
+                    "_resolve_processed_image_path",
+                    return_value=processed_image_path,
+                ),
+                patch.object(dataset_export_service, "_get_image_export_data", return_value=export_data),
+            ):
+                dataset_export_service.export_dataset_json_format(
+                    image_ids=[1], output_path=output_path, resolution=512
+                )
+
+            metadata_file = output_path / "metadata.json"
+            with open(metadata_file, encoding="utf-8") as f:
+                metadata = json.load(f)
+            expected_image_path = str(output_path / "test_project_00001.webp")
+            assert metadata[expected_image_path]["score_labels"] == []
+
+    def test_export_dataset_txt_format_excludes_score_labels(
+        self,
+        dataset_export_service,
+        mock_file_system_manager,
+        sample_image_data,
+        sample_score_labels,
+    ):
+        """TXT Export では score_labels が tags / caption ファイルに混入しない (ADR 0028)。"""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            output_path = Path(temp_dir) / "export"
+            output_path.mkdir()
+            processed_image_path = Path("/mock/processed/test_project_00001.webp")
+
+            export_data = {**sample_image_data, "score_labels": sample_score_labels}
+            with (
+                patch.object(
+                    dataset_export_service,
+                    "_resolve_processed_image_path",
+                    return_value=processed_image_path,
+                ),
+                patch.object(dataset_export_service, "_get_image_export_data", return_value=export_data),
+            ):
+                dataset_export_service.export_dataset_txt_format(
+                    image_ids=[1], output_path=output_path, resolution=512, merge_caption=False
+                )
+
+            txt_file = output_path / "test_project_00001.txt"
+            caption_file = output_path / "test_project_00001.caption"
+            tags_content = txt_file.read_text(encoding="utf-8")
+            caption_content = caption_file.read_text(encoding="utf-8")
+
+            # ADR 0028 / 0027: content tag 専用 file に score_labels 混入禁止
+            for label in ["very aesthetic", "aesthetic"]:
+                assert label not in tags_content
+            for model in ["aesthetic_shadow_v1", "cafe_aesthetic"]:
+                assert model not in tags_content
+                assert model not in caption_content
+
     def test_get_available_resolutions(self, dataset_export_service, mock_db_manager):
         """利用可能解像度取得テスト"""
 

--- a/tests/unit/test_dataset_export_service.py
+++ b/tests/unit/test_dataset_export_service.py
@@ -394,24 +394,34 @@ class TestDatasetExportService:
     def test_export_dataset_json_format_includes_score_labels(
         self,
         dataset_export_service,
+        mock_db_manager,
         mock_file_system_manager,
         sample_image_data,
         sample_score_labels,
     ):
-        """JSON Export の metadata に score_labels が構造化 list で含まれる (ADR 0028)。"""
+        """JSON Export の metadata に score_labels が構造化 list で含まれる (ADR 0028)。
+
+        silent バグ防止: ``db_manager.get_image_annotations`` 経由で score_labels が
+        取れる経路まで含めて検証する (Codex 指摘の盲点を mock レベルで塞ぐ)。
+        """
         with tempfile.TemporaryDirectory() as temp_dir:
             output_path = Path(temp_dir) / "export"
             output_path.mkdir()
             processed_image_path = Path("/mock/processed/test_project_00001.webp")
 
-            export_data = {**sample_image_data, "score_labels": sample_score_labels}
-            with (
-                patch.object(
-                    dataset_export_service,
-                    "_resolve_processed_image_path",
-                    return_value=processed_image_path,
-                ),
-                patch.object(dataset_export_service, "_get_image_export_data", return_value=export_data),
+            # _get_image_export_data は mock しない (実経路を test)
+            mock_db_manager.get_image_metadata.return_value = sample_image_data["metadata"]
+            mock_db_manager.get_image_annotations.return_value = {
+                "tags": sample_image_data["tags"],
+                "captions": sample_image_data["captions"],
+                "scores": [],
+                "score_labels": sample_score_labels,
+                "ratings": [],
+            }
+            with patch.object(
+                dataset_export_service,
+                "_resolve_processed_image_path",
+                return_value=processed_image_path,
             ):
                 dataset_export_service.export_dataset_json_format(
                     image_ids=[1], output_path=output_path, resolution=512
@@ -434,7 +444,11 @@ class TestDatasetExportService:
             assert "aesthetic" in labels
 
     def test_export_dataset_json_format_empty_score_labels(
-        self, dataset_export_service, mock_file_system_manager, sample_image_data
+        self,
+        dataset_export_service,
+        mock_db_manager,
+        mock_file_system_manager,
+        sample_image_data,
     ):
         """JSON Export で score_labels が空の場合、metadata の値は [] となる。"""
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -442,14 +456,18 @@ class TestDatasetExportService:
             output_path.mkdir()
             processed_image_path = Path("/mock/processed/test_project_00001.webp")
 
-            export_data = {**sample_image_data, "score_labels": []}
-            with (
-                patch.object(
-                    dataset_export_service,
-                    "_resolve_processed_image_path",
-                    return_value=processed_image_path,
-                ),
-                patch.object(dataset_export_service, "_get_image_export_data", return_value=export_data),
+            mock_db_manager.get_image_metadata.return_value = sample_image_data["metadata"]
+            mock_db_manager.get_image_annotations.return_value = {
+                "tags": sample_image_data["tags"],
+                "captions": sample_image_data["captions"],
+                "scores": [],
+                "score_labels": [],
+                "ratings": [],
+            }
+            with patch.object(
+                dataset_export_service,
+                "_resolve_processed_image_path",
+                return_value=processed_image_path,
             ):
                 dataset_export_service.export_dataset_json_format(
                     image_ids=[1], output_path=output_path, resolution=512
@@ -461,9 +479,52 @@ class TestDatasetExportService:
             expected_image_path = str(output_path / "test_project_00001.webp")
             assert metadata[expected_image_path]["score_labels"] == []
 
+    def test_export_dataset_json_format_silent_drop_regression(
+        self,
+        dataset_export_service,
+        mock_db_manager,
+        mock_file_system_manager,
+        sample_image_data,
+    ):
+        """Regression: get_image_annotations が score_labels key を返却しない場合に
+        export が key 欠落で KeyError 等の悪化を起こさず、graceful に [] へ
+        fallback することを検証する (PR #286 Codex 指摘の核)。
+
+        将来 ``get_image_annotations`` の戻り値仕様変更時にこの test が早期警告となる。
+        """
+        with tempfile.TemporaryDirectory() as temp_dir:
+            output_path = Path(temp_dir) / "export"
+            output_path.mkdir()
+
+            # 旧仕様 (score_labels key 欠落) を mock で再現
+            mock_db_manager.get_image_metadata.return_value = sample_image_data["metadata"]
+            mock_db_manager.get_image_annotations.return_value = {
+                "tags": sample_image_data["tags"],
+                "captions": sample_image_data["captions"],
+                "scores": [],
+                "ratings": [],
+                # score_labels key は意図的に欠落
+            }
+            with patch.object(
+                dataset_export_service,
+                "_resolve_processed_image_path",
+                return_value=Path("/mock/processed/test_project_00001.webp"),
+            ):
+                dataset_export_service.export_dataset_json_format(
+                    image_ids=[1], output_path=output_path, resolution=512
+                )
+
+            metadata_file = output_path / "metadata.json"
+            with open(metadata_file, encoding="utf-8") as f:
+                metadata = json.load(f)
+            entry = metadata[str(output_path / "test_project_00001.webp")]
+            assert "score_labels" in entry
+            assert entry["score_labels"] == []
+
     def test_export_dataset_txt_format_excludes_score_labels(
         self,
         dataset_export_service,
+        mock_db_manager,
         mock_file_system_manager,
         sample_image_data,
         sample_score_labels,
@@ -474,14 +535,18 @@ class TestDatasetExportService:
             output_path.mkdir()
             processed_image_path = Path("/mock/processed/test_project_00001.webp")
 
-            export_data = {**sample_image_data, "score_labels": sample_score_labels}
-            with (
-                patch.object(
-                    dataset_export_service,
-                    "_resolve_processed_image_path",
-                    return_value=processed_image_path,
-                ),
-                patch.object(dataset_export_service, "_get_image_export_data", return_value=export_data),
+            mock_db_manager.get_image_metadata.return_value = sample_image_data["metadata"]
+            mock_db_manager.get_image_annotations.return_value = {
+                "tags": sample_image_data["tags"],
+                "captions": sample_image_data["captions"],
+                "scores": [],
+                "score_labels": sample_score_labels,
+                "ratings": [],
+            }
+            with patch.object(
+                dataset_export_service,
+                "_resolve_processed_image_path",
+                return_value=processed_image_path,
             ):
                 dataset_export_service.export_dataset_txt_format(
                     image_ids=[1], output_path=output_path, resolution=512, merge_caption=False


### PR DESCRIPTION
## Summary

ADR 0028 (already merged in `main`) で確定した SSoT に基づき、canonical scorer の `score_labels` を **GUI 表示** + **JSON Export** に反映。Issue #281 / PR #283 で DB 保存経路を追加した後の silent stored 状態を解消する。

- **GUI**: `AnnotationDataDisplayWidget` に新 `groupBoxScoreLabels` (compact pill 群) を追加、各 scorer model 1 pill で `[model] label` を表示
- **Export**: `DatasetExportService.export_dataset_json_format` の metadata に `{model, label, is_edited_manually}` の構造化 list を埋め込み
- **DB**: `_format_score_labels` helper 追加 + `selectinload` chain で N+1 回避

Closes #284

## 設計判断 (ADR 0028 参照)

| 項目 | 判断 |
|---|---|
| データ形状 | `[{model, label, is_edited_manually}, ...]` で常に model 名と組で保持 |
| Scalar shorthand | 不採用 (multi-scorer 集約 / 多数決と矛盾) |
| GUI | compact pill group で全 scorer 並列表示 |
| TXT export | 出力なし (ADR 0027 content tag 専用化と整合) |
| JSON export | 構造化 list で埋め込み |

## 採用ユースケース (ADR 0028)

- **UC-A**: Quality Export Filter (多数決方式の majority vote 含む、Filter 実装は別 Issue)
- **UC-C**: 複数 scorer の不一致発見 (GUI で並列比較)
- **UC-E**: データセット品質統計レポート (別 Issue)

**不採用**: UC-B (LoRA caption 混入)、UC-D (検索 filter は別 Issue で interface 指針のみ予約)

## Files changed

| Layer | File | Change |
|---|---|---|
| DB | `src/lorairo/database/db_repository.py` | `_format_score_labels` 追加 + `_fetch_*_metadata` selectinload 拡張 |
| GUI | `src/lorairo/gui/designer/AnnotationDataDisplayWidget.ui` | `groupBoxScoreLabels` 追加 |
| GUI | `src/lorairo/gui/designer/AnnotationDataDisplayWidget_ui.py` | regenerate |
| GUI | `src/lorairo/gui/widgets/annotation_data_display_widget.py` | `_update_score_labels_display`, `_setup_score_labels_compact_view`, `set_group_box_visibility` 拡張 |
| Export | `src/lorairo/services/dataset_export_service.py` | `_get_image_export_data` + `export_dataset_json_format` で score_labels を扱う |
| Test | `tests/unit/database/test_db_repository_score_labels.py` | `TestFormatScoreLabels` 5 件 |
| Test | `tests/unit/database/test_db_repository_annotations.py` | 既存 fixture に `score_labels=[]` 追加 (regression fix) |
| Test | `tests/unit/gui/widgets/test_annotation_data_display_widget.py` | 6 件追加 |
| Test | `tests/unit/test_dataset_export_service.py` | 5 件追加 |

`scripts/generate_ui.py` 実行で `_ui.py` 19 ファイルが noise re-generate。

## Test plan

- [x] DB regression: `pytest tests/unit/database/test_db_repository_score_labels.py -v` → 10 件 pass
- [x] GUI regression: `QT_QPA_PLATFORM=offscreen pytest tests/unit/gui/widgets/test_annotation_data_display_widget.py -v` → 19 件 pass
- [x] Export regression: `pytest tests/unit/test_dataset_export_service.py -v` → 27 件 pass
- [x] **LoRAIro CI-equivalent filter**: `pytest -m "not gui_show and not real_api and not slow" --timeout=60` → **2285 passed, 2 skipped, regression なし**
- [ ] 手動 smoke (任意): `uv run lorairo` → 画像 + canonical scorer annotation → AnnotationDataDisplayWidget pill 確認 → Export JSON で `score_labels` key 確認

## Follow-up Issues 候補 (本 PR scope 外)

- Filter 実装 (`ImageFilterCriteria.score_label_filter` + majority vote, ADR 0028 で interface 指針予約済)
- データセット品質統計レポート (label distribution viewer / CSV export)

## 関連

- **Issue**: #284
- **親 ADR (本 PR で初実装)**: `docs/decisions/0028-score-labels-usage-and-display.md`
- **基盤 ADR**: `docs/decisions/0027-score-labels-db-storage.md`
- **基盤 PR (merged)**: #283 (DB 保存経路 + ADR 0027)

🤖 Generated with [Claude Code](https://claude.com/claude-code)