### PR TITLE
[codex] Defer project DB migration prep

### DIFF
--- a/src/lorairo/database/db_core.py
+++ b/src/lorairo/database/db_core.py
@@ -6,7 +6,7 @@
 """
 
 import logging
-from collections.abc import Generator
+from collections.abc import Callable, Generator
 from contextlib import contextmanager
 from pathlib import Path
 from typing import Any
@@ -308,11 +308,11 @@ def _make_alembic_config(project_db_path: Path) -> Any:
     """Create an Alembic config pinned to the given project database."""
     from alembic.config import Config
 
-    project_root = Path(__file__).resolve().parents[3]
-    alembic_config = Config(str(project_root / "alembic.ini"))
+    migrations_dir = Path(__file__).resolve().parent / "migrations"
+    alembic_config = Config()
     alembic_config.set_main_option(
         "script_location",
-        str(project_root / "src/lorairo/database/migrations"),
+        str(migrations_dir),
     )
     alembic_config.set_main_option(
         "sqlalchemy.url",
@@ -400,15 +400,29 @@ def create_project_session_factory(project_db_path: Path) -> sessionmaker[Sessio
 
 # --- デフォルトの Engine と Session Factory --- #
 # 通常のアプリケーション実行時に使用される
-default_engine = _prepare_project_database(IMG_DB_PATH)
-DefaultSessionLocal = create_session_factory(default_engine)
+default_engine = create_db_engine(DATABASE_URL)
+_default_session_factory: sessionmaker[Session] | None = None
 logger.info(f"Default database core initialized. Image DB: {IMG_DB_PATH} (Tag DB managed via public API)")
+
+
+def _get_default_session_factory() -> sessionmaker[Session]:
+    """Prepare the default project DB lazily and return its session factory."""
+    global default_engine, _default_session_factory
+    if _default_session_factory is None:
+        default_engine = _prepare_project_database(IMG_DB_PATH)
+        _default_session_factory = create_session_factory(default_engine)
+    return _default_session_factory
+
+
+def DefaultSessionLocal() -> Session:
+    """Return a session for the default project DB, preparing migrations on first use."""
+    return _get_default_session_factory()()
 
 
 # --- セッションコンテキストマネージャ (ファクトリを受け取るように変更) --- #
 @contextmanager
 def get_db_session(
-    session_factory: sessionmaker[Session] = DefaultSessionLocal,
+    session_factory: Callable[[], Session] = DefaultSessionLocal,
 ) -> Generator[Session, None, None]:
     """
     指定されたセッションファクトリを使用して、一連の操作に対するトランザクションスコープを提供します。

--- a/src/lorairo/database/db_repository.py
+++ b/src/lorairo/database/db_repository.py
@@ -1,6 +1,7 @@
 """DBリポジトリ"""
 
 import datetime
+from collections.abc import Callable
 from pathlib import Path
 from typing import Any, cast
 
@@ -12,7 +13,7 @@ from genai_tag_db_tools.utils.cleanup_str import TagCleaner
 from sqlalchemy import Select, and_, delete, exists, func, not_, or_, select, update
 from sqlalchemy.engine import CursorResult
 from sqlalchemy.exc import IntegrityError, SQLAlchemyError
-from sqlalchemy.orm import Session, selectinload, sessionmaker
+from sqlalchemy.orm import Session, selectinload
 
 from ..domain.quality_tier import compute_quality_summary
 from ..utils.log import logger
@@ -64,7 +65,7 @@ class ImageRepository:
     # IN句以外にもクエリ内で変数を使うため余裕を持たせる
     BATCH_CHUNK_SIZE = 15000
 
-    def __init__(self, session_factory: sessionmaker[Session] = DefaultSessionLocal):
+    def __init__(self, session_factory: Callable[[], Session] = DefaultSessionLocal):
         """ImageRepositoryのコンストラクタ。
 
         Args:

--- a/tests/unit/database/test_migration_a7b8c9d0e1f2_score_labels.py
+++ b/tests/unit/database/test_migration_a7b8c9d0e1f2_score_labels.py
@@ -144,3 +144,44 @@ def test_project_database_prepare_upgrades_alembic_managed_db(tmp_path: Path) ->
 
     assert version == "a7b8c9d0e1f2"
     assert score_label_count == 0
+
+
+@pytest.mark.unit
+def test_alembic_config_uses_package_relative_migrations(tmp_path: Path) -> None:
+    """Runtime Alembic config does not depend on a source checkout alembic.ini."""
+    from lorairo.database import db_core
+
+    cfg = db_core._make_alembic_config(tmp_path / "project.db")
+
+    assert cfg.config_file_name is None
+    assert Path(cfg.get_main_option("script_location")) == Path(db_core.__file__).parent / "migrations"
+
+
+@pytest.mark.unit
+def test_default_session_local_prepares_database_lazily(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Importing db_core should not run migrations; first session creation should."""
+    from lorairo.database import db_core
+
+    calls: list[Path] = []
+    session = object()
+
+    def fake_prepare_project_database(db_path: Path) -> object:
+        calls.append(db_path)
+        return object()
+
+    def fake_create_session_factory(_engine: object) -> object:
+        return lambda: session
+
+    db_path = tmp_path / "image_database.db"
+    monkeypatch.setattr(db_core, "IMG_DB_PATH", db_path)
+    monkeypatch.setattr(db_core, "_default_session_factory", None)
+    monkeypatch.setattr(db_core, "_prepare_project_database", fake_prepare_project_database)
+    monkeypatch.setattr(db_core, "create_session_factory", fake_create_session_factory)
+
+    assert calls == []
+    assert db_core.DefaultSessionLocal() is session
+    assert calls == [db_path]
+    assert db_core.DefaultSessionLocal() is session
+    assert calls == [db_path]


### PR DESCRIPTION
## Summary
- Resolve PR #325 review feedback by building Alembic config from package-relative migration resources instead of checkout-relative `alembic.ini` paths.
- Keep default project DB migration prep lazy: import still creates only the lightweight engine, and migrations run on first default session use.
- Broaden the session factory type to any callable returning a SQLAlchemy `Session` so the lazy default factory fits the repository contract.
- Add regression tests for package-relative Alembic config and lazy default session preparation.

## Validation
- `uv run ruff check src/lorairo/database/db_core.py src/lorairo/database/db_repository.py tests/unit/database/test_migration_a7b8c9d0e1f2_score_labels.py`
- `uv run pytest tests/unit/database/test_migration_e3f4a5b6c7d8_model_types_rename.py tests/unit/database/test_migration_d8e9f0a1b2c3_litellm_unique.py tests/unit/database/test_migration_a7b8c9d0e1f2_score_labels.py -q`
- `uv run python -c "import lorairo.database.db_core as d; print(d._default_session_factory is None); print(d._make_alembic_config.__name__)"`
- `git diff --check`