### PR TITLE
docs: add Codex parallel agent workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,6 +50,14 @@
 - Do not spawn sub-agents for trivial single-file fixes, one-command tasks, or changes where coordination overhead is larger than the work.
 - When a parent issue has a checklist of independent sub-issues, treat it as a default candidate for parallel workers and one PR per sub-issue unless the issue text explicitly requests a combined PR.
 
+## Codex tmux Monitoring Workflow
+- For large parallel work, Codex may create a `tmux` session to monitor worker progress in split panes.
+- Prefer one pane per worker worktree when practical, plus one lead pane for coordination.
+- Each worker pane should show the worker name, worktree path, branch, git status, latest commit, and current validation command or log.
+- `tmux` monitoring is observational; it does not replace the rule that each worker must use a dedicated `/tmp/worktrees/` checkout.
+- Use stable session names tied to the parent issue or branch, for example `codex-308` or `codex-agent-rules`.
+- Do not leave required long-running `tmux` sessions active without reporting the session name, active panes, and commands to the user.
+
 ## Security & Configuration Tips
 - Store API keys in a local `.env` (see `.env.example`). Never commit secrets.
 - Keep local data and logs out of version control (`logs/`, `lorairo_data/`).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,6 +38,18 @@
 - Create worktrees from the current remote base, for example: `git fetch origin && git worktree add /tmp/worktrees/issue-123 -b fix/issue-123 origin/main`.
 - Keep agent-specific rules as references to this file and `.claude/rules/git-workflow.md` rather than duplicating conflicting workflow text.
 
+## Codex Parallel Agent Workflow
+- For large, multi-issue, multi-PR, or broad refactoring work, Codex should proactively use sub-agents instead of serializing all work in one session.
+- Use parallel workers when tasks can be split by issue, module, ownership boundary, or test/verification responsibility.
+- Each worker must use its own dedicated git worktree under `/tmp/worktrees/`; do not let multiple workers edit the same worktree.
+- Assign each worker a clear branch name and file/module ownership before implementation starts, for example:
+  `git worktree add /tmp/worktrees/issue-304 -b fix/issue-304-thumbnail origin/main`.
+- Keep worker write scopes disjoint whenever possible. If two workers must touch the same file, the lead agent should sequence those changes or handle that integration directly.
+- The lead Codex session is responsible for coordination: defining worker scope, checking for overlapping edits, reviewing diffs, running or confirming tests, creating PRs, and updating parent issue checklists after merge.
+- Prefer worker agents for implementation, explorer agents for codebase investigation, test-runner agents for verification, and code-reviewer agents for PR review when those roles can run independently.
+- Do not spawn sub-agents for trivial single-file fixes, one-command tasks, or changes where coordination overhead is larger than the work.
+- When a parent issue has a checklist of independent sub-issues, treat it as a default candidate for parallel workers and one PR per sub-issue unless the issue text explicitly requests a combined PR.
+
 ## Security & Configuration Tips
 - Store API keys in a local `.env` (see `.env.example`). Never commit secrets.
 - Keep local data and logs out of version control (`logs/`, `lorairo_data/`).


### PR DESCRIPTION
## Summary
- Add Codex-specific guidance for proactively using sub-agents on large multi-issue or multi-PR work
- Require a dedicated git worktree per worker under /tmp/worktrees
- Clarify lead-agent coordination duties for PR creation, merge checks, and parent issue checklist updates

## Validation
- Documentation-only change; no tests run