### PR TITLE
[codex] Separate CLI log file

### DIFF
--- a/src/lorairo/cli/main.py
+++ b/src/lorairo/cli/main.py
@@ -22,7 +22,7 @@ from lorairo.cli._console import make_console
 from lorairo.cli._glyphs import FAIL, OK
 from lorairo.cli.commands import annotate, export, images, models, project
 from lorairo.services.service_container import get_service_container
-from lorairo.utils.config import DEFAULT_CONFIG_PATH
+from lorairo.utils.config import DEFAULT_CLI_LOG_PATH, DEFAULT_CONFIG_PATH
 from lorairo.utils.log import initialize_logging
 
 if TYPE_CHECKING:
@@ -133,7 +133,14 @@ def main() -> None:
     import os
 
     os.environ.setdefault("LORAIRO_CLI_MODE", "true")
-    initialize_logging({"level": "WARNING"})  # CLI モード: DEBUG/INFO を抑制
+    initialize_logging(
+        {
+            "level": "WARNING",  # CLI モード: DEBUG/INFO を抑制
+            "file_path": str(DEFAULT_CLI_LOG_PATH),
+            "rotation": "25 MB",
+            "levels": {},
+        }
+    )
     app()
 
 

--- a/src/lorairo/utils/config.py
+++ b/src/lorairo/utils/config.py
@@ -27,6 +27,7 @@ def get_project_root() -> Path:
 PROJECT_ROOT = get_project_root()
 DEFAULT_CONFIG_PATH = PROJECT_ROOT / "config" / "lorairo.toml"
 DEFAULT_LOG_PATH = PROJECT_ROOT / "logs" / "lorairo.log"
+DEFAULT_CLI_LOG_PATH = PROJECT_ROOT / "logs" / "lorairo-cli.log"
 
 # デフォルト設定
 DEFAULT_CONFIG = {

--- a/tests/unit/cli/test_main.py
+++ b/tests/unit/cli/test_main.py
@@ -1,5 +1,6 @@
 """CLI メインモジュール テスト。"""
 
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -167,8 +168,9 @@ def test_main_configures_logging_warning_level() -> None:
     mock_init_log.assert_called_once()
     config_arg = mock_init_log.call_args[0][0]
     assert config_arg["level"] == "WARNING"
-    assert config_arg["file_path"].endswith("logs/lorairo-cli.log")
-    assert "lorairo.log" not in config_arg["file_path"]
+    log_path = Path(config_arg["file_path"])
+    assert log_path.name == "lorairo-cli.log"
+    assert log_path.parent.name == "logs"
 
 
 # Issue #254: stdio init / Windows console code page / loguru sink クリア の test は

--- a/tests/unit/cli/test_main.py
+++ b/tests/unit/cli/test_main.py
@@ -159,7 +159,7 @@ def test_project_help() -> None:
 @pytest.mark.unit
 @pytest.mark.cli
 def test_main_configures_logging_warning_level() -> None:
-    """Test: main() が CLI モードで loguru を WARNING レベルに設定する。"""
+    """Test: main() が CLI モードで専用ログファイルを WARNING レベルに設定する。"""
     with patch("lorairo.cli.main.initialize_logging") as mock_init_log, patch("lorairo.cli.main.app"):
         from lorairo.cli.main import main
 
@@ -167,6 +167,8 @@ def test_main_configures_logging_warning_level() -> None:
     mock_init_log.assert_called_once()
     config_arg = mock_init_log.call_args[0][0]
     assert config_arg["level"] == "WARNING"
+    assert config_arg["file_path"].endswith("logs/lorairo-cli.log")
+    assert "lorairo.log" not in config_arg["file_path"]
 
 
 # Issue #254: stdio init / Windows console code page / loguru sink クリア の test は


### PR DESCRIPTION
## Summary
- add a dedicated default CLI log path at `logs/lorairo-cli.log`
- configure `lorairo-cli` startup to write file logs to the CLI-specific path while keeping WARNING as the default CLI level
- update the CLI main test to assert the GUI log file is not used for CLI logging

## Impact
CLI executions now keep their logs separate from GUI runs. The GUI default remains `logs/lorairo.log`.

## Validation
- `uv run pytest tests/unit/cli/test_main.py`
- `uv run ruff check src/lorairo/cli/main.py src/lorairo/utils/config.py tests/unit/cli/test_main.py`