### PR TITLE
fix: normalize local model provider filtering

### DIFF
--- a/src/lorairo/services/model_selection_service.py
+++ b/src/lorairo/services/model_selection_service.py
@@ -18,7 +18,7 @@ class ModelSelectionCriteria:
     capabilities: list[str] | None = None
     only_recommended: bool = False
     only_available: bool = True
-    exclude_local: bool = False  # True の場合、provider="local" を除外（API モデルのみ表示）
+    exclude_local: bool = False  # True の場合、provider が local/None のモデルを除外
     execution_env: str | None = None  # "APIモデルのみ" or "ローカルモデルのみ" or None/"すべて"
 
 
@@ -87,6 +87,13 @@ class ModelSelectionService:
         """推奨モデルのみを取得（DB Modelプロパティ使用）"""
         return [m for m in self._all_models if m.is_recommended]
 
+    @staticmethod
+    def _provider_key(provider: str | None) -> str:
+        """フィルタ比較用の provider 正規化キーを返す。"""
+        if not provider:
+            return "local"
+        return provider.lower()
+
     def filter_models(
         self,
         criteria: ModelSelectionCriteria | None = None,
@@ -117,14 +124,13 @@ class ModelSelectionService:
 
         # プロバイダーフィルタ
         if criteria.provider and criteria.provider != "すべて":
-            filtered = [
-                m for m in filtered if m.provider and m.provider.lower() == criteria.provider.lower()
-            ]
+            provider_key = self._provider_key(criteria.provider)
+            filtered = [m for m in filtered if self._provider_key(m.provider) == provider_key]
             logger.debug(f"  プロバイダーフィルタ後: {len(filtered)}件 (provider={criteria.provider})")
 
-        # ローカルモデル除外フィルタ（API モデルのみ表示）
+        # ローカルモデル除外フィルタ（provider=None はローカルモデル扱い）
         if criteria.exclude_local:
-            filtered = [m for m in filtered if m.provider and m.provider.lower() != "local"]
+            filtered = [m for m in filtered if self._provider_key(m.provider) != "local"]
             logger.debug(f"  ローカルモデル除外後: {len(filtered)}件")
 
         # 機能フィルタ
@@ -155,7 +161,7 @@ class ModelSelectionService:
         """プロバイダー別にモデルをグループ化（DB Model使用）"""
         groups: dict[str, list[Model]] = {}
         for model in models:
-            provider = model.provider or "local"
+            provider = self._provider_key(model.provider)
             if provider not in groups:
                 groups[provider] = []
             groups[provider].append(model)

--- a/src/lorairo/services/model_sync_service.py
+++ b/src/lorairo/services/model_sync_service.py
@@ -259,9 +259,8 @@ class ModelSyncService:
                 db_model_types = self._map_library_model_type_to_db(info)
 
                 # API モデルで provider 不明 (PydanticAI 直接モデル等) は "unknown" に
-                # フォールバック。ローカルモデルは provider=None のままにし
-                # 既存の「provider=None → local」解釈 (model_selection_service の
-                # exclude_local / "provider or 'local'") を維持する。
+                # フォールバック。ローカルモデルは provider=None のままにし、
+                # model_selection_service の provider 正規化で local 扱いする。
                 provider = info.provider or ("unknown" if info.is_api else None)
 
                 # ADR 0023 Phase 1.11 (Issue #238): litellm_model_id は registry key

--- a/tests/unit/services/test_model_selection_service.py
+++ b/tests/unit/services/test_model_selection_service.py
@@ -82,7 +82,7 @@ class TestModelSelectionService:
 
         clip_model = Model(
             name="clip-aesthetic",
-            provider="local",
+            provider=None,
             litellm_model_id=None,
             requires_api_key=False,
             estimated_size_gb=1.2,
@@ -237,6 +237,15 @@ class TestModelSelectionService:
         assert len(grouped["anthropic"]) == 1
         assert len(grouped["local"]) == 2
 
+    def test_filter_models_provider_local_includes_none_provider(self, service):
+        """provider=None のローカルモデルは provider='local' 指定で一致する"""
+        service.load_models()
+
+        criteria = ModelSelectionCriteria(provider="local")
+        local_models = service.filter_models(criteria)
+
+        assert {model.name for model in local_models} == {"wd-v1-4", "clip-aesthetic"}
+
     # create_model_tooltip, create_model_display_name, _is_recommended_model メソッドは
     # DB中心アーキテクチャでWidgetに移動されたため、テストを削除
 
@@ -260,14 +269,25 @@ class TestModelSelectionService:
         criteria = ModelSelectionCriteria(exclude_local=True)
         api_models = service.filter_models(criteria)
 
-        # local provider を除外
+        # local provider と provider=None のローカルモデルを除外
         for model in api_models:
             assert model.provider != "local"
+            assert model.provider is not None
 
         # OpenAI, Anthropic のみが返される
         assert len(api_models) == 2
         provider_names = {m.provider for m in api_models}
         assert provider_names == {"openai", "anthropic"}
+
+    def test_filter_models_execution_env_uses_requires_api_key(self, service):
+        """execution_env は provider ではなく requires_api_key で分類する"""
+        service.load_models()
+
+        api_models = service.filter_models(ModelSelectionCriteria(execution_env="APIモデルのみ"))
+        local_models = service.filter_models(ModelSelectionCriteria(execution_env="ローカルモデルのみ"))
+
+        assert {model.name for model in api_models} == {"gpt-4o", "claude-3-5-sonnet"}
+        assert {model.name for model in local_models} == {"wd-v1-4", "clip-aesthetic"}
 
     def test_filter_models_with_user_provider(self, service, mock_db_repository):
         """provider='user'を持つモデルがフィルタリングされることをテスト"""


### PR DESCRIPTION
## Summary
- Treat provider=None as local for model provider filtering
- Exclude provider=None local models when exclude_local=True
- Clarify the model sync comment and add regression coverage

## Tests
- uv run pytest tests/unit/services/test_model_selection_service.py -q

Fixes #298