### PR TITLE
fix(#288): hook rule 整理 + worktree workflow docs 明文化

### DIFF
--- a/.claude/hooks/rules/hook_pre_commands_rules.json
+++ b/.claude/hooks/rules/hook_pre_commands_rules.json
@@ -11,11 +11,6 @@
       "suggestion": "make clean or confirm with user"
     },
     {
-      "pattern": "cd.*local_packages/[^/]+.*[;&].*uv run",
-      "reason": "Creates separate .venv in local package",
-      "suggestion": "Run from project root: uv run pytest local_packages/<pkg>/tests/"
-    },
-    {
       "pattern": "uv\\s+run\\s+(--[\\w-]+\\s+)*--active",
       "reason": "並列実行時に .venv を破損させる原因（Issue #222）。--active は単一プロセスかつ VIRTUAL_ENV と pyproject.toml の Python が完全一致する場合のみ安全",
       "suggestion": "通常は --active を外して `uv run` を使用（uv-managed venv で並列セーフ）。意図的に使う場合は .venv/bin/python を直接呼ぶか .claude/rules/parallel-execution.md を参照"

--- a/.claude/hooks/rules/hook_pre_pr_submodule_check_rules.json
+++ b/.claude/hooks/rules/hook_pre_pr_submodule_check_rules.json
@@ -3,7 +3,7 @@
   "packages": {
     "local_packages/image-annotator-lib": {
       "working_directory": "local_packages/image-annotator-lib",
-      "ci_filter": "-m \"not real_api and not heavy and not system_integration\""
+      "ci_filter": "-m \"not downloads_and_runs_model and not calls_real_webapi\""
     },
     "local_packages/genai-tag-db-tools": {
       "working_directory": "local_packages/genai-tag-db-tools",

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -308,6 +308,40 @@ uv run pytest -m "not downloads_and_runs_model and not calls_real_webapi"
 
 `gh pr create` 実行時に `local_packages/*` の submodule pin 変更を含む場合、`.claude/hooks/hook_pre_pr_submodule_check.py` が CI-equivalent test 実行確認を要求する。bypass は command 内に `CI-EQUIV-TESTED` marker comment を含める。詳細は hook script ヘッダー参照。
 
+### Worktree / bind mount I/O 制約 と local package test
+
+LoRAIro #288 で判明した制約。`.claude/rules/parallel-execution.md` の worktree 配置ルールと合わせて運用する。
+
+#### devcontainer mount 構成
+
+- `/workspaces/LoRAIro/` 全体: Windows 9p **bind mount** (低速 I/O)
+- `/workspaces/LoRAIro/.venv`: **named volume** `lorairo-venv` (高速 I/O)
+- `/tmp/worktrees/`: **named volume** `lorairo-worktrees` (高速 I/O)
+
+`/workspaces/LoRAIro/local_packages/<pkg>/.venv` を `cd <pkg> && uv sync` 等で作ると bind mount 上に作成され、test 実行が極端に遅くなる (実用不能)。
+
+#### 回避策
+
+1. **Worktree 内で test 実行** (current best practice):
+
+   ```bash
+   # worktree は /tmp/worktrees/ 配下 (named volume)
+   cd /tmp/worktrees/<wt>
+   make test-iam-lib
+   # → /tmp/worktrees/<wt>/local_packages/image-annotator-lib/.venv が named volume 上に作成、I/O 高速
+   ```
+
+2. **将来: LoRAIro root `.venv` 共有** ([NEXTAltair/image-annotator-lib#74](https://github.com/NEXTAltair/image-annotator-lib/issues/74), [NEXTAltair/LoRAIro#291](https://github.com/NEXTAltair/LoRAIro/issues/291)): iam-lib `requires-python` を `>=3.12` に拡張し、`UV_PROJECT_ENVIRONMENT=/workspaces/LoRAIro/.venv` で venv 共有。pytest セッション境界 (ADR 0024) は維持しつつ I/O 問題を完全解消する計画。
+
+#### Hook との関係
+
+`.claude/hooks/rules/hook_pre_commands_rules.json` から `cd...local_packages...uv run` block rule を削除 (Issue #288 fix)。ADR 0024 で `cd <pkg> && uv run pytest` は正規運用、`make test-iam-lib` も同 pattern を内部実行する。
+
+並列 `uv sync` (Issue #222 教訓) のガードは引き続き以下で担保:
+
+- `.claude/hooks/rules/hook_pre_commands_rules.json` の `uv\s+run.*--active` block
+- `.claude/rules/parallel-execution.md` の worktree 分離 rule
+
 ### Lazy import refactor との関係
 
 torch / tensorflow 等 heavy native dep の lazy import 化を行う場合は SKILL `lazy-import-refactor` が test 副作用 (`@patch("module.torch")` 等) を予測し、本セクションの filter で検証することを義務付ける。


### PR DESCRIPTION
## 背景

Issue #288 で議論された 3 つの矛盾を解消する:

1. **`hook_pre_pr_submodule_check_rules.json` の marker rename 漏れ** (PR #289 取りこぼし): iam-lib `ci_filter` がまだ rename 前 (`not real_api and not heavy and not system_integration`) のままで、hook gate を旧 marker filter で走らせていた bug。
2. **Hook `cd.*local_packages...uv run` block が ADR 0024 と矛盾**: ADR 0024 (2026-05-13) が package directory 内での `uv run pytest` を正規運用に格上げした後も、古い suggestion「Run from project root」が残存し ADR 違反を強制していた。
3. **bind mount I/O 制約の未文書化**: `/workspaces/LoRAIro/` は Windows 9p bind mount (低速)、`/workspaces/LoRAIro/.venv` と `/tmp/worktrees/` のみ named volume (高速)。`local_packages/<pkg>/.venv` を作ると bind mount 上に置かれて I/O 激遅で実用不能。

## 変更内容

- `.claude/hooks/rules/hook_pre_pr_submodule_check_rules.json`: iam-lib `ci_filter` を新 marker (`not downloads_and_runs_model and not calls_real_webapi`) に rename
- `.claude/hooks/rules/hook_pre_commands_rules.json`: 古い package directory uv run block rule を完全削除 (ADR 0024 整合)
- `.claude/rules/testing.md`: 「Worktree / bind mount I/O 制約 と local package test」セクションを追加。devcontainer mount 構成 / 回避策 / Hook との関係を明文化

## 並列実行ガード

Hook rule 削除後も、Issue #222 (並列 uv sync で .venv 破損) のガードは以下で担保:

- `.claude/hooks/rules/hook_pre_commands_rules.json` の `uv\s+run.*--active` block
- `.claude/rules/parallel-execution.md` の worktree 分離 rule

## Follow-up Issues (将来の venv 共有実装)

本 PR scope 外。bind mount I/O 問題の根本解決 (LoRAIro root `.venv` を iam-lib test でも共有) は以下で計画:

- iam-lib: NEXTAltair/image-annotator-lib#74 (`requires-python` 拡張: `>=3.12,<3.13` → `>=3.12` + Python 3.13 CI matrix)
- LoRAIro: #291 (Makefile `UV_PROJECT_ENVIRONMENT` 切替 + ADR 0024 amendment)

## Verification

```
# JSON syntax check (Phase 1)
python3 -c "import json; json.load(open('.claude/hooks/rules/hook_pre_commands_rules.json')); json.load(open('.claude/hooks/rules/hook_pre_pr_submodule_check_rules.json')); print('JSON OK')"
# → JSON OK

# Hook rule 削除動作確認 (Phase 4)
# 入力 stdin: package directory 内 uv run pytest コマンド
# hook 出力: exit 0 (allow)
```

LoRAIro 本体 source code は変更しないため、test regression は発生しない。

## 影響範囲

- LoRAIro 本体 `src/` / `tests/`: 影響なし
- Hook 動作: ADR 0024 整合性回復、`make test-iam-lib` 等の正規運用が Claude 経由で実行可能になる
- submodule pin: 変更なし (hook gate は本 PR では fire しない)

## 関連

- closes #288
- 依存先 PR (merged): #289 (iam-lib marker rename follow-up、rename 漏れの origin)
- Follow-up: NEXTAltair/image-annotator-lib#74, #291
- 関連 ADR: ADR 0024 (pytest セッション境界 = package 境界、本 PR で整合性回復、amendment は #291 で実施)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
