### PR TITLE
fix: simplify batch annotation model filters

### DIFF
--- a/src/lorairo/gui/designer/AnnotationFilterWidget_ui.py
+++ b/src/lorairo/gui/designer/AnnotationFilterWidget_ui.py
@@ -1,0 +1,94 @@
+# -*- coding: utf-8 -*-
+
+################################################################################
+## Form generated from reading UI file 'AnnotationFilterWidget.ui'
+##
+## Created by: Qt User Interface Compiler version 6.11.1
+##
+## WARNING! All changes made in this file will be lost when recompiling UI file!
+################################################################################
+
+from PySide6.QtCore import (QCoreApplication, QDate, QDateTime, QLocale,
+    QMetaObject, QObject, QPoint, QRect,
+    QSize, QTime, QUrl, Qt)
+from PySide6.QtGui import (QBrush, QColor, QConicalGradient, QCursor,
+    QFont, QFontDatabase, QGradient, QIcon,
+    QImage, QKeySequence, QLinearGradient, QPainter,
+    QPalette, QPixmap, QRadialGradient, QTransform)
+from PySide6.QtWidgets import (QApplication, QCheckBox, QGroupBox, QHBoxLayout,
+    QSizePolicy, QSpacerItem, QVBoxLayout, QWidget)
+
+class Ui_AnnotationFilterWidget(object):
+    def setupUi(self, AnnotationFilterWidget: QWidget) -> None:
+        if not AnnotationFilterWidget.objectName():
+            AnnotationFilterWidget.setObjectName(u"AnnotationFilterWidget")
+        AnnotationFilterWidget.resize(300, 120)
+        self.mainLayout = QVBoxLayout(AnnotationFilterWidget)
+        self.mainLayout.setSpacing(6)
+        self.mainLayout.setObjectName(u"mainLayout")
+        self.mainLayout.setContentsMargins(0, 0, 0, 0)
+        self.groupBoxFunctionType = QGroupBox(AnnotationFilterWidget)
+        self.groupBoxFunctionType.setObjectName(u"groupBoxFunctionType")
+        self.horizontalLayoutFunctionType = QHBoxLayout(self.groupBoxFunctionType)
+        self.horizontalLayoutFunctionType.setSpacing(6)
+        self.horizontalLayoutFunctionType.setObjectName(u"horizontalLayoutFunctionType")
+        self.checkBoxCaption = QCheckBox(self.groupBoxFunctionType)
+        self.checkBoxCaption.setObjectName(u"checkBoxCaption")
+
+        self.horizontalLayoutFunctionType.addWidget(self.checkBoxCaption)
+
+        self.checkBoxTags = QCheckBox(self.groupBoxFunctionType)
+        self.checkBoxTags.setObjectName(u"checkBoxTags")
+
+        self.horizontalLayoutFunctionType.addWidget(self.checkBoxTags)
+
+        self.checkBoxScore = QCheckBox(self.groupBoxFunctionType)
+        self.checkBoxScore.setObjectName(u"checkBoxScore")
+
+        self.horizontalLayoutFunctionType.addWidget(self.checkBoxScore)
+
+        self.horizontalSpacerFunctionType = QSpacerItem(40, 20, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum)
+
+        self.horizontalLayoutFunctionType.addItem(self.horizontalSpacerFunctionType)
+
+
+        self.mainLayout.addWidget(self.groupBoxFunctionType)
+
+        self.groupBoxEnvironment = QGroupBox(AnnotationFilterWidget)
+        self.groupBoxEnvironment.setObjectName(u"groupBoxEnvironment")
+        self.horizontalLayoutEnvironment = QHBoxLayout(self.groupBoxEnvironment)
+        self.horizontalLayoutEnvironment.setSpacing(6)
+        self.horizontalLayoutEnvironment.setObjectName(u"horizontalLayoutEnvironment")
+        self.checkBoxWebAPI = QCheckBox(self.groupBoxEnvironment)
+        self.checkBoxWebAPI.setObjectName(u"checkBoxWebAPI")
+
+        self.horizontalLayoutEnvironment.addWidget(self.checkBoxWebAPI)
+
+        self.checkBoxLocal = QCheckBox(self.groupBoxEnvironment)
+        self.checkBoxLocal.setObjectName(u"checkBoxLocal")
+
+        self.horizontalLayoutEnvironment.addWidget(self.checkBoxLocal)
+
+        self.horizontalSpacerEnvironment = QSpacerItem(40, 20, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum)
+
+        self.horizontalLayoutEnvironment.addItem(self.horizontalSpacerEnvironment)
+
+
+        self.mainLayout.addWidget(self.groupBoxEnvironment)
+
+
+        self.retranslateUi(AnnotationFilterWidget)
+
+        QMetaObject.connectSlotsByName(AnnotationFilterWidget)
+    # setupUi
+
+    def retranslateUi(self, AnnotationFilterWidget: QWidget) -> None:
+        AnnotationFilterWidget.setWindowTitle(QCoreApplication.translate("AnnotationFilterWidget", u"Annotation Filter", None))
+        self.groupBoxFunctionType.setTitle(QCoreApplication.translate("AnnotationFilterWidget", u"\u6a5f\u80fd\u30bf\u30a4\u30d7", None))
+        self.checkBoxCaption.setText(QCoreApplication.translate("AnnotationFilterWidget", u"Caption\u751f\u6210", None))
+        self.checkBoxTags.setText(QCoreApplication.translate("AnnotationFilterWidget", u"Tag\u751f\u6210", None))
+        self.checkBoxScore.setText(QCoreApplication.translate("AnnotationFilterWidget", u"\u54c1\u8cea\u30b9\u30b3\u30a2", None))
+        self.groupBoxEnvironment.setTitle(QCoreApplication.translate("AnnotationFilterWidget", u"\u5b9f\u884c\u74b0\u5883\u9078\u629e", None))
+        self.checkBoxWebAPI.setText(QCoreApplication.translate("AnnotationFilterWidget", u"Web API", None))
+        self.checkBoxLocal.setText(QCoreApplication.translate("AnnotationFilterWidget", u"\u30ed\u30fc\u30ab\u30eb\u30e2\u30c7\u30eb", None))
+    # retranslateUi

--- a/src/lorairo/gui/designer/ErrorDetailDialog_ui.py
+++ b/src/lorairo/gui/designer/ErrorDetailDialog_ui.py
@@ -1,0 +1,202 @@
+# -*- coding: utf-8 -*-
+
+################################################################################
+## Form generated from reading UI file 'ErrorDetailDialog.ui'
+##
+## Created by: Qt User Interface Compiler version 6.11.1
+##
+## WARNING! All changes made in this file will be lost when recompiling UI file!
+################################################################################
+
+from PySide6.QtCore import (QCoreApplication, QDate, QDateTime, QLocale,
+    QMetaObject, QObject, QPoint, QRect,
+    QSize, QTime, QUrl, Qt)
+from PySide6.QtGui import (QBrush, QColor, QConicalGradient, QCursor,
+    QFont, QFontDatabase, QGradient, QIcon,
+    QImage, QKeySequence, QLinearGradient, QPainter,
+    QPalette, QPixmap, QRadialGradient, QTransform)
+from PySide6.QtWidgets import (QApplication, QDialog, QFormLayout, QGroupBox,
+    QHBoxLayout, QLabel, QLineEdit, QPushButton,
+    QSizePolicy, QSpacerItem, QTextEdit, QVBoxLayout,
+    QWidget)
+
+class Ui_ErrorDetailDialog(object):
+    def setupUi(self, ErrorDetailDialog: QWidget) -> None:
+        if not ErrorDetailDialog.objectName():
+            ErrorDetailDialog.setObjectName(u"ErrorDetailDialog")
+        ErrorDetailDialog.resize(600, 700)
+        ErrorDetailDialog.setModal(True)
+        self.verticalLayoutMain = QVBoxLayout(ErrorDetailDialog)
+        self.verticalLayoutMain.setSpacing(6)
+        self.verticalLayoutMain.setObjectName(u"verticalLayoutMain")
+        self.verticalLayoutMain.setContentsMargins(12, 12, 12, 12)
+        self.groupBoxBasicInfo = QGroupBox(ErrorDetailDialog)
+        self.groupBoxBasicInfo.setObjectName(u"groupBoxBasicInfo")
+        self.formLayoutBasicInfo = QFormLayout(self.groupBoxBasicInfo)
+        self.formLayoutBasicInfo.setObjectName(u"formLayoutBasicInfo")
+        self.formLayoutBasicInfo.setFieldGrowthPolicy(QFormLayout.FieldGrowthPolicy.ExpandingFieldsGrow)
+        self.labelOperationTypeText = QLabel(self.groupBoxBasicInfo)
+        self.labelOperationTypeText.setObjectName(u"labelOperationTypeText")
+
+        self.formLayoutBasicInfo.setWidget(0, QFormLayout.ItemRole.LabelRole, self.labelOperationTypeText)
+
+        self.lineEditOperationType = QLineEdit(self.groupBoxBasicInfo)
+        self.lineEditOperationType.setObjectName(u"lineEditOperationType")
+        self.lineEditOperationType.setReadOnly(True)
+
+        self.formLayoutBasicInfo.setWidget(0, QFormLayout.ItemRole.FieldRole, self.lineEditOperationType)
+
+        self.labelErrorTypeText = QLabel(self.groupBoxBasicInfo)
+        self.labelErrorTypeText.setObjectName(u"labelErrorTypeText")
+
+        self.formLayoutBasicInfo.setWidget(1, QFormLayout.ItemRole.LabelRole, self.labelErrorTypeText)
+
+        self.lineEditErrorType = QLineEdit(self.groupBoxBasicInfo)
+        self.lineEditErrorType.setObjectName(u"lineEditErrorType")
+        self.lineEditErrorType.setReadOnly(True)
+
+        self.formLayoutBasicInfo.setWidget(1, QFormLayout.ItemRole.FieldRole, self.lineEditErrorType)
+
+        self.labelErrorMessageText = QLabel(self.groupBoxBasicInfo)
+        self.labelErrorMessageText.setObjectName(u"labelErrorMessageText")
+
+        self.formLayoutBasicInfo.setWidget(2, QFormLayout.ItemRole.LabelRole, self.labelErrorMessageText)
+
+        self.textEditErrorMessage = QTextEdit(self.groupBoxBasicInfo)
+        self.textEditErrorMessage.setObjectName(u"textEditErrorMessage")
+        self.textEditErrorMessage.setMaximumSize(QSize(16777215, 60))
+        self.textEditErrorMessage.setReadOnly(True)
+
+        self.formLayoutBasicInfo.setWidget(2, QFormLayout.ItemRole.FieldRole, self.textEditErrorMessage)
+
+        self.labelFilePathText = QLabel(self.groupBoxBasicInfo)
+        self.labelFilePathText.setObjectName(u"labelFilePathText")
+
+        self.formLayoutBasicInfo.setWidget(3, QFormLayout.ItemRole.LabelRole, self.labelFilePathText)
+
+        self.lineEditFilePath = QLineEdit(self.groupBoxBasicInfo)
+        self.lineEditFilePath.setObjectName(u"lineEditFilePath")
+        self.lineEditFilePath.setReadOnly(True)
+
+        self.formLayoutBasicInfo.setWidget(3, QFormLayout.ItemRole.FieldRole, self.lineEditFilePath)
+
+        self.labelModelNameText = QLabel(self.groupBoxBasicInfo)
+        self.labelModelNameText.setObjectName(u"labelModelNameText")
+
+        self.formLayoutBasicInfo.setWidget(4, QFormLayout.ItemRole.LabelRole, self.labelModelNameText)
+
+        self.lineEditModelName = QLineEdit(self.groupBoxBasicInfo)
+        self.lineEditModelName.setObjectName(u"lineEditModelName")
+        self.lineEditModelName.setReadOnly(True)
+
+        self.formLayoutBasicInfo.setWidget(4, QFormLayout.ItemRole.FieldRole, self.lineEditModelName)
+
+        self.labelCreatedAtText = QLabel(self.groupBoxBasicInfo)
+        self.labelCreatedAtText.setObjectName(u"labelCreatedAtText")
+
+        self.formLayoutBasicInfo.setWidget(5, QFormLayout.ItemRole.LabelRole, self.labelCreatedAtText)
+
+        self.lineEditCreatedAt = QLineEdit(self.groupBoxBasicInfo)
+        self.lineEditCreatedAt.setObjectName(u"lineEditCreatedAt")
+        self.lineEditCreatedAt.setReadOnly(True)
+
+        self.formLayoutBasicInfo.setWidget(5, QFormLayout.ItemRole.FieldRole, self.lineEditCreatedAt)
+
+        self.labelRetryCountText = QLabel(self.groupBoxBasicInfo)
+        self.labelRetryCountText.setObjectName(u"labelRetryCountText")
+
+        self.formLayoutBasicInfo.setWidget(6, QFormLayout.ItemRole.LabelRole, self.labelRetryCountText)
+
+        self.lineEditRetryCount = QLineEdit(self.groupBoxBasicInfo)
+        self.lineEditRetryCount.setObjectName(u"lineEditRetryCount")
+        self.lineEditRetryCount.setReadOnly(True)
+
+        self.formLayoutBasicInfo.setWidget(6, QFormLayout.ItemRole.FieldRole, self.lineEditRetryCount)
+
+        self.labelResolvedAtText = QLabel(self.groupBoxBasicInfo)
+        self.labelResolvedAtText.setObjectName(u"labelResolvedAtText")
+
+        self.formLayoutBasicInfo.setWidget(7, QFormLayout.ItemRole.LabelRole, self.labelResolvedAtText)
+
+        self.lineEditResolvedAt = QLineEdit(self.groupBoxBasicInfo)
+        self.lineEditResolvedAt.setObjectName(u"lineEditResolvedAt")
+        self.lineEditResolvedAt.setReadOnly(True)
+
+        self.formLayoutBasicInfo.setWidget(7, QFormLayout.ItemRole.FieldRole, self.lineEditResolvedAt)
+
+
+        self.verticalLayoutMain.addWidget(self.groupBoxBasicInfo)
+
+        self.groupBoxStackTrace = QGroupBox(ErrorDetailDialog)
+        self.groupBoxStackTrace.setObjectName(u"groupBoxStackTrace")
+        self.verticalLayoutStackTrace = QVBoxLayout(self.groupBoxStackTrace)
+        self.verticalLayoutStackTrace.setObjectName(u"verticalLayoutStackTrace")
+        self.textEditStackTrace = QTextEdit(self.groupBoxStackTrace)
+        self.textEditStackTrace.setObjectName(u"textEditStackTrace")
+        self.textEditStackTrace.setReadOnly(True)
+        self.textEditStackTrace.setLineWrapMode(QTextEdit.LineWrapMode.NoWrap)
+
+        self.verticalLayoutStackTrace.addWidget(self.textEditStackTrace)
+
+
+        self.verticalLayoutMain.addWidget(self.groupBoxStackTrace)
+
+        self.groupBoxImagePreview = QGroupBox(ErrorDetailDialog)
+        self.groupBoxImagePreview.setObjectName(u"groupBoxImagePreview")
+        self.verticalLayoutImagePreview = QVBoxLayout(self.groupBoxImagePreview)
+        self.verticalLayoutImagePreview.setObjectName(u"verticalLayoutImagePreview")
+        self.labelImagePreview = QLabel(self.groupBoxImagePreview)
+        self.labelImagePreview.setObjectName(u"labelImagePreview")
+        self.labelImagePreview.setMinimumSize(QSize(400, 300))
+        self.labelImagePreview.setMaximumSize(QSize(400, 400))
+        self.labelImagePreview.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        self.labelImagePreview.setScaledContents(False)
+
+        self.verticalLayoutImagePreview.addWidget(self.labelImagePreview)
+
+
+        self.verticalLayoutMain.addWidget(self.groupBoxImagePreview)
+
+        self.horizontalLayoutButtons = QHBoxLayout()
+        self.horizontalLayoutButtons.setObjectName(u"horizontalLayoutButtons")
+        self.buttonMarkResolved = QPushButton(ErrorDetailDialog)
+        self.buttonMarkResolved.setObjectName(u"buttonMarkResolved")
+
+        self.horizontalLayoutButtons.addWidget(self.buttonMarkResolved)
+
+        self.horizontalSpacerButtons = QSpacerItem(40, 20, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum)
+
+        self.horizontalLayoutButtons.addItem(self.horizontalSpacerButtons)
+
+        self.buttonClose = QPushButton(ErrorDetailDialog)
+        self.buttonClose.setObjectName(u"buttonClose")
+
+        self.horizontalLayoutButtons.addWidget(self.buttonClose)
+
+
+        self.verticalLayoutMain.addLayout(self.horizontalLayoutButtons)
+
+
+        self.retranslateUi(ErrorDetailDialog)
+        self.buttonClose.clicked.connect(ErrorDetailDialog.accept)
+
+        QMetaObject.connectSlotsByName(ErrorDetailDialog)
+    # setupUi
+
+    def retranslateUi(self, ErrorDetailDialog: QWidget) -> None:
+        ErrorDetailDialog.setWindowTitle(QCoreApplication.translate("ErrorDetailDialog", u"\u30a8\u30e9\u30fc\u8a73\u7d30", None))
+        self.groupBoxBasicInfo.setTitle(QCoreApplication.translate("ErrorDetailDialog", u"\u57fa\u672c\u60c5\u5831", None))
+        self.labelOperationTypeText.setText(QCoreApplication.translate("ErrorDetailDialog", u"\u64cd\u4f5c\u7a2e\u5225:", None))
+        self.labelErrorTypeText.setText(QCoreApplication.translate("ErrorDetailDialog", u"\u30a8\u30e9\u30fc\u7a2e\u5225:", None))
+        self.labelErrorMessageText.setText(QCoreApplication.translate("ErrorDetailDialog", u"\u30a8\u30e9\u30fc\u30e1\u30c3\u30bb\u30fc\u30b8:", None))
+        self.labelFilePathText.setText(QCoreApplication.translate("ErrorDetailDialog", u"\u753b\u50cf\u30d1\u30b9:", None))
+        self.labelModelNameText.setText(QCoreApplication.translate("ErrorDetailDialog", u"\u30e2\u30c7\u30eb\u540d:", None))
+        self.labelCreatedAtText.setText(QCoreApplication.translate("ErrorDetailDialog", u"\u4f5c\u6210\u65e5\u6642:", None))
+        self.labelRetryCountText.setText(QCoreApplication.translate("ErrorDetailDialog", u"\u518d\u8a66\u884c\u56de\u6570:", None))
+        self.labelResolvedAtText.setText(QCoreApplication.translate("ErrorDetailDialog", u"\u89e3\u6c7a\u65e5\u6642:", None))
+        self.groupBoxStackTrace.setTitle(QCoreApplication.translate("ErrorDetailDialog", u"\u30b9\u30bf\u30c3\u30af\u30c8\u30ec\u30fc\u30b9", None))
+        self.groupBoxImagePreview.setTitle(QCoreApplication.translate("ErrorDetailDialog", u"\u753b\u50cf\u30d7\u30ec\u30d3\u30e5\u30fc", None))
+        self.labelImagePreview.setText(QCoreApplication.translate("ErrorDetailDialog", u"\u753b\u50cf\u30d7\u30ec\u30d3\u30e5\u30fc\u306a\u3057", None))
+        self.buttonMarkResolved.setText(QCoreApplication.translate("ErrorDetailDialog", u"\u89e3\u6c7a\u6e08\u307f\u306b\u30de\u30fc\u30af", None))
+        self.buttonClose.setText(QCoreApplication.translate("ErrorDetailDialog", u"\u9589\u3058\u308b", None))
+    # retranslateUi

--- a/src/lorairo/gui/designer/ErrorLogViewerWidget_ui.py
+++ b/src/lorairo/gui/designer/ErrorLogViewerWidget_ui.py
@@ -1,0 +1,229 @@
+# -*- coding: utf-8 -*-
+
+################################################################################
+## Form generated from reading UI file 'ErrorLogViewerWidget.ui'
+##
+## Created by: Qt User Interface Compiler version 6.11.1
+##
+## WARNING! All changes made in this file will be lost when recompiling UI file!
+################################################################################
+
+from PySide6.QtCore import (QCoreApplication, QDate, QDateTime, QLocale,
+    QMetaObject, QObject, QPoint, QRect,
+    QSize, QTime, QUrl, Qt)
+from PySide6.QtGui import (QBrush, QColor, QConicalGradient, QCursor,
+    QFont, QFontDatabase, QGradient, QIcon,
+    QImage, QKeySequence, QLinearGradient, QPainter,
+    QPalette, QPixmap, QRadialGradient, QTransform)
+from PySide6.QtWidgets import (QAbstractItemView, QApplication, QCheckBox, QComboBox,
+    QGroupBox, QHBoxLayout, QHeaderView, QLabel,
+    QPushButton, QSizePolicy, QSpacerItem, QSpinBox,
+    QTableWidget, QTableWidgetItem, QVBoxLayout, QWidget)
+
+class Ui_ErrorLogViewerWidget(object):
+    def setupUi(self, ErrorLogViewerWidget: QWidget) -> None:
+        if not ErrorLogViewerWidget.objectName():
+            ErrorLogViewerWidget.setObjectName(u"ErrorLogViewerWidget")
+        ErrorLogViewerWidget.resize(800, 600)
+        self.verticalLayoutMain = QVBoxLayout(ErrorLogViewerWidget)
+        self.verticalLayoutMain.setSpacing(6)
+        self.verticalLayoutMain.setObjectName(u"verticalLayoutMain")
+        self.verticalLayoutMain.setContentsMargins(6, 6, 6, 6)
+        self.groupBoxFilters = QGroupBox(ErrorLogViewerWidget)
+        self.groupBoxFilters.setObjectName(u"groupBoxFilters")
+        self.horizontalLayoutFilters = QHBoxLayout(self.groupBoxFilters)
+        self.horizontalLayoutFilters.setObjectName(u"horizontalLayoutFilters")
+        self.labelOperationType = QLabel(self.groupBoxFilters)
+        self.labelOperationType.setObjectName(u"labelOperationType")
+
+        self.horizontalLayoutFilters.addWidget(self.labelOperationType)
+
+        self.comboOperationType = QComboBox(self.groupBoxFilters)
+        self.comboOperationType.addItem("")
+        self.comboOperationType.addItem("")
+        self.comboOperationType.addItem("")
+        self.comboOperationType.addItem("")
+        self.comboOperationType.addItem("")
+        self.comboOperationType.addItem("")
+        self.comboOperationType.setObjectName(u"comboOperationType")
+
+        self.horizontalLayoutFilters.addWidget(self.comboOperationType)
+
+        self.checkBoxShowResolved = QCheckBox(self.groupBoxFilters)
+        self.checkBoxShowResolved.setObjectName(u"checkBoxShowResolved")
+
+        self.horizontalLayoutFilters.addWidget(self.checkBoxShowResolved)
+
+        self.buttonRefresh = QPushButton(self.groupBoxFilters)
+        self.buttonRefresh.setObjectName(u"buttonRefresh")
+
+        self.horizontalLayoutFilters.addWidget(self.buttonRefresh)
+
+        self.horizontalSpacerFilters = QSpacerItem(40, 20, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum)
+
+        self.horizontalLayoutFilters.addItem(self.horizontalSpacerFilters)
+
+
+        self.verticalLayoutMain.addWidget(self.groupBoxFilters)
+
+        self.tableWidgetErrors = QTableWidget(ErrorLogViewerWidget)
+        if (self.tableWidgetErrors.columnCount() < 8):
+            self.tableWidgetErrors.setColumnCount(8)
+        __qtablewidgetitem = QTableWidgetItem()
+        self.tableWidgetErrors.setHorizontalHeaderItem(0, __qtablewidgetitem)
+        __qtablewidgetitem1 = QTableWidgetItem()
+        self.tableWidgetErrors.setHorizontalHeaderItem(1, __qtablewidgetitem1)
+        __qtablewidgetitem2 = QTableWidgetItem()
+        self.tableWidgetErrors.setHorizontalHeaderItem(2, __qtablewidgetitem2)
+        __qtablewidgetitem3 = QTableWidgetItem()
+        self.tableWidgetErrors.setHorizontalHeaderItem(3, __qtablewidgetitem3)
+        __qtablewidgetitem4 = QTableWidgetItem()
+        self.tableWidgetErrors.setHorizontalHeaderItem(4, __qtablewidgetitem4)
+        __qtablewidgetitem5 = QTableWidgetItem()
+        self.tableWidgetErrors.setHorizontalHeaderItem(5, __qtablewidgetitem5)
+        __qtablewidgetitem6 = QTableWidgetItem()
+        self.tableWidgetErrors.setHorizontalHeaderItem(6, __qtablewidgetitem6)
+        __qtablewidgetitem7 = QTableWidgetItem()
+        self.tableWidgetErrors.setHorizontalHeaderItem(7, __qtablewidgetitem7)
+        self.tableWidgetErrors.setObjectName(u"tableWidgetErrors")
+        sizePolicy = QSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Expanding)
+        sizePolicy.setHorizontalStretch(0)
+        sizePolicy.setVerticalStretch(1)
+        sizePolicy.setHeightForWidth(self.tableWidgetErrors.sizePolicy().hasHeightForWidth())
+        self.tableWidgetErrors.setSizePolicy(sizePolicy)
+        self.tableWidgetErrors.setAlternatingRowColors(True)
+        self.tableWidgetErrors.setSelectionMode(QAbstractItemView.SelectionMode.ExtendedSelection)
+        self.tableWidgetErrors.setSelectionBehavior(QAbstractItemView.SelectionBehavior.SelectRows)
+        self.tableWidgetErrors.setHorizontalScrollMode(QAbstractItemView.ScrollMode.ScrollPerItem)
+        self.tableWidgetErrors.setSortingEnabled(True)
+        self.tableWidgetErrors.setWordWrap(False)
+        self.tableWidgetErrors.setColumnCount(8)
+        self.tableWidgetErrors.horizontalHeader().setVisible(True)
+        self.tableWidgetErrors.horizontalHeader().setStretchLastSection(True)
+        self.tableWidgetErrors.verticalHeader().setVisible(False)
+        self.tableWidgetErrors.verticalHeader().setDefaultSectionSize(24)
+
+        self.verticalLayoutMain.addWidget(self.tableWidgetErrors)
+
+        self.horizontalLayoutPagination = QHBoxLayout()
+        self.horizontalLayoutPagination.setObjectName(u"horizontalLayoutPagination")
+        self.buttonPreviousPage = QPushButton(ErrorLogViewerWidget)
+        self.buttonPreviousPage.setObjectName(u"buttonPreviousPage")
+
+        self.horizontalLayoutPagination.addWidget(self.buttonPreviousPage)
+
+        self.labelPageInfo = QLabel(ErrorLogViewerWidget)
+        self.labelPageInfo.setObjectName(u"labelPageInfo")
+        self.labelPageInfo.setAlignment(Qt.AlignmentFlag.AlignCenter)
+
+        self.horizontalLayoutPagination.addWidget(self.labelPageInfo)
+
+        self.buttonNextPage = QPushButton(ErrorLogViewerWidget)
+        self.buttonNextPage.setObjectName(u"buttonNextPage")
+
+        self.horizontalLayoutPagination.addWidget(self.buttonNextPage)
+
+        self.horizontalSpacerPagination = QSpacerItem(40, 20, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum)
+
+        self.horizontalLayoutPagination.addItem(self.horizontalSpacerPagination)
+
+        self.labelPageSize = QLabel(ErrorLogViewerWidget)
+        self.labelPageSize.setObjectName(u"labelPageSize")
+
+        self.horizontalLayoutPagination.addWidget(self.labelPageSize)
+
+        self.spinBoxPageSize = QSpinBox(ErrorLogViewerWidget)
+        self.spinBoxPageSize.setObjectName(u"spinBoxPageSize")
+        self.spinBoxPageSize.setMinimum(10)
+        self.spinBoxPageSize.setMaximum(500)
+        self.spinBoxPageSize.setValue(100)
+
+        self.horizontalLayoutPagination.addWidget(self.spinBoxPageSize)
+
+
+        self.verticalLayoutMain.addLayout(self.horizontalLayoutPagination)
+
+        self.horizontalLayoutButtons = QHBoxLayout()
+        self.horizontalLayoutButtons.setObjectName(u"horizontalLayoutButtons")
+        self.buttonViewDetails = QPushButton(ErrorLogViewerWidget)
+        self.buttonViewDetails.setObjectName(u"buttonViewDetails")
+
+        self.horizontalLayoutButtons.addWidget(self.buttonViewDetails)
+
+        self.buttonMarkResolved = QPushButton(ErrorLogViewerWidget)
+        self.buttonMarkResolved.setObjectName(u"buttonMarkResolved")
+
+        self.horizontalLayoutButtons.addWidget(self.buttonMarkResolved)
+
+        self.buttonExportLog = QPushButton(ErrorLogViewerWidget)
+        self.buttonExportLog.setObjectName(u"buttonExportLog")
+
+        self.horizontalLayoutButtons.addWidget(self.buttonExportLog)
+
+        self.horizontalSpacerButtons = QSpacerItem(40, 20, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum)
+
+        self.horizontalLayoutButtons.addItem(self.horizontalSpacerButtons)
+
+
+        self.verticalLayoutMain.addLayout(self.horizontalLayoutButtons)
+
+
+        self.retranslateUi(ErrorLogViewerWidget)
+
+        QMetaObject.connectSlotsByName(ErrorLogViewerWidget)
+    # setupUi
+
+    def retranslateUi(self, ErrorLogViewerWidget: QWidget) -> None:
+        ErrorLogViewerWidget.setWindowTitle(QCoreApplication.translate("ErrorLogViewerWidget", u"Error Log Viewer", None))
+        self.groupBoxFilters.setTitle(QCoreApplication.translate("ErrorLogViewerWidget", u"\u30d5\u30a3\u30eb\u30bf", None))
+        self.labelOperationType.setText(QCoreApplication.translate("ErrorLogViewerWidget", u"\u64cd\u4f5c\u7a2e\u5225:", None))
+        self.comboOperationType.setItemText(0, QCoreApplication.translate("ErrorLogViewerWidget", u"\u5168\u3066", None))
+        self.comboOperationType.setItemText(1, QCoreApplication.translate("ErrorLogViewerWidget", u"registration", None))
+        self.comboOperationType.setItemText(2, QCoreApplication.translate("ErrorLogViewerWidget", u"annotation", None))
+        self.comboOperationType.setItemText(3, QCoreApplication.translate("ErrorLogViewerWidget", u"processing", None))
+        self.comboOperationType.setItemText(4, QCoreApplication.translate("ErrorLogViewerWidget", u"search", None))
+        self.comboOperationType.setItemText(5, QCoreApplication.translate("ErrorLogViewerWidget", u"thumbnail", None))
+
+        self.checkBoxShowResolved.setText(QCoreApplication.translate("ErrorLogViewerWidget", u"\u89e3\u6c7a\u6e08\u307f\u3092\u8868\u793a", None))
+        self.buttonRefresh.setText(QCoreApplication.translate("ErrorLogViewerWidget", u"\u66f4\u65b0", None))
+        ___qtablewidgetitem = self.tableWidgetErrors.horizontalHeaderItem(0)
+        ___qtablewidgetitem.setText(QCoreApplication.translate("ErrorLogViewerWidget", u"ID", None))
+        ___qtablewidgetitem1 = self.tableWidgetErrors.horizontalHeaderItem(1)
+        ___qtablewidgetitem1.setText(QCoreApplication.translate("ErrorLogViewerWidget", u"\u4f5c\u6210\u65e5\u6642", None))
+        ___qtablewidgetitem2 = self.tableWidgetErrors.horizontalHeaderItem(2)
+        ___qtablewidgetitem2.setText(QCoreApplication.translate("ErrorLogViewerWidget", u"\u64cd\u4f5c\u7a2e\u5225", None))
+        ___qtablewidgetitem3 = self.tableWidgetErrors.horizontalHeaderItem(3)
+        ___qtablewidgetitem3.setText(QCoreApplication.translate("ErrorLogViewerWidget", u"\u30a8\u30e9\u30fc\u7a2e\u5225", None))
+        ___qtablewidgetitem4 = self.tableWidgetErrors.horizontalHeaderItem(4)
+        ___qtablewidgetitem4.setText(QCoreApplication.translate("ErrorLogViewerWidget", u"\u30a8\u30e9\u30fc\u30e1\u30c3\u30bb\u30fc\u30b8", None))
+        ___qtablewidgetitem5 = self.tableWidgetErrors.horizontalHeaderItem(5)
+        ___qtablewidgetitem5.setText(QCoreApplication.translate("ErrorLogViewerWidget", u"\u753b\u50cf\u30d5\u30a1\u30a4\u30eb\u540d", None))
+        ___qtablewidgetitem6 = self.tableWidgetErrors.horizontalHeaderItem(6)
+        ___qtablewidgetitem6.setText(QCoreApplication.translate("ErrorLogViewerWidget", u"\u30e2\u30c7\u30eb\u540d", None))
+        ___qtablewidgetitem7 = self.tableWidgetErrors.horizontalHeaderItem(7)
+        ___qtablewidgetitem7.setText(QCoreApplication.translate("ErrorLogViewerWidget", u"\u72b6\u614b", None))
+        self.tableWidgetErrors.setStyleSheet(QCoreApplication.translate("ErrorLogViewerWidget", u"QTableWidget {\n"
+"    font-size: 9px;\n"
+"    gridline-color: #e0e0e0;\n"
+"    selection-background-color: #e3f2fd;\n"
+"}\n"
+"QTableWidget::item {\n"
+"    padding: 4px;\n"
+"    color: palette(text);\n"
+"}\n"
+"QHeaderView::section {\n"
+"    font-size: 9px;\n"
+"    font-weight: bold;\n"
+"    background-color: palette(button);\n"
+"    color: palette(buttonText);\n"
+"    border: 1px solid palette(mid);\n"
+"    padding: 4px;\n"
+"}", None))
+        self.buttonPreviousPage.setText(QCoreApplication.translate("ErrorLogViewerWidget", u"< \u524d\u30da\u30fc\u30b8", None))
+        self.labelPageInfo.setText(QCoreApplication.translate("ErrorLogViewerWidget", u"Page 1 / 1", None))
+        self.buttonNextPage.setText(QCoreApplication.translate("ErrorLogViewerWidget", u"\u6b21\u30da\u30fc\u30b8 >", None))
+        self.labelPageSize.setText(QCoreApplication.translate("ErrorLogViewerWidget", u"\u8868\u793a\u4ef6\u6570:", None))
+        self.buttonViewDetails.setText(QCoreApplication.translate("ErrorLogViewerWidget", u"\u8a73\u7d30\u8868\u793a", None))
+        self.buttonMarkResolved.setText(QCoreApplication.translate("ErrorLogViewerWidget", u"\u89e3\u6c7a\u6e08\u307f\u306b\u30de\u30fc\u30af", None))
+        self.buttonExportLog.setText(QCoreApplication.translate("ErrorLogViewerWidget", u"\u30ed\u30b0\u3092\u30a8\u30af\u30b9\u30dd\u30fc\u30c8", None))
+    # retranslateUi

--- a/src/lorairo/gui/designer/TagManagementWidget_ui.py
+++ b/src/lorairo/gui/designer/TagManagementWidget_ui.py
@@ -1,0 +1,102 @@
+# -*- coding: utf-8 -*-
+
+################################################################################
+## Form generated from reading UI file 'TagManagementWidget.ui'
+##
+## Created by: Qt User Interface Compiler version 6.11.1
+##
+## WARNING! All changes made in this file will be lost when recompiling UI file!
+################################################################################
+
+from PySide6.QtCore import (QCoreApplication, QDate, QDateTime, QLocale,
+    QMetaObject, QObject, QPoint, QRect,
+    QSize, QTime, QUrl, Qt)
+from PySide6.QtGui import (QBrush, QColor, QConicalGradient, QCursor,
+    QFont, QFontDatabase, QGradient, QIcon,
+    QImage, QKeySequence, QLinearGradient, QPainter,
+    QPalette, QPixmap, QRadialGradient, QTransform)
+from PySide6.QtWidgets import (QAbstractItemView, QApplication, QHBoxLayout, QHeaderView,
+    QLabel, QPushButton, QSizePolicy, QSpacerItem,
+    QTableWidget, QTableWidgetItem, QVBoxLayout, QWidget)
+
+class Ui_TagManagementWidget(object):
+    def setupUi(self, TagManagementWidget: QWidget) -> None:
+        if not TagManagementWidget.objectName():
+            TagManagementWidget.setObjectName(u"TagManagementWidget")
+        TagManagementWidget.resize(800, 600)
+        self.verticalLayoutMain = QVBoxLayout(TagManagementWidget)
+        self.verticalLayoutMain.setSpacing(6)
+        self.verticalLayoutMain.setObjectName(u"verticalLayoutMain")
+        self.verticalLayoutMain.setContentsMargins(6, 6, 6, 6)
+        self.labelTitle = QLabel(TagManagementWidget)
+        self.labelTitle.setObjectName(u"labelTitle")
+        font = QFont()
+        font.setPointSize(12)
+        font.setBold(True)
+        self.labelTitle.setFont(font)
+
+        self.verticalLayoutMain.addWidget(self.labelTitle)
+
+        self.tableWidgetTags = QTableWidget(TagManagementWidget)
+        if (self.tableWidgetTags.columnCount() < 5):
+            self.tableWidgetTags.setColumnCount(5)
+        __qtablewidgetitem = QTableWidgetItem()
+        self.tableWidgetTags.setHorizontalHeaderItem(0, __qtablewidgetitem)
+        __qtablewidgetitem1 = QTableWidgetItem()
+        self.tableWidgetTags.setHorizontalHeaderItem(1, __qtablewidgetitem1)
+        __qtablewidgetitem2 = QTableWidgetItem()
+        self.tableWidgetTags.setHorizontalHeaderItem(2, __qtablewidgetitem2)
+        __qtablewidgetitem3 = QTableWidgetItem()
+        self.tableWidgetTags.setHorizontalHeaderItem(3, __qtablewidgetitem3)
+        __qtablewidgetitem4 = QTableWidgetItem()
+        self.tableWidgetTags.setHorizontalHeaderItem(4, __qtablewidgetitem4)
+        self.tableWidgetTags.setObjectName(u"tableWidgetTags")
+        self.tableWidgetTags.setEditTriggers(QAbstractItemView.EditTrigger.NoEditTriggers)
+        self.tableWidgetTags.setSelectionMode(QAbstractItemView.SelectionMode.NoSelection)
+        self.tableWidgetTags.setSelectionBehavior(QAbstractItemView.SelectionBehavior.SelectRows)
+        self.tableWidgetTags.setSortingEnabled(False)
+
+        self.verticalLayoutMain.addWidget(self.tableWidgetTags)
+
+        self.horizontalLayoutBottom = QHBoxLayout()
+        self.horizontalLayoutBottom.setObjectName(u"horizontalLayoutBottom")
+        self.labelStatus = QLabel(TagManagementWidget)
+        self.labelStatus.setObjectName(u"labelStatus")
+
+        self.horizontalLayoutBottom.addWidget(self.labelStatus)
+
+        self.horizontalSpacerBottom = QSpacerItem(40, 20, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum)
+
+        self.horizontalLayoutBottom.addItem(self.horizontalSpacerBottom)
+
+        self.buttonUpdate = QPushButton(TagManagementWidget)
+        self.buttonUpdate.setObjectName(u"buttonUpdate")
+        self.buttonUpdate.setEnabled(False)
+
+        self.horizontalLayoutBottom.addWidget(self.buttonUpdate)
+
+
+        self.verticalLayoutMain.addLayout(self.horizontalLayoutBottom)
+
+
+        self.retranslateUi(TagManagementWidget)
+
+        QMetaObject.connectSlotsByName(TagManagementWidget)
+    # setupUi
+
+    def retranslateUi(self, TagManagementWidget: QWidget) -> None:
+        TagManagementWidget.setWindowTitle(QCoreApplication.translate("TagManagementWidget", u"Tag Management", None))
+        self.labelTitle.setText(QCoreApplication.translate("TagManagementWidget", u"Unknown Type \u30bf\u30b0\u4e00\u89a7", None))
+        ___qtablewidgetitem = self.tableWidgetTags.horizontalHeaderItem(0)
+        ___qtablewidgetitem.setText(QCoreApplication.translate("TagManagementWidget", u"\u9078\u629e", None))
+        ___qtablewidgetitem1 = self.tableWidgetTags.horizontalHeaderItem(1)
+        ___qtablewidgetitem1.setText(QCoreApplication.translate("TagManagementWidget", u"Tag", None))
+        ___qtablewidgetitem2 = self.tableWidgetTags.horizontalHeaderItem(2)
+        ___qtablewidgetitem2.setText(QCoreApplication.translate("TagManagementWidget", u"Source Tag", None))
+        ___qtablewidgetitem3 = self.tableWidgetTags.horizontalHeaderItem(3)
+        ___qtablewidgetitem3.setText(QCoreApplication.translate("TagManagementWidget", u"Current Type", None))
+        ___qtablewidgetitem4 = self.tableWidgetTags.horizontalHeaderItem(4)
+        ___qtablewidgetitem4.setText(QCoreApplication.translate("TagManagementWidget", u"New Type", None))
+        self.labelStatus.setText(QCoreApplication.translate("TagManagementWidget", u"Status: Ready", None))
+        self.buttonUpdate.setText(QCoreApplication.translate("TagManagementWidget", u"\u66f4\u65b0\u5b9f\u884c", None))
+    # retranslateUi

--- a/src/lorairo/gui/services/widget_setup_service.py
+++ b/src/lorairo/gui/services/widget_setup_service.py
@@ -23,6 +23,16 @@ class WidgetSetupService:
     """
 
     @staticmethod
+    def _build_model_selection_filters(filters: dict[str, Any]) -> dict[str, Any]:
+        """AnnotationFilterWidget の出力を ModelSelectionWidget.apply_filters 引数へ変換する。"""
+        environment = filters.get("environment")
+        return {
+            "provider": "local" if environment == "local" else None,
+            "capabilities": filters.get("capabilities", []),
+            "exclude_local": environment == "api",
+        }
+
+    @staticmethod
     def setup_thumbnail_selector(
         main_window: Any, dataset_state_manager: DatasetStateManager | None
     ) -> None:
@@ -357,9 +367,7 @@ class WidgetSetupService:
         ):
             main_window.batchAnnotationFilter.filter_changed.connect(
                 lambda filters: main_window.batchModelSelection.apply_filters(
-                    provider="local" if filters.get("environment") == "local" else None,
-                    capabilities=filters.get("capabilities", []) or ["caption", "tags", "scores"],
-                    exclude_local=filters.get("environment") == "api",
+                    **WidgetSetupService._build_model_selection_filters(filters)
                 )
             )
             # アノテーション走査用デフォルトフィルター（upscaler除外）

--- a/src/lorairo/gui/services/widget_setup_service.py
+++ b/src/lorairo/gui/services/widget_setup_service.py
@@ -26,11 +26,22 @@ class WidgetSetupService:
     def _build_model_selection_filters(filters: dict[str, Any]) -> dict[str, Any]:
         """AnnotationFilterWidget の出力を ModelSelectionWidget.apply_filters 引数へ変換する。"""
         environment = filters.get("environment")
+        execution_env = {
+            "api": "APIモデルのみ",
+            "local": "ローカルモデルのみ",
+        }.get(environment)
         return {
-            "provider": "local" if environment == "local" else None,
+            "provider": None,
             "capabilities": filters.get("capabilities", []),
-            "exclude_local": environment == "api",
+            "exclude_local": False,
+            "execution_env": execution_env,
         }
+
+    @staticmethod
+    def _configure_batch_model_selection_widget(model_widget: Any) -> None:
+        """Batch annotation では外側の環境フィルターを唯一の操作面にする。"""
+        if hasattr(model_widget, "executionEnvCombo"):
+            model_widget.executionEnvCombo.setVisible(False)
 
     @staticmethod
     def setup_thumbnail_selector(
@@ -356,6 +367,8 @@ class WidgetSetupService:
 
             main_window.batchModelSelection = model_widget
             logger.info("✅ ModelSelectionWidget を追加完了 (mode=advanced)")
+
+        WidgetSetupService._configure_batch_model_selection_widget(main_window.batchModelSelection)
 
         # Signal接続
         if (

--- a/src/lorairo/gui/services/widget_setup_service.py
+++ b/src/lorairo/gui/services/widget_setup_service.py
@@ -26,10 +26,16 @@ class WidgetSetupService:
     def _build_model_selection_filters(filters: dict[str, Any]) -> dict[str, Any]:
         """AnnotationFilterWidget の出力を ModelSelectionWidget.apply_filters 引数へ変換する。"""
         environment = filters.get("environment")
-        execution_env = {
-            "api": "APIモデルのみ",
-            "local": "ローカルモデルのみ",
-        }.get(environment)
+        if not isinstance(environment, str):
+            environment = None
+        execution_env = (
+            {
+                "api": "APIモデルのみ",
+                "local": "ローカルモデルのみ",
+            }.get(environment)
+            if environment is not None
+            else None
+        )
         return {
             "provider": None,
             "capabilities": filters.get("capabilities", []),

--- a/tests/unit/gui/services/test_widget_setup_service.py
+++ b/tests/unit/gui/services/test_widget_setup_service.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from unittest.mock import Mock
+
 from lorairo.gui.services.widget_setup_service import WidgetSetupService
 
 
@@ -17,7 +19,8 @@ class TestWidgetSetupServiceModelSelectionFilters:
         assert filters == {
             "provider": None,
             "capabilities": [],
-            "exclude_local": True,
+            "exclude_local": False,
+            "execution_env": "APIモデルのみ",
         }
 
     def test_local_environment_keeps_empty_capabilities(self) -> None:
@@ -27,9 +30,10 @@ class TestWidgetSetupServiceModelSelectionFilters:
         )
 
         assert filters == {
-            "provider": "local",
+            "provider": None,
             "capabilities": [],
             "exclude_local": False,
+            "execution_env": "ローカルモデルのみ",
         }
 
     def test_capabilities_are_not_replaced_with_defaults(self) -> None:
@@ -42,6 +46,7 @@ class TestWidgetSetupServiceModelSelectionFilters:
             "provider": None,
             "capabilities": ["caption"],
             "exclude_local": False,
+            "execution_env": None,
         }
 
     def test_missing_capabilities_defaults_to_empty_list(self) -> None:
@@ -52,4 +57,13 @@ class TestWidgetSetupServiceModelSelectionFilters:
             "provider": None,
             "capabilities": [],
             "exclude_local": False,
+            "execution_env": None,
         }
+
+    def test_batch_model_selection_hides_internal_execution_env_combo(self) -> None:
+        """Batch annotationではModelSelectionWidget側の環境Comboを操作面にしない"""
+        model_widget = Mock()
+
+        WidgetSetupService._configure_batch_model_selection_widget(model_widget)
+
+        model_widget.executionEnvCombo.setVisible.assert_called_once_with(False)

--- a/tests/unit/gui/services/test_widget_setup_service.py
+++ b/tests/unit/gui/services/test_widget_setup_service.py
@@ -1,0 +1,55 @@
+"""WidgetSetupService の単体テスト"""
+
+from __future__ import annotations
+
+from lorairo.gui.services.widget_setup_service import WidgetSetupService
+
+
+class TestWidgetSetupServiceModelSelectionFilters:
+    """AnnotationFilterWidget から ModelSelectionWidget へのフィルター変換テスト"""
+
+    def test_api_environment_keeps_empty_capabilities(self) -> None:
+        """API環境のみ指定時、空capabilitiesは全件表示として保持する"""
+        filters = WidgetSetupService._build_model_selection_filters(
+            {"capabilities": [], "environment": "api"}
+        )
+
+        assert filters == {
+            "provider": None,
+            "capabilities": [],
+            "exclude_local": True,
+        }
+
+    def test_local_environment_keeps_empty_capabilities(self) -> None:
+        """ローカル環境のみ指定時、空capabilitiesは全件表示として保持する"""
+        filters = WidgetSetupService._build_model_selection_filters(
+            {"capabilities": [], "environment": "local"}
+        )
+
+        assert filters == {
+            "provider": "local",
+            "capabilities": [],
+            "exclude_local": False,
+        }
+
+    def test_capabilities_are_not_replaced_with_defaults(self) -> None:
+        """選択済みcapabilitiesは接続側でデフォルト上書きしない"""
+        filters = WidgetSetupService._build_model_selection_filters(
+            {"capabilities": ["caption"], "environment": None}
+        )
+
+        assert filters == {
+            "provider": None,
+            "capabilities": ["caption"],
+            "exclude_local": False,
+        }
+
+    def test_missing_capabilities_defaults_to_empty_list(self) -> None:
+        """capabilitiesキー欠落時も絞り込みなしとして扱う"""
+        filters = WidgetSetupService._build_model_selection_filters({"environment": None})
+
+        assert filters == {
+            "provider": None,
+            "capabilities": [],
+            "exclude_local": False,
+        }


### PR DESCRIPTION
## Summary
- Preserve empty capability filters from AnnotationFilterWidget instead of replacing them with caption/tags/scores
- Use AnnotationFilterWidget as the single execution environment source in batch annotation
- Hide ModelSelectionWidget.executionEnvCombo in the batch annotation model selection area
- Route environment filtering through execution_env instead of provider/exclude_local UI wiring
- Add WidgetSetupService regression tests for empty capability filters and batch environment ownership

## Tests
- uv run pytest tests/unit/gui/widgets/test_annotation_filter_widget.py tests/unit/gui/services/test_widget_setup_service.py -q
- uv run pytest tests/unit/gui/services/test_widget_setup_service.py -q
- uv run ruff check src/lorairo/gui/services/widget_setup_service.py tests/unit/gui/services/test_widget_setup_service.py

Fixes #299
Fixes #300