### PR TITLE
[codex] fix skill YAML frontmatter descriptions

### DIFF
--- a/.agents/skills/claude-md-progressive-disclosurer/SKILL.md
+++ b/.agents/skills/claude-md-progressive-disclosurer/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: claude-md-progressive-disclosurer
 version: "1.0.0"
-description: Optimize CLAUDE.md files using progressive disclosure: reduce bloat, move details to references, extract reusable patterns into skills, improve context efficiency. Use when CLAUDE.md is too long or needs restructuring.
+description: "Optimize CLAUDE.md files using progressive disclosure: reduce bloat, move details to references, extract reusable patterns into skills, improve context efficiency. Use when CLAUDE.md is too long or needs restructuring."
 ---
 
 # CLAUDE.md Progressive Disclosure Optimizer

--- a/.agents/skills/github-ops/SKILL.md
+++ b/.agents/skills/github-ops/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: github-ops
 version: "1.0.0"
-description: GitHub operations via gh CLI and GitHub API: create/view/merge PRs, manage issues, query API endpoints, handle workflows in enterprise or public GitHub environments.
+description: "GitHub operations via gh CLI and GitHub API: create/view/merge PRs, manage issues, query API endpoints, handle workflows in enterprise or public GitHub environments."
 ---
 
 # GitHub Operations

--- a/.agents/skills/lorairo-repository-pattern/SKILL.md
+++ b/.agents/skills/lorairo-repository-pattern/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: lorairo-repository-pattern
 version: "1.0.0"
-description: SQLAlchemy repository pattern for LoRAIro: type-safe transactions, session management, ORM best practices. Use when creating repositories or implementing data persistence patterns.
+description: "SQLAlchemy repository pattern for LoRAIro: type-safe transactions, session management, ORM best practices. Use when creating repositories or implementing data persistence patterns."
 metadata:
   short-description: LoRAIro向けSQLAlchemyリポジトリ実装（トランザクション、セッション、ORM）。
 allowed-tools:

--- a/.agents/skills/qa-expert/SKILL.md
+++ b/.agents/skills/qa-expert/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: qa-expert
 version: "1.0.0"
-description: Establish QA testing processes: test strategies, Google Testing Standards, P0-P4 bug tracking, OWASP security, quality metrics, 90% coverage targets. Includes master prompts for autonomous execution and third-party QA team handoff documentation.
+description: "Establish QA testing processes: test strategies, Google Testing Standards, P0-P4 bug tracking, OWASP security, quality metrics, 90% coverage targets. Includes master prompts for autonomous execution and third-party QA team handoff documentation."
 keywords: [qa, testing, test-cases, bug-tracking, google-standards, owasp, security, automation, quality-gates, metrics]
 ---
 


### PR DESCRIPTION
## Summary

- Quote four skill `description` frontmatter values that contain `: ` sequences.
- Keep the change limited to YAML validity; no skill body or metadata restructuring.

## Validation

- Ran `rg -n '^description: [^\"].*: ' .agents/skills -g 'SKILL.md'` and confirmed no remaining matches.