### PR TITLE
feat: image-annotator-lib model-native ratings を canonical rating にマッピング (#333)

### DIFF
--- a/docs/decisions/0031-ai-rating-mapping.md
+++ b/docs/decisions/0031-ai-rating-mapping.md
@@ -1,0 +1,100 @@
+# ADR 0031: AI Rating Mapping to Canonical Rating
+
+- **日付**: 2026-05-21
+- **ステータス**: Accepted
+
+## Context
+
+image-annotator-lib は Issue #80 (closed) で rating 出力を **model-native** な
+`RatingPrediction(raw_label, confidence_score, source_scheme)` のリストとして
+`UnifiedAnnotationResult.ratings` で返すようになった。ライブラリは LoRAIro の
+`PG/PG-13/R/X/XXX` へは変換しない (責務分離: library はモデルが出した raw label /
+confidence / source scheme を返すだけ)。
+
+しかし LoRAIro 側 `AnnotationSaveService._append_model_result()` は `ratings` を
+`str(ratings)` で雑に文字列化しており、`raw_rating_value` / `normalized_rating` の
+両方に `"[RatingPrediction(...)]"` という壊れた値が入っていた。結果として:
+
+- `normalized_rating` が canonical 値にならず、特定レーティング検索
+  (`_apply_ai_rating_filter` の通常分岐) で永久にヒットしない。
+- DB に意味のある AI rating が保存されない。
+
+rating はデータセットごとに分類体系が異なる (Danbooru 系 `general/sensitive/
+questionable/explicit`、e621 系 `safe/questionable/explicit`、anime_rating
+`safe/r15/r18` 等)。LoRAIro 側でこれらを canonical rating に変換する mapper が必要。
+
+## Decision
+
+1. **model-native rating → canonical rating の変換は LoRAIro 側責務とする。**
+   純粋関数モジュール `src/lorairo/domain/rating_mapper.py` に集約する
+   (`domain/quality_tier.py` と同じ derived-view パターン)。
+
+2. **マッピング表** (`(source_scheme, raw_label) -> canonical rating`):
+
+   | source_scheme (alias) | raw label | canonical |
+   |---|---|---|
+   | `danbooru4` (`wdtagger`, `camie`) | `general` | `PG` |
+   | `danbooru4` | `sensitive` | `PG-13` |
+   | `danbooru4` | `questionable` | `R` |
+   | `danbooru4` | `explicit` | `X` |
+   | `e6213` (`z3d`, `danbooru3`) | `safe` / `general` | `PG` |
+   | `e6213` | `questionable` | `R` |
+   | `e6213` | `explicit` | `X` |
+   | `sankaku3` (`anime_rating`) | `safe` | `PG` |
+   | `sankaku3` | `r15` | `R` |
+   | `sankaku3` | `r18` | `X` |
+   | `binary_nsfw` | `sfw` | `PG` |
+   | `binary_nsfw` | `nsfw` | `R` |
+
+3. **`r15` は `R` にマッピングする** (Issue #333 で「設定/方針で決定」とされた曖昧点)。
+   「R15 (15 歳以上推奨)」を成人向け寄りに保守的に解釈し、`danbooru4` の
+   `questionable→R` と同列に扱う。
+
+4. **`XXX` は mapper から自動生成しない。** mapper の出力は `PG/PG-13/R/X` のみ。
+   `XXX` は別基準 (手動・専用判定) なしに自動付与しない。
+
+5. **list[RatingPrediction] は最高 `confidence_score` の 1 件に絞る。**
+   `Rating` テーブルは `(image_id, model_id)` で upsert されるため 1 モデル = 1 行。
+   `confidence_score` が `None` の予測は最下位扱い、全 None / 同値なら先頭 (top-1)。
+
+6. **マッピング不能 (未知 scheme / 未知 label) は保存せず skip + warning。**
+   壊れた値を DB に入れるより、その画像を AI rating 未設定のまま残す方が安全。
+
+7. **`source_scheme` は DB に保存しない。** `ratings` テーブルに保存先カラムが無く、
+   mapper の判定入力としてのみ使う。
+
+8. **後方互換 `str` / `list[str]` 経路を維持する。** `source_scheme` を持たないため
+   canonical 値とみなし、`PG/PG-13/R/X/XXX` であればそのまま保存、それ以外は skip。
+
+## Rationale
+
+- **なぜ `domain/` に置くか**: `quality_tier.py` が `(model_name, raw_label) ->
+  QualityTier` の純粋マッピングを既に `domain/` で担っており、rating mapper も
+  raw annotation を変更しない derived-view 計算で同性質。レイヤーの一貫性。
+- **なぜ skip するか (マッピング不能時)**: ADR 0015 の「書き込み・読み込みの対称性」
+  教訓どおり、`normalized_rating` は検索フィルタが参照する canonical 集合に限定する。
+  未知値を入れると「成功したが 0 件」のサイレント不整合を生む。
+- **なぜ最高 confidence か**: 現状 lib は ONNX tagger で argmax 済みの 1 要素 list を
+  返すが、将来の multi-label rating 分類器に備え list 入力でも決定的に 1 行へ正規化。
+- **scheme エイリアス**: lib が現在 emit するのは `danbooru4` / `e6213` のみ。
+  Issue #81 の新規 rating モデル候補 (`anime_rating` 等) に備え、表記揺れ・モデル系統
+  差をエイリアスで吸収しておく (forward-compat)。
+
+## Consequences
+
+- 良い点: AI rating が canonical 値で `ratings` テーブルに保存され、「AIレーティング:
+  未設定のみ」検索で保存済み画像が再対象にならない。特定レーティング検索も機能する。
+- 良い点: 既存 tags/captions/scores 保存経路は不変。manual rating (`MANUAL_EDIT`) と
+  AI rating の優先・分離 (`_apply_ai_rating_filter` の `Model.name != "MANUAL_EDIT"`)
+  は保たれる。
+- トレードオフ: 未知 scheme のモデルは AI rating が保存されず未設定のまま残る
+  (`source_scheme="unknown"` 等)。新 scheme 追加時は `rating_mapper.py` の表更新が必要。
+- 新しい rating モデル / scheme を追加する場合は `_LABEL_MAP` / `_SCHEME_ALIASES` に
+  行を追加し、`tests/unit/domain/test_rating_mapper.py` にテストを追加する。
+
+## 関連
+
+- Issue: NEXTAltair/LoRAIro#333
+- Upstream: NEXTAltair/image-annotator-lib#79 (parent) / #80 (rating 出力実装) /
+  #81 (新規 rating model 候補)
+- ADR 0015 (Manual Rating Storage Unification) — manual / AI rating の Rating テーブル統一

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -34,6 +34,7 @@ LoRAIro の重要な設計判断を記録するドキュメント群。
 | [0028](0028-score-labels-usage-and-display.md) | Score Labels Usage and Display Strategy | 2026-05-18 | Accepted |
 | [0029](0029-unified-dataset-quality-tier.md) | Unified Dataset Quality Tier | 2026-05-19 | Accepted |
 | [0030](0030-batch-annotation-model-selection-ui.md) | Batch Annotation Model Selection UI | 2026-05-20 | Accepted |
+| [0031](0031-ai-rating-mapping.md) | AI Rating Mapping to Canonical Rating | 2026-05-21 | Accepted |
 
 ## ADR テンプレート
 

--- a/src/lorairo/domain/rating_mapper.py
+++ b/src/lorairo/domain/rating_mapper.py
@@ -1,0 +1,87 @@
+"""image-annotator-lib の model-native rating を LoRAIro canonical rating に変換する (Issue #333)。
+
+image-annotator-lib は rating を model-native な ``RatingPrediction``
+(``raw_label`` / ``confidence_score`` / ``source_scheme``) で返す。LoRAIro 側の
+``PG / PG-13 / R / X`` への変換は LoRAIro の責務 (ADR 0031)。
+
+このモジュールは ``(source_scheme, raw_label)`` を canonical rating に変換する純粋関数を
+提供する。``raw annotation`` は変更せず、保存時の derived 値として計算する。
+
+新しい rating モデル / scheme を追加する場合:
+
+1. ``_LABEL_MAP`` に scheme 行、または ``_SCHEME_ALIASES`` に別名を追加
+2. 該当する unit test を追加 (``tests/unit/domain/test_rating_mapper.py``)
+
+設計方針:
+
+- mapper の出力は ``PG / PG-13 / R / X`` のみ。``XXX`` は別基準なしに自動生成しない。
+- 未知 scheme / 未知 label は ``None`` を返す (呼び出し側で skip)。
+"""
+
+from __future__ import annotations
+
+# source_scheme の別名 -> 正規 scheme 名。
+# image-annotator-lib が emit する scheme 文字列の表記揺れ・モデル系統差を吸収する。
+_SCHEME_ALIASES: dict[str, str] = {
+    "wdtagger": "danbooru4",
+    "camie": "danbooru4",
+    "z3d": "e6213",
+    "danbooru3": "e6213",
+    "anime_rating": "sankaku3",
+}
+
+# 正規 scheme 名 -> {raw_label: canonical rating}。
+# raw_label は lowercase + space->underscore 正規化済みの値で照合する。
+_LABEL_MAP: dict[str, dict[str, str]] = {
+    # Danbooru 4 分類 (WDTagger / camie 系)
+    "danbooru4": {
+        "general": "PG",
+        "sensitive": "PG-13",
+        "questionable": "R",
+        "explicit": "X",
+    },
+    # e621 / Safebooru 3 分類 (Z3D / danbooru3 系)
+    "e6213": {
+        "safe": "PG",
+        "general": "PG",
+        "questionable": "R",
+        "explicit": "X",
+    },
+    # Sankaku / anime_rating 3 分類
+    "sankaku3": {
+        "safe": "PG",
+        "r15": "R",
+        "r18": "X",
+    },
+    # 二値 NSFW classifier
+    "binary_nsfw": {
+        "sfw": "PG",
+        "nsfw": "R",
+    },
+}
+
+
+def _normalize_scheme(source_scheme: str) -> str:
+    """source_scheme を strip + lower + alias 解決して正規 scheme 名にする。"""
+    scheme = source_scheme.strip().lower()
+    return _SCHEME_ALIASES.get(scheme, scheme)
+
+
+def _normalize_label(raw_label: str) -> str:
+    """raw_label を strip + lower + space->underscore で正規化する。"""
+    return raw_label.strip().lower().replace(" ", "_")
+
+
+def map_rating(raw_label: str, source_scheme: str) -> str | None:
+    """model-native rating を LoRAIro canonical rating に変換する。
+
+    Args:
+        raw_label: モデルが出力した生の rating ラベル (例: "general", "explicit")。
+        source_scheme: rating ラベルの分類スキーム (例: "danbooru4", "e6213")。
+
+    Returns:
+        canonical rating ("PG" / "PG-13" / "R" / "X")。未知の scheme / label の場合は None。
+    """
+    scheme = _normalize_scheme(source_scheme)
+    label = _normalize_label(raw_label)
+    return _LABEL_MAP.get(scheme, {}).get(label)

--- a/src/lorairo/services/annotation_save_service.py
+++ b/src/lorairo/services/annotation_save_service.py
@@ -10,10 +10,11 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
 from lorairo.database.db_repository import ImageRepository
+from lorairo.domain.rating_mapper import map_rating
 from lorairo.utils.log import logger
 
 if TYPE_CHECKING:
-    from lorairo.database.schema import AnnotationsDict
+    from lorairo.database.schema import AnnotationsDict, RatingAnnotationData
 
 
 @dataclass(frozen=True)
@@ -106,14 +107,106 @@ class AnnotationSaveService:
                     }
                 )
         if ratings:
-            result["ratings"].append(
-                {
-                    "model_id": model_id,
-                    "raw_rating_value": str(ratings),
-                    "normalized_rating": str(ratings),
-                    "confidence_score": None,
-                }
-            )
+            self._append_rating_row(model_id, ratings, result)
+
+    def _append_rating_row(self, model_id: int, ratings: Any, result: AnnotationsDict) -> None:
+        """rating を canonical 値に変換して result["ratings"] へ追加する (変換不能なら無視)。"""
+        rating_row = self._build_rating_row(model_id, ratings)
+        if rating_row is not None:
+            result["ratings"].append(rating_row)
+
+    # canonical rating の有効値 (後方互換 str 経路の検証用)。
+    # api/types.py の _VALID_RATINGS から保存対象外の UNRATED を除いた集合。
+    _CANONICAL_RATINGS: frozenset[str] = frozenset({"PG", "PG-13", "R", "X", "XXX"})
+
+    @staticmethod
+    def _extract_prediction_attr(prediction: Any, name: str) -> Any:
+        """RatingPrediction (Pydantic モデル) / 辞書の両対応で属性を取得する。"""
+        if isinstance(prediction, dict):
+            return prediction.get(name)
+        return getattr(prediction, name, None)
+
+    def _select_rating_prediction(self, ratings: Any) -> Any | None:
+        """structured rating 群から最高 confidence の予測を 1 件選ぶ。
+
+        ``list[RatingPrediction]`` が主経路。``confidence_score`` が None の予測は
+        最下位扱い。全 None / 同値の場合は ``max`` の安定性により先頭 (top-1) を選ぶ。
+
+        Args:
+            ratings: image-annotator-lib の ``UnifiedAnnotationResult.ratings`` 相当。
+
+        Returns:
+            選択された RatingPrediction 相当のオブジェクト。候補が無ければ None。
+        """
+        candidates = ratings if isinstance(ratings, list) else [ratings]
+        predictions = [p for p in candidates if isinstance(p, dict) or hasattr(p, "raw_label")]
+        if not predictions:
+            return None
+        return max(
+            predictions,
+            key=lambda p: self._extract_prediction_attr(p, "confidence_score") or -1.0,
+        )
+
+    def _build_canonical_str_row(self, model_id: int, value: str) -> RatingAnnotationData | None:
+        """後方互換: source_scheme を持たない str rating を canonical 値として保存する。
+
+        ``source_scheme`` が無いため変換できず、値が canonical rating
+        (``PG/PG-13/R/X/XXX``) であればそのまま保存、そうでなければスキップする。
+        """
+        normalized = value.strip().upper()
+        if normalized not in self._CANONICAL_RATINGS:
+            logger.warning(f"canonical でない str rating をスキップ: {value!r}")
+            return None
+        return {
+            "model_id": model_id,
+            "raw_rating_value": value.strip(),
+            "normalized_rating": normalized,
+            "confidence_score": None,
+        }
+
+    def _build_rating_row(self, model_id: int, ratings: Any) -> RatingAnnotationData | None:
+        """``ratings`` を canonical rating 1 行 (RatingAnnotationData) に変換する。
+
+        ``Rating`` テーブルは ``(image_id, model_id)`` で upsert されるため、list が
+        来ても 1 行に絞る。マッピング不能・未知スキーマの場合は None を返す
+        (壊れた値を保存せずスキップ)。
+
+        Args:
+            model_id: rating を出力したモデルの DB ID。
+            ratings: image-annotator-lib 由来の rating (structured / str 後方互換)。
+
+        Returns:
+            保存用 RatingAnnotationData。変換不能なら None。
+        """
+        # 後方互換: str / list[str] は source_scheme を持たないため canonical 値とみなす
+        if isinstance(ratings, str):
+            return self._build_canonical_str_row(model_id, ratings)
+        if isinstance(ratings, list) and ratings and all(isinstance(r, str) for r in ratings):
+            return self._build_canonical_str_row(model_id, ratings[0])
+
+        prediction = self._select_rating_prediction(ratings)
+        if prediction is None:
+            logger.warning(f"rating 予測を抽出できません: {ratings!r}")
+            return None
+
+        raw_label = self._extract_prediction_attr(prediction, "raw_label")
+        source_scheme = self._extract_prediction_attr(prediction, "source_scheme")
+        confidence = self._extract_prediction_attr(prediction, "confidence_score")
+        if not raw_label or not source_scheme:
+            logger.warning(f"rating 予測に raw_label / source_scheme が欠落: {prediction!r}")
+            return None
+
+        normalized = map_rating(str(raw_label), str(source_scheme))
+        if normalized is None:
+            logger.warning(f"rating マッピング不能: scheme={source_scheme!r} label={raw_label!r}")
+            return None
+
+        return {
+            "model_id": model_id,
+            "raw_rating_value": str(raw_label),
+            "normalized_rating": normalized,
+            "confidence_score": confidence,
+        }
 
     # ADR 0023 Phase 1.5 (Issue #42): image-annotator-lib 側で refusal を検出した
     # 場合、UnifiedAnnotationResult.error は f"{type(refusal_exc).__name__}: {msg}"

--- a/src/lorairo/services/annotation_save_service.py
+++ b/src/lorairo/services/annotation_save_service.py
@@ -126,6 +126,11 @@ class AnnotationSaveService:
             return prediction.get(name)
         return getattr(prediction, name, None)
 
+    def _confidence_sort_key(self, prediction: Any) -> float:
+        """confidence_score の sort key。欠損 (None) は最下位扱い、実値 0.0 はそのまま保持する。"""
+        score = self._extract_prediction_attr(prediction, "confidence_score")
+        return -1.0 if score is None else float(score)
+
     def _select_rating_prediction(self, ratings: Any) -> Any | None:
         """structured rating 群から最高 confidence の予測を 1 件選ぶ。
 
@@ -142,10 +147,7 @@ class AnnotationSaveService:
         predictions = [p for p in candidates if isinstance(p, dict) or hasattr(p, "raw_label")]
         if not predictions:
             return None
-        return max(
-            predictions,
-            key=lambda p: self._extract_prediction_attr(p, "confidence_score") or -1.0,
-        )
+        return max(predictions, key=self._confidence_sort_key)
 
     def _build_canonical_str_row(self, model_id: int, value: str) -> RatingAnnotationData | None:
         """後方互換: source_scheme を持たない str rating を canonical 値として保存する。

--- a/tests/integration/test_rating_save_integration.py
+++ b/tests/integration/test_rating_save_integration.py
@@ -1,0 +1,163 @@
+"""AI rating 保存・検索フィルタの統合テスト (Issue #333)。
+
+AnnotationSaveService → rating_mapper → ImageRepository → DB → AI rating filter
+の end-to-end フローを実 SQLite (in-memory) で検証する。
+"""
+
+from types import SimpleNamespace
+
+import pytest
+from sqlalchemy import select
+
+from lorairo.database.db_repository import ImageRepository
+from lorairo.database.filter_criteria import ImageFilterCriteria
+from lorairo.database.schema import Image, Model, Rating
+from lorairo.services.annotation_save_service import AnnotationSaveService
+
+_PHASH = "phash_rating_test_001"
+_LITELLM_ID = "wd-vit-tagger-v3"
+
+
+@pytest.fixture
+def rating_repository(db_session_factory) -> ImageRepository:
+    """session_factory ベースの ImageRepository (get_images_by_filter 等が動作する)。"""
+    return ImageRepository(db_session_factory)
+
+
+@pytest.fixture
+def seeded_ids(db_session_factory) -> dict[str, int]:
+    """rating テスト用に Image 1 件と AI Model 1 件を投入する。"""
+    with db_session_factory() as session:
+        image = Image(
+            uuid="rating-test-uuid-001",
+            phash=_PHASH,
+            original_image_path="/tmp/rating_test.png",
+            stored_image_path="/tmp/rating_test.png",
+            width=256,
+            height=256,
+            format="PNG",
+            extension=".png",
+        )
+        model = Model(name="wd-vit-tagger-v3", provider="local", litellm_model_id=_LITELLM_ID)
+        session.add_all([image, model])
+        session.commit()
+        return {"image_id": image.id, "model_id": model.id}
+
+
+def _result_with_rating(raw_label: str, source_scheme: str, confidence: float) -> SimpleNamespace:
+    """ratings のみを持つ UnifiedAnnotationResult 相当のテストダブル。"""
+    return SimpleNamespace(
+        error=None,
+        tags=None,
+        captions=None,
+        scores=None,
+        score_labels=None,
+        ratings=[
+            SimpleNamespace(raw_label=raw_label, source_scheme=source_scheme, confidence_score=confidence)
+        ],
+    )
+
+
+@pytest.mark.integration
+def test_structured_rating_persisted_with_canonical_value(
+    rating_repository: ImageRepository,
+    seeded_ids: dict[str, int],
+    db_session_factory,
+) -> None:
+    """model-native rating が canonical 値で ratings テーブルへ保存される。"""
+    service = AnnotationSaveService(rating_repository)
+
+    results = {_PHASH: {_LITELLM_ID: _result_with_rating("questionable", "danbooru4", 0.83)}}
+    save_result = service.save_annotation_results(results)
+
+    assert save_result.success_count == 1
+    assert save_result.error_count == 0
+
+    with db_session_factory() as session:
+        rating = session.execute(
+            select(Rating).where(Rating.image_id == seeded_ids["image_id"])
+        ).scalar_one()
+        assert rating.raw_rating_value == "questionable"
+        assert rating.normalized_rating == "R"
+        assert rating.confidence_score == pytest.approx(0.83)
+
+
+@pytest.mark.integration
+def test_saved_ai_rating_excluded_from_unrated_and_matched_by_value(
+    rating_repository: ImageRepository,
+    seeded_ids: dict[str, int],
+) -> None:
+    """保存後の画像が AI rating UNRATED から外れ、該当 rating 検索でヒットする。"""
+    service = AnnotationSaveService(rating_repository)
+    service.save_annotation_results(
+        {_PHASH: {_LITELLM_ID: _result_with_rating("questionable", "danbooru4", 0.83)}}
+    )
+
+    # 保存前は対象だった「AIレーティング: 未設定のみ」から外れる
+    unrated_images, unrated_count = rating_repository.get_images_by_filter(
+        ImageFilterCriteria(ai_rating_filter="UNRATED")
+    )
+    assert unrated_count == 0
+    assert unrated_images == []
+
+    # canonical 値 "R" で検索するとヒットする
+    matched_images, matched_count = rating_repository.get_images_by_filter(
+        ImageFilterCriteria(ai_rating_filter="R")
+    )
+    assert matched_count == 1
+    assert matched_images[0]["id"] == seeded_ids["image_id"]
+
+
+@pytest.mark.integration
+def test_unmappable_scheme_is_skipped(
+    rating_repository: ImageRepository,
+    seeded_ids: dict[str, int],
+    db_session_factory,
+) -> None:
+    """未知 source_scheme の rating は保存されず、AI rating UNRATED のままになる。"""
+    service = AnnotationSaveService(rating_repository)
+    service.save_annotation_results({_PHASH: {_LITELLM_ID: _result_with_rating("general", "unknown", 0.9)}})
+
+    with db_session_factory() as session:
+        ratings = (
+            session.execute(select(Rating).where(Rating.image_id == seeded_ids["image_id"])).scalars().all()
+        )
+        assert ratings == []
+
+    _, unrated_count = rating_repository.get_images_by_filter(
+        ImageFilterCriteria(ai_rating_filter="UNRATED")
+    )
+    assert unrated_count == 1
+
+
+@pytest.mark.integration
+def test_manual_rating_isolated_from_ai_rating(
+    rating_repository: ImageRepository,
+    seeded_ids: dict[str, int],
+) -> None:
+    """manual rating (MANUAL_EDIT) が共存しても AI rating フィルタは AI 行のみ対象とする。
+
+    AI / manual とも非 NSFW 値 (PG / PG-13) を使い、NSFW 除外フィルタの影響を避ける。
+    """
+    service = AnnotationSaveService(rating_repository)
+    # AI rating は "PG" (general -> PG)
+    service.save_annotation_results(
+        {_PHASH: {_LITELLM_ID: _result_with_rating("general", "danbooru4", 0.7)}}
+    )
+    # 同じ画像に AI とは異なる手動 rating "PG-13" を付与 (MANUAL_EDIT モデル行)
+    rating_repository.update_manual_rating(seeded_ids["image_id"], "PG-13")
+
+    # AI rating フィルタ "PG" は AI 行のみ対象 -> ヒットする
+    pg_images, pg_count = rating_repository.get_images_by_filter(ImageFilterCriteria(ai_rating_filter="PG"))
+    assert pg_count == 1
+    assert pg_images[0]["id"] == seeded_ids["image_id"]
+
+    # AI rating フィルタ "PG-13" は manual の "PG-13" に引きずられず 0 件 (AI 行に PG-13 は無い)
+    _, ai_pg13_count = rating_repository.get_images_by_filter(ImageFilterCriteria(ai_rating_filter="PG-13"))
+    assert ai_pg13_count == 0
+
+    # 手動 rating フィルタ "PG-13" はヒットする
+    _, manual_count = rating_repository.get_images_by_filter(
+        ImageFilterCriteria(manual_rating_filter="PG-13")
+    )
+    assert manual_count == 1

--- a/tests/unit/domain/test_rating_mapper.py
+++ b/tests/unit/domain/test_rating_mapper.py
@@ -1,0 +1,110 @@
+"""rating_mapper ユニットテスト (Issue #333)。"""
+
+import pytest
+
+from lorairo.domain.rating_mapper import map_rating
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("raw_label", "source_scheme", "expected"),
+    [
+        # Danbooru 4 分類
+        ("general", "danbooru4", "PG"),
+        ("sensitive", "danbooru4", "PG-13"),
+        ("questionable", "danbooru4", "R"),
+        ("explicit", "danbooru4", "X"),
+        # e621 / Safebooru 3 分類
+        ("safe", "e6213", "PG"),
+        ("general", "e6213", "PG"),
+        ("questionable", "e6213", "R"),
+        ("explicit", "e6213", "X"),
+        # Sankaku / anime_rating 3 分類 (r15 -> R は ADR 0031 で確定)
+        ("safe", "sankaku3", "PG"),
+        ("r15", "sankaku3", "R"),
+        ("r18", "sankaku3", "X"),
+        # 二値 NSFW
+        ("sfw", "binary_nsfw", "PG"),
+        ("nsfw", "binary_nsfw", "R"),
+    ],
+)
+def test_map_rating_canonical_pairs(raw_label: str, source_scheme: str, expected: str) -> None:
+    """Issue #333 の対応表どおりに canonical rating へ変換される。"""
+    assert map_rating(raw_label, source_scheme) == expected
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("alias", "canonical"),
+    [
+        ("wdtagger", "danbooru4"),
+        ("camie", "danbooru4"),
+        ("z3d", "e6213"),
+        ("danbooru3", "e6213"),
+        ("anime_rating", "sankaku3"),
+    ],
+)
+def test_map_rating_scheme_aliases(alias: str, canonical: str) -> None:
+    """scheme 別名は正規 scheme と同じ結果になる。"""
+    assert map_rating("explicit" if canonical != "sankaku3" else "r18", alias) == map_rating(
+        "explicit" if canonical != "sankaku3" else "r18", canonical
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("raw_label", "source_scheme"),
+    [
+        ("GENERAL", "DANBOORU4"),
+        ("  Explicit  ", "  Danbooru4  "),
+        ("R15", "Sankaku3"),
+        ("not safe", "binary_nsfw"),  # space -> underscore 正規化はされるが not_safe は未知 -> None
+    ],
+)
+def test_map_rating_case_and_whitespace_insensitive(raw_label: str, source_scheme: str) -> None:
+    """大文字小文字・前後空白に依存せず照合できる。"""
+    # "not safe" は未知ラベルなので None、それ以外は変換成功
+    result = map_rating(raw_label, source_scheme)
+    if raw_label.strip().lower() == "not safe":
+        assert result is None
+    else:
+        assert result is not None
+
+
+@pytest.mark.unit
+def test_map_rating_unknown_scheme_returns_none() -> None:
+    """未知の source_scheme は None を返す。"""
+    assert map_rating("general", "unknown") is None
+    assert map_rating("general", "") is None
+
+
+@pytest.mark.unit
+def test_map_rating_unknown_label_returns_none() -> None:
+    """既知 scheme でも未知 label は None を返す。"""
+    assert map_rating("nonexistent", "danbooru4") is None
+    assert map_rating("sensitive", "e6213") is None  # e6213 に sensitive は無い
+
+
+@pytest.mark.unit
+def test_map_rating_never_produces_xxx() -> None:
+    """mapper は XXX を自動生成しない (ADR 0031)。"""
+    all_outputs = set()
+    schemes = ["danbooru4", "e6213", "sankaku3", "binary_nsfw"]
+    labels = [
+        "general",
+        "sensitive",
+        "questionable",
+        "explicit",
+        "safe",
+        "r15",
+        "r18",
+        "sfw",
+        "nsfw",
+    ]
+    for scheme in schemes:
+        for label in labels:
+            mapped = map_rating(label, scheme)
+            if mapped is not None:
+                all_outputs.add(mapped)
+    assert "XXX" not in all_outputs
+    assert all_outputs <= {"PG", "PG-13", "R", "X"}

--- a/tests/unit/services/test_annotation_save_service.py
+++ b/tests/unit/services/test_annotation_save_service.py
@@ -324,6 +324,24 @@ def test_build_rating_row_picks_highest_confidence(service: AnnotationSaveServic
 
 
 @pytest.mark.unit
+def test_build_rating_row_real_zero_confidence_beats_missing(
+    service: AnnotationSaveService,
+) -> None:
+    """confidence 0.0 (実値) は欠損 (None) より高位扱いで選ばれる。"""
+    ratings = [
+        _rating("explicit", "danbooru4", None),
+        _rating("general", "danbooru4", 0.0),
+    ]
+
+    row = service._build_rating_row(model_id=5, ratings=ratings)
+
+    assert row is not None
+    assert row["raw_rating_value"] == "general"
+    assert row["normalized_rating"] == "PG"
+    assert row["confidence_score"] == 0.0
+
+
+@pytest.mark.unit
 def test_build_rating_row_accepts_dict_prediction(service: AnnotationSaveService) -> None:
     """辞書形式の RatingPrediction も変換できる。"""
     ratings = [{"raw_label": "safe", "source_scheme": "e6213", "confidence_score": 0.5}]

--- a/tests/unit/services/test_annotation_save_service.py
+++ b/tests/unit/services/test_annotation_save_service.py
@@ -1,10 +1,16 @@
 """AnnotationSaveService ユニットテスト。"""
 
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
 
 from lorairo.services.annotation_save_service import AnnotationSaveResult, AnnotationSaveService
+
+
+def _rating(raw_label: str, source_scheme: str, confidence: float | None) -> SimpleNamespace:
+    """RatingPrediction 相当のテストダブル (raw_label / source_scheme / confidence_score)。"""
+    return SimpleNamespace(raw_label=raw_label, source_scheme=source_scheme, confidence_score=confidence)
 
 
 @pytest.fixture
@@ -280,3 +286,107 @@ def test_save_score_labels_skipped_when_error_present(
 
     # error 検出時は _save_single 内で空 dict 判定で skip され save_annotations は呼ばれない
     mock_repository.save_annotations.assert_not_called()
+
+
+# === rating マッピング (Issue #333) ===
+
+
+@pytest.mark.unit
+def test_build_rating_row_maps_structured_prediction(service: AnnotationSaveService) -> None:
+    """list[RatingPrediction] が canonical rating 1 行に変換される。"""
+    ratings = [_rating("explicit", "danbooru4", 0.92)]
+
+    row = service._build_rating_row(model_id=5, ratings=ratings)
+
+    assert row == {
+        "model_id": 5,
+        "raw_rating_value": "explicit",
+        "normalized_rating": "X",
+        "confidence_score": 0.92,
+    }
+
+
+@pytest.mark.unit
+def test_build_rating_row_picks_highest_confidence(service: AnnotationSaveService) -> None:
+    """複数候補のうち最高 confidence の予測が選ばれる。"""
+    ratings = [
+        _rating("general", "danbooru4", 0.10),
+        _rating("questionable", "danbooru4", 0.75),
+        _rating("sensitive", "danbooru4", 0.40),
+    ]
+
+    row = service._build_rating_row(model_id=5, ratings=ratings)
+
+    assert row is not None
+    assert row["raw_rating_value"] == "questionable"
+    assert row["normalized_rating"] == "R"
+    assert row["confidence_score"] == 0.75
+
+
+@pytest.mark.unit
+def test_build_rating_row_accepts_dict_prediction(service: AnnotationSaveService) -> None:
+    """辞書形式の RatingPrediction も変換できる。"""
+    ratings = [{"raw_label": "safe", "source_scheme": "e6213", "confidence_score": 0.5}]
+
+    row = service._build_rating_row(model_id=7, ratings=ratings)
+
+    assert row is not None
+    assert row["normalized_rating"] == "PG"
+
+
+@pytest.mark.unit
+def test_build_rating_row_unknown_scheme_returns_none(service: AnnotationSaveService) -> None:
+    """未知 source_scheme はマッピング不能のため None (保存しない)。"""
+    ratings = [_rating("general", "unknown", 0.9)]
+
+    assert service._build_rating_row(model_id=5, ratings=ratings) is None
+
+
+@pytest.mark.unit
+def test_build_rating_row_backward_compat_canonical_str(service: AnnotationSaveService) -> None:
+    """後方互換: canonical な str rating はそのまま 1 行で保存される。"""
+    row = service._build_rating_row(model_id=3, ratings="R")
+
+    assert row == {
+        "model_id": 3,
+        "raw_rating_value": "R",
+        "normalized_rating": "R",
+        "confidence_score": None,
+    }
+
+
+@pytest.mark.unit
+def test_build_rating_row_backward_compat_noncanonical_str_returns_none(
+    service: AnnotationSaveService,
+) -> None:
+    """後方互換: canonical でない str rating は None (保存しない)。"""
+    assert service._build_rating_row(model_id=3, ratings="general") is None
+
+
+@pytest.mark.unit
+def test_save_annotation_results_persists_mapped_rating(
+    service: AnnotationSaveService,
+    mock_repository: MagicMock,
+) -> None:
+    """structured ratings が save_annotations に canonical 値で渡る (end-to-end)。"""
+    mock_model = MagicMock()
+    mock_model.id = 42
+    mock_repository.find_image_ids_by_phashes.return_value = {"phash001": 1}
+    mock_repository.get_models_by_litellm_ids.return_value = {"wd-vit-tagger-v3": mock_model}
+
+    rating_result = _make_success_result()
+    rating_result.ratings = [_rating("questionable", "danbooru4", 0.81)]
+
+    results = {"phash001": {"wd-vit-tagger-v3": rating_result}}
+
+    service.save_annotation_results(results)
+
+    annotations_arg = mock_repository.save_annotations.call_args[0][1]
+    assert annotations_arg["ratings"] == [
+        {
+            "model_id": 42,
+            "raw_rating_value": "questionable",
+            "normalized_rating": "R",
+            "confidence_score": 0.81,
+        }
+    ]


### PR DESCRIPTION
## 概要

Issue #333。image-annotator-lib (Issue #80, closed) が rating を model-native な `RatingPrediction(raw_label, confidence_score, source_scheme)` で返すようになったが、LoRAIro 側 `AnnotationSaveService._append_model_result()` は `str(ratings)` で雑に文字列化しており、`raw_rating_value` / `normalized_rating` の両方に `"[RatingPrediction(...)]"` という壊れた値が入っていた。

そのため `normalized_rating` が canonical 値 (`PG/PG-13/R/X/XXX`) にならず、特定レーティング検索でヒットせず、DB に意味のある AI rating が保存されなかった。

本 PR で model-native rating を canonical rating へ変換する mapper を LoRAIro 側に追加し、structured `ratings` を正しく `ratings` テーブルへ保存する。

## 変更内容

- **新規 `src/lorairo/domain/rating_mapper.py`** — `(source_scheme, raw_label)` を canonical rating (`PG/PG-13/R/X`) に変換する純粋関数 `map_rating()`。`domain/quality_tier.py` と同じ derived-view パターン。scheme エイリアス (`wdtagger`/`camie`→`danbooru4` 等) で forward-compat 対応。
- **`AnnotationSaveService`** — `_build_rating_row()` / `_select_rating_prediction()` / `_append_rating_row()` を追加。`list[RatingPrediction]` から最高 confidence の 1 件を選択 (`Rating` テーブルの `(image_id, model_id)` upsert に対応)、mapper で変換。マッピング不能 (未知 scheme) は skip + warning。後方互換 `str`/`list[str]` 経路を維持。
- **submodule `image-annotator-lib`** を #80 (rating 出力実装, PR #83) を含む pin に更新。
- **ADR 0031** — マッピング表 / `r15→R` 決定 / `XXX` 非生成 / top-1 (最高 confidence) 選択を記録。

## 設計判断

- `r15` → **`R`** にマッピング (Issue で「設定/方針で決定」とされた曖昧点を確定)。
- `source_scheme` は schema にカラムが無いため保存せず、mapper の判定入力のみに使用。
- マッピング不能時は壊れた値を保存せず skip (その画像は AI rating 未設定のまま)。

## テスト

- `tests/unit/domain/test_rating_mapper.py` (新規) — マッピング表全パターン・scheme エイリアス・大文字小文字・未知値・`XXX` 非生成。
- `tests/unit/services/test_annotation_save_service.py` — rating テスト 7 件追加 (structured / 最高 confidence 選択 / dict 形式 / 未知 scheme skip / 後方互換 str)。
- `tests/integration/test_rating_save_integration.py` (新規) — 実 SQLite で save-service→DB→AI rating filter の end-to-end 検証 (canonical 保存 / UNRATED 除外 / 該当値ヒット / manual・AI 分離)。

## 検証結果

CI-EQUIV-TESTED:

- LoRAIro CI-equivalent filter: **2417 passed**, 2 skipped, リグレッションなし
- image-annotator-lib CI-equivalent filter (`make test-iam-lib`): **670 passed**, 9 deselected
- `make mypy`: Success, no issues (147 files)
- `ruff format` / `ruff check`: All checks passed

残: 手動 GUI 確認 (「AIレーティング: 未設定のみ」→ アノテーション実行 → 再検索で対象から外れる)。

Closes #333

🤖 Generated with [Claude Code](https://claude.com/claude-code)