### PR TITLE
[codex] Make search count estimates asynchronous

### DIFF
--- a/src/lorairo/gui/widgets/filter_search_panel.py
+++ b/src/lorairo/gui/widgets/filter_search_panel.py
@@ -941,6 +941,7 @@ class FilterSearchPanel(QScrollArea):
             if conditions is None:
                 self._estimated_count_label.setText("該当件数: -")
                 self._pending_count_estimate = None
+                self._invalidate_count_estimate_requests()
                 return
 
             self._estimated_count_label.setText("該当件数: 計算中...")
@@ -963,6 +964,11 @@ class FilterSearchPanel(QScrollArea):
             return
 
         self._start_count_estimate_task(request_id, conditions)
+
+    def _invalidate_count_estimate_requests(self) -> None:
+        """実行中・保留中の件数見積もり結果を無効化する。"""
+        self._count_estimate_request_seq += 1
+        self._latest_count_estimate_request_id = self._count_estimate_request_seq
 
     def _start_count_estimate_task(self, request_id: int, conditions: "SearchConditions") -> None:
         """件数見積もりタスクを開始する。"""

--- a/src/lorairo/gui/widgets/filter_search_panel.py
+++ b/src/lorairo/gui/widgets/filter_search_panel.py
@@ -929,6 +929,8 @@ class FilterSearchPanel(QScrollArea):
         del args
         if not self.search_filter_service:
             return
+        self._pending_count_estimate = None
+        self._invalidate_count_estimate_requests()
         self._realtime_count_timer.start()
 
     def _update_realtime_count(self) -> None:

--- a/src/lorairo/gui/widgets/filter_search_panel.py
+++ b/src/lorairo/gui/widgets/filter_search_panel.py
@@ -45,6 +45,37 @@ class _TagSuggestionTask(QRunnable):
             self.signals.failed.emit(self._request_id, self._query, str(e))
 
 
+class _CountEstimateTaskSignals(QObject):
+    """件数見積もりタスク用シグナル。"""
+
+    finished = Signal(int, int)  # request_id, estimated_count
+    failed = Signal(int, str)  # request_id, error_message
+
+
+class _CountEstimateTask(QRunnable):
+    """SearchFilterService.get_estimated_count をバックグラウンドで実行するタスク。"""
+
+    def __init__(
+        self,
+        request_id: int,
+        conditions: "SearchConditions",
+        service: "SearchFilterService",
+    ) -> None:
+        super().__init__()
+        self._request_id = request_id
+        self._conditions = conditions
+        self._service = service
+        self.signals = _CountEstimateTaskSignals()
+
+    def run(self) -> None:
+        """バックグラウンドで件数を取得して UI スレッドへ通知する。"""
+        try:
+            estimated_count = self._service.get_estimated_count(self._conditions)
+            self.signals.finished.emit(self._request_id, estimated_count)
+        except Exception as e:
+            self.signals.failed.emit(self._request_id, str(e))
+
+
 class PipelineState(Enum):
     """Pipeline state machine for search-thumbnail integration (Phase 3)"""
 
@@ -109,6 +140,13 @@ class FilterSearchPanel(QScrollArea):
         self._realtime_count_timer.setSingleShot(True)
         self._realtime_count_timer.setInterval(500)
         self._realtime_count_timer.timeout.connect(self._update_realtime_count)
+        self._count_estimate_pool = QThreadPool(self)
+        self._count_estimate_pool.setMaxThreadCount(1)
+        self._count_estimate_request_seq = 0
+        self._latest_count_estimate_request_id = 0
+        self._active_count_estimate_request_id = 0
+        self._count_estimate_in_flight = False
+        self._pending_count_estimate: tuple[int, SearchConditions] | None = None
 
         # Phase 3: Pipeline State Management
         self._current_state: PipelineState = PipelineState.IDLE
@@ -364,11 +402,15 @@ class FilterSearchPanel(QScrollArea):
         self.ui.lineEditSearch.setCursorPosition(len(new_text))
 
     def closeEvent(self, event: QCloseEvent) -> None:
-        """ウィジェット破棄時にタグ候補検索リソースをクリーンアップする。"""
+        """ウィジェット破棄時にバックグラウンド検索リソースをクリーンアップする。"""
         self._tag_suggestion_timer.stop()
         self._pending_tag_token = None
         self._tag_lookup_pool.clear()
         self._tag_lookup_pool.waitForDone(1000)
+        self._realtime_count_timer.stop()
+        self._pending_count_estimate = None
+        self._count_estimate_pool.clear()
+        self._count_estimate_pool.waitForDone(1000)
         super().closeEvent(event)
 
     def setup_favorite_filters_ui(self) -> None:
@@ -898,13 +940,72 @@ class FilterSearchPanel(QScrollArea):
             conditions = self._build_search_conditions_from_ui(show_status=False)
             if conditions is None:
                 self._estimated_count_label.setText("該当件数: -")
+                self._pending_count_estimate = None
                 return
 
-            estimated_count = self.search_filter_service.get_estimated_count(conditions)
-            self._estimated_count_label.setText(f"該当件数: {estimated_count:,}件")
+            self._estimated_count_label.setText("該当件数: 計算中...")
+            self._request_count_estimate(conditions)
         except Exception as e:
             logger.debug(f"推定件数更新に失敗: {e}")
             self._estimated_count_label.setText("該当件数: -")
+
+    def _request_count_estimate(self, conditions: "SearchConditions") -> None:
+        """件数見積もりをバックグラウンド実行する。実行中なら最新条件だけを保留する。"""
+        if self.search_filter_service is None:
+            return
+
+        self._count_estimate_request_seq += 1
+        request_id = self._count_estimate_request_seq
+        self._latest_count_estimate_request_id = request_id
+
+        if self._count_estimate_in_flight:
+            self._pending_count_estimate = (request_id, conditions)
+            return
+
+        self._start_count_estimate_task(request_id, conditions)
+
+    def _start_count_estimate_task(self, request_id: int, conditions: "SearchConditions") -> None:
+        """件数見積もりタスクを開始する。"""
+        if self.search_filter_service is None:
+            return
+
+        self._count_estimate_in_flight = True
+        self._active_count_estimate_request_id = request_id
+
+        task = _CountEstimateTask(request_id, conditions, self.search_filter_service)
+        task.signals.finished.connect(self._on_count_estimate_finished)
+        task.signals.failed.connect(self._on_count_estimate_failed)
+        self._count_estimate_pool.start(task)
+
+    def _on_count_estimate_finished(self, request_id: int, estimated_count: int) -> None:
+        """件数見積もり完了時に最新リクエストだけ UI に反映する。"""
+        if request_id == self._latest_count_estimate_request_id:
+            self._estimated_count_label.setText(f"該当件数: {estimated_count:,}件")
+
+        self._finish_count_estimate_request(request_id)
+
+    def _on_count_estimate_failed(self, request_id: int, error_message: str) -> None:
+        """件数見積もり失敗時に最新リクエストだけ UI に反映する。"""
+        logger.debug(f"推定件数更新に失敗: {error_message}")
+        if request_id == self._latest_count_estimate_request_id:
+            self._estimated_count_label.setText("該当件数: -")
+
+        self._finish_count_estimate_request(request_id)
+
+    def _finish_count_estimate_request(self, request_id: int) -> None:
+        """完了した件数見積もりの後処理と保留中リクエストの起動を行う。"""
+        if request_id != self._active_count_estimate_request_id:
+            return
+
+        self._count_estimate_in_flight = False
+        self._active_count_estimate_request_id = 0
+
+        if self._pending_count_estimate is None:
+            return
+
+        pending_request_id, pending_conditions = self._pending_count_estimate
+        self._pending_count_estimate = None
+        self._start_count_estimate_task(pending_request_id, pending_conditions)
 
     def get_date_range_from_slider(self) -> tuple[datetime | None, datetime | None]:
         """CustomRangeSliderから日付範囲を取得してdatetimeオブジェクトに変換

--- a/tests/unit/gui/widgets/test_custom_range_slider.py
+++ b/tests/unit/gui/widgets/test_custom_range_slider.py
@@ -697,6 +697,50 @@ class TestFilterSearchPanel:
         # 入力が有効のままであることを確認
         filter_panel.ui.lineEditSearch.setEnabled.assert_called_with(True)
 
+    def test_realtime_count_update_requests_async_estimate(self, filter_panel):
+        """リアルタイム件数更新は同期DB集計を直接呼ばず、非同期見積もりを予約する。"""
+        conditions = Mock()
+        filter_panel._build_search_conditions_from_ui = Mock(return_value=conditions)
+        filter_panel._request_count_estimate = Mock()
+        filter_panel.search_filter_service.get_estimated_count.side_effect = AssertionError(
+            "get_estimated_count must not run on the UI thread"
+        )
+
+        filter_panel._update_realtime_count()
+
+        filter_panel._estimated_count_label.setText.assert_called_with("該当件数: 計算中...")
+        filter_panel._request_count_estimate.assert_called_once_with(conditions)
+        filter_panel.search_filter_service.get_estimated_count.assert_not_called()
+
+    def test_count_estimate_request_coalesces_while_in_flight(self, filter_panel):
+        """件数見積もり実行中の変更は最新条件だけを保留する。"""
+        first_conditions = Mock()
+        latest_conditions = Mock()
+        filter_panel._count_estimate_in_flight = True
+        filter_panel._start_count_estimate_task = Mock()
+
+        filter_panel._request_count_estimate(first_conditions)
+        filter_panel._request_count_estimate(latest_conditions)
+
+        filter_panel._start_count_estimate_task.assert_not_called()
+        pending_request_id, pending_conditions = filter_panel._pending_count_estimate
+        assert pending_request_id == filter_panel._latest_count_estimate_request_id
+        assert pending_conditions is latest_conditions
+
+    def test_finish_count_estimate_starts_pending_latest_request(self, filter_panel):
+        """実行中の件数見積もり完了後、保留中の最新リクエストを開始する。"""
+        pending_conditions = Mock()
+        filter_panel._count_estimate_in_flight = True
+        filter_panel._active_count_estimate_request_id = 10
+        filter_panel._pending_count_estimate = (11, pending_conditions)
+        filter_panel._start_count_estimate_task = Mock()
+
+        filter_panel._finish_count_estimate_request(10)
+
+        assert filter_panel._count_estimate_in_flight is False
+        filter_panel._start_count_estimate_task.assert_called_once_with(11, pending_conditions)
+        assert filter_panel._pending_count_estimate is None
+
 
 class TestFilterWidgetIntegration:
     """フィルターウィジェット統合テスト"""

--- a/tests/unit/gui/widgets/test_custom_range_slider.py
+++ b/tests/unit/gui/widgets/test_custom_range_slider.py
@@ -733,6 +733,26 @@ class TestFilterSearchPanel:
         filter_panel._estimated_count_label.setText.assert_not_called()
         assert filter_panel._count_estimate_in_flight is False
 
+    def test_filter_value_changed_invalidates_active_estimate_before_debounce(self, filter_panel):
+        """条件変更直後、デバウンス実行前でも古い件数見積もり結果を反映しない。"""
+        filter_panel._active_count_estimate_request_id = 1
+        filter_panel._latest_count_estimate_request_id = 1
+        filter_panel._count_estimate_request_seq = 1
+        filter_panel._count_estimate_in_flight = True
+        filter_panel._pending_count_estimate = (2, Mock())
+        filter_panel._realtime_count_timer = Mock()
+
+        filter_panel._on_filter_value_changed()
+
+        assert filter_panel._pending_count_estimate is None
+        assert filter_panel._latest_count_estimate_request_id == 2
+        filter_panel._realtime_count_timer.start.assert_called_once_with()
+
+        filter_panel._on_count_estimate_finished(1, 1234)
+
+        filter_panel._estimated_count_label.setText.assert_not_called()
+        assert filter_panel._count_estimate_in_flight is False
+
     def test_count_estimate_request_coalesces_while_in_flight(self, filter_panel):
         """件数見積もり実行中の変更は最新条件だけを保留する。"""
         first_conditions = Mock()

--- a/tests/unit/gui/widgets/test_custom_range_slider.py
+++ b/tests/unit/gui/widgets/test_custom_range_slider.py
@@ -712,6 +712,30 @@ class TestFilterSearchPanel:
         filter_panel._request_count_estimate.assert_called_once_with(conditions)
         filter_panel.search_filter_service.get_estimated_count.assert_not_called()
 
+    def test_realtime_count_update_invalidates_active_estimate_when_conditions_empty(self, filter_panel):
+        """条件なしになったら実行中の古い件数見積もり結果を無効化する。"""
+        filter_panel._build_search_conditions_from_ui = Mock(return_value=None)
+        filter_panel._latest_count_estimate_request_id = 1
+        filter_panel._count_estimate_request_seq = 1
+        filter_panel._pending_count_estimate = (2, Mock())
+
+        filter_panel._update_realtime_count()
+
+        filter_panel._estimated_count_label.setText.assert_called_with("該当件数: -")
+        assert filter_panel._pending_count_estimate is None
+        assert filter_panel._latest_count_estimate_request_id == 2
+
+    def test_stale_count_estimate_does_not_update_label_after_invalidation(self, filter_panel):
+        """無効化後に古い件数見積もりが完了してもラベルを上書きしない。"""
+        filter_panel._active_count_estimate_request_id = 1
+        filter_panel._latest_count_estimate_request_id = 2
+        filter_panel._count_estimate_in_flight = True
+
+        filter_panel._on_count_estimate_finished(1, 1234)
+
+        filter_panel._estimated_count_label.setText.assert_not_called()
+        assert filter_panel._count_estimate_in_flight is False
+
     def test_count_estimate_request_coalesces_while_in_flight(self, filter_panel):
         """件数見積もり実行中の変更は最新条件だけを保留する。"""
         first_conditions = Mock()

--- a/tests/unit/gui/widgets/test_custom_range_slider.py
+++ b/tests/unit/gui/widgets/test_custom_range_slider.py
@@ -713,10 +713,12 @@ class TestFilterSearchPanel:
         filter_panel.search_filter_service.get_estimated_count.assert_not_called()
 
     def test_realtime_count_update_invalidates_active_estimate_when_conditions_empty(self, filter_panel):
-        """条件なしになったら実行中の古い件数見積もり結果を無効化する。"""
+        """条件なしになったら実行中の古い件数見積もり結果を無効化して反映しない。"""
         filter_panel._build_search_conditions_from_ui = Mock(return_value=None)
+        filter_panel._active_count_estimate_request_id = 1
         filter_panel._latest_count_estimate_request_id = 1
         filter_panel._count_estimate_request_seq = 1
+        filter_panel._count_estimate_in_flight = True
         filter_panel._pending_count_estimate = (2, Mock())
 
         filter_panel._update_realtime_count()
@@ -725,12 +727,7 @@ class TestFilterSearchPanel:
         assert filter_panel._pending_count_estimate is None
         assert filter_panel._latest_count_estimate_request_id == 2
 
-    def test_stale_count_estimate_does_not_update_label_after_invalidation(self, filter_panel):
-        """無効化後に古い件数見積もりが完了してもラベルを上書きしない。"""
-        filter_panel._active_count_estimate_request_id = 1
-        filter_panel._latest_count_estimate_request_id = 2
-        filter_panel._count_estimate_in_flight = True
-
+        filter_panel._estimated_count_label.setText.reset_mock()
         filter_panel._on_count_estimate_finished(1, 1234)
 
         filter_panel._estimated_count_label.setText.assert_not_called()


### PR DESCRIPTION
## Summary
- Move realtime search count estimation off the GUI thread into a QRunnable/QThreadPool task.
- Coalesce repeated filter changes so only the latest pending count estimate is run after an in-flight estimate completes.
- Add unit coverage to ensure realtime count updates no longer call the DB count path synchronously.

## Root Cause
Changing filter controls, including rating dropdowns, scheduled a realtime count refresh that called `SearchFilterService.get_estimated_count()` directly on the UI thread. Rating COUNT queries can take long enough to make the dropdown interaction feel frozen.

## Validation
- `uv run pytest tests/unit/gui/widgets/test_custom_range_slider.py -q`
- `uv run ruff check src/lorairo/gui/widgets/filter_search_panel.py tests/unit/gui/widgets/test_custom_range_slider.py`
- `uv run mypy src/lorairo/gui/widgets/filter_search_panel.py`