### PR TITLE
feat(#287): unified dataset quality tier (ADR 0029)

### DIFF
--- a/docs/decisions/0029-unified-dataset-quality-tier.md
+++ b/docs/decisions/0029-unified-dataset-quality-tier.md
@@ -1,0 +1,301 @@
+# ADR 0029: Unified Dataset Quality Tier
+
+- **日付**: 2026-05-19
+- **ステータス**: Accepted
+
+## Context
+
+ADR 0027 で scorer 由来の categorical label を `score_labels` テーブルに保存し、
+ADR 0028 で `{model, label}` の raw list を GUI / JSON export に表示する経路を追加した。
+
+しかし LoRA 学習用データセット作成では、scorer ごとの raw value を直接指定する filter は
+使いにくい。
+
+- `aesthetic_shadow_v1/v2` は `very aesthetic` / `aesthetic` /
+  `displeasing` / `very displeasing` を返す
+- `cafe_aesthetic` は `aesthetic` / `not_aesthetic` を返す
+- 手動 score は 0.00-10.00 の DB float (UI は 0-1000)
+- regression scorer は model ごとに scale が異なる
+
+ユーザーが dataset export/search で求めている操作は、個別 scorer の詳細条件ではなく
+「一定水準以上の画像」「低品質候補」「未採点画像」の抽出である。したがって LoRAIro 側に
+検索・表示用の統一品質 tier が必要。
+
+なお、NovelAI / Danbooru / 現代 anime diffusion model 文化では
+`masterpiece`, `best quality`, `good quality`, `normal quality`, `low quality`,
+`worst quality` が広く使われている。例として Anima は
+`masterpiece ... worst quality` を human score based quality tags とし、別系統の
+`score_9 ... score_1` を aesthetic model based tags として併用している。NovelAI 公式も
+quality tags と aesthetic tags を分離しているが、prompt 実務では両者が品質表現として
+近接して使われる。
+
+LoRAIro はこの慣れた語彙を UI / filter value に採用する。ただし外部モデル共通の客観基準
+としてではなく、LoRAIro 独自の **dataset quality tier** として定義する。
+
+## Decision
+
+### Raw annotation は変更しない
+
+`scores` / `score_labels` に保存済みの model raw output は変更しない。
+統一品質 tier は raw annotation の上に乗る derived view とする。
+
+```text
+raw scores / score_labels
+  -> quality mapping
+  -> dataset quality tier
+  -> GUI badge / JSON export / search filter
+```
+
+mapping を変更しても DB の raw annotation は書き換えない。検索結果と表示だけが新 mapping に
+従って再計算される。
+
+### Tier vocabulary
+
+検索 UI / API / JSON export の表示語彙は以下を採用する。
+
+| tier | 用途 |
+|---|---|
+| `masterpiece` | 最上位。強い採用候補 |
+| `best quality` | 高品質。採用候補 |
+| `good quality` | 実用上採用可能 |
+| `normal quality` | 中立。明確な高品質ではないが除外とも言い切れない |
+| `low quality` | 低品質。除外候補 |
+| `worst quality` | 最低品質。強い除外候補 |
+| `no score` | score 系 annotation が存在しない |
+| `unknown` | raw value は存在するが mapping 未定義 |
+
+`no score` と `unknown` は分離する。未採点画像の抽出と、新 model / 未定義 label の検出は
+別ユースケースだからである。
+
+### Initial mapping
+
+初期 mapping は canonical scorer と manual score を対象にする。
+
+```text
+aesthetic_shadow_v1 / aesthetic_shadow_v2:
+  very aesthetic     -> masterpiece
+  aesthetic          -> best quality
+  displeasing        -> low quality
+  very displeasing   -> worst quality
+
+cafe_aesthetic:
+  aesthetic          -> good quality
+  not_aesthetic      -> low quality
+
+manual score (0.00-10.00):
+  9.00-10.00         -> masterpiece
+  8.00-8.99          -> best quality
+  6.00-7.99          -> good quality
+  5.00-5.99          -> normal quality
+  3.00-4.99          -> low quality
+  0.00-2.99          -> worst quality
+```
+
+`ImprovedAesthetic` / `WaifuAesthetic` などの regression scorer は初期 mapping から外す。
+これらは scale と閾値の意味が model-specific であり、ADR 0022 / iam-lib ADR 0002 で
+model 横断比較不可と整理済みである。後続 ADR で閾値を決めた場合のみ mapping に追加する。
+
+### Aggregation rule (集約規約)
+
+1 image に複数 scorer の `score_labels` と manual score がある場合、それぞれを
+**vote** として扱い、統一 tier に集約する。集約は **median + is_unanimous hybrid**
+方式を採用する。
+
+- `votes` を known (mapping 定義済) / unknown (mapping 未定義) に分類する。
+- known votes が 1 件以上ある場合:
+  - `tier` = known votes の tier を順序尺度に変換しソートした **中央値**。
+    偶数件の tie は higher 寄り (`sorted_tiers[len // 2]`) で決定的に解決する。
+  - `is_unanimous` = 全 known votes が同一 tier かつ unknown vote が 0 件のとき `true`。
+- known votes が 0 件で vote 自体は存在する場合 → `tier = "unknown"`。
+- vote が 1 件も無い場合 → `tier = "no score"`、`no_score = true`。
+
+median を採用する理由は Rationale 参照。`is_unanimous` は per-scorer pill
+(ADR 0028) を見なくても scorer 合意の有無を 1 field で判定できるようにするための
+補助 signal である。
+
+集約パターンの比較検討 (median / most common / lowest / highest / mixed sentinel /
+votes-only) は #287 の planning フェーズで実施した。median は順序尺度として安定で
+filter の `min_tier` 比較と整合し、`is_unanimous` で不一致 (UC-C) も表現できる。
+
+### Search filter behavior
+
+dataset search/export filter は model-specific raw value ではなく tier を主 interface にする。
+
+```python
+class QualityTierFilter(TypedDict):
+    min_tier: str  # e.g. "good quality"
+    vote_mode: str  # "any" | "majority" | "all"
+    no_score_mode: str  # "exclude" | "include" | "only"
+```
+
+想定 UI:
+
+```text
+品質: good quality 以上
+一致条件: 1件以上 / 過半数 / 全件
+未採点: 除外 / 含める / 未採点のみ
+```
+
+`min_tier` 比較では、上位から下位の順序を以下で固定する。
+
+```text
+masterpiece > best quality > good quality > normal quality > low quality > worst quality
+```
+
+`unknown` は既定では条件一致に含めない。必要な場合は別 UI / filter で抽出する。
+
+### Export / GUI
+
+JSON export では raw `score_labels` を維持し、追加で `quality_summary` を出力する。
+
+```json
+{
+  "score_labels": [
+    {"model": "aesthetic_shadow_v2", "label": "aesthetic"}
+  ],
+  "quality_summary": {
+    "mapping_version": "quality-tier-v1",
+    "tier": "best quality",
+    "is_unanimous": true,
+    "known_count": 1,
+    "unknown_count": 0,
+    "no_score": false,
+    "votes": [
+      {
+        "model": "aesthetic_shadow_v2",
+        "source": "score_label",
+        "raw_label": "aesthetic",
+        "quality_tier": "best quality"
+      }
+    ]
+  }
+}
+```
+
+`votes[]` 要素は `source` で `"score_label"` / `"manual_score"` を識別し、
+score_label は `raw_label`、manual_score は `raw_score` (float) を持つ。
+unknown vote は `quality_tier = "unknown"` (sentinel) を出力する。
+
+GUI は ADR 0028 の per-scorer pill を残し、統一 tier は別 badge として `groupBoxScoreLabels`
+内の最上段に単一 QLabel で併記する (例: `品質: best quality (2 scorer)` / `品質: masterpiece
+(3 scorer) (全 scorer 一致)`)。`tier="no score"` / `"unknown"` のときは known_count 抜きで
+`品質: no score` / `品質: unknown` を表示する。`quality_summary` が空 dict のときは
+badge を hide する (旧データ互換、graceful fallback)。
+
+TXT export には出力しない (ADR 0028 と同じ理由: content tag 専用 file 汚染を避ける)。
+
+### Mapping SSoT
+
+mapping SSoT は **code module** `src/lorairo/domain/quality_tier.py` とする。
+
+- `QualityTier` (IntEnum、順序尺度) と `(model, label) -> QualityTier` の dict 定数、
+  manual score の range mapping 関数、`MAPPING_VERSION` 定数を持つ。
+- `compute_quality_summary(score_labels, scores) -> dict` が derived view を計算する。
+- `database` / `services` / `gui` 層は `domain` を一方向 import する (循環なし)。
+
+TOML config (`src/lorairo/config/quality_tier_mapping.toml`) によるユーザー override は
+本 ADR の scope 外とし、必要になった時点で別 ADR / `mapping_version` v2 で検討する。
+
+mapping はアプリ仕様であり user annotation ではない。DB に保存すると migration / seed /
+stale derived data の負担が大きいため、性能課題が出るまで derived calculation に留める。
+`get_image_annotations()` が戻り値 dict に `quality_summary` キーを derived 計算で含める。
+
+### Sentinel tier (`no score` / `unknown`) の扱い
+
+`no score` と `unknown` は ordinal 比較の対象外の sentinel である。
+
+- `no score`: score 系 annotation (score_labels / manual score) が 1 件も無い。
+- `unknown`: vote は存在するが mapping 未定義 (新 scorer / 未登録 label / 範囲外 manual score)。
+
+両者を `low quality` 等の実 tier に丸めると、未採点抽出と mapping 漏れ検出が
+区別できなくなる。GUI / JSON export では sentinel literal をそのまま出力し、
+filter (out-of-scope) では `no_score_mode` で別途扱う。
+
+### New scorer 追加時の運用
+
+新 scorer (例: `WaifuAesthetic`) を unified tier に参加させる手順:
+
+1. `_SCORE_LABEL_TO_TIER` に `(model_name, label) -> QualityTier` の行を追加する。
+2. mapping を変更した場合は `MAPPING_VERSION` を bump する (例: `quality-tier-v2`)。
+3. `tests/unit/domain/test_quality_tier.py` に該当 mapping の test を追加する。
+4. mapping 未追加のままの新 scorer label は `unknown` に落ちる (silent misclassification
+   ではなく明示的に検出可能)。
+
+## Rationale
+
+### 慣れた語彙を UI に使う理由
+
+`masterpiece` / `best quality` / `low quality` は anime image generation / LoRA 文脈で
+広く共有された語彙であり、`EXCELLENT` / `PASS` などの抽象名より一見して意味が伝わる。
+
+ただし NovelAI、Anima、NoobAI、Animagine などで付与基準は異なるため、本 ADR では
+外部標準ではなく LoRAIro の dataset search 用 alias として定義する。
+
+### Raw value と derived tier を分ける理由
+
+model raw output は再現性の源泉である。mapping を変えるたびに DB annotation を書き換えると、
+過去の annotation 結果が失われ、export / search の再現性も曖昧になる。
+
+raw value を保存し、tier を派生計算にすることで:
+
+- mapping を後から修正できる
+- 元の scorer 出力を監査できる
+- JSON export で raw と derived を両方出せる
+- `unknown` を検出して新 model / label 対応漏れを見つけられる
+
+### Numeric aggregation を初期採用しない理由
+
+`scores` は model ごとに scale が異なる。
+
+- `aesthetic_shadow`: `hq` / `lq` probability
+- `cafe_aesthetic`: `aesthetic` / `not_aesthetic` probability
+- manual score: 0.00-10.00
+- `ImprovedAesthetic`: 1-10 regression
+- `WaifuAesthetic`: 0-1 regression
+
+単純平均や confidence-weighted aggregation は、scale の意味を混同する。初期実装では
+canonical label と manual score の rule-based mapping に限定する。
+
+### `no score` を tier として扱う理由
+
+データセット作成では、未採点画像を探して追加 scoring する操作が重要である。
+`no score` を低品質と同一視すると、未判定と低品質が混ざってしまう。
+
+## Consequences
+
+### 良い点
+
+- dataset export/search で「good quality 以上」のような自然な条件指定ができる
+- scorer ごとの raw value をユーザーが覚えなくてよい
+- raw DB annotation は不変で、mapping 変更に強い
+- `no score only` で未採点画像を抽出できる
+- `unknown` で mapping 漏れを検出できる
+
+### 悪い点・トレードオフ
+
+- `masterpiece` 等の語彙は外部モデルごとに意味が異なるため、LoRAIro 独自定義であることを
+  UI / ADR / docs で明示する必要がある
+- 初期 mapping は rule-based であり、完全に客観的な美的尺度ではない
+- regression scorer は初期 filter に含まれないため、利用するには後続 ADR が必要
+- tier filter を SQL で高速化する場合、`score_labels` の追加 index や
+  `(image_id, model_id)` unique constraint を検討する必要がある
+
+### 運用ルール
+
+- `scores` / `score_labels` raw value を tier に変換して DB 上書きしない
+- mapping 変更時は `mapping_version` を上げる
+- 未定義 raw label / model は `unknown` として扱い、黙って近い tier に丸めない
+- `no score` は annotation absence として扱い、`unknown` と混同しない
+- new scorer を unified tier filter に参加させる場合は mapping と unit test を追加する
+
+## Related
+
+- **Issue**: NEXTAltair/LoRAIro#287
+- **Parent ADR**: 0027 (Score Labels DB Storage)
+- **Parent ADR**: 0028 (Score Labels Usage and Display Strategy)
+- **Related ADR**: 0022 (Aesthetic Score Predictor Model Survey)
+- **iam-lib ADR**: `local_packages/image-annotator-lib/docs/decisions/0002-score-model-output-contract.md`
+- **External reference**:
+  - NovelAI docs: quality tags and aesthetic tags
+  - `circlestone-labs/Anima`: human score based quality tags and aesthetic model based score tags
+  - Animagine / NoobAI model cards: model-specific quality tag criteria

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -32,6 +32,7 @@ LoRAIro の重要な設計判断を記録するドキュメント群。
 | [0026](0026-on-demand-runtime-validation-strategy.md) | On-Demand Runtime Validation Strategy | 2026-05-17 | Accepted |
 | [0027](0027-score-labels-db-storage.md) | Score Labels DB Storage | 2026-05-17 | Accepted |
 | [0028](0028-score-labels-usage-and-display.md) | Score Labels Usage and Display Strategy | 2026-05-18 | Accepted |
+| [0029](0029-unified-dataset-quality-tier.md) | Unified Dataset Quality Tier | 2026-05-19 | Accepted |
 
 ## ADR テンプレート
 

--- a/src/lorairo/database/db_repository.py
+++ b/src/lorairo/database/db_repository.py
@@ -2554,6 +2554,12 @@ class ImageRepository:
         self._format_score_labels(image, annotations)
         self._format_ratings(image, annotations)
 
+        # ADR 0029: derived view。GUI のメタデータ経路 (SelectedImageDetailsWidget) も
+        # quality_summary を受け取れるよう、get_image_annotations と同じく派生計算する。
+        annotations["quality_summary"] = compute_quality_summary(
+            annotations.get("score_labels", []), annotations.get("scores", [])
+        )
+
         logger.debug(
             f"Formatted annotations: tags={len(annotations.get('tags', []))}, "
             f"captions={len(annotations.get('captions', []))}, "

--- a/src/lorairo/database/db_repository.py
+++ b/src/lorairo/database/db_repository.py
@@ -14,6 +14,7 @@ from sqlalchemy.engine import CursorResult
 from sqlalchemy.exc import IntegrityError, SQLAlchemyError
 from sqlalchemy.orm import Session, selectinload, sessionmaker
 
+from ..domain.quality_tier import compute_quality_summary
 from ..utils.log import logger
 from .db_core import DefaultSessionLocal
 from .filter_criteria import ImageFilterCriteria
@@ -1924,7 +1925,7 @@ class ImageRepository:
             "updated_at": sl.updated_at,
         }
 
-    def get_image_annotations(self, image_id: int) -> dict[str, list[dict[str, Any]]]:
+    def get_image_annotations(self, image_id: int) -> dict[str, Any]:
         """指定された画像IDのアノテーション(タグ、キャプション、スコア、スコアラベル、レーティング)を取得する。
 
         Eager Loadingを使用して関連データを効率的に取得する。
@@ -1934,7 +1935,8 @@ class ImageRepository:
 
         Returns:
             アノテーションデータを含む辞書。
-            キー: 'tags', 'captions', 'scores', 'score_labels', 'ratings'
+            キー: 'tags', 'captions', 'scores', 'score_labels', 'ratings',
+            'quality_summary' (ADR 0029、derived view)
             画像が存在しない場合は空のリストを持つ辞書を返す。
 
         Raises:
@@ -1944,12 +1946,13 @@ class ImageRepository:
         from sqlalchemy.orm import joinedload
 
         logger.debug(f"Getting annotations for image_id: {image_id}")
-        annotations: dict[str, list[dict[str, Any]]] = {
+        annotations: dict[str, Any] = {
             "tags": [],
             "captions": [],
             "scores": [],
             "score_labels": [],
             "ratings": [],
+            "quality_summary": {},
         }
 
         with self.session_factory() as session:
@@ -1986,6 +1989,11 @@ class ImageRepository:
                     ]
                 if image.ratings:
                     annotations["ratings"] = [self._format_rating_annotation(r) for r in image.ratings]
+
+                # ADR 0029: derived view、永続化しない。raw annotation から毎回計算する。
+                annotations["quality_summary"] = compute_quality_summary(
+                    annotations["score_labels"], annotations["scores"]
+                )
 
                 logger.info(
                     f"取得したアノテーション数: tags={len(annotations['tags'])}, "

--- a/src/lorairo/domain/__init__.py
+++ b/src/lorairo/domain/__init__.py
@@ -1,0 +1,1 @@
+"""LoRAIro domain logic (annotation 派生計算等)。"""

--- a/src/lorairo/domain/quality_tier.py
+++ b/src/lorairo/domain/quality_tier.py
@@ -1,0 +1,241 @@
+"""Unified Dataset Quality Tier mapping (ADR 0029).
+
+scorer 由来の categorical ``score_labels`` と manual score を、LoRAIro 独自の
+統一品質 tier (`masterpiece` ... `worst quality` + sentinel `no score` / `unknown`)
+に正規化する。raw annotation は変更せず、derived view として計算する。
+
+集約規約は **median + is_unanimous hybrid**:
+
+- ``tier``: known votes の順序中央値 (tie は higher 寄り = ``sorted[len // 2]``)
+- ``is_unanimous``: 全 known votes が同 tier かつ unknown vote なし
+
+filter ロジック (out-of-scope) は ``QualityTier`` の ordinal 比較で実装する。
+sentinel 値は ordinal 比較に乗らないため、filter 側で別途扱う。
+
+新 scorer (例: ``WaifuAesthetic``) を mapping に追加する場合:
+
+1. ``_SCORE_LABEL_TO_TIER`` に ``(model_name, label)`` 行を追加
+2. mapping を変更する場合は ``MAPPING_VERSION`` を bump
+3. 該当する unit test を追加 (``tests/unit/domain/test_quality_tier.py``)
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import IntEnum
+from typing import Any
+
+MAPPING_VERSION: str = "quality-tier-v1"
+"""mapping table の version 識別子。mapping を変更する際に bump する。"""
+
+NO_SCORE: str = "no score"
+"""score 系 annotation が存在しない sentinel tier。"""
+
+UNKNOWN: str = "unknown"
+"""raw value は存在するが mapping 未定義の sentinel tier。"""
+
+MANUAL_MODEL_NAME: str = "manual"
+"""manual score の vote 出力で使う model 名 sentinel。"""
+
+
+class QualityTier(IntEnum):
+    """順序尺度の品質 tier。値が高いほど高品質。"""
+
+    MASTERPIECE = 6
+    BEST_QUALITY = 5
+    GOOD_QUALITY = 4
+    NORMAL_QUALITY = 3
+    LOW_QUALITY = 2
+    WORST_QUALITY = 1
+
+    @property
+    def label(self) -> str:
+        """user-facing label (例: ``"best quality"``)。"""
+        return _TIER_TO_LABEL[self]
+
+
+_TIER_TO_LABEL: dict[QualityTier, str] = {
+    QualityTier.MASTERPIECE: "masterpiece",
+    QualityTier.BEST_QUALITY: "best quality",
+    QualityTier.GOOD_QUALITY: "good quality",
+    QualityTier.NORMAL_QUALITY: "normal quality",
+    QualityTier.LOW_QUALITY: "low quality",
+    QualityTier.WORST_QUALITY: "worst quality",
+}
+
+_LABEL_TO_TIER: dict[str, QualityTier] = {label: tier for tier, label in _TIER_TO_LABEL.items()}
+
+# (model_name, raw_label) -> QualityTier
+_SCORE_LABEL_TO_TIER: dict[tuple[str, str], QualityTier] = {
+    ("aesthetic_shadow_v1", "very aesthetic"): QualityTier.MASTERPIECE,
+    ("aesthetic_shadow_v1", "aesthetic"): QualityTier.BEST_QUALITY,
+    ("aesthetic_shadow_v1", "displeasing"): QualityTier.LOW_QUALITY,
+    ("aesthetic_shadow_v1", "very displeasing"): QualityTier.WORST_QUALITY,
+    ("aesthetic_shadow_v2", "very aesthetic"): QualityTier.MASTERPIECE,
+    ("aesthetic_shadow_v2", "aesthetic"): QualityTier.BEST_QUALITY,
+    ("aesthetic_shadow_v2", "displeasing"): QualityTier.LOW_QUALITY,
+    ("aesthetic_shadow_v2", "very displeasing"): QualityTier.WORST_QUALITY,
+    ("cafe_aesthetic", "aesthetic"): QualityTier.GOOD_QUALITY,
+    ("cafe_aesthetic", "not_aesthetic"): QualityTier.LOW_QUALITY,
+}
+
+
+def map_score_label_to_tier(model: str, label: str) -> QualityTier | None:
+    """scorer raw label を tier に変換する。未定義は ``None``。"""
+    return _SCORE_LABEL_TO_TIER.get((model, label))
+
+
+def map_manual_score_to_tier(score: float) -> QualityTier | None:
+    """manual score (0.00-10.00) を tier に変換する。範囲外は ``None``。
+
+    ADR 0029 の境界仕様:
+
+    - 9.00 ≤ score ≤ 10.00 -> masterpiece
+    - 8.00 ≤ score < 9.00 -> best quality
+    - 6.00 ≤ score < 8.00 -> good quality
+    - 5.00 ≤ score < 6.00 -> normal quality
+    - 3.00 ≤ score < 5.00 -> low quality
+    - 0.00 ≤ score < 3.00 -> worst quality
+    """
+    if score < 0.0 or score > 10.0:
+        return None
+    if score >= 9.0:
+        return QualityTier.MASTERPIECE
+    if score >= 8.0:
+        return QualityTier.BEST_QUALITY
+    if score >= 6.0:
+        return QualityTier.GOOD_QUALITY
+    if score >= 5.0:
+        return QualityTier.NORMAL_QUALITY
+    if score >= 3.0:
+        return QualityTier.LOW_QUALITY
+    return QualityTier.WORST_QUALITY
+
+
+def tier_label_to_value(label: str) -> QualityTier | None:
+    """user-facing tier label を ``QualityTier`` enum に逆変換する。
+
+    filter follow-up で ``min_tier: "good quality"`` を ordinal 比較する用途。
+    sentinel (``"no score"`` / ``"unknown"``) には ordinal 値がないので ``None``。
+    """
+    return _LABEL_TO_TIER.get(label)
+
+
+@dataclass
+class _Vote:
+    """compute_quality_summary 内部の vote 表現。"""
+
+    source: str  # "score_label" | "manual_score"
+    model: str  # scorer model 名、manual score は MANUAL_MODEL_NAME
+    raw_label: str | None  # score_label の場合の raw label
+    raw_score: float | None  # manual_score の場合の raw 数値
+    tier: QualityTier | None  # None = mapping 未定義
+
+
+def compute_quality_summary(
+    score_labels: list[dict[str, Any]],
+    scores: list[dict[str, Any]],
+) -> dict[str, Any]:
+    """raw annotation から quality_summary を計算する (ADR 0029)。
+
+    Args:
+        score_labels: ``{"model": str, "label": str, ...}`` の list。
+            通常 ``get_image_annotations`` 戻り値の ``"score_labels"`` キー。
+        scores: ``{"score": float, "is_edited_manually": bool, ...}`` の list。
+            ``is_edited_manually == True`` のエントリのみ manual score とみなす
+            (AI scorer numeric は model 間 scale 不揃いのため tier 化しない)。
+
+    Returns:
+        次の形状の dict::
+
+            {
+                "mapping_version": str,
+                "tier": str,                  # tier label or "no score" / "unknown"
+                "is_unanimous": bool,
+                "known_count": int,
+                "unknown_count": int,
+                "no_score": bool,
+                "votes": list[dict],          # 各 vote の詳細
+            }
+    """
+    votes: list[_Vote] = []
+
+    for sl in score_labels:
+        model = sl.get("model", "")
+        label = sl.get("label", "")
+        tier = map_score_label_to_tier(model, label)
+        votes.append(_Vote(source="score_label", model=model, raw_label=label, raw_score=None, tier=tier))
+
+    for sc in scores:
+        if not sc.get("is_edited_manually"):
+            continue
+        raw_score = sc.get("score")
+        if raw_score is None:
+            continue
+        score_value = float(raw_score)
+        tier = map_manual_score_to_tier(score_value)
+        votes.append(
+            _Vote(
+                source="manual_score",
+                model=MANUAL_MODEL_NAME,
+                raw_label=None,
+                raw_score=score_value,
+                tier=tier,
+            )
+        )
+
+    serialized_votes = [_serialize_vote(v) for v in votes]
+    known_votes = [v for v in votes if v.tier is not None]
+    unknown_count = sum(1 for v in votes if v.tier is None)
+
+    if not votes:
+        return {
+            "mapping_version": MAPPING_VERSION,
+            "tier": NO_SCORE,
+            "is_unanimous": False,
+            "known_count": 0,
+            "unknown_count": 0,
+            "no_score": True,
+            "votes": [],
+        }
+
+    if not known_votes:
+        return {
+            "mapping_version": MAPPING_VERSION,
+            "tier": UNKNOWN,
+            "is_unanimous": False,
+            "known_count": 0,
+            "unknown_count": unknown_count,
+            "no_score": False,
+            "votes": serialized_votes,
+        }
+
+    # median (tie は higher 寄り)
+    sorted_tiers = sorted([v.tier for v in known_votes if v.tier is not None])
+    median_tier = sorted_tiers[len(sorted_tiers) // 2]
+
+    is_unanimous = len({v.tier for v in known_votes}) == 1 and unknown_count == 0
+
+    return {
+        "mapping_version": MAPPING_VERSION,
+        "tier": median_tier.label,
+        "is_unanimous": is_unanimous,
+        "known_count": len(known_votes),
+        "unknown_count": unknown_count,
+        "no_score": False,
+        "votes": serialized_votes,
+    }
+
+
+def _serialize_vote(v: _Vote) -> dict[str, Any]:
+    """vote を JSON-safe dict に変換する。"""
+    out: dict[str, Any] = {
+        "model": v.model,
+        "source": v.source,
+        "quality_tier": v.tier.label if v.tier is not None else UNKNOWN,
+    }
+    if v.raw_label is not None:
+        out["raw_label"] = v.raw_label
+    if v.raw_score is not None:
+        out["raw_score"] = v.raw_score
+    return out

--- a/src/lorairo/gui/widgets/annotation_data_display_widget.py
+++ b/src/lorairo/gui/widgets/annotation_data_display_widget.py
@@ -35,6 +35,8 @@ class AnnotationData:
     score_type: str = "Aesthetic"
     # ADR 0028: canonical scorer の categorical label を {model, label, ...} ペアで保持
     score_labels: list[dict[str, Any]] = field(default_factory=list)
+    # ADR 0029: 統一品質 tier (raw annotation からの derived view)
+    quality_summary: dict[str, Any] = field(default_factory=dict)
     # 翻訳データ: {tag_id: {language: translated_text}}
     tag_translations: dict[int, dict[str, str]] = field(default_factory=dict)
     # 利用可能な言語リスト（get_tag_languages()から取得）
@@ -88,6 +90,7 @@ class AnnotationDataDisplayWidget(QWidget, Ui_AnnotationDataDisplayWidget):
         self._setup_tags_compact_view()
         self._setup_caption_compact_view()
         self._setup_score_labels_compact_view()
+        self._setup_quality_tier_badge()
         self._adjust_content_heights()
 
         # 言語コンボボックスのシグナル接続
@@ -148,6 +151,18 @@ class AnnotationDataDisplayWidget(QWidget, Ui_AnnotationDataDisplayWidget):
         self._score_labels_container.setVisible(False)
         self.verticalLayoutScoreLabels.addWidget(self._score_labels_container)
 
+    def _setup_quality_tier_badge(self) -> None:
+        """品質 tier badge の初期化 (ADR 0029)。
+
+        ``groupBoxScoreLabels`` 内、per-scorer pill コンテナの上に単一 QLabel を配置する。
+        ``quality_summary`` が空のときは hide する。
+        """
+        self._quality_tier_label = QLabel(self.groupBoxScoreLabels)
+        self._quality_tier_label.setText("品質: -")
+        self._quality_tier_label.setVisible(False)
+        # pill コンテナの前 (上) に挿入
+        self.verticalLayoutScoreLabels.insertWidget(0, self._quality_tier_label)
+
     def update_data(self, data: AnnotationData) -> None:
         """アノテーションデータで表示を更新"""
         try:
@@ -164,6 +179,9 @@ class AnnotationDataDisplayWidget(QWidget, Ui_AnnotationDataDisplayWidget):
 
             # スコアラベル表示更新 (ADR 0028)
             self._update_score_labels_display(data.score_labels)
+
+            # 品質 tier badge 更新 (ADR 0029)
+            self._update_quality_tier_display(data.quality_summary)
 
             self._adjust_content_heights()
 
@@ -379,6 +397,38 @@ class AnnotationDataDisplayWidget(QWidget, Ui_AnnotationDataDisplayWidget):
         except Exception as e:
             logger.error(f"Error updating score_labels display: {e}")
 
+    def _update_quality_tier_display(self, summary: dict[str, Any]) -> None:
+        """品質 tier badge を更新する (ADR 0029)。
+
+        ``quality_summary`` は ``lorairo.domain.quality_tier.compute_quality_summary``
+        が返す形状の dict。空 dict / ``no_score`` / ``unknown`` / 通常 tier の各ケースを
+        graceful に扱う。
+
+        Args:
+            summary: ``compute_quality_summary`` 戻り値の dict。空 dict (= フィールド
+                自体が無い旧データ互換) のときは badge を hide する。
+        """
+        try:
+            tier = summary.get("tier") if summary else None
+            if not tier:
+                self._quality_tier_label.setVisible(False)
+                return
+
+            known_count = summary.get("known_count", 0)
+            is_unanimous = summary.get("is_unanimous", False)
+
+            if known_count == 0:
+                # tier は "no score" / "unknown" sentinel
+                self._quality_tier_label.setText(f"品質: {tier}")
+            else:
+                suffix = " (全 scorer 一致)" if is_unanimous else ""
+                self._quality_tier_label.setText(f"品質: {tier} ({known_count} scorer){suffix}")
+
+            self._quality_tier_label.setVisible(True)
+
+        except Exception as e:
+            logger.error(f"Error updating quality tier display: {e}")
+
     @Slot()
     def clear_data(self) -> None:
         """表示データをクリア"""
@@ -398,6 +448,8 @@ class AnnotationDataDisplayWidget(QWidget, Ui_AnnotationDataDisplayWidget):
 
             # スコアラベル pill もクリア
             self._update_score_labels_display([])
+            # 品質 tier badge もクリア (ADR 0029)
+            self._update_quality_tier_display({})
 
             self._tags_compact_label.setText("-")
             self._adjust_content_heights()

--- a/src/lorairo/gui/widgets/selected_image_details_widget.py
+++ b/src/lorairo/gui/widgets/selected_image_details_widget.py
@@ -414,6 +414,8 @@ class SelectedImageDetailsWidget(QWidget):
         tags_text = metadata.get("tags_text", "")
         # ADR 0028: canonical scorer の score_labels を AnnotationData に渡す
         score_labels_list = metadata.get("score_labels", [])
+        # ADR 0029: 統一品質 tier (derived view) を AnnotationData に渡す
+        quality_summary = metadata.get("quality_summary", {})
 
         # 翻訳データ取得（N+1回避のためバッチ取得）
         tag_translations: dict[int, dict[str, str]] = {}
@@ -433,6 +435,7 @@ class SelectedImageDetailsWidget(QWidget):
             aesthetic_score=score_value,
             overall_score=0,  # Rating値は文字列なのでoverall_scoreには使用しない
             score_labels=score_labels_list,
+            quality_summary=quality_summary,
             tag_translations=tag_translations,
             available_languages=self._available_languages,
         )

--- a/src/lorairo/services/dataset_export_service.py
+++ b/src/lorairo/services/dataset_export_service.py
@@ -217,6 +217,8 @@ class DatasetExportService:
                     "tags": tags,
                     "caption": captions,
                     "score_labels": score_labels,
+                    # ADR 0029: 統一品質 tier (derived view)
+                    "quality_summary": image_data.get("quality_summary", {}),
                 }
 
                 exported_count += 1
@@ -384,6 +386,8 @@ class DatasetExportService:
                 "captions": annotations.get("captions", []),
                 # ADR 0028: canonical scorer の categorical label を {model, label} ペアで保持
                 "score_labels": annotations.get("score_labels", []),
+                # ADR 0029: 統一品質 tier (derived view)
+                "quality_summary": annotations.get("quality_summary", {}),
             }
 
         except Exception as e:

--- a/tests/unit/database/test_db_repository_annotations.py
+++ b/tests/unit/database/test_db_repository_annotations.py
@@ -99,6 +99,16 @@ class TestFormatAnnotationsForMetadata:
             "score_labels": [],
             "ratings": [],
             "rating_value": "",  # Issue #4: Rating値は文字列型
+            # ADR 0029: derived view。score 系が空なので tier="no score"
+            "quality_summary": {
+                "mapping_version": "quality-tier-v1",
+                "tier": "no score",
+                "is_unanimous": False,
+                "known_count": 0,
+                "unknown_count": 0,
+                "no_score": True,
+                "votes": [],
+            },
         }
 
         assert result == expected
@@ -227,6 +237,39 @@ class TestFormatAnnotationsForMetadata:
         assert result["tags"][0]["confidence_score"] == 0.95
         assert result["tags"][1]["confidence_score"] == 0.85
         assert result["tags_text"] == "tag1, tag2"
+
+    def test_format_annotations_includes_quality_summary(self, repository):
+        """ADR 0029: score_labels がある場合、quality_summary が derived 計算される。
+
+        GUI のメタデータ経路 (SelectedImageDetailsWidget) も _format_annotations_for_metadata
+        を経由するため、quality tier badge が機能するには本経路での計算が必須 (PR #297 Codex P1)。
+        """
+        from types import SimpleNamespace
+
+        image = Mock(spec=Image)
+        image.tags = []
+        image.captions = []
+        image.scores = []
+        image.ratings = []
+        image.score_labels = [
+            SimpleNamespace(
+                id=1,
+                image_id=100,
+                model_id=42,
+                label="aesthetic",
+                is_edited_manually=False,
+                created_at=datetime(2026, 5, 19, 10, 0, 0),
+                updated_at=datetime(2026, 5, 19, 10, 0, 0),
+                model=SimpleNamespace(name="aesthetic_shadow_v2"),
+            )
+        ]
+
+        result = repository._format_annotations_for_metadata(image)
+
+        assert "quality_summary" in result
+        assert result["quality_summary"]["tier"] == "best quality"
+        assert result["quality_summary"]["known_count"] == 1
+        assert result["quality_summary"]["is_unanimous"] is True
 
 
 class TestFetchFilteredMetadataAnnotations:

--- a/tests/unit/database/test_db_repository_score_labels.py
+++ b/tests/unit/database/test_db_repository_score_labels.py
@@ -342,3 +342,84 @@ class TestGetImageAnnotationsScoreLabels:
         assert len(annotations["score_labels"]) == 3
         models = [e["model"] for e in annotations["score_labels"]]
         assert models == ["aesthetic_shadow_v1", "aesthetic_shadow_v2", "cafe_aesthetic"]
+
+
+class TestGetImageAnnotationsQualitySummary:
+    """``get_image_annotations`` が ADR 0029 の ``quality_summary`` を含む。"""
+
+    @pytest.fixture
+    def repository(self) -> ImageRepository:
+        mock_session_factory = MagicMock()
+        return ImageRepository(session_factory=mock_session_factory)
+
+    def _setup_session_with_image(
+        self, repository: ImageRepository, image: SimpleNamespace | None
+    ) -> MagicMock:
+        mock_session = MagicMock()
+        mock_session.__enter__ = Mock(return_value=mock_session)
+        mock_session.__exit__ = Mock(return_value=False)
+        mock_result = MagicMock()
+        mock_result.unique.return_value.scalar_one_or_none.return_value = image
+        mock_session.execute.return_value = mock_result
+        repository.session_factory = MagicMock(return_value=mock_session)
+        return mock_session
+
+    def test_quality_summary_no_score_when_empty(self, repository: ImageRepository) -> None:
+        """画像なしでも ``quality_summary`` キーが空 dict で返る。"""
+        self._setup_session_with_image(repository, None)
+
+        annotations = repository.get_image_annotations(image_id=100)
+
+        assert "quality_summary" in annotations
+        assert annotations["quality_summary"] == {}
+
+    def test_quality_summary_no_score_when_image_has_no_annotations(
+        self, repository: ImageRepository
+    ) -> None:
+        """画像はあるが score 系が空の場合、quality_summary.tier == 'no score'。"""
+        image = SimpleNamespace(tags=[], captions=[], scores=[], ratings=[], score_labels=[])
+        self._setup_session_with_image(repository, image)
+
+        annotations = repository.get_image_annotations(image_id=100)
+
+        assert annotations["quality_summary"]["tier"] == "no score"
+        assert annotations["quality_summary"]["no_score"] is True
+
+    def test_quality_summary_with_score_labels(self, repository: ImageRepository) -> None:
+        """score_labels あり -> mapped tier が返る。"""
+        sl = SimpleNamespace(
+            id=1,
+            image_id=100,
+            model_id=42,
+            label="aesthetic",
+            is_edited_manually=False,
+            created_at=datetime.datetime(2026, 5, 19, 10, 0, 0),
+            updated_at=datetime.datetime(2026, 5, 19, 10, 0, 0),
+            model=SimpleNamespace(name="aesthetic_shadow_v2"),
+        )
+        image = SimpleNamespace(tags=[], captions=[], scores=[], ratings=[], score_labels=[sl])
+        self._setup_session_with_image(repository, image)
+
+        annotations = repository.get_image_annotations(image_id=100)
+
+        assert annotations["quality_summary"]["tier"] == "best quality"
+        assert annotations["quality_summary"]["known_count"] == 1
+        assert annotations["quality_summary"]["is_unanimous"] is True
+
+    def test_quality_summary_includes_manual_score(self, repository: ImageRepository) -> None:
+        """manual score (is_edited_manually=True) が tier に反映される。"""
+        score = SimpleNamespace(
+            id=1,
+            score=9.5,
+            model_id=99,
+            is_edited_manually=True,
+            created_at=datetime.datetime(2026, 5, 19, 10, 0, 0),
+            updated_at=datetime.datetime(2026, 5, 19, 10, 0, 0),
+        )
+        image = SimpleNamespace(tags=[], captions=[], scores=[score], ratings=[], score_labels=[])
+        self._setup_session_with_image(repository, image)
+
+        annotations = repository.get_image_annotations(image_id=100)
+
+        assert annotations["quality_summary"]["tier"] == "masterpiece"
+        assert annotations["quality_summary"]["known_count"] == 1

--- a/tests/unit/domain/test_quality_tier.py
+++ b/tests/unit/domain/test_quality_tier.py
@@ -1,0 +1,253 @@
+"""Unit tests for ``lorairo.domain.quality_tier`` (ADR 0029)。"""
+
+from __future__ import annotations
+
+import pytest
+
+from lorairo.domain.quality_tier import (
+    MANUAL_MODEL_NAME,
+    MAPPING_VERSION,
+    NO_SCORE,
+    UNKNOWN,
+    QualityTier,
+    compute_quality_summary,
+    map_manual_score_to_tier,
+    map_score_label_to_tier,
+    tier_label_to_value,
+)
+
+pytestmark = pytest.mark.unit
+
+
+class TestQualityTierEnum:
+    def test_ordinal_ordering(self) -> None:
+        assert QualityTier.MASTERPIECE > QualityTier.BEST_QUALITY
+        assert QualityTier.BEST_QUALITY > QualityTier.GOOD_QUALITY
+        assert QualityTier.GOOD_QUALITY > QualityTier.NORMAL_QUALITY
+        assert QualityTier.NORMAL_QUALITY > QualityTier.LOW_QUALITY
+        assert QualityTier.LOW_QUALITY > QualityTier.WORST_QUALITY
+
+    def test_label_property(self) -> None:
+        assert QualityTier.MASTERPIECE.label == "masterpiece"
+        assert QualityTier.BEST_QUALITY.label == "best quality"
+        assert QualityTier.GOOD_QUALITY.label == "good quality"
+        assert QualityTier.NORMAL_QUALITY.label == "normal quality"
+        assert QualityTier.LOW_QUALITY.label == "low quality"
+        assert QualityTier.WORST_QUALITY.label == "worst quality"
+
+
+class TestScoreLabelMapping:
+    @pytest.mark.parametrize(
+        ("model", "label", "expected"),
+        [
+            ("aesthetic_shadow_v1", "very aesthetic", QualityTier.MASTERPIECE),
+            ("aesthetic_shadow_v1", "aesthetic", QualityTier.BEST_QUALITY),
+            ("aesthetic_shadow_v1", "displeasing", QualityTier.LOW_QUALITY),
+            ("aesthetic_shadow_v1", "very displeasing", QualityTier.WORST_QUALITY),
+            ("aesthetic_shadow_v2", "very aesthetic", QualityTier.MASTERPIECE),
+            ("aesthetic_shadow_v2", "aesthetic", QualityTier.BEST_QUALITY),
+            ("aesthetic_shadow_v2", "displeasing", QualityTier.LOW_QUALITY),
+            ("aesthetic_shadow_v2", "very displeasing", QualityTier.WORST_QUALITY),
+            ("cafe_aesthetic", "aesthetic", QualityTier.GOOD_QUALITY),
+            ("cafe_aesthetic", "not_aesthetic", QualityTier.LOW_QUALITY),
+        ],
+    )
+    def test_known_mappings(self, model: str, label: str, expected: QualityTier) -> None:
+        assert map_score_label_to_tier(model, label) == expected
+
+    def test_unknown_model(self) -> None:
+        assert map_score_label_to_tier("waifu_aesthetic", "very aesthetic") is None
+
+    def test_unknown_label(self) -> None:
+        assert map_score_label_to_tier("aesthetic_shadow_v1", "mediocre") is None
+
+
+class TestManualScoreMapping:
+    @pytest.mark.parametrize(
+        ("score", "expected"),
+        [
+            (10.0, QualityTier.MASTERPIECE),
+            (9.0, QualityTier.MASTERPIECE),
+            (8.99, QualityTier.BEST_QUALITY),
+            (8.0, QualityTier.BEST_QUALITY),
+            (7.99, QualityTier.GOOD_QUALITY),
+            (6.0, QualityTier.GOOD_QUALITY),
+            (5.99, QualityTier.NORMAL_QUALITY),
+            (5.0, QualityTier.NORMAL_QUALITY),
+            (4.99, QualityTier.LOW_QUALITY),
+            (3.0, QualityTier.LOW_QUALITY),
+            (2.99, QualityTier.WORST_QUALITY),
+            (0.0, QualityTier.WORST_QUALITY),
+        ],
+    )
+    def test_known_ranges(self, score: float, expected: QualityTier) -> None:
+        assert map_manual_score_to_tier(score) == expected
+
+    @pytest.mark.parametrize("score", [-0.1, 10.01, -100.0, 100.0])
+    def test_out_of_range_returns_none(self, score: float) -> None:
+        assert map_manual_score_to_tier(score) is None
+
+
+class TestTierLabelToValue:
+    def test_known_labels(self) -> None:
+        assert tier_label_to_value("best quality") == QualityTier.BEST_QUALITY
+        assert tier_label_to_value("worst quality") == QualityTier.WORST_QUALITY
+
+    def test_sentinel_returns_none(self) -> None:
+        assert tier_label_to_value(NO_SCORE) is None
+        assert tier_label_to_value(UNKNOWN) is None
+
+    def test_unknown_label_returns_none(self) -> None:
+        assert tier_label_to_value("EXCELLENT") is None
+
+
+class TestComputeQualitySummary:
+    def test_empty_inputs_returns_no_score(self) -> None:
+        result = compute_quality_summary([], [])
+        assert result["tier"] == NO_SCORE
+        assert result["no_score"] is True
+        assert result["is_unanimous"] is False
+        assert result["known_count"] == 0
+        assert result["unknown_count"] == 0
+        assert result["votes"] == []
+        assert result["mapping_version"] == MAPPING_VERSION
+
+    def test_only_unknown_labels_returns_unknown_tier(self) -> None:
+        score_labels = [{"model": "waifu_aesthetic", "label": "very aesthetic"}]
+        result = compute_quality_summary(score_labels, [])
+        assert result["tier"] == UNKNOWN
+        assert result["no_score"] is False
+        assert result["is_unanimous"] is False
+        assert result["known_count"] == 0
+        assert result["unknown_count"] == 1
+        assert len(result["votes"]) == 1
+        assert result["votes"][0]["quality_tier"] == UNKNOWN
+
+    def test_single_known_label(self) -> None:
+        score_labels = [{"model": "aesthetic_shadow_v2", "label": "aesthetic"}]
+        result = compute_quality_summary(score_labels, [])
+        assert result["tier"] == "best quality"
+        assert result["is_unanimous"] is True
+        assert result["known_count"] == 1
+        assert result["unknown_count"] == 0
+
+    def test_unanimous_high_quality(self) -> None:
+        score_labels = [
+            {"model": "aesthetic_shadow_v1", "label": "aesthetic"},
+            {"model": "aesthetic_shadow_v2", "label": "aesthetic"},
+        ]
+        result = compute_quality_summary(score_labels, [])
+        assert result["tier"] == "best quality"
+        assert result["is_unanimous"] is True
+        assert result["known_count"] == 2
+
+    def test_median_odd_n(self) -> None:
+        # [best, best, good] -> sorted [good, best, best] -> index 1 -> best
+        score_labels = [
+            {"model": "aesthetic_shadow_v1", "label": "aesthetic"},  # best
+            {"model": "aesthetic_shadow_v2", "label": "aesthetic"},  # best
+            {"model": "cafe_aesthetic", "label": "aesthetic"},  # good
+        ]
+        result = compute_quality_summary(score_labels, [])
+        assert result["tier"] == "best quality"
+        assert result["is_unanimous"] is False
+        assert result["known_count"] == 3
+
+    def test_median_disagreement(self) -> None:
+        # [best, good, low] -> sorted [low, good, best] -> index 1 -> good
+        score_labels = [
+            {"model": "aesthetic_shadow_v1", "label": "aesthetic"},  # best
+            {"model": "cafe_aesthetic", "label": "aesthetic"},  # good
+            {"model": "aesthetic_shadow_v2", "label": "displeasing"},  # low
+        ]
+        result = compute_quality_summary(score_labels, [])
+        assert result["tier"] == "good quality"
+        assert result["is_unanimous"] is False
+
+    def test_median_even_n_higher_priority(self) -> None:
+        # [best, good] -> sorted [good, best] -> n//2 = 1 -> best (higher 寄り)
+        score_labels = [
+            {"model": "aesthetic_shadow_v1", "label": "aesthetic"},  # best
+            {"model": "cafe_aesthetic", "label": "aesthetic"},  # good
+        ]
+        result = compute_quality_summary(score_labels, [])
+        assert result["tier"] == "best quality"
+        assert result["is_unanimous"] is False
+
+    def test_unanimous_false_when_unknown_present(self) -> None:
+        score_labels = [
+            {"model": "aesthetic_shadow_v1", "label": "aesthetic"},  # best
+            {"model": "aesthetic_shadow_v2", "label": "aesthetic"},  # best
+            {"model": "waifu_aesthetic", "label": "very aesthetic"},  # unknown
+        ]
+        result = compute_quality_summary(score_labels, [])
+        assert result["tier"] == "best quality"
+        assert result["is_unanimous"] is False
+        assert result["known_count"] == 2
+        assert result["unknown_count"] == 1
+
+    def test_manual_score_contributes(self) -> None:
+        # score_labels: [best], scores: manual 9.5 (-> masterpiece)
+        # known votes: [best, masterpiece] -> sorted [best, masterpiece]
+        # n//2 = 1 -> masterpiece
+        score_labels = [{"model": "aesthetic_shadow_v2", "label": "aesthetic"}]  # best
+        scores = [{"score": 9.5, "is_edited_manually": True}]
+        result = compute_quality_summary(score_labels, scores)
+        assert result["tier"] == "masterpiece"
+        assert result["known_count"] == 2
+        manual_votes = [v for v in result["votes"] if v["source"] == "manual_score"]
+        assert len(manual_votes) == 1
+        assert manual_votes[0]["model"] == MANUAL_MODEL_NAME
+        assert manual_votes[0]["raw_score"] == 9.5
+        assert manual_votes[0]["quality_tier"] == "masterpiece"
+
+    def test_ai_scorer_numeric_score_excluded(self) -> None:
+        # is_edited_manually=False scores are AI scorer outputs, NOT counted.
+        score_labels = [{"model": "aesthetic_shadow_v2", "label": "aesthetic"}]
+        scores = [
+            {"score": 0.92, "is_edited_manually": False},  # AI scorer, excluded
+            {"score": 0.08, "is_edited_manually": False},  # AI scorer, excluded
+        ]
+        result = compute_quality_summary(score_labels, scores)
+        # only score_labels vote counted
+        assert result["known_count"] == 1
+        assert result["tier"] == "best quality"
+        manual_votes = [v for v in result["votes"] if v["source"] == "manual_score"]
+        assert len(manual_votes) == 0
+
+    def test_manual_score_out_of_range_becomes_unknown(self) -> None:
+        scores = [{"score": 99.9, "is_edited_manually": True}]
+        result = compute_quality_summary([], scores)
+        assert result["tier"] == UNKNOWN
+        assert result["known_count"] == 0
+        assert result["unknown_count"] == 1
+        assert result["votes"][0]["quality_tier"] == UNKNOWN
+
+    def test_manual_score_missing_value_skipped(self) -> None:
+        scores = [
+            {"score": None, "is_edited_manually": True},
+            {"is_edited_manually": True},
+        ]
+        result = compute_quality_summary([], scores)
+        assert result["tier"] == NO_SCORE
+        assert result["no_score"] is True
+
+    def test_vote_shape_for_score_label(self) -> None:
+        score_labels = [{"model": "cafe_aesthetic", "label": "not_aesthetic"}]
+        result = compute_quality_summary(score_labels, [])
+        vote = result["votes"][0]
+        assert vote["model"] == "cafe_aesthetic"
+        assert vote["source"] == "score_label"
+        assert vote["raw_label"] == "not_aesthetic"
+        assert vote["quality_tier"] == "low quality"
+        assert "raw_score" not in vote
+
+    def test_vote_shape_for_manual_score(self) -> None:
+        scores = [{"score": 7.5, "is_edited_manually": True}]
+        result = compute_quality_summary([], scores)
+        vote = result["votes"][0]
+        assert vote["model"] == MANUAL_MODEL_NAME
+        assert vote["source"] == "manual_score"
+        assert vote["raw_score"] == 7.5
+        assert vote["quality_tier"] == "good quality"
+        assert "raw_label" not in vote

--- a/tests/unit/gui/widgets/test_annotation_data_display_widget.py
+++ b/tests/unit/gui/widgets/test_annotation_data_display_widget.py
@@ -273,3 +273,113 @@ class TestAnnotationDataDisplayWidget:
         widget.set_group_box_visibility(tags=False)
         # score_labels は default で visible 設定 → isHidden() は False
         assert not widget.groupBoxScoreLabels.isHidden()
+
+
+class TestQualityTierBadge:
+    """ADR 0029: 統一品質 tier badge の表示挙動。"""
+
+    @pytest.fixture
+    def widget(self, qtbot):
+        w = AnnotationDataDisplayWidget()
+        qtbot.addWidget(w)
+        return w
+
+    def test_badge_hidden_initially(self, widget):
+        """初期状態で badge が hidden。"""
+        assert widget._quality_tier_label.isHidden()
+
+    def test_badge_hidden_when_quality_summary_empty(self, widget):
+        """quality_summary が空 dict のとき badge は hidden (旧データ互換)。"""
+        widget.update_data(AnnotationData(quality_summary={}))
+        assert widget._quality_tier_label.isHidden()
+
+    def test_badge_shows_no_score_sentinel(self, widget):
+        """tier='no score' のとき badge が表示され known_count=0 用の text を出す。"""
+        widget.update_data(
+            AnnotationData(
+                quality_summary={
+                    "tier": "no score",
+                    "is_unanimous": False,
+                    "known_count": 0,
+                    "unknown_count": 0,
+                    "no_score": True,
+                    "votes": [],
+                }
+            )
+        )
+        assert not widget._quality_tier_label.isHidden()
+        assert "no score" in widget._quality_tier_label.text()
+
+    def test_badge_shows_unknown_sentinel(self, widget):
+        """tier='unknown' のとき badge が表示される。"""
+        widget.update_data(
+            AnnotationData(
+                quality_summary={
+                    "tier": "unknown",
+                    "is_unanimous": False,
+                    "known_count": 0,
+                    "unknown_count": 1,
+                    "no_score": False,
+                    "votes": [],
+                }
+            )
+        )
+        assert not widget._quality_tier_label.isHidden()
+        assert "unknown" in widget._quality_tier_label.text()
+
+    def test_badge_shows_tier_with_count(self, widget):
+        """known_count >= 1 のとき '品質: <tier> (<n> scorer)' フォーマット。"""
+        widget.update_data(
+            AnnotationData(
+                quality_summary={
+                    "tier": "best quality",
+                    "is_unanimous": False,
+                    "known_count": 2,
+                    "unknown_count": 0,
+                    "no_score": False,
+                    "votes": [],
+                }
+            )
+        )
+        text = widget._quality_tier_label.text()
+        assert "best quality" in text
+        assert "2 scorer" in text
+        assert "一致" not in text
+
+    def test_badge_shows_unanimous_suffix(self, widget):
+        """is_unanimous=True で全 scorer 一致 suffix が付与される。"""
+        widget.update_data(
+            AnnotationData(
+                quality_summary={
+                    "tier": "masterpiece",
+                    "is_unanimous": True,
+                    "known_count": 3,
+                    "unknown_count": 0,
+                    "no_score": False,
+                    "votes": [],
+                }
+            )
+        )
+        text = widget._quality_tier_label.text()
+        assert "masterpiece" in text
+        assert "3 scorer" in text
+        assert "全 scorer 一致" in text
+
+    def test_badge_clear_data_hides_badge(self, widget):
+        """clear_data で badge が hidden に戻る。"""
+        widget.update_data(
+            AnnotationData(
+                quality_summary={
+                    "tier": "best quality",
+                    "is_unanimous": True,
+                    "known_count": 1,
+                    "unknown_count": 0,
+                    "no_score": False,
+                    "votes": [],
+                }
+            )
+        )
+        assert not widget._quality_tier_label.isHidden()
+
+        widget.clear_data()
+        assert widget._quality_tier_label.isHidden()

--- a/tests/unit/gui/widgets/test_selected_image_details_widget.py
+++ b/tests/unit/gui/widgets/test_selected_image_details_widget.py
@@ -328,3 +328,51 @@ class TestSelectedImageDetailsWidget:
 
         assert details.annotation_data is not None
         assert details.annotation_data.score_labels == []
+
+    def test_build_metadata_populates_quality_summary(self, widget):
+        """metadata の quality_summary が AnnotationData に渡されること (ADR 0029)。
+
+        PR #297 Codex P1 の核: GUI のメタデータ経路で quality_summary を埋めないと、
+        統一 tier badge が常に hidden になる silent バグの回帰防止。
+        """
+        quality_summary = {
+            "mapping_version": "quality-tier-v1",
+            "tier": "best quality",
+            "is_unanimous": True,
+            "known_count": 2,
+            "unknown_count": 0,
+            "no_score": False,
+            "votes": [],
+        }
+        metadata = {
+            "id": 1,
+            "file_path": "/test/img.jpg",
+            "tags": [],
+            "caption_text": "",
+            "tags_text": "",
+            "score_value": 0,
+            "rating_value": "",
+            "score_labels": [],
+            "quality_summary": quality_summary,
+        }
+        details = widget._build_image_details_from_metadata(metadata)
+
+        assert details.annotation_data is not None
+        assert details.annotation_data.quality_summary == quality_summary
+
+    def test_build_metadata_quality_summary_missing_defaults_empty(self, widget):
+        """metadata に quality_summary key が無い場合は default {} になる (旧データ互換)。"""
+        metadata = {
+            "id": 1,
+            "file_path": "/test/img.jpg",
+            "tags": [],
+            "caption_text": "",
+            "tags_text": "",
+            "score_value": 0,
+            "rating_value": "",
+            # quality_summary なし
+        }
+        details = widget._build_image_details_from_metadata(metadata)
+
+        assert details.annotation_data is not None
+        assert details.annotation_data.quality_summary == {}

--- a/tests/unit/test_dataset_export_service.py
+++ b/tests/unit/test_dataset_export_service.py
@@ -521,6 +521,127 @@ class TestDatasetExportService:
             assert "score_labels" in entry
             assert entry["score_labels"] == []
 
+    def test_get_image_export_data_includes_quality_summary(
+        self, dataset_export_service, mock_db_manager, sample_image_data, sample_score_labels
+    ):
+        """_get_image_export_data の return に quality_summary が含まれる (ADR 0029)。"""
+        mock_db_manager.get_image_metadata.return_value = sample_image_data["metadata"]
+        mock_db_manager.get_image_annotations.return_value = {
+            "tags": sample_image_data["tags"],
+            "captions": sample_image_data["captions"],
+            "score_labels": sample_score_labels,
+            "quality_summary": {
+                "mapping_version": "quality-tier-v1",
+                "tier": "best quality",
+                "is_unanimous": False,
+                "known_count": 2,
+                "unknown_count": 0,
+                "no_score": False,
+                "votes": [],
+            },
+        }
+
+        result = dataset_export_service._get_image_export_data(1)
+
+        assert result is not None
+        assert "quality_summary" in result
+        assert result["quality_summary"]["tier"] == "best quality"
+
+    def test_export_dataset_json_format_includes_quality_summary(
+        self,
+        dataset_export_service,
+        mock_db_manager,
+        mock_file_system_manager,
+        sample_image_data,
+        sample_score_labels,
+    ):
+        """JSON Export の metadata に quality_summary が構造化 dict で含まれる (ADR 0029)。"""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            output_path = Path(temp_dir) / "export"
+            output_path.mkdir()
+            processed_image_path = Path("/mock/processed/test_project_00001.webp")
+
+            quality_summary = {
+                "mapping_version": "quality-tier-v1",
+                "tier": "masterpiece",
+                "is_unanimous": True,
+                "known_count": 2,
+                "unknown_count": 0,
+                "no_score": False,
+                "votes": [
+                    {
+                        "model": "aesthetic_shadow_v1",
+                        "source": "score_label",
+                        "raw_label": "very aesthetic",
+                        "quality_tier": "masterpiece",
+                    },
+                ],
+            }
+            mock_db_manager.get_image_metadata.return_value = sample_image_data["metadata"]
+            mock_db_manager.get_image_annotations.return_value = {
+                "tags": sample_image_data["tags"],
+                "captions": sample_image_data["captions"],
+                "scores": [],
+                "score_labels": sample_score_labels,
+                "ratings": [],
+                "quality_summary": quality_summary,
+            }
+            with patch.object(
+                dataset_export_service,
+                "_resolve_processed_image_path",
+                return_value=processed_image_path,
+            ):
+                dataset_export_service.export_dataset_json_format(
+                    image_ids=[1], output_path=output_path, resolution=512
+                )
+
+            metadata_file = output_path / "metadata.json"
+            with open(metadata_file, encoding="utf-8") as f:
+                metadata = json.load(f)
+            entry = metadata[str(output_path / "test_project_00001.webp")]
+
+            assert "quality_summary" in entry
+            assert entry["quality_summary"]["tier"] == "masterpiece"
+            assert entry["quality_summary"]["is_unanimous"] is True
+            assert entry["quality_summary"]["mapping_version"] == "quality-tier-v1"
+
+    def test_export_dataset_json_format_missing_quality_summary_fallback(
+        self,
+        dataset_export_service,
+        mock_db_manager,
+        mock_file_system_manager,
+        sample_image_data,
+    ):
+        """get_image_annotations が quality_summary key を欠落しても KeyError しない (graceful fallback)。"""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            output_path = Path(temp_dir) / "export"
+            output_path.mkdir()
+
+            mock_db_manager.get_image_metadata.return_value = sample_image_data["metadata"]
+            mock_db_manager.get_image_annotations.return_value = {
+                "tags": sample_image_data["tags"],
+                "captions": sample_image_data["captions"],
+                "scores": [],
+                "score_labels": [],
+                "ratings": [],
+                # quality_summary 欠落 (旧仕様互換)
+            }
+            with patch.object(
+                dataset_export_service,
+                "_resolve_processed_image_path",
+                return_value=Path("/mock/processed/test_project_00001.webp"),
+            ):
+                dataset_export_service.export_dataset_json_format(
+                    image_ids=[1], output_path=output_path, resolution=512
+                )
+
+            metadata_file = output_path / "metadata.json"
+            with open(metadata_file, encoding="utf-8") as f:
+                metadata = json.load(f)
+            entry = metadata[str(output_path / "test_project_00001.webp")]
+            assert "quality_summary" in entry
+            assert entry["quality_summary"] == {}
+
     def test_export_dataset_txt_format_excludes_score_labels(
         self,
         dataset_export_service,


### PR DESCRIPTION
## 背景

LoRAIro #284 (merged PR #286、ADR 0028) で canonical scorer の `score_labels` を GUI compact pill と JSON Export に追加した。しかし scorer ごとに label 表現が異なる (`very aesthetic` / `aesthetic` / `displeasing` / `not_aesthetic` 等) ため、dataset 全体の品質を一目で判定する用途には統一尺度が必要。

本 PR は **LoRAIro 独自の dataset quality tier** (`masterpiece` / `best quality` / `good quality` / `normal quality` / `low quality` / `worst quality` + sentinel `no score` / `unknown`) を導入し、`score_labels` + manual score を統一 tier に正規化して GUI / JSON Export で表示する。

## 設計判断 (ADR 0029)

- **raw annotation は不変**: `scores` / `score_labels` は変更せず、`quality_summary` を derived view として計算
- **集約規約 = median + is_unanimous hybrid**: 複数 scorer の votes を順序中央値で集約 (tie は higher 寄り)、`is_unanimous` で全 scorer 一致を 1 field 表現。#287 planning で 7 パターン比較の上 user 確認済
- **mapping SSoT = code module** `src/lorairo/domain/quality_tier.py` (DB 永続化しない、`MAPPING_VERSION` で版管理)
- **sentinel 分離**: `no score` (未採点) と `unknown` (mapping 未定義) を別扱い、silent misclassification を回避
- Filter / Statistics は **out-of-scope** (別 Issue、ADR で interface のみ予約)

## 変更内容

| ファイル | 変更 |
|---|---|
| `src/lorairo/domain/quality_tier.py` (新規) | `QualityTier` IntEnum、mapping table、`compute_quality_summary()` 等 |
| `src/lorairo/database/db_repository.py` | `get_image_annotations()` が `quality_summary` を derived 計算で返す |
| `src/lorairo/services/dataset_export_service.py` | JSON Export の metadata entry に `quality_summary` 追加 (`score_labels` は不変) |
| `src/lorairo/gui/widgets/annotation_data_display_widget.py` | `groupBoxScoreLabels` 内に統一 tier badge を追加 (per-scorer pill と併存) |
| `docs/decisions/0029-unified-dataset-quality-tier.md` (新規) | ADR finalize |
| `docs/decisions/README.md` | ADR 0029 index 登録 |

## Verification

```
# 新規 unit test (domain)
.venv/bin/pytest tests/unit/domain/test_quality_tier.py
# → 47 passed

# CI-equivalent filter (regression check)
QT_QPA_PLATFORM=offscreen .venv/bin/pytest -m "not gui_show and not real_api and not slow" --timeout=60
# → 2361 passed, 2 skipped, 1 deselected

# mypy
.venv/bin/mypy -p lorairo
# → Success: no issues found in 148 source files
```

新規テスト: domain unit 47 + Repository 4 + Export 3 + GUI widget 7 = 61 件。

GUI badge の表示挙動 (no_score / unknown / 通常 tier / unanimous suffix / clear) は devcontainer headless 環境のため `QT_QPA_PLATFORM=offscreen` の widget test 7 ケースで検証 (実 GUI 手動確認は未実施)。

## 影響範囲

- raw DB annotation: 変更なし (`scores` / `score_labels` テーブル不変)
- JSON Export: `quality_summary` field 追加 (`score_labels` 構造は不変、downstream 後方互換)
- GUI: AnnotationDataDisplayWidget に tier badge 追加 (既存 pill と併存)
- submodule (`local_packages/*`): 変更なし

## 関連

- closes #287
- 親 ADR: 0027 (Score Labels DB Storage)、0028 (Score Labels Usage and Display)
- 関連 ADR: 0015 (Manual Rating Storage Unification)、0022 (Aesthetic Score Predictor Survey)
- 親 PR (merged): #283 (DB 保存)、#286 (GUI pill + JSON export)
- Follow-up Issue 候補: Filter 実装 (`QualityTierFilter`)、Statistics report viewer、regression scorer mapping 拡張

🤖 Generated with [Claude Code](https://claude.com/claude-code)
