### PR TITLE
[codex] Document agent worktree workflow

### DIFF
--- a/.claude/agents/build-error-resolver.md
+++ b/.claude/agents/build-error-resolver.md
@@ -5,6 +5,10 @@ color: orange
 tools: Read, Grep, Glob, Bash
 ---
 
+## Repository Rules Reference
+
+Before implementation, mutation, branch, commit, push, or PR work, read [Repository Guidelines](../../AGENTS.md) and [Git Workflow Rules](../rules/git-workflow.md). Issue/feature work must use a dedicated `/tmp/worktrees/` worktree, not the shared `/workspaces/LoRAIro` checkout.
+
 # Build Error Resolution Specialist
 
 You are a Build Error Analysis Expert specializing in Python/PySide6 development. Your expertise lies in diagnosing test failures, type errors, and lint violations, then providing actionable fixes.

--- a/.claude/agents/code-formatter.md
+++ b/.claude/agents/code-formatter.md
@@ -5,6 +5,10 @@ color: orange
 tools: Read, Edit, Bash
 ---
 
+## Repository Rules Reference
+
+Before implementation, mutation, branch, commit, push, or PR work, read [Repository Guidelines](../../AGENTS.md) and [Git Workflow Rules](../rules/git-workflow.md). Issue/feature work must use a dedicated `/tmp/worktrees/` worktree, not the shared `/workspaces/LoRAIro` checkout.
+
 You are a Python code formatting specialist focused on maintaining consistent code quality using Ruff. Your primary responsibility is to format and lint Python code according to project standards.
 
 When formatting code, you will:

--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -5,6 +5,10 @@ color: blue
 tools: Read, Grep, Glob, Bash
 ---
 
+## Repository Rules Reference
+
+Before implementation, mutation, branch, commit, push, or PR work, read [Repository Guidelines](../../AGENTS.md) and [Git Workflow Rules](../rules/git-workflow.md). Issue/feature work must use a dedicated `/tmp/worktrees/` worktree, not the shared `/workspaces/LoRAIro` checkout.
+
 # Code Review Specialist
 
 You are a Code Quality Expert specializing in Python/PySide6 development. Your expertise lies in ensuring code quality, maintainability, and adherence to LoRAIro project standards.

--- a/.claude/agents/db-schema-reviewer.md
+++ b/.claude/agents/db-schema-reviewer.md
@@ -5,6 +5,10 @@ color: pink
 tools: Read, Grep, Glob
 ---
 
+## Repository Rules Reference
+
+Before implementation, mutation, branch, commit, push, or PR work, read [Repository Guidelines](../../AGENTS.md) and [Git Workflow Rules](../rules/git-workflow.md). Issue/feature work must use a dedicated `/tmp/worktrees/` worktree, not the shared `/workspaces/LoRAIro` checkout.
+
 # Database Schema Review Specialist
 
 You are a Database Schema Review Specialist for the LoRAIro project. Your expertise is analyzing SQLAlchemy schema definitions, reviewing Alembic migrations for correctness, and ensuring database design quality.

--- a/.claude/agents/investigation.md
+++ b/.claude/agents/investigation.md
@@ -5,6 +5,10 @@ color: purple
 tools: Read, Grep, Glob, Bash
 ---
 
+## Repository Rules Reference
+
+Before implementation, mutation, branch, commit, push, or PR work, read [Repository Guidelines](../../AGENTS.md) and [Git Workflow Rules](../rules/git-workflow.md). Issue/feature work must use a dedicated `/tmp/worktrees/` worktree, not the shared `/workspaces/LoRAIro` checkout.
+
 You are a Code Investigation Specialist, an expert in analyzing codebases, understanding architectural patterns, and conducting comprehensive code research. Your expertise lies in efficiently navigating complex codebases using semantic tools and providing deep insights into code structure and relationships.
 
 When conducting code investigations, you will:

--- a/.claude/agents/library-research.md
+++ b/.claude/agents/library-research.md
@@ -6,6 +6,10 @@ color: blue
 tools: WebFetch, WebSearch, Read, Bash
 ---
 
+## Repository Rules Reference
+
+Before implementation, mutation, branch, commit, push, or PR work, read [Repository Guidelines](../../AGENTS.md) and [Git Workflow Rules](../rules/git-workflow.md). Issue/feature work must use a dedicated `/tmp/worktrees/` worktree, not the shared `/workspaces/LoRAIro` checkout.
+
 You are a Library Research Specialist, an expert technical researcher with deep knowledge of software libraries, frameworks, and development tools across multiple programming languages and domains. Your expertise lies in quickly identifying, evaluating, and recommending the most suitable technical solutions for specific implementation needs.
 
 When conducting library research, you will:

--- a/.claude/agents/query-analyzer.md
+++ b/.claude/agents/query-analyzer.md
@@ -5,6 +5,10 @@ color: cyan
 tools: Read, Grep, Glob, Bash
 ---
 
+## Repository Rules Reference
+
+Before implementation, mutation, branch, commit, push, or PR work, read [Repository Guidelines](../../AGENTS.md) and [Git Workflow Rules](../rules/git-workflow.md). Issue/feature work must use a dedicated `/tmp/worktrees/` worktree, not the shared `/workspaces/LoRAIro` checkout.
+
 You are a SQLAlchemy Query Optimization Specialist for the LoRAIro project. Your expertise is analyzing existing database queries, detecting performance issues, and providing concrete optimization recommendations.
 
 ## Core Responsibilities

--- a/.claude/agents/security-reviewer.md
+++ b/.claude/agents/security-reviewer.md
@@ -5,6 +5,10 @@ color: red
 tools: Read, Grep, Glob
 ---
 
+## Repository Rules Reference
+
+Before implementation, mutation, branch, commit, push, or PR work, read [Repository Guidelines](../../AGENTS.md) and [Git Workflow Rules](../rules/git-workflow.md). Issue/feature work must use a dedicated `/tmp/worktrees/` worktree, not the shared `/workspaces/LoRAIro` checkout.
+
 # Security Review Specialist
 
 You are a Security Analysis Expert specializing in Python/PySide6 application security. Your expertise lies in identifying vulnerabilities, ensuring OWASP Top 10 compliance, and preventing security issues before they reach production.

--- a/.claude/agents/solutions.md
+++ b/.claude/agents/solutions.md
@@ -5,6 +5,10 @@ color: green
 tools: Read, WebFetch, Grep, Glob, Bash
 ---
 
+## Repository Rules Reference
+
+Before implementation, mutation, branch, commit, push, or PR work, read [Repository Guidelines](../../AGENTS.md) and [Git Workflow Rules](../rules/git-workflow.md). Issue/feature work must use a dedicated `/tmp/worktrees/` worktree, not the shared `/workspaces/LoRAIro` checkout.
+
 You are a Solutions Architecture Specialist, an expert in analyzing complex problems and designing comprehensive solution strategies. Your expertise lies in generating multiple viable approaches, conducting thorough comparative analysis, and recommending optimal solutions based on technical constraints, implementation costs, and long-term sustainability.
 
 When developing solution strategies, you will:

--- a/.claude/agents/test-runner.md
+++ b/.claude/agents/test-runner.md
@@ -5,6 +5,10 @@ color: yellow
 tools: Read, Bash, Grep, Glob
 ---
 
+## Repository Rules Reference
+
+Before implementation, mutation, branch, commit, push, or PR work, read [Repository Guidelines](../../AGENTS.md) and [Git Workflow Rules](../rules/git-workflow.md). Issue/feature work must use a dedicated `/tmp/worktrees/` worktree, not the shared `/workspaces/LoRAIro` checkout.
+
 # Test Runner Specialist
 
 You are a Test Execution Specialist for the LoRAIro project. Your expertise is running tests, analyzing failures, and providing actionable feedback to teammates in Agent Teams scenarios.

--- a/.codex/agents/build-error-resolver.toml
+++ b/.codex/agents/build-error-resolver.toml
@@ -1,5 +1,9 @@
 description = "pytest失敗、mypy/Ruffエラーの自動診断・修正提案を行う専門エージェント。エラーログを解析し、根本原因を特定して具体的な修正案を提示します。"
 developer_instructions = """
+## Repository Rules Reference
+
+Before implementation, mutation, branch, commit, push, or PR work, read [Repository Guidelines](../../AGENTS.md) and [Git Workflow Rules](../../.claude/rules/git-workflow.md). Issue/feature work must use a dedicated `/tmp/worktrees/` worktree, not the shared `/workspaces/LoRAIro` checkout.
+
 # Build Error Resolution Specialist
 
 You are a Build Error Analysis Expert specializing in Python/PySide6 development. Your expertise lies in diagnosing test failures, type errors, and lint violations, then providing actionable fixes.

--- a/.codex/agents/code-formatter.toml
+++ b/.codex/agents/code-formatter.toml
@@ -1,5 +1,9 @@
 description = "コードフォーマット・整形・品質改善を行う専門エージェント。Ruffを使用したPythonコードの自動フォーマット、リント修正、コード品質向上を実行します。"
 developer_instructions = """
+## Repository Rules Reference
+
+Before implementation, mutation, branch, commit, push, or PR work, read [Repository Guidelines](../../AGENTS.md) and [Git Workflow Rules](../../.claude/rules/git-workflow.md). Issue/feature work must use a dedicated `/tmp/worktrees/` worktree, not the shared `/workspaces/LoRAIro` checkout.
+
 You are a Python code formatting specialist focused on maintaining consistent code quality using Ruff. Your primary responsibility is to format and lint Python code according to project standards.
 
 When formatting code, you will:

--- a/.codex/agents/code-reviewer.toml
+++ b/.codex/agents/code-reviewer.toml
@@ -1,5 +1,9 @@
 description = "コード品質、可読性、LoRAIro規約準拠の自動レビューを行う専門エージェント。Ruff/mypy統合、型ヒント検証、アーキテクチャパターン準拠を確認します。"
 developer_instructions = """
+## Repository Rules Reference
+
+Before implementation, mutation, branch, commit, push, or PR work, read [Repository Guidelines](../../AGENTS.md) and [Git Workflow Rules](../../.claude/rules/git-workflow.md). Issue/feature work must use a dedicated `/tmp/worktrees/` worktree, not the shared `/workspaces/LoRAIro` checkout.
+
 # Code Review Specialist
 
 You are a Code Quality Expert specializing in Python/PySide6 development. Your expertise lies in ensuring code quality, maintainability, and adherence to LoRAIro project standards.

--- a/.codex/agents/db-schema-reviewer.toml
+++ b/.codex/agents/db-schema-reviewer.toml
@@ -1,5 +1,9 @@
 description = "SQLAlchemyスキーマ定義とAlembicマイグレーションの整合性・品質検査を行う専門エージェント。スキーマ変更時のレビューやマイグレーション計画の検証に特化しています。"
 developer_instructions = """
+## Repository Rules Reference
+
+Before implementation, mutation, branch, commit, push, or PR work, read [Repository Guidelines](../../AGENTS.md) and [Git Workflow Rules](../../.claude/rules/git-workflow.md). Issue/feature work must use a dedicated `/tmp/worktrees/` worktree, not the shared `/workspaces/LoRAIro` checkout.
+
 # Database Schema Review Specialist
 
 You are a Database Schema Review Specialist for the LoRAIro project. Your expertise is analyzing SQLAlchemy schema definitions, reviewing Alembic migrations for correctness, and ensuring database design quality.

--- a/.codex/agents/investigation.toml
+++ b/.codex/agents/investigation.toml
@@ -1,5 +1,9 @@
 description = "コードベース調査・分析・アーキテクチャ理解を行う専門エージェント。シンボル検索、依存関係分析、プロジェクト構造把握を高速・高精度で実行します。"
 developer_instructions = '''
+## Repository Rules Reference
+
+Before implementation, mutation, branch, commit, push, or PR work, read [Repository Guidelines](../../AGENTS.md) and [Git Workflow Rules](../../.claude/rules/git-workflow.md). Issue/feature work must use a dedicated `/tmp/worktrees/` worktree, not the shared `/workspaces/LoRAIro` checkout.
+
 You are a Code Investigation Specialist, an expert in analyzing codebases, understanding architectural patterns, and conducting comprehensive code research. Your expertise lies in efficiently navigating complex codebases using semantic tools and providing deep insights into code structure and relationships.
 
 When conducting code investigations, you will:

--- a/.codex/agents/query-analyzer.toml
+++ b/.codex/agents/query-analyzer.toml
@@ -1,5 +1,9 @@
 description = "SQLAlchemyクエリの分析・最適化提案を行う専門エージェント。既存クエリのN+1検出、EXPLAIN解析、インデックス提案、バルク操作への変換提案を実行します。"
 developer_instructions = '''
+## Repository Rules Reference
+
+Before implementation, mutation, branch, commit, push, or PR work, read [Repository Guidelines](../../AGENTS.md) and [Git Workflow Rules](../../.claude/rules/git-workflow.md). Issue/feature work must use a dedicated `/tmp/worktrees/` worktree, not the shared `/workspaces/LoRAIro` checkout.
+
 You are a SQLAlchemy Query Optimization Specialist for the LoRAIro project. Your expertise is analyzing existing database queries, detecting performance issues, and providing concrete optimization recommendations.
 
 ## Core Responsibilities

--- a/.codex/agents/security-reviewer.toml
+++ b/.codex/agents/security-reviewer.toml
@@ -1,5 +1,9 @@
 description = "セキュリティ脆弱性分析とOWASP Top 10コンプライアンス検査を行う専門エージェント。API Key漏洩、インジェクション攻撃、危険な関数使用を検出します。"
 developer_instructions = '''
+## Repository Rules Reference
+
+Before implementation, mutation, branch, commit, push, or PR work, read [Repository Guidelines](../../AGENTS.md) and [Git Workflow Rules](../../.claude/rules/git-workflow.md). Issue/feature work must use a dedicated `/tmp/worktrees/` worktree, not the shared `/workspaces/LoRAIro` checkout.
+
 # Security Review Specialist
 
 You are a Security Analysis Expert specializing in Python/PySide6 application security. Your expertise lies in identifying vulnerabilities, ensuring OWASP Top 10 compliance, and preventing security issues before they reach production.

--- a/.codex/agents/solutions.toml
+++ b/.codex/agents/solutions.toml
@@ -1,5 +1,9 @@
 description = "問題解決策の包括的検討・評価・選択を行う専門エージェント。複数のアプローチを生成し、技術的制約、実装コスト、リスクを総合的に評価して最適解を特定します。"
 developer_instructions = '''
+## Repository Rules Reference
+
+Before implementation, mutation, branch, commit, push, or PR work, read [Repository Guidelines](../../AGENTS.md) and [Git Workflow Rules](../../.claude/rules/git-workflow.md). Issue/feature work must use a dedicated `/tmp/worktrees/` worktree, not the shared `/workspaces/LoRAIro` checkout.
+
 You are a Solutions Architecture Specialist, an expert in analyzing complex problems and designing comprehensive solution strategies. Your expertise lies in generating multiple viable approaches, conducting thorough comparative analysis, and recommending optimal solutions based on technical constraints, implementation costs, and long-term sustainability.
 
 When developing solution strategies, you will:

--- a/.codex/agents/test-runner.toml
+++ b/.codex/agents/test-runner.toml
@@ -1,5 +1,9 @@
 description = "テスト実行・結果解析を行う専門エージェント。pytest実行、失敗分析、カバレッジレポートを提供します。Agent Teamsのチームメートとして並列テスト検証に特化しています。"
 developer_instructions = """
+## Repository Rules Reference
+
+Before implementation, mutation, branch, commit, push, or PR work, read [Repository Guidelines](../../AGENTS.md) and [Git Workflow Rules](../../.claude/rules/git-workflow.md). Issue/feature work must use a dedicated `/tmp/worktrees/` worktree, not the shared `/workspaces/LoRAIro` checkout.
+
 # Test Runner Specialist
 
 You are a Test Execution Specialist for the LoRAIro project. Your expertise is running tests, analyzing failures, and providing actionable feedback to teammates in Agent Teams scenarios.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,6 +32,12 @@
 - PRs should include a clear description, test results, and screenshots for GUI changes.
 - Link related issues and note any migration or config changes.
 
+## Agent Git Workflow
+- Issue resolution, feature work, PR preparation, and any multi-file implementation must start from a dedicated git worktree under `/tmp/worktrees/`.
+- Do not edit, stage, commit, rebase, or push from the shared main checkout at `/workspaces/LoRAIro` for implementation work.
+- Create worktrees from the current remote base, for example: `git fetch origin && git worktree add /tmp/worktrees/issue-123 -b fix/issue-123 origin/main`.
+- Keep agent-specific rules as references to this file and `.claude/rules/git-workflow.md` rather than duplicating conflicting workflow text.
+
 ## Security & Configuration Tips
 - Store API keys in a local `.env` (see `.env.example`). Never commit secrets.
 - Keep local data and logs out of version control (`logs/`, `lorairo_data/`).


### PR DESCRIPTION
## Summary
- add shared agent git workflow guidance to `AGENTS.md`
- link Claude agent markdown files to the shared repository and git workflow rules
- link Codex agent TOML instructions to the same shared rules to avoid duplicated/conflicting workflow policy

## Validation
- `python3 -c "import pathlib,tomllib; [tomllib.loads(p.read_text()) for p in pathlib.Path('.codex/agents').glob('*.toml')]; print('codex agent toml ok')"`

## Notes
- Work was done in `/tmp/worktrees/codex-agent-worktree-rules`, leaving the shared `/workspaces/LoRAIro` checkout untouched.
- `uv run` validation was not used because this fresh worktree has uninitialized submodules; TOML syntax was verified with system Python instead.