### PR TITLE
[codex] Apply project DB migrations before use

### DIFF
--- a/src/lorairo/database/db_core.py
+++ b/src/lorairo/database/db_core.py
@@ -12,7 +12,7 @@ from pathlib import Path
 from typing import Any
 
 # SQLAlchemy imports
-from sqlalchemy import StaticPool, create_engine, event
+from sqlalchemy import StaticPool, create_engine, event, inspect
 from sqlalchemy.engine import Engine
 from sqlalchemy.orm import Session, sessionmaker
 
@@ -304,11 +304,89 @@ def _ensure_model_types_seeded(engine: Engine) -> None:
         logger.info("Seeded model_types rows: %s", ", ".join(model.name for model in missing))
 
 
+def _make_alembic_config(project_db_path: Path) -> Any:
+    """Create an Alembic config pinned to the given project database."""
+    from alembic.config import Config
+
+    project_root = Path(__file__).resolve().parents[3]
+    alembic_config = Config(str(project_root / "alembic.ini"))
+    alembic_config.set_main_option(
+        "script_location",
+        str(project_root / "src/lorairo/database/migrations"),
+    )
+    alembic_config.set_main_option(
+        "sqlalchemy.url",
+        f"sqlite:///{project_db_path.resolve()}?check_same_thread=False",
+    )
+    return alembic_config
+
+
+def _user_table_names(engine: Engine) -> set[str]:
+    """Return application table names, excluding Alembic's version table."""
+    return set(inspect(engine).get_table_names()) - {"alembic_version"}
+
+
+def _has_alembic_version_table(engine: Engine) -> bool:
+    """Return whether this DB is already tracked by Alembic."""
+    return inspect(engine).has_table("alembic_version")
+
+
+def _stamp_alembic_head(project_db_path: Path) -> None:
+    """Mark a metadata-created DB as current with the migration graph."""
+    from alembic import command
+
+    command.stamp(_make_alembic_config(project_db_path), "head")
+
+
+def _upgrade_alembic_head(project_db_path: Path) -> None:
+    """Apply pending migrations to an Alembic-managed project database."""
+    from alembic import command
+
+    command.upgrade(_make_alembic_config(project_db_path), "head")
+
+
+def _prepare_project_database(project_db_path: Path) -> Engine:
+    """Create or migrate a project image DB before repositories use it.
+
+    New DBs are still initialized from SQLAlchemy metadata for compatibility with
+    the existing project creation flow, then stamped to the current Alembic head.
+    Existing Alembic-managed DBs are upgraded before ``create_all`` can mask
+    missing tables, which prevents stale production DBs from failing later during
+    search result loading.
+    """
+    from .schema import Base
+
+    project_db_path.parent.mkdir(parents=True, exist_ok=True)
+    db_url = f"sqlite:///{project_db_path.resolve()}?check_same_thread=False"
+    engine = create_db_engine(db_url)
+
+    if not _user_table_names(engine):
+        Base.metadata.create_all(engine)
+        _ensure_model_types_seeded(engine)
+        _stamp_alembic_head(project_db_path)
+        logger.info("Initialized new project DB schema and stamped Alembic head: %s", project_db_path)
+        return engine
+
+    if _has_alembic_version_table(engine):
+        _upgrade_alembic_head(project_db_path)
+        logger.info("Applied pending Alembic migrations for project DB: %s", project_db_path)
+    else:
+        logger.warning(
+            "Project DB has existing tables but no alembic_version table; "
+            "leaving migration state unchanged: %s",
+            project_db_path,
+        )
+
+    Base.metadata.create_all(engine)
+    _ensure_model_types_seeded(engine)
+    return engine
+
+
 def create_project_session_factory(project_db_path: Path) -> sessionmaker[Session]:
     """指定プロジェクト DB 用セッションファクトリを生成。
 
     新規 DB（touch で空ファイル）の場合はスキーマを初期化する。
-    既存テーブルは変更しない（create_all は冪等）。
+    Alembic 管理済みの既存 DB は利用前に head まで migration する。
 
     Args:
         project_db_path: プロジェクト DB ファイルの絶対パス。
@@ -316,18 +394,13 @@ def create_project_session_factory(project_db_path: Path) -> sessionmaker[Sessio
     Returns:
         sessionmaker[Session]: プロジェクト専用セッションファクトリ。
     """
-    from .schema import Base
-
-    db_url = f"sqlite:///{project_db_path.resolve()}?check_same_thread=False"
-    engine = create_db_engine(db_url)
-    Base.metadata.create_all(engine)
-    _ensure_model_types_seeded(engine)
+    engine = _prepare_project_database(project_db_path)
     return create_session_factory(engine)
 
 
 # --- デフォルトの Engine と Session Factory --- #
 # 通常のアプリケーション実行時に使用される
-default_engine = create_db_engine(DATABASE_URL)
+default_engine = _prepare_project_database(IMG_DB_PATH)
 DefaultSessionLocal = create_session_factory(default_engine)
 logger.info(f"Default database core initialized. Image DB: {IMG_DB_PATH} (Tag DB managed via public API)")
 

--- a/src/lorairo/database/migrations/versions/a7b8c9d0e1f2_add_score_labels_table.py
+++ b/src/lorairo/database/migrations/versions/a7b8c9d0e1f2_add_score_labels_table.py
@@ -20,6 +20,7 @@ from collections.abc import Sequence
 
 import sqlalchemy as sa
 from alembic import op
+from sqlalchemy import inspect
 
 revision: str = "a7b8c9d0e1f2"
 down_revision: str | None = "e3f4a5b6c7d8"
@@ -29,37 +30,46 @@ depends_on: str | Sequence[str] | None = None
 
 def upgrade() -> None:
     """Upgrade: score_labels テーブルを追加する。"""
-    op.create_table(
-        "score_labels",
-        sa.Column("id", sa.Integer(), primary_key=True),
-        sa.Column(
-            "image_id",
-            sa.Integer(),
-            sa.ForeignKey("images.id", ondelete="CASCADE"),
-            nullable=False,
-        ),
-        sa.Column(
-            "model_id",
-            sa.Integer(),
-            sa.ForeignKey("models.id", ondelete="CASCADE"),
-            nullable=False,
-        ),
-        sa.Column("label", sa.String(), nullable=False),
-        sa.Column("is_edited_manually", sa.Boolean(), nullable=True),
-        sa.Column(
-            "created_at",
-            sa.TIMESTAMP(timezone=True),
-            server_default=sa.func.now(),
-            nullable=False,
-        ),
-        sa.Column(
-            "updated_at",
-            sa.TIMESTAMP(timezone=True),
-            server_default=sa.func.now(),
-            nullable=False,
-        ),
-    )
-    op.create_index("ix_score_labels_image_id", "score_labels", ["image_id"])
+    inspector = inspect(op.get_bind())
+
+    # create_all() used to run before Alembic on project DB open. If that already
+    # created score_labels while alembic_version stayed old, make this migration
+    # converge instead of failing with "table already exists".
+    if not inspector.has_table("score_labels"):
+        op.create_table(
+            "score_labels",
+            sa.Column("id", sa.Integer(), primary_key=True),
+            sa.Column(
+                "image_id",
+                sa.Integer(),
+                sa.ForeignKey("images.id", ondelete="CASCADE"),
+                nullable=False,
+            ),
+            sa.Column(
+                "model_id",
+                sa.Integer(),
+                sa.ForeignKey("models.id", ondelete="CASCADE"),
+                nullable=False,
+            ),
+            sa.Column("label", sa.String(), nullable=False),
+            sa.Column("is_edited_manually", sa.Boolean(), nullable=True),
+            sa.Column(
+                "created_at",
+                sa.TIMESTAMP(timezone=True),
+                server_default=sa.func.now(),
+                nullable=False,
+            ),
+            sa.Column(
+                "updated_at",
+                sa.TIMESTAMP(timezone=True),
+                server_default=sa.func.now(),
+                nullable=False,
+            ),
+        )
+
+    indexes = {index["name"] for index in inspector.get_indexes("score_labels")}
+    if "ix_score_labels_image_id" not in indexes:
+        op.create_index("ix_score_labels_image_id", "score_labels", ["image_id"])
 
 
 def downgrade() -> None:

--- a/tests/unit/database/test_migration_a7b8c9d0e1f2_score_labels.py
+++ b/tests/unit/database/test_migration_a7b8c9d0e1f2_score_labels.py
@@ -1,0 +1,146 @@
+"""Alembic migration `a7b8c9d0e1f2` convergence checks."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from alembic import command
+from alembic.config import Config
+from sqlalchemy import create_engine, inspect, text
+
+
+def _make_alembic_config(db_path: Path) -> Config:
+    """Build an Alembic Config that targets the temporary DB."""
+    project_root = Path(__file__).resolve().parents[3]
+    cfg = Config(str(project_root / "alembic.ini"))
+    cfg.set_main_option("script_location", str(project_root / "src/lorairo/database/migrations"))
+    cfg.set_main_option("sqlalchemy.url", f"sqlite:///{db_path}")
+    return cfg
+
+
+def _create_d8_schema_with_precreated_score_labels(db_path: Path) -> None:
+    """Create the stale state caused by metadata create_all before migration."""
+    engine = create_engine(f"sqlite:///{db_path}")
+    with engine.begin() as conn:
+        conn.execute(
+            text(
+                """
+                CREATE TABLE images (
+                    id INTEGER NOT NULL PRIMARY KEY,
+                    uuid VARCHAR NOT NULL,
+                    phash VARCHAR NOT NULL,
+                    original_image_path VARCHAR NOT NULL,
+                    stored_image_path VARCHAR NOT NULL,
+                    width INTEGER NOT NULL,
+                    height INTEGER NOT NULL,
+                    format VARCHAR NOT NULL,
+                    mode VARCHAR NOT NULL,
+                    has_alpha BOOLEAN NOT NULL,
+                    filename VARCHAR NOT NULL,
+                    extension VARCHAR NOT NULL,
+                    color_space VARCHAR,
+                    icc_profile BLOB,
+                    manual_rating VARCHAR,
+                    project_id INTEGER,
+                    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
+                    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL
+                )
+                """
+            )
+        )
+        conn.execute(
+            text(
+                """
+                CREATE TABLE models (
+                    id INTEGER NOT NULL PRIMARY KEY,
+                    name VARCHAR NOT NULL,
+                    provider VARCHAR,
+                    discontinued_at TIMESTAMP,
+                    litellm_model_id VARCHAR NOT NULL,
+                    estimated_size_gb FLOAT,
+                    requires_api_key BOOLEAN DEFAULT '0' NOT NULL,
+                    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
+                    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
+                    UNIQUE (litellm_model_id)
+                )
+                """
+            )
+        )
+        conn.execute(
+            text(
+                """
+                CREATE TABLE model_types (
+                    id INTEGER NOT NULL PRIMARY KEY,
+                    name VARCHAR NOT NULL UNIQUE
+                )
+                """
+            )
+        )
+        conn.execute(
+            text(
+                "INSERT INTO model_types (id, name) VALUES "
+                "(1, 'tags'), (2, 'scores'), (3, 'caption'), "
+                "(4, 'upscaler'), (5, 'multimodal')"
+            )
+        )
+        conn.execute(
+            text(
+                """
+                CREATE TABLE score_labels (
+                    id INTEGER NOT NULL PRIMARY KEY,
+                    image_id INTEGER NOT NULL,
+                    model_id INTEGER NOT NULL,
+                    label VARCHAR NOT NULL,
+                    is_edited_manually BOOLEAN,
+                    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
+                    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
+                    FOREIGN KEY(image_id) REFERENCES images (id) ON DELETE CASCADE,
+                    FOREIGN KEY(model_id) REFERENCES models (id) ON DELETE CASCADE
+                )
+                """
+            )
+        )
+        conn.execute(text("CREATE TABLE alembic_version (version_num VARCHAR(32) PRIMARY KEY)"))
+        conn.execute(text("INSERT INTO alembic_version (version_num) VALUES ('d8e9f0a1b2c3')"))
+    engine.dispose()
+
+
+@pytest.mark.unit
+def test_score_labels_migration_converges_when_table_was_precreated(tmp_path: Path) -> None:
+    """Upgrade succeeds even if create_all already added score_labels."""
+    db_path = tmp_path / "stale.db"
+    _create_d8_schema_with_precreated_score_labels(db_path)
+
+    command.upgrade(_make_alembic_config(db_path), "head")
+
+    engine = create_engine(f"sqlite:///{db_path}")
+    inspector = inspect(engine)
+    indexes = {index["name"] for index in inspector.get_indexes("score_labels")}
+    with engine.connect() as conn:
+        version = conn.execute(text("SELECT version_num FROM alembic_version")).scalar_one()
+    engine.dispose()
+
+    assert version == "a7b8c9d0e1f2"
+    assert "ix_score_labels_image_id" in indexes
+
+
+@pytest.mark.unit
+def test_project_database_prepare_upgrades_alembic_managed_db(tmp_path: Path) -> None:
+    """Project DB preparation applies pending migrations before repository use."""
+    from lorairo.database.db_core import _prepare_project_database
+
+    db_path = tmp_path / "project.db"
+    _create_d8_schema_with_precreated_score_labels(db_path)
+
+    engine = _prepare_project_database(db_path)
+    engine.dispose()
+
+    engine = create_engine(f"sqlite:///{db_path}")
+    with engine.connect() as conn:
+        version = conn.execute(text("SELECT version_num FROM alembic_version")).scalar_one()
+        score_label_count = conn.execute(text("SELECT count(*) FROM score_labels")).scalar_one()
+    engine.dispose()
+
+    assert version == "a7b8c9d0e1f2"
+    assert score_label_count == 0


### PR DESCRIPTION
## Summary
- Run pending Alembic migrations before opening the default or active project image DB.
- Stamp brand-new metadata-created project DBs to the current Alembic head.
- Make the `score_labels` migration converge if `create_all()` already created the table while `alembic_version` stayed stale.
- Add regression coverage for the stale production DB state that caused `no such table: score_labels` during search result loading.

## Root Cause
The app opened project DBs with `Base.metadata.create_all()` before checking Alembic state. That could create missing tables without advancing `alembic_version`, leaving production DBs in a mixed state where code expected the new schema but migration bookkeeping stayed old.

## Validation
- `uv run ruff check src/lorairo/database/db_core.py src/lorairo/database/migrations/versions/a7b8c9d0e1f2_add_score_labels_table.py tests/unit/database/test_migration_a7b8c9d0e1f2_score_labels.py`
- `uv run pytest tests/unit/database/test_migration_a7b8c9d0e1f2_score_labels.py -q`
- `uv run pytest tests/unit/database/test_migration_e3f4a5b6c7d8_model_types_rename.py tests/unit/database/test_migration_d8e9f0a1b2c3_litellm_unique.py tests/unit/database/test_migration_a7b8c9d0e1f2_score_labels.py -q`
- `git diff --check`