### PR TITLE
docs: clarify AI rating mapping ADR

### DIFF
--- a/docs/decisions/0015-manual-rating-storage-unification.md
+++ b/docs/decisions/0015-manual-rating-storage-unification.md
@@ -62,9 +62,17 @@
 - Alembic マイグレーション 1 回が必要（既存データを Rating テーブルへ移行）。
 - 「解除」操作が DELETE のため、過去の手動評価履歴は残らない（ADR 0002 の明示例外）。
 
+### 後続 ADR との関係
+
+ADR 0031 は、AI モデルが返す model-native rating も同じ `ratings` テーブルに保存する方針を
+追加する。これは本 ADR の「manual rating を `Rating` テーブルへ一元化する」判断を拡張する
+ものであり、手動評価は引き続き `model_id = MANUAL_EDIT` と DELETE による解除を使う。
+モデル出力の mapping / confidence / raw label の扱いは ADR 0031 に従う。
+
 ## Related
 
 - ADR 0002: Database Schema Decisions（履歴保持方針）
+- ADR 0031: AI Rating Mapping to Canonical Rating
 - Issue #118: NSFW フィルタの類似バグ
 - Issue #119: manual_rating フィルタのバグ
 - `src/lorairo/database/migrations/versions/e4a8f1b2c3d5_remove_image_manual_rating_unify_to_.py`

--- a/docs/decisions/0027-score-labels-db-storage.md
+++ b/docs/decisions/0027-score-labels-db-storage.md
@@ -48,6 +48,11 @@ ADR 0015 で manual rating を `ratings` テーブルに統一する判断と同
 **「異なる意味を持つアノテーション系は独立テーブルに分離する」**。
 score (数値) と label (categorical) は意味が異なる別 dimension のため分離。
 
+この方針は「外部モデルごとの label scheme ごとに新テーブルを作る」という意味ではない。
+ADR 0031 の model-native rating は、Danbooru / e621 / Sankaku / binary NSFW のように
+scheme が異なっても rating という同一 dimension であり、既存 `ratings` テーブルに保存する。
+LoRAIro canonical rating への変換は mapper の責務で、DB schema の追加では扱わない。
+
 ### iam-lib ADR 0002 との対称性
 
 iam-lib ADR 0002 で `tags` field と `score_labels` field を独立に保つ判断と
@@ -104,5 +109,6 @@ iam-lib ADR 0002 で「整数 bin tag (`[CAFE]score_N` / `[IAP]score_N` /
 - **LoRAIro 先例 ADR**:
   - 0015 (Manual Rating Storage Unification) — 別テーブル化の先例
   - 0023 (PydanticAI/LiteLLM WebAPI Inference Boundary) — annotation result contract
+  - 0031 (AI Rating Mapping to Canonical Rating) — model-native rating は既存 `ratings` テーブルに保存
 - **LoRAIro 起源 issue**: #273 (closed/migrated to iam-lib #66)
 - **submodule pin update PR (merged)**: #282

--- a/docs/decisions/0031-ai-rating-mapping.md
+++ b/docs/decisions/0031-ai-rating-mapping.md
@@ -53,18 +53,40 @@ questionable/explicit`、e621 系 `safe/questionable/explicit`、anime_rating
 4. **`XXX` は mapper から自動生成しない。** mapper の出力は `PG/PG-13/R/X` のみ。
    `XXX` は別基準 (手動・専用判定) なしに自動付与しない。
 
-5. **list[RatingPrediction] は最高 `confidence_score` の 1 件に絞る。**
+5. **保存先は既存 `ratings` テーブルを使う。** rating scheme ごとの新規テーブル・
+   新規カラムは作らない。`raw_rating_value` には model-native label、
+   `normalized_rating` には LoRAIro canonical rating を保存する。
+
+6. **list[RatingPrediction] は最高 `confidence_score` の 1 件に絞る。**
    `Rating` テーブルは `(image_id, model_id)` で upsert されるため 1 モデル = 1 行。
    `confidence_score` が `None` の予測は最下位扱い、全 None / 同値なら先頭 (top-1)。
 
-6. **マッピング不能 (未知 scheme / 未知 label) は保存せず skip + warning。**
+7. **マッピング不能 (未知 scheme / 未知 label) は保存せず skip + warning。**
    壊れた値を DB に入れるより、その画像を AI rating 未設定のまま残す方が安全。
 
-7. **`source_scheme` は DB に保存しない。** `ratings` テーブルに保存先カラムが無く、
+8. **`source_scheme` は DB に保存しない。** `ratings` テーブルに保存先カラムが無く、
    mapper の判定入力としてのみ使う。
 
-8. **後方互換 `str` / `list[str]` 経路を維持する。** `source_scheme` を持たないため
+9. **後方互換 `str` / `list[str]` 経路を維持する。** `source_scheme` を持たないため
    canonical 値とみなし、`PG/PG-13/R/X/XXX` であればそのまま保存、それ以外は skip。
+
+### Unmapped labels
+
+mapper が `source_scheme` + `raw_label` を解決できない場合、LoRAIro は誤った
+`normalized_rating` を保存しない。該当 rating は保存対象から外し、warning を出す。
+
+未知 label は主に以下のケースで発生する。
+
+- image-annotator-lib に新しい `source_scheme` が追加されたが、LoRAIro 側 mapper が未対応。
+- 既存 scheme に新しい label が増えた。例: `danbooru4` に未知の rating tier が追加される。
+- model card / `config.json` の label spelling が変わった。例: `sfw` と想定していたが `normal`
+  や `safe_for_work` が返る。
+- provider / WebAPI が prompt にない自由記述を返す。例: `probably safe`, `borderline`, `adult`.
+- rating ではない content category が混入する。例: `anime picture`.
+- `source_scheme` が欠落・typo している。
+
+これらを `PG` や `UNRATED` に丸めると、安全側の判定を誤る。未知 label は保存しないことで
+「未判定」として残し、mapper 追加・model adapter 修正・手動 rating のいずれかで解決する。
 
 ## Rationale
 
@@ -79,6 +101,16 @@ questionable/explicit`、e621 系 `safe/questionable/explicit`、anime_rating
 - **scheme エイリアス**: lib が現在 emit するのは `danbooru4` / `e6213` のみ。
   Issue #81 の新規 rating モデル候補 (`anime_rating` 等) に備え、表記揺れ・モデル系統
   差をエイリアスで吸収しておく (forward-compat)。
+- **なぜ Civitai 互換を優先するか**: LoRAIro の rating は、dataset 作成だけでなく
+  Civitai 投稿・WebAPI 投入・NSFW 除外の判断にも使われる。Civitai の browsing /
+  generation 制限では `R` 以上が mature / NSFW 側として扱われるため、
+  `questionable` / `r15` / binary `NSFW` のような曖昧な signal は `PG-13` ではなく
+  `R` に寄せる。これにより、LoRAIro の既存 NSFW 除外 (`R` / `X` / `XXX`) と
+  mapping の意味が一致する。
+- **なぜ binary NSFW を専用項目にしないか**: binary NSFW は、細かな rating を決める
+  というより API 送信可否や除外判定に使う signal である。専用カラムを増やすと、
+  既存の rating / NSFW filter と二重管理になる。永続化が必要な場合は
+  `SFW -> PG`、`NSFW -> R` として既存 rating record に寄せる。
 
 ## Consequences
 


### PR DESCRIPTION
## Summary
- clarify how ADR 0031 stores model-native rating labels in existing ratings rows
- document unmapped-label handling and Civitai/binary NSFW rationale
- cross-reference ADR 0031 from ADR 0015 and ADR 0027

## Tests
- git diff --check