### PR TITLE
[codex] Add agent diagnostic log guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,12 @@
 - Coverage: fails under 75% (`coverage` config in `pyproject.toml`).
 - Example: `uv run pytest -m "fast"` to run quick unit tests.
 
+## Diagnostic Log Context
+- `logs/lorairo.log` and `logs/image-annotator-lib.log` are intentionally gitignored, but they are first-class debugging context.
+- When investigating runtime errors, failed GUI flows, annotation/model issues, worker failures, or test failures that may involve app behavior, inspect these logs proactively even if the user did not attach or mention them.
+- Prefer bounded reads such as `tail -200 logs/lorairo.log` and `tail -200 logs/image-annotator-lib.log`; if a file is missing, note that and continue.
+- Do not add these logs to git or include large log dumps in responses; summarize only the relevant lines.
+
 ## Commit & Pull Request Guidelines
 - Commit messages follow Conventional Commits: `feat: ...`, `refactor: ...`, `docs: ...`, `test: ...`, `chore: ...`.
 - PRs should include a clear description, test results, and screenshots for GUI changes.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,6 +74,19 @@ make test-genai-tag                # genai-tag-db-tools
 make test-all                      # 3 セッションを順次実行
 ```
 
+### Diagnostic Logs
+
+`logs/lorairo.log` and `logs/image-annotator-lib.log` are intentionally gitignored, but they are first-class debugging context. When investigating runtime errors, failed GUI flows, annotation/model issues, worker failures, or test failures that may involve app behavior, inspect them proactively even if the user did not attach or mention them.
+
+Use bounded reads:
+
+```bash
+tail -200 logs/lorairo.log
+tail -200 logs/image-annotator-lib.log
+```
+
+If a log file is missing, note that and continue. Do not add these logs to git or paste large log dumps in responses; summarize only relevant lines.
+
 ### Code Quality
 
 ```bash


### PR DESCRIPTION
## Summary

Adds explicit diagnostic log guidance for both Codex and Claude Code so the gitignored runtime logs are still treated as first-class debugging context when investigating app behavior.

## Changes

- Documents proactive bounded reads of `logs/lorairo.log` in `AGENTS.md`.
- Documents proactive bounded reads of `logs/image-annotator-lib.log` in `AGENTS.md` and `CLAUDE.md`.
- Clarifies that agents should summarize relevant log lines without adding logs to git or pasting large dumps.

## Validation

- Ran `git diff --check` locally before publishing.
- Verified GitHub compare: branch is 2 commits ahead of `main`, touching only `AGENTS.md` and `CLAUDE.md`.

## Notes

Local `gh` auth and SSH push were unavailable in the workspace, so the remote branch and commits were created through the GitHub connector.