### PR TITLE
refactor: finish issue 308 compatibility cleanup

### DIFF
--- a/docs/decisions/0030-batch-annotation-model-selection-ui.md
+++ b/docs/decisions/0030-batch-annotation-model-selection-ui.md
@@ -1,0 +1,212 @@
+# ADR 0030: Batch Annotation Model Selection UI
+
+- **日付**: 2026-05-20
+- **ステータス**: Accepted
+
+## Context
+
+Batch Tag のアノテーション設定 UI は、モデル選択の入口が複数あり、現在の適用条件をユーザーが
+読み取りにくい。
+
+現在の主な構成は以下。
+
+- `AnnotationFilterWidget`
+  - 機能タイプ: `Caption生成` / `Tag生成` / `品質スコア`
+  - 実行環境: `Web API` / `ローカルモデル`
+- `ModelSelectionWidget`
+  - 一覧上部に `executionEnvCombo` (`すべて` / `APIモデルのみ` / `ローカルモデルのみ`)
+  - `apply_filters(provider, capabilities, exclude_local, execution_env)` で複数条件を受ける
+- `WidgetSetupService`
+  - `AnnotationFilterWidget.filter_changed` を `ModelSelectionWidget.apply_filters()` に接続
+  - 空の `capabilities` を `["caption", "tags", "scores"]` に置換
+
+この構成では、実行環境フィルタが二系統に分かれ、さらに UI のチェック状態と実際の適用条件が
+一致しない。結果として「表示されない」「絞り込みが効いているのか分からない」という体験になる。
+
+関連 Issue:
+
+- LoRAIro #298: provider=None のローカル/APIモデル判定とフィルタ条件の不整合
+- LoRAIro #299: 空の機能フィルタ時にデフォルト上書きされ全件表示が不可能
+- LoRAIro #300: モデル実行環境フィルタが複数 UI 経路で分断され UX が不明瞭
+
+### Historical Background
+
+この UI は一度に設計されたものではなく、複数回の段階的統合と不具合回避の積み重ねで現在の形に
+なっている。
+
+- 2025-07-29: `924e1f0d` (`feat: Add hybrid annotation UI prototype and supporting components`)
+  - multi-model annotation interface の基礎として `ModelSelectionWidget` が追加された。
+- 2025-07-29: `3a2e44f5`
+  (`feat: Complete Phase 1 hybrid annotation UI implementation and plan Phase 2.5 architecture refactoring`)
+  - `AnnotationControlWidget` が追加され、当時の設計書
+    `tasks/plans/hybrid_annotation_ui_comprehensive_design_plan_20250729.md` では
+    「実行環境選択 (Web API / ローカルモデル)」と「機能タイプ選択」を持つ設計だった。
+  - 同設計書は「既存ウィジェット最大活用」「デッドコード削除」を掲げていたが、後続で UI が分割され、
+    一部の責務が複数 Widget に残った。
+- 2025-07-30: `4043e581`
+  (`feat: Complete Phase 2.5 architectural refactoring with unified filter system`)
+  - Qt Designer + Service layer 分離の一環として `ModelSelectionWidget.ui` と
+    `ModelSelectionService` が整備された。
+- 2025-08-06: `88203110`
+  (`feat: complete Phase 4 ModelSelectionWidget integration`)
+  - `ModelSelectionWidget` が `ModelSelectionCriteria` を使う高度なフィルタリング UI として
+    近代化された。この時点で汎用性・後方互換性を重視した設計が入った。
+- 2026-01-21: `9ebe8733`
+  (`feat: Add AnnotationFilterWidget for batch tag annotation filtering`)
+  - Batch Tag タブ向けに `AnnotationFilterWidget` が追加され、capability checkbox と
+    environment checkbox が `ModelSelectionWidget` へ接続された。
+  - 同時に `exclude_local` が追加され、Web API フィルタを provider 系の条件で表現する経路が入った。
+- 2026-01-22: `08af6c23`
+  (`fix: AnnotationFilterWidget set_filters environment clearing`)
+  - `set_filters(environment=None)` のクリア挙動を直すため `_UNSET` sentinel が追加された。
+  - これは「未指定」と「明示クリア」を区別するための互換実装で、現在の UI 状態モデルを複雑にしている。
+- 2026-02-10: `170e5904`
+  (`fix: アノテーション走査でアップスケーラーモデルを非表示化`)
+  - 初期状態で upscaler が表示される問題を避けるため、`["caption", "tags", "scores"]` の
+    デフォルト capability filter が追加された。
+- 2026-02-10: `e760506c`
+  (`fix: Web APIフィルター適用時のマニュアルedit・アップスケーラー表示除外`)
+  - 環境フィルタだけ操作した場合にも MANUAL_EDIT / upscaler が表示されないよう、
+    空 capability を `["caption", "tags", "scores"]` に補完する処理が追加された。
+- 2026-05-12: `6415d54c` (`fix(#245): ライブラリ送信値を Model.litellm_model_id に統一`)
+  - GUI のモデル識別子が `Model.name` から `Model.litellm_model_id` へ移った。
+- 2026-05-13: `780b624e`
+  (`fix(#241): API key 状況に応じたモデル表示フィルタと事前 validation`)
+  - direct / openrouter route の畳み込みと API key 状況に応じた表示制御が追加された。
+- 2026-05-13: `e90121b1`
+  (`feat(#249): モデル route preference の永続化と GUI 設定 (Phase 2)`)
+  - route preference が config / 設定画面に移され、`ModelSelectionWidget` は route 表示・選択も
+    担うようになった。
+
+つまり現在の使いにくさは、過去の個別問題に対して `WidgetSetupService` と
+`ModelSelectionWidget` に条件を追加してきた結果であり、単一の設計意図ではない。
+
+## Decision
+
+Batch Tag のアノテーションモデル選択 UI は、以下の **二段階フィルタ** に統一する。
+
+1. **実行環境を選ぶ**
+   - `Web API`
+   - `ローカル`
+2. **選択された実行環境の中でタスクを絞る**
+   - `Caption`
+   - `Tags`
+   - `Scores`
+   - `すべて`
+
+### SSoT
+
+Batch annotation におけるフィルタ状態の SSoT は、アノテーション設定領域のフィルタ UI とする。
+
+`ModelSelectionWidget` は、渡されたフィルタ状態に従って候補モデルを表示し、選択状態を管理する
+表示・選択コンポーネントに寄せる。
+
+### 削除・非採用
+
+以下は Batch annotation UI から削除する。
+
+- `ModelSelectionWidget.executionEnvCombo`
+  - 理由: `AnnotationFilterWidget` 側の実行環境選択と重複し、現在の適用条件を不透明にするため。
+- `exclude_local` を UI 層で直接受け渡す経路
+  - 理由: 「APIのみ」という UI 表現と provider 正規化が混ざるため。実行環境は
+    `environment = "api" | "local"` として表現する。
+- 空の `capabilities` を `["caption", "tags", "scores"]` に暗黙補完する経路
+  - 理由: UI 上の未選択状態と実際のフィルタ条件がズレるため。
+- `provider="local"` を UI 層から直接注入する経路
+  - 理由: provider と実行環境は同じ概念ではない。ローカル判定は `requires_api_key` /
+    model registry metadata 側で扱う。
+
+### 採用する意味論
+
+`environment`:
+
+```python
+Literal["api", "local"]
+```
+
+Batch annotation の実行対象モデル選択では、環境未選択状態を持たない。初期値は利用者が次に行う
+実行を明確にするため `api` または `local` のどちらかに決める。初期値は実装時に config /
+利用頻度を見て決めるが、UI 上は常に片方が選択される。
+
+`task_filter`:
+
+```python
+Literal["all", "caption", "tags", "scores"]
+```
+
+`all` は「選択中の実行環境に存在する全タスク」を意味する。空配列や `None` を UI 操作上の
+「すべて」として扱わない。
+
+### 表示方針
+
+- フィルタは上から順に `環境 -> タスク -> モデル一覧` の順で配置する。
+- モデル一覧の上には現在の適用条件を短く表示する。
+  - 例: `Web API / Tags`
+  - 例: `ローカル / すべて`
+- モデル一覧は provider group よりもタスク適合性と選択状態を優先して見せる。
+- route preference (`auto` / `direct` / `openrouter`) はモデル実行経路の設定であり、
+  Batch annotation の一次フィルタ UI には出さない。既存の設定画面に残す。
+
+## Rationale
+
+### なぜ二段階フィルタか
+
+アノテーション実行時に最初に必要な判断は「Web API を使うか、ローカルで処理するか」である。
+この判断は API key、速度、コスト、オフライン性に直結するため、タスク種別よりも上位の意思決定になる。
+
+その後に `Caption` / `Tags` / `Scores` を絞る方が、ユーザーの意図とモデル候補の出方が一致する。
+
+### なぜ `executionEnvCombo` を残さないか
+
+同じ概念を別 UI に残すと、片方の見た目と実際の適用条件がズレる。これは実装上の互換性よりも
+操作体験への悪影響が大きい。
+
+Batch annotation の model selection では `AnnotationFilterWidget` 相当のフィルタ UI を
+唯一の入力源にする。
+
+### なぜ空配列を「すべて」としないか
+
+空配列は「何も選んでいない」に見える。これを内部で `caption/tags/scores` に置換すると、
+UI 表示と適用条件が一致しなくなる。
+
+ユーザーに見える状態として `すべて` を用意し、その値をそのままフィルタ条件へ渡す。
+
+### なぜ provider ではなく environment か
+
+`provider` は `openai` / `anthropic` / `google` / `openrouter` / `local` などの
+ルーティング・由来の情報であり、実行環境とは一致しない。
+
+Batch annotation の一次判断は `requires_api_key` に近い。UI は provider を直接操作せず、
+`environment` として扱う。
+
+## Consequences
+
+### 良い点
+
+- 現在の適用条件が `環境 -> タスク` の順で読み取れる。
+- 実行環境フィルタの重複がなくなる。
+- 「全件表示」が明示的に表現できる。
+- UI 層から provider 正規化の知識を削れる。
+- 古い互換経路を減らし、テスト対象が狭くなる。
+
+### 悪い点・トレードオフ
+
+- `ModelSelectionWidget` を他画面で汎用フィルタ UI として使っている場合、呼び出し側の移行が必要。
+- `executionEnvCombo` に依存した既存テストは削除または仕様変更が必要。
+- 初期値を `api` / `local` のどちらにするかは、実利用に基づいて別途決める必要がある。
+
+### 実装方針
+
+実装 Issue では以下の順で進める。
+
+1. `AnnotationFilterWidget` の UI モデルを `environment` + `task_filter` に再定義する。
+2. `ModelSelectionWidget.apply_filters()` の入力を `environment` + `task_filter` 中心に縮約する。
+3. Batch annotation 経路から `executionEnvCombo` / `exclude_local` / `provider="local"` 注入を削除する。
+4. `ModelSelectionService` 側は `environment` を `requires_api_key` 判定へ変換し、provider 直指定に依存しない。
+5. 既存テストを二段階フィルタ仕様へ更新する。
+
+## Related
+
+- ADR 0023: PydanticAI / LiteLLM WebAPI Inference Boundary
+- ADR 0026: On-Demand Runtime Validation Strategy
+- ADR 0029: Unified Dataset Quality Tier

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -33,6 +33,7 @@ LoRAIro の重要な設計判断を記録するドキュメント群。
 | [0027](0027-score-labels-db-storage.md) | Score Labels DB Storage | 2026-05-17 | Accepted |
 | [0028](0028-score-labels-usage-and-display.md) | Score Labels Usage and Display Strategy | 2026-05-18 | Accepted |
 | [0029](0029-unified-dataset-quality-tier.md) | Unified Dataset Quality Tier | 2026-05-19 | Accepted |
+| [0030](0030-batch-annotation-model-selection-ui.md) | Batch Annotation Model Selection UI | 2026-05-20 | Accepted |
 
 ## ADR テンプレート
 

--- a/src/lorairo/gui/services/search_filter_service.py
+++ b/src/lorairo/gui/services/search_filter_service.py
@@ -58,12 +58,10 @@ class SearchFilterService:
         self.model_selection_service = model_selection_service
         self.model_registry = model_registry or NullModelRegistry()
 
-        # 新しいサービス層(依存性注入)
-        from ...services.model_filter_service import ModelFilterService
+        # 検索実行は SearchCriteriaProcessor を正規経路とし、GUI サービスは条件構築に寄せる。
         from ...services.search_criteria_processor import SearchCriteriaProcessor
 
         self.criteria_processor = SearchCriteriaProcessor(db_manager)
-        self.model_filter_service = ModelFilterService(db_manager, model_selection_service)
 
         # UI状態管理
         self.current_conditions: SearchConditions | None = None
@@ -326,8 +324,6 @@ class SearchFilterService:
         """UI状態管理:現在の検索条件を取得"""
         return self.current_conditions
 
-    # === 後方互換性ラッパーメソッド(段階的移行用) ===
-
     def get_estimated_count(self, conditions: SearchConditions) -> int:
         """現在の検索条件に対する概算件数を取得する。"""
         try:
@@ -335,18 +331,6 @@ class SearchFilterService:
         except Exception as e:
             logger.error(f"概算件数の取得中にエラーが発生しました: {e}", exc_info=True)
             return 0
-
-    def execute_search_with_filters(self, conditions: SearchConditions) -> tuple[list[dict[str, Any]], int]:
-        """後方互換性ラッパー:SearchCriteriaProcessorに委譲"""
-        return self.criteria_processor.execute_search_with_filters(conditions)
-
-    def get_annotation_models_list(self) -> list[dict[str, Any]]:
-        """後方互換性ラッパー:ModelFilterServiceに委譲"""
-        return self.model_filter_service.get_annotation_models_list()
-
-    def validate_annotation_settings(self, settings: dict[str, Any]) -> ValidationResult:
-        """後方互換性ラッパー:ModelFilterServiceに委譲"""
-        return self.model_filter_service.validate_annotation_settings(settings)
 
     def filter_models_by_criteria(
         self,

--- a/src/lorairo/gui/widgets/filter_search_panel.py
+++ b/src/lorairo/gui/widgets/filter_search_panel.py
@@ -1274,8 +1274,11 @@ class FilterSearchPanel(QScrollArea):
             if conditions is None:
                 return
 
-            # 検索実行
-            results, count = self.search_filter_service.execute_search_with_filters(conditions)
+            # 検索実行は SearchCriteriaProcessor を正規経路とする。
+            # SearchFilterService の旧委譲 API は #308 完了条件に従って削除済み。
+            results, count = self.search_filter_service.criteria_processor.execute_search_with_filters(
+                conditions
+            )
 
             # プレビュー更新
             self.update_search_preview(count)

--- a/tests/integration/gui/test_filter_search_integration.py
+++ b/tests/integration/gui/test_filter_search_integration.py
@@ -105,6 +105,7 @@ class TestFilterSearchIntegration:
     def test_service_layer_integration(self, integrated_services, mock_dependencies):
         """サービス層統合テスト"""
         search_filter_service = integrated_services["search_filter_service"]
+        criteria_processor = integrated_services["criteria_processor"]
         mock_images = mock_dependencies["mock_images"]
 
         # 検索条件作成
@@ -113,7 +114,7 @@ class TestFilterSearchIntegration:
         )
 
         # 検索実行（新しいサービス層経由）
-        results, count = search_filter_service.execute_search_with_filters(conditions)
+        results, count = criteria_processor.execute_search_with_filters(conditions)
 
         # 結果確認
         assert len(results) == 2

--- a/tests/unit/gui/services/test_search_filter_service.py
+++ b/tests/unit/gui/services/test_search_filter_service.py
@@ -341,30 +341,6 @@ class TestSearchFilterServiceDatabase:
         assert service_with_db.db_manager == mock_db_manager
         assert service_with_db.current_conditions is None
 
-    def test_execute_search_with_filters_success(self, service_with_db, mock_db_manager):
-        """検索実行成功テスト"""
-        # モックデータベースマネージャーの設定
-        mock_images = [
-            {"id": 1, "width": 1024, "height": 768, "created_at": "2023-01-01T00:00:00Z"},
-            {"id": 2, "width": 512, "height": 512, "created_at": "2023-06-01T00:00:00Z"},
-        ]
-        mock_db_manager.get_images_by_filter.return_value = (mock_images, 2)
-
-        # 検索条件作成
-        conditions = SearchConditions(search_type="tags", keywords=["test"], tag_logic="and")
-
-        # 検索実行
-        results, count = service_with_db.execute_search_with_filters(conditions)
-
-        # 結果検証
-        assert len(results) == 2
-        assert count == 2
-        assert results[0]["id"] == 1
-        assert results[1]["id"] == 2
-
-        # データベースマネージャーが正しく呼ばれたことを確認
-        mock_db_manager.get_images_by_filter.assert_called_once()
-
 
 class TestSearchFilterServiceAnnotation:
     """SearchFilterService のアノテーション系機能テスト（Phase 2拡張）"""
@@ -376,17 +352,14 @@ class TestSearchFilterServiceAnnotation:
 
         return Mock()
 
-    def test_get_annotation_models_list_modernized(self, mock_db_manager):
-        """現代化されたSearchFilterServiceでのモデル一覧取得テスト"""
+    def test_annotation_model_filter_service_is_not_exposed(self, mock_db_manager):
+        """SearchFilterService はモデル一覧互換ラッパーを公開しない。"""
         from unittest.mock import Mock
 
-        # NullModelRegistryを使用する現代化されたSearchFilterService
         mock_model_selection_service = Mock()
         service = SearchFilterService(
             db_manager=mock_db_manager, model_selection_service=mock_model_selection_service
         )
 
-        models = service.get_annotation_models_list()
-
-        # NullModelRegistryでは空リストが返される
-        assert models == []
+        assert not hasattr(service, "get_annotation_models_list")
+        assert not hasattr(service, "validate_annotation_settings")

--- a/tests/unit/gui/widgets/test_custom_range_slider.py
+++ b/tests/unit/gui/widgets/test_custom_range_slider.py
@@ -555,7 +555,7 @@ class TestFilterSearchPanel:
             "search_text": "test",
             "search_type": "tags",
         }
-        mock_search_service.execute_search_with_filters.return_value = ([], 0)
+        mock_search_service.criteria_processor.execute_search_with_filters.return_value = ([], 0)
         filter_panel.search_filter_service = mock_search_service
 
         # UI状態をセットアップ（直接モックされた要素を使用、チェックボックス更新）


### PR DESCRIPTION
## Summary
- Remove remaining SearchFilterService compatibility wrapper methods and route the FilterSearchPanel synchronous fallback through SearchCriteriaProcessor
- Drop the unused ModelFilterService delegate from SearchFilterService
- Commit ADR 0030 as Accepted and register it in the ADR index

## Issue #308 follow-up
This addresses the two gaps noted after reopening #308:
- #303 compatibility wrappers are removed instead of retained without a deadline
- ADR 0030 is committed as Accepted and indexed

## Validation
- uv run pytest tests/unit/gui/services/test_search_filter_service.py tests/integration/gui/test_filter_search_integration.py tests/unit/gui/widgets/test_custom_range_slider.py -q
- uv run ruff check src/lorairo/gui/services/search_filter_service.py src/lorairo/gui/widgets/filter_search_panel.py tests/unit/gui/services/test_search_filter_service.py tests/integration/gui/test_filter_search_integration.py tests/unit/gui/widgets/test_custom_range_slider.py
- uv run mypy src/lorairo/gui/services/search_filter_service.py src/lorairo/gui/widgets/filter_search_panel.py
- git diff --check

Closes #308