### PR TITLE
fix: refine batch annotation model filtering

### DIFF
--- a/src/lorairo/gui/designer/AnnotationFilterWidget.ui
+++ b/src/lorairo/gui/designer/AnnotationFilterWidget.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>300</width>
-    <height>120</height>
+    <height>150</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -29,52 +29,6 @@
    <property name="bottomMargin">
     <number>0</number>
    </property>
-   <item>
-    <widget class="QGroupBox" name="groupBoxFunctionType">
-     <property name="title">
-      <string>機能タイプ</string>
-     </property>
-     <layout class="QHBoxLayout" name="horizontalLayoutFunctionType">
-      <property name="spacing">
-       <number>6</number>
-      </property>
-      <item>
-       <widget class="QCheckBox" name="checkBoxCaption">
-        <property name="text">
-         <string>Caption生成</string>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="checkBoxTags">
-        <property name="text">
-         <string>Tag生成</string>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="checkBoxScore">
-        <property name="text">
-         <string>品質スコア</string>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <spacer name="horizontalSpacerFunctionType">
-        <property name="orientation">
-         <enum>Qt::Orientation::Horizontal</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>40</width>
-          <height>20</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-     </layout>
-    </widget>
-   </item>
    <item>
     <widget class="QGroupBox" name="groupBoxEnvironment">
      <property name="title">
@@ -100,6 +54,59 @@
       </item>
       <item>
        <spacer name="horizontalSpacerEnvironment">
+        <property name="orientation">
+         <enum>Qt::Orientation::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>40</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QGroupBox" name="groupBoxFunctionType">
+     <property name="title">
+      <string>ローカルモデル対応機能</string>
+     </property>
+     <layout class="QHBoxLayout" name="horizontalLayoutFunctionType">
+      <property name="spacing">
+       <number>6</number>
+      </property>
+      <item>
+       <widget class="QCheckBox" name="checkBoxTags">
+        <property name="text">
+         <string>タグ対応</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="checkBoxCaption">
+        <property name="text">
+         <string>キャプション対応</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="checkBoxScore">
+        <property name="text">
+         <string>スコア対応</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="checkBoxRating">
+        <property name="text">
+         <string>レーティング対応</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <spacer name="horizontalSpacerFunctionType">
         <property name="orientation">
          <enum>Qt::Orientation::Horizontal</enum>
         </property>

--- a/src/lorairo/gui/designer/AnnotationFilterWidget_ui.py
+++ b/src/lorairo/gui/designer/AnnotationFilterWidget_ui.py
@@ -22,38 +22,11 @@ class Ui_AnnotationFilterWidget(object):
     def setupUi(self, AnnotationFilterWidget: QWidget) -> None:
         if not AnnotationFilterWidget.objectName():
             AnnotationFilterWidget.setObjectName(u"AnnotationFilterWidget")
-        AnnotationFilterWidget.resize(300, 120)
+        AnnotationFilterWidget.resize(300, 150)
         self.mainLayout = QVBoxLayout(AnnotationFilterWidget)
         self.mainLayout.setSpacing(6)
         self.mainLayout.setObjectName(u"mainLayout")
         self.mainLayout.setContentsMargins(0, 0, 0, 0)
-        self.groupBoxFunctionType = QGroupBox(AnnotationFilterWidget)
-        self.groupBoxFunctionType.setObjectName(u"groupBoxFunctionType")
-        self.horizontalLayoutFunctionType = QHBoxLayout(self.groupBoxFunctionType)
-        self.horizontalLayoutFunctionType.setSpacing(6)
-        self.horizontalLayoutFunctionType.setObjectName(u"horizontalLayoutFunctionType")
-        self.checkBoxCaption = QCheckBox(self.groupBoxFunctionType)
-        self.checkBoxCaption.setObjectName(u"checkBoxCaption")
-
-        self.horizontalLayoutFunctionType.addWidget(self.checkBoxCaption)
-
-        self.checkBoxTags = QCheckBox(self.groupBoxFunctionType)
-        self.checkBoxTags.setObjectName(u"checkBoxTags")
-
-        self.horizontalLayoutFunctionType.addWidget(self.checkBoxTags)
-
-        self.checkBoxScore = QCheckBox(self.groupBoxFunctionType)
-        self.checkBoxScore.setObjectName(u"checkBoxScore")
-
-        self.horizontalLayoutFunctionType.addWidget(self.checkBoxScore)
-
-        self.horizontalSpacerFunctionType = QSpacerItem(40, 20, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum)
-
-        self.horizontalLayoutFunctionType.addItem(self.horizontalSpacerFunctionType)
-
-
-        self.mainLayout.addWidget(self.groupBoxFunctionType)
-
         self.groupBoxEnvironment = QGroupBox(AnnotationFilterWidget)
         self.groupBoxEnvironment.setObjectName(u"groupBoxEnvironment")
         self.horizontalLayoutEnvironment = QHBoxLayout(self.groupBoxEnvironment)
@@ -76,6 +49,37 @@ class Ui_AnnotationFilterWidget(object):
 
         self.mainLayout.addWidget(self.groupBoxEnvironment)
 
+        self.groupBoxFunctionType = QGroupBox(AnnotationFilterWidget)
+        self.groupBoxFunctionType.setObjectName(u"groupBoxFunctionType")
+        self.horizontalLayoutFunctionType = QHBoxLayout(self.groupBoxFunctionType)
+        self.horizontalLayoutFunctionType.setSpacing(6)
+        self.horizontalLayoutFunctionType.setObjectName(u"horizontalLayoutFunctionType")
+        self.checkBoxTags = QCheckBox(self.groupBoxFunctionType)
+        self.checkBoxTags.setObjectName(u"checkBoxTags")
+
+        self.horizontalLayoutFunctionType.addWidget(self.checkBoxTags)
+
+        self.checkBoxCaption = QCheckBox(self.groupBoxFunctionType)
+        self.checkBoxCaption.setObjectName(u"checkBoxCaption")
+
+        self.horizontalLayoutFunctionType.addWidget(self.checkBoxCaption)
+
+        self.checkBoxScore = QCheckBox(self.groupBoxFunctionType)
+        self.checkBoxScore.setObjectName(u"checkBoxScore")
+
+        self.horizontalLayoutFunctionType.addWidget(self.checkBoxScore)
+
+        self.checkBoxRating = QCheckBox(self.groupBoxFunctionType)
+        self.checkBoxRating.setObjectName(u"checkBoxRating")
+
+        self.horizontalLayoutFunctionType.addWidget(self.checkBoxRating)
+
+        self.horizontalSpacerFunctionType = QSpacerItem(40, 20, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum)
+
+        self.horizontalLayoutFunctionType.addItem(self.horizontalSpacerFunctionType)
+
+
+        self.mainLayout.addWidget(self.groupBoxFunctionType)
 
         self.retranslateUi(AnnotationFilterWidget)
 
@@ -84,11 +88,12 @@ class Ui_AnnotationFilterWidget(object):
 
     def retranslateUi(self, AnnotationFilterWidget: QWidget) -> None:
         AnnotationFilterWidget.setWindowTitle(QCoreApplication.translate("AnnotationFilterWidget", u"Annotation Filter", None))
-        self.groupBoxFunctionType.setTitle(QCoreApplication.translate("AnnotationFilterWidget", u"\u6a5f\u80fd\u30bf\u30a4\u30d7", None))
-        self.checkBoxCaption.setText(QCoreApplication.translate("AnnotationFilterWidget", u"Caption\u751f\u6210", None))
-        self.checkBoxTags.setText(QCoreApplication.translate("AnnotationFilterWidget", u"Tag\u751f\u6210", None))
-        self.checkBoxScore.setText(QCoreApplication.translate("AnnotationFilterWidget", u"\u54c1\u8cea\u30b9\u30b3\u30a2", None))
         self.groupBoxEnvironment.setTitle(QCoreApplication.translate("AnnotationFilterWidget", u"\u5b9f\u884c\u74b0\u5883\u9078\u629e", None))
         self.checkBoxWebAPI.setText(QCoreApplication.translate("AnnotationFilterWidget", u"Web API", None))
         self.checkBoxLocal.setText(QCoreApplication.translate("AnnotationFilterWidget", u"\u30ed\u30fc\u30ab\u30eb\u30e2\u30c7\u30eb", None))
+        self.groupBoxFunctionType.setTitle(QCoreApplication.translate("AnnotationFilterWidget", u"\u30ed\u30fc\u30ab\u30eb\u30e2\u30c7\u30eb\u5bfe\u5fdc\u6a5f\u80fd", None))
+        self.checkBoxTags.setText(QCoreApplication.translate("AnnotationFilterWidget", u"\u30bf\u30b0\u5bfe\u5fdc", None))
+        self.checkBoxCaption.setText(QCoreApplication.translate("AnnotationFilterWidget", u"\u30ad\u30e3\u30d7\u30b7\u30e7\u30f3\u5bfe\u5fdc", None))
+        self.checkBoxScore.setText(QCoreApplication.translate("AnnotationFilterWidget", u"\u30b9\u30b3\u30a2\u5bfe\u5fdc", None))
+        self.checkBoxRating.setText(QCoreApplication.translate("AnnotationFilterWidget", u"\u30ec\u30fc\u30c6\u30a3\u30f3\u30b0\u5bfe\u5fdc", None))
     # retranslateUi

--- a/src/lorairo/gui/services/widget_setup_service.py
+++ b/src/lorairo/gui/services/widget_setup_service.py
@@ -41,6 +41,7 @@ class WidgetSetupService:
             "capabilities": filters.get("capabilities", []),
             "exclude_local": False,
             "execution_env": execution_env,
+            "annotation_only": True,
         }
 
     @staticmethod
@@ -48,6 +49,8 @@ class WidgetSetupService:
         """Batch annotation では外側の環境フィルターを唯一の操作面にする。"""
         if hasattr(model_widget, "executionEnvCombo"):
             model_widget.executionEnvCombo.setVisible(False)
+        if hasattr(model_widget, "set_annotation_only_filtering"):
+            model_widget.set_annotation_only_filtering(True)
 
     @staticmethod
     def setup_thumbnail_selector(
@@ -391,7 +394,7 @@ class WidgetSetupService:
             )
             # アノテーション走査用デフォルトフィルター（upscaler除外）
             # 初期状態でアップスケーラーモデルを表示しない
-            main_window.batchModelSelection.apply_filters(capabilities=["caption", "tags", "scores"])
+            main_window.batchModelSelection.apply_filters(annotation_only=True)
             main_window._annotation_filter_connected = True
             logger.info("✅ フィルター → モデル選択 Signal接続完了")
 

--- a/src/lorairo/gui/widgets/annotation_filter_widget.py
+++ b/src/lorairo/gui/widgets/annotation_filter_widget.py
@@ -1,7 +1,7 @@
 """
 Annotation Filter Widget - アノテーションフィルターウィジェット
 
-アノテーション機能タイプ（Caption/Tag/Score）と実行環境（Web API/ローカル）の
+ローカルモデル対応機能（Caption/Tag/Score/Rating）と実行環境（Web API/ローカル）の
 フィルタリングUIを提供する。ModelSelectionWidget と連携してモデル一覧を
 動的にフィルタリングする。
 
@@ -36,7 +36,7 @@ class AnnotationFilterWidget(QWidget, Ui_AnnotationFilterWidget):
     """
     アノテーションフィルターウィジェット
 
-    機能タイプ（Caption生成、Tag生成、品質スコア）と実行環境（Web API、ローカルモデル）の
+    ローカルモデル対応機能と実行環境（Web API、ローカルモデル）の
     チェックボックスによるフィルタリングUIを提供。
 
     Signals:
@@ -58,6 +58,7 @@ class AnnotationFilterWidget(QWidget, Ui_AnnotationFilterWidget):
         checkBoxCaption: QCheckBox
         checkBoxTags: QCheckBox
         checkBoxScore: QCheckBox
+        checkBoxRating: QCheckBox
         checkBoxWebAPI: QCheckBox
         checkBoxLocal: QCheckBox
 
@@ -72,6 +73,7 @@ class AnnotationFilterWidget(QWidget, Ui_AnnotationFilterWidget):
         self.setupUi(self)
 
         self._connect_signals()
+        self._update_capability_controls()
         logger.debug("AnnotationFilterWidget initialized")
 
     def _connect_signals(self) -> None:
@@ -80,6 +82,7 @@ class AnnotationFilterWidget(QWidget, Ui_AnnotationFilterWidget):
         self.checkBoxCaption.stateChanged.connect(self._on_filter_changed)
         self.checkBoxTags.stateChanged.connect(self._on_filter_changed)
         self.checkBoxScore.stateChanged.connect(self._on_filter_changed)
+        self.checkBoxRating.stateChanged.connect(self._on_filter_changed)
 
         # 実行環境チェックボックス
         self.checkBoxWebAPI.stateChanged.connect(self._on_filter_changed)
@@ -92,9 +95,26 @@ class AnnotationFilterWidget(QWidget, Ui_AnnotationFilterWidget):
         Args:
             _state: チェックボックスの状態（未使用、シグナル接続用）
         """
+        self._update_capability_controls()
         filters = self.get_current_filters()
         logger.debug(f"Filter changed: {filters}")
         self.filter_changed.emit(filters)
+
+    def _is_local_only_environment(self) -> bool:
+        """Capability filter is meaningful only when the environment is local-only."""
+        return self.checkBoxLocal.isChecked() and not self.checkBoxWebAPI.isChecked()
+
+    def _update_capability_controls(self) -> None:
+        """ローカル専用時だけ capability control を有効化する。"""
+        enabled = self._is_local_only_environment()
+        self.groupBoxFunctionType.setEnabled(enabled)
+        for checkbox in (
+            self.checkBoxTags,
+            self.checkBoxCaption,
+            self.checkBoxScore,
+            self.checkBoxRating,
+        ):
+            checkbox.setEnabled(enabled)
 
     def get_current_filters(self) -> dict[str, Any]:
         """
@@ -102,18 +122,9 @@ class AnnotationFilterWidget(QWidget, Ui_AnnotationFilterWidget):
 
         Returns:
             dict: フィルター状態
-                - capabilities: list[str] - 選択された機能タイプ ('caption', 'tags', 'scores')
+                - capabilities: list[str] - 選択された対応機能 ('caption', 'tags', 'scores', 'ratings')
                 - environment: str | None - 実行環境 ('local', 'api', None)
         """
-        # 機能タイプ: DB ModelType.name 値と一致させる ('caption', 'tags', 'scores')
-        capabilities: list[str] = []
-        if self.checkBoxCaption.isChecked():
-            capabilities.append("caption")
-        if self.checkBoxTags.isChecked():
-            capabilities.append("tags")
-        if self.checkBoxScore.isChecked():
-            capabilities.append("scores")
-
         # 実行環境
         environment: str | None = None
         web_api = self.checkBoxWebAPI.isChecked()
@@ -124,6 +135,18 @@ class AnnotationFilterWidget(QWidget, Ui_AnnotationFilterWidget):
         elif web_api and not local:
             environment = "api"
         # 両方チェックまたは両方未チェック → None (フィルターなし)
+
+        # ローカルモデル対応機能: DB ModelType.name 値と一致させる。
+        capabilities: list[str] = []
+        if environment == "local":
+            if self.checkBoxTags.isChecked():
+                capabilities.append("tags")
+            if self.checkBoxCaption.isChecked():
+                capabilities.append("caption")
+            if self.checkBoxScore.isChecked():
+                capabilities.append("scores")
+            if self.checkBoxRating.isChecked():
+                capabilities.append("ratings")
 
         return {"capabilities": capabilities, "environment": environment}
 
@@ -136,7 +159,7 @@ class AnnotationFilterWidget(QWidget, Ui_AnnotationFilterWidget):
         フィルター状態を設定
 
         Args:
-            capabilities: 機能タイプリスト ('caption', 'tags', 'scores')、None でクリア
+            capabilities: 対応機能リスト ('caption', 'tags', 'scores', 'ratings')、None でクリア
             environment: 実行環境 ('local', 'api')、None でクリア
 
         Note:
@@ -146,12 +169,13 @@ class AnnotationFilterWidget(QWidget, Ui_AnnotationFilterWidget):
         self.blockSignals(True)
 
         try:
-            # 機能タイプ設定 (DB ModelType.name 値と一致: 'caption', 'tags', 'scores')
+            # 機能タイプ設定 (DB ModelType.name 値と一致)
             if capabilities is not _UNSET:
                 caps = cast("list[str]", capabilities if capabilities is not None else [])
                 self.checkBoxCaption.setChecked("caption" in caps)
                 self.checkBoxTags.setChecked("tags" in caps)
                 self.checkBoxScore.setChecked("scores" in caps)
+                self.checkBoxRating.setChecked("ratings" in caps)
 
             # 実行環境設定
             if environment is not _UNSET:
@@ -166,6 +190,7 @@ class AnnotationFilterWidget(QWidget, Ui_AnnotationFilterWidget):
         finally:
             self.blockSignals(False)
 
+        self._update_capability_controls()
         # 設定後にシグナルを発火
         self.filter_changed.emit(self.get_current_filters())
 
@@ -177,11 +202,13 @@ class AnnotationFilterWidget(QWidget, Ui_AnnotationFilterWidget):
             self.checkBoxCaption.setChecked(False)
             self.checkBoxTags.setChecked(False)
             self.checkBoxScore.setChecked(False)
+            self.checkBoxRating.setChecked(False)
             self.checkBoxWebAPI.setChecked(False)
             self.checkBoxLocal.setChecked(False)
 
         finally:
             self.blockSignals(False)
 
+        self._update_capability_controls()
         self.filter_changed.emit(self.get_current_filters())
         logger.debug("All filters cleared")

--- a/src/lorairo/gui/widgets/model_selection_widget.py
+++ b/src/lorairo/gui/widgets/model_selection_widget.py
@@ -86,6 +86,10 @@ if not __name__ == "__main__":
         # シグナル定義 (Issue #245: selected_litellm_model_ids を emit)
         model_selection_changed = Signal(list)  # selected_litellm_model_ids
         selection_count_changed = Signal(int, int)  # selected_count, total_count
+        WEB_API_BATCH_PLACEHOLDER = (
+            "Web APIモデルはローカルモデル絞り込みの対象外です。"
+            "開始時のモデル選択ダイアログで使用モデルを選択します。"
+        )
 
         # UI elements type hints (from Ui_ModelSelectionWidget via multi-inheritance)
         if TYPE_CHECKING:
@@ -132,6 +136,8 @@ if not __name__ == "__main__":
             self.current_capability_filters: list[str] = []
             self.current_exclude_local: bool = False
             self.current_execution_env: str | None = None  # "すべて", "APIモデルのみ", "ローカルモデルのみ"
+            self.annotation_only_filtering: bool = False
+            self._default_placeholder_text = self.placeholderLabel.text()
 
             # executionEnvCombo シグナル接続
             if hasattr(self, "executionEnvCombo"):
@@ -280,6 +286,7 @@ if not __name__ == "__main__":
             capabilities: list[str] | None = None,
             exclude_local: bool = False,
             execution_env: str | None = None,
+            annotation_only: bool | None = None,
         ) -> None:
             """フィルタリング適用
 
@@ -288,12 +295,19 @@ if not __name__ == "__main__":
                 capabilities: 機能フィルタ（["caption", "tags", "scores"]）
                 exclude_local: True の場合、ローカルモデルを除外（API モデルのみ表示）
                 execution_env: 実行環境フィルタ（"すべて", "APIモデルのみ", "ローカルモデルのみ"）
+                annotation_only: True の場合、batch annotation 対象モデルだけを表示
             """
             self.current_provider_filter = provider
             self.current_capability_filters = capabilities or []
             self.current_exclude_local = exclude_local
             self.current_execution_env = execution_env
+            if annotation_only is not None:
+                self.annotation_only_filtering = annotation_only
             self.update_model_display()
+
+        def set_annotation_only_filtering(self, enabled: bool) -> None:
+            """Batch annotation 用の annotation-eligible モデル絞り込みを切り替える。"""
+            self.annotation_only_filtering = enabled
 
         def update_model_display(self) -> None:
             """モデル表示更新 (Issue #241: route 畳み込み済み view model 経由)。
@@ -303,6 +317,16 @@ if not __name__ == "__main__":
             """
             # 現在の表示をクリア
             self._clear_model_display()
+
+            if self._should_show_web_api_batch_placeholder():
+                self.filtered_options = []
+                self.filtered_models = []
+                self.placeholderLabel.setText(self.WEB_API_BATCH_PLACEHOLDER)
+                self.placeholderLabel.setVisible(True)
+                self._update_selection_count()
+                return
+
+            self.placeholderLabel.setText(self._default_placeholder_text)
 
             available_providers = self._build_available_providers()
             route_preference = self._get_route_preference()
@@ -391,6 +415,7 @@ if not __name__ == "__main__":
                     only_available=True,
                     exclude_local=self.current_exclude_local,
                     execution_env=self.current_execution_env,
+                    annotation_only=self.annotation_only_filtering,
                 )
 
                 options = self.model_selection_service.load_grouped_models(
@@ -430,7 +455,16 @@ if not __name__ == "__main__":
                     if any(cap in m.capabilities for cap in self.current_capability_filters)
                 ]
 
+            if self.annotation_only_filtering:
+                filtered = [
+                    m for m in filtered if self.model_selection_service._is_annotation_eligible_model(m)
+                ]
+
             return filtered
+
+        def _should_show_web_api_batch_placeholder(self) -> bool:
+            """Batch annotation の Web API only ではローカルモデル一覧を表示しない。"""
+            return self.annotation_only_filtering and self.current_execution_env == "APIモデルのみ"
 
         def _group_options_by_provider(
             self, options: list[DisplayModelOption]

--- a/src/lorairo/services/model_selection_service.py
+++ b/src/lorairo/services/model_selection_service.py
@@ -20,6 +20,7 @@ class ModelSelectionCriteria:
     only_available: bool = True
     exclude_local: bool = False  # True の場合、provider が local/None のモデルを除外
     execution_env: str | None = None  # "APIモデルのみ" or "ローカルモデルのみ" or None/"すべて"
+    annotation_only: bool = False  # True の場合、batch annotation 対象モデルだけに絞る
 
 
 class ModelSelectionService:
@@ -94,6 +95,39 @@ class ModelSelectionService:
             return "local"
         return provider.lower()
 
+    @staticmethod
+    def _model_capability_names(model: Model) -> set[str]:
+        """Model capabilities/model_types から構造化された capability 名を取得する。"""
+        capabilities = getattr(model, "capabilities", None)
+        if capabilities is not None:
+            return {str(capability) for capability in capabilities}
+
+        model_types = getattr(model, "model_types", [])
+        return {
+            str(getattr(model_type, "name", model_type))
+            for model_type in model_types
+            if getattr(model_type, "name", model_type) is not None
+        }
+
+    @classmethod
+    def _is_annotation_eligible_model(cls, model: Model) -> bool:
+        """Batch annotation に使える model_types/capabilities を持つか判定する。"""
+        annotation_types = {"caption", "tags", "scores", "ratings", "multimodal"}
+        return bool(cls._model_capability_names(model) & annotation_types)
+
+    @classmethod
+    def _filter_annotation_eligible(
+        cls,
+        models: list[Model],
+        annotation_only: bool,
+    ) -> list[Model]:
+        """annotation_only が有効な場合だけ batch annotation 対象モデルに絞る。"""
+        if not annotation_only:
+            return models
+        filtered = [model for model in models if cls._is_annotation_eligible_model(model)]
+        logger.debug(f"  アノテーション対象フィルタ後: {len(filtered)}件")
+        return filtered
+
     def filter_models(
         self,
         criteria: ModelSelectionCriteria | None = None,
@@ -107,6 +141,7 @@ class ModelSelectionService:
             f"モデルフィルタリング開始: provider={criteria.provider}, "
             f"exclude_local={criteria.exclude_local}, execution_env={criteria.execution_env}, "
             f"capabilities={criteria.capabilities}, "
+            f"annotation_only={criteria.annotation_only}, "
             f"only_recommended={criteria.only_recommended}, only_available={criteria.only_available}, "
             f"対象モデル数={len(self._all_models)}"
         )
@@ -133,9 +168,16 @@ class ModelSelectionService:
             filtered = [m for m in filtered if self._provider_key(m.provider) != "local"]
             logger.debug(f"  ローカルモデル除外後: {len(filtered)}件")
 
+        # Batch annotation 対象モデルのみ: upscaler 専用など annotation 非対応モデルを除外
+        filtered = self._filter_annotation_eligible(filtered, criteria.annotation_only)
+
         # 機能フィルタ
         if criteria.capabilities:
-            filtered = [m for m in filtered if any(cap in m.capabilities for cap in criteria.capabilities)]
+            filtered = [
+                m
+                for m in filtered
+                if any(cap in self._model_capability_names(m) for cap in criteria.capabilities)
+            ]
             logger.debug(f"  機能フィルタ後: {len(filtered)}件 (capabilities={criteria.capabilities})")
 
         # 推奨フィルタ（DB Modelプロパティ使用）

--- a/tests/unit/gui/services/test_widget_setup_service.py
+++ b/tests/unit/gui/services/test_widget_setup_service.py
@@ -21,6 +21,7 @@ class TestWidgetSetupServiceModelSelectionFilters:
             "capabilities": [],
             "exclude_local": False,
             "execution_env": "APIモデルのみ",
+            "annotation_only": True,
         }
 
     def test_local_environment_keeps_empty_capabilities(self) -> None:
@@ -34,6 +35,7 @@ class TestWidgetSetupServiceModelSelectionFilters:
             "capabilities": [],
             "exclude_local": False,
             "execution_env": "ローカルモデルのみ",
+            "annotation_only": True,
         }
 
     def test_capabilities_are_not_replaced_with_defaults(self) -> None:
@@ -47,6 +49,7 @@ class TestWidgetSetupServiceModelSelectionFilters:
             "capabilities": ["caption"],
             "exclude_local": False,
             "execution_env": None,
+            "annotation_only": True,
         }
 
     def test_missing_capabilities_defaults_to_empty_list(self) -> None:
@@ -58,6 +61,7 @@ class TestWidgetSetupServiceModelSelectionFilters:
             "capabilities": [],
             "exclude_local": False,
             "execution_env": None,
+            "annotation_only": True,
         }
 
     def test_batch_model_selection_hides_internal_execution_env_combo(self) -> None:
@@ -67,3 +71,4 @@ class TestWidgetSetupServiceModelSelectionFilters:
         WidgetSetupService._configure_batch_model_selection_widget(model_widget)
 
         model_widget.executionEnvCombo.setVisible.assert_called_once_with(False)
+        model_widget.set_annotation_only_filtering.assert_called_once_with(True)

--- a/tests/unit/gui/widgets/test_annotation_filter_widget.py
+++ b/tests/unit/gui/widgets/test_annotation_filter_widget.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import pytest
-from PySide6.QtCore import Qt
 
 
 @pytest.fixture
@@ -23,14 +22,17 @@ class TestAnnotationFilterWidgetInitialization:
         """初期状態で全チェックボックスが未チェック"""
         widget = annotation_filter_widget
 
-        # 機能タイプ
         assert not widget.checkBoxCaption.isChecked()
         assert not widget.checkBoxTags.isChecked()
         assert not widget.checkBoxScore.isChecked()
-
-        # 実行環境
+        assert not widget.checkBoxRating.isChecked()
         assert not widget.checkBoxWebAPI.isChecked()
         assert not widget.checkBoxLocal.isChecked()
+
+        assert not widget.checkBoxCaption.isEnabled()
+        assert not widget.checkBoxTags.isEnabled()
+        assert not widget.checkBoxScore.isEnabled()
+        assert not widget.checkBoxRating.isEnabled()
 
     def test_initial_filters_empty(self, annotation_filter_widget):
         """初期状態でフィルターが空"""
@@ -39,53 +41,75 @@ class TestAnnotationFilterWidgetInitialization:
         assert filters["capabilities"] == []
         assert filters["environment"] is None
 
+    def test_labels_show_environment_before_local_capabilities(self, annotation_filter_widget):
+        """実行環境がローカルモデル対応機能より上に表示される"""
+        widget = annotation_filter_widget
+
+        assert widget.mainLayout.indexOf(widget.groupBoxEnvironment) < widget.mainLayout.indexOf(
+            widget.groupBoxFunctionType
+        )
+        assert widget.groupBoxFunctionType.title() == "ローカルモデル対応機能"
+        assert widget.checkBoxTags.text() == "タグ対応"
+        assert widget.checkBoxCaption.text() == "キャプション対応"
+        assert widget.checkBoxScore.text() == "スコア対応"
+        assert widget.checkBoxRating.text() == "レーティング対応"
+
 
 class TestAnnotationFilterWidgetCapabilities:
-    """機能タイプフィルターテスト"""
+    """ローカルモデル対応機能フィルターテスト"""
 
-    def test_caption_filter(self, annotation_filter_widget, qtbot):
-        """Caption生成フィルター"""
+    def test_caption_filter(self, annotation_filter_widget):
+        """キャプション対応フィルター"""
         widget = annotation_filter_widget
 
+        widget.checkBoxLocal.setChecked(True)
         widget.checkBoxCaption.setChecked(True)
         filters = widget.get_current_filters()
 
-        assert "caption" in filters["capabilities"]
-        assert "tags" not in filters["capabilities"]
-        assert "scores" not in filters["capabilities"]
+        assert filters["capabilities"] == ["caption"]
 
     def test_tags_filter(self, annotation_filter_widget):
-        """Tag生成フィルター"""
+        """タグ対応フィルター"""
         widget = annotation_filter_widget
 
+        widget.checkBoxLocal.setChecked(True)
         widget.checkBoxTags.setChecked(True)
         filters = widget.get_current_filters()
 
-        assert "tags" in filters["capabilities"]
-        assert "caption" not in filters["capabilities"]
+        assert filters["capabilities"] == ["tags"]
 
     def test_score_filter(self, annotation_filter_widget):
-        """品質スコアフィルター"""
+        """スコア対応フィルター"""
         widget = annotation_filter_widget
 
+        widget.checkBoxLocal.setChecked(True)
         widget.checkBoxScore.setChecked(True)
         filters = widget.get_current_filters()
 
-        assert "scores" in filters["capabilities"]
+        assert filters["capabilities"] == ["scores"]
+
+    def test_ratings_filter(self, annotation_filter_widget):
+        """レーティング対応フィルター"""
+        widget = annotation_filter_widget
+
+        widget.checkBoxLocal.setChecked(True)
+        widget.checkBoxRating.setChecked(True)
+        filters = widget.get_current_filters()
+
+        assert filters["capabilities"] == ["ratings"]
 
     def test_multiple_capabilities(self, annotation_filter_widget):
-        """複数の機能タイプを選択"""
+        """複数の対応機能を選択"""
         widget = annotation_filter_widget
 
-        widget.checkBoxCaption.setChecked(True)
+        widget.checkBoxLocal.setChecked(True)
         widget.checkBoxTags.setChecked(True)
+        widget.checkBoxCaption.setChecked(True)
         widget.checkBoxScore.setChecked(True)
+        widget.checkBoxRating.setChecked(True)
         filters = widget.get_current_filters()
 
-        assert len(filters["capabilities"]) == 3
-        assert "caption" in filters["capabilities"]
-        assert "tags" in filters["capabilities"]
-        assert "scores" in filters["capabilities"]
+        assert filters["capabilities"] == ["tags", "caption", "scores", "ratings"]
 
 
 class TestAnnotationFilterWidgetEnvironment:
@@ -118,12 +142,37 @@ class TestAnnotationFilterWidgetEnvironment:
         filters = widget.get_current_filters()
 
         assert filters["environment"] is None
+        assert filters["capabilities"] == []
 
     def test_neither_environment_selected(self, annotation_filter_widget):
         """両方未選択時はフィルターなし"""
         filters = annotation_filter_widget.get_current_filters()
 
         assert filters["environment"] is None
+        assert filters["capabilities"] == []
+
+    @pytest.mark.parametrize(
+        ("web_api", "local", "enabled"),
+        [
+            (False, True, True),
+            (True, False, False),
+            (True, True, False),
+            (False, False, False),
+        ],
+    )
+    def test_capability_controls_enabled_only_for_local_only(
+        self, annotation_filter_widget, web_api, local, enabled
+    ):
+        """Capability controls はローカルのみ選択時だけ有効"""
+        widget = annotation_filter_widget
+
+        widget.checkBoxWebAPI.setChecked(web_api)
+        widget.checkBoxLocal.setChecked(local)
+
+        assert widget.checkBoxCaption.isEnabled() is enabled
+        assert widget.checkBoxTags.isEnabled() is enabled
+        assert widget.checkBoxScore.isEnabled() is enabled
+        assert widget.checkBoxRating.isEnabled() is enabled
 
 
 class TestAnnotationFilterWidgetSignals:
@@ -133,11 +182,12 @@ class TestAnnotationFilterWidgetSignals:
         """Caption チェック時に filter_changed シグナル発火"""
         widget = annotation_filter_widget
 
+        widget.checkBoxLocal.setChecked(True)
         with qtbot.waitSignal(widget.filter_changed, timeout=1000) as blocker:
             widget.checkBoxCaption.setChecked(True)
 
         filters = blocker.args[0]
-        assert "caption" in filters["capabilities"]
+        assert filters["capabilities"] == ["caption"]
 
     def test_filter_changed_signal_on_environment_check(self, annotation_filter_widget, qtbot):
         """環境チェック時に filter_changed シグナル発火"""
@@ -153,15 +203,17 @@ class TestAnnotationFilterWidgetSignals:
 class TestAnnotationFilterWidgetSetFilters:
     """set_filters メソッドテスト"""
 
-    def test_set_capabilities(self, annotation_filter_widget, qtbot):
+    def test_set_capabilities(self, annotation_filter_widget):
         """capabilities を設定"""
         widget = annotation_filter_widget
 
-        widget.set_filters(capabilities=["caption", "tags"])
+        widget.set_filters(capabilities=["caption", "tags", "ratings"], environment="local")
 
         assert widget.checkBoxCaption.isChecked()
         assert widget.checkBoxTags.isChecked()
+        assert widget.checkBoxRating.isChecked()
         assert not widget.checkBoxScore.isChecked()
+        assert widget.get_current_filters()["capabilities"] == ["tags", "caption", "ratings"]
 
     def test_set_environment_local(self, annotation_filter_widget):
         """environment を local に設定"""
@@ -171,6 +223,7 @@ class TestAnnotationFilterWidgetSetFilters:
 
         assert widget.checkBoxLocal.isChecked()
         assert not widget.checkBoxWebAPI.isChecked()
+        assert widget.checkBoxCaption.isEnabled()
 
     def test_set_environment_api(self, annotation_filter_widget):
         """environment を api に設定"""
@@ -180,50 +233,51 @@ class TestAnnotationFilterWidgetSetFilters:
 
         assert widget.checkBoxWebAPI.isChecked()
         assert not widget.checkBoxLocal.isChecked()
+        assert not widget.checkBoxCaption.isEnabled()
+        assert widget.get_current_filters()["capabilities"] == []
 
 
 class TestAnnotationFilterWidgetClearFilters:
     """clear_filters メソッドテスト"""
 
-    def test_clear_all_filters(self, annotation_filter_widget, qtbot):
+    def test_clear_all_filters(self, annotation_filter_widget):
         """全フィルターをクリア"""
         widget = annotation_filter_widget
 
-        # まず全てチェック
+        widget.checkBoxLocal.setChecked(True)
         widget.checkBoxCaption.setChecked(True)
         widget.checkBoxTags.setChecked(True)
         widget.checkBoxScore.setChecked(True)
+        widget.checkBoxRating.setChecked(True)
         widget.checkBoxWebAPI.setChecked(True)
 
-        # クリア
         widget.clear_filters()
 
-        # 全て未チェック
         assert not widget.checkBoxCaption.isChecked()
         assert not widget.checkBoxTags.isChecked()
         assert not widget.checkBoxScore.isChecked()
+        assert not widget.checkBoxRating.isChecked()
         assert not widget.checkBoxWebAPI.isChecked()
         assert not widget.checkBoxLocal.isChecked()
 
-        # フィルターも空
         filters = widget.get_current_filters()
         assert filters["capabilities"] == []
         assert filters["environment"] is None
 
 
 class TestAnnotationFilterWidgetEmptyCapabilitiesWithEnvironment:
-    """環境フィルターのみ設定時のテスト（修正内容関連）"""
+    """環境フィルターのみ設定時のテスト"""
 
     def test_web_api_only_empty_capabilities(self, annotation_filter_widget):
         """Web APIのみチェック時、capabilityは空"""
         widget = annotation_filter_widget
 
+        widget.checkBoxCaption.setChecked(True)
+        widget.checkBoxTags.setChecked(True)
         widget.checkBoxWebAPI.setChecked(True)
         filters = widget.get_current_filters()
 
-        # capabilityは未チェックなので空リスト
         assert filters["capabilities"] == []
-        # 環境はapi
         assert filters["environment"] == "api"
 
     def test_local_only_empty_capabilities(self, annotation_filter_widget):
@@ -233,24 +287,5 @@ class TestAnnotationFilterWidgetEmptyCapabilitiesWithEnvironment:
         widget.checkBoxLocal.setChecked(True)
         filters = widget.get_current_filters()
 
-        # capabilityは未チェックなので空リスト
         assert filters["capabilities"] == []
-        # 環境はlocal
         assert filters["environment"] == "local"
-
-    def test_mixed_capabilities_and_environment(self, annotation_filter_widget):
-        """Capabilityと環境を混在チェック"""
-        widget = annotation_filter_widget
-
-        # Capabilityはcaption, tagsのみ
-        widget.checkBoxCaption.setChecked(True)
-        widget.checkBoxTags.setChecked(True)
-        # 環境はWeb APIのみ
-        widget.checkBoxWebAPI.setChecked(True)
-
-        filters = widget.get_current_filters()
-
-        # capabilityはcaption, tags
-        assert filters["capabilities"] == ["caption", "tags"]
-        # 環境はapi
-        assert filters["environment"] == "api"

--- a/tests/unit/gui/widgets/test_model_selection_widget.py
+++ b/tests/unit/gui/widgets/test_model_selection_widget.py
@@ -100,6 +100,42 @@ class TestModelSelectionWidgetFilters:
     def test_set_selected_models_does_not_crash_with_empty_list(self, widget):
         widget.set_selected_models([])
 
+    def test_batch_web_api_only_shows_placeholder_without_model_rows(self, qtbot, mock_model_service):
+        """Batch annotation の Web API only では通常モデル行を表示しない"""
+        mock_model_service.load_grouped_models.return_value = []
+        w = ModelSelectionWidget(model_selection_service=mock_model_service, mode="advanced")
+        qtbot.addWidget(w)
+
+        w.apply_filters(execution_env="APIモデルのみ", annotation_only=True)
+
+        assert not w.placeholderLabel.isHidden()
+        assert w.placeholderLabel.text() == ModelSelectionWidget.WEB_API_BATCH_PLACEHOLDER
+        assert w.model_checkbox_widgets == {}
+        assert w.get_selected_models() == []
+
+    def test_non_batch_web_api_only_uses_normal_filtering(self, qtbot, mock_model_service):
+        """通常利用時の Web API only は batch placeholder 分岐に入らない"""
+        mock_model_service.load_grouped_models.return_value = []
+        w = ModelSelectionWidget(model_selection_service=mock_model_service, mode="advanced")
+        qtbot.addWidget(w)
+
+        w.apply_filters(execution_env="APIモデルのみ")
+
+        assert w.placeholderLabel.text() != ModelSelectionWidget.WEB_API_BATCH_PLACEHOLDER
+        assert mock_model_service.load_grouped_models.call_args[0][0].execution_env == "APIモデルのみ"
+
+    def test_batch_annotation_filtering_passes_annotation_only_criteria(self, qtbot, mock_model_service):
+        """Batch annotation opt-in 時だけ annotation_only criteria を渡す"""
+        mock_model_service.load_grouped_models.return_value = []
+        w = ModelSelectionWidget(model_selection_service=mock_model_service, mode="advanced")
+        qtbot.addWidget(w)
+
+        w.apply_filters(execution_env="ローカルモデルのみ", annotation_only=True)
+
+        criteria = mock_model_service.load_grouped_models.call_args[0][0]
+        assert criteria.annotation_only is True
+        assert criteria.execution_env == "ローカルモデルのみ"
+
 
 class TestModelSelectionWidgetRefreshThread:
     def test_stop_refresh_thread_quits_and_waits(self, widget):

--- a/tests/unit/services/test_model_selection_service.py
+++ b/tests/unit/services/test_model_selection_service.py
@@ -1,5 +1,6 @@
 # tests/unit/services/test_model_selection_service.py
 
+from types import SimpleNamespace
 from unittest.mock import Mock
 
 import pytest
@@ -245,6 +246,57 @@ class TestModelSelectionService:
         local_models = service.filter_models(criteria)
 
         assert {model.name for model in local_models} == {"wd-v1-4", "clip-aesthetic"}
+
+    def test_annotation_only_filter_excludes_pure_upscaler(self, service):
+        """annotation_only は model_types/capabilities で pure upscaler を除外する"""
+        caption_model = SimpleNamespace(
+            name="caption-model",
+            provider="local",
+            capabilities=["caption"],
+            is_recommended=False,
+            available=True,
+        )
+        multimodal_model = SimpleNamespace(
+            name="multimodal-model",
+            provider="local",
+            capabilities=["multimodal", "upscaler"],
+            is_recommended=False,
+            available=True,
+        )
+        upscaler_model = SimpleNamespace(
+            name="upscaler-model",
+            provider="local",
+            capabilities=["upscaler"],
+            is_recommended=False,
+            available=True,
+        )
+        service._all_models = [caption_model, multimodal_model, upscaler_model]
+
+        filtered = service.filter_models(ModelSelectionCriteria(annotation_only=True))
+
+        assert {model.name for model in filtered} == {"caption-model", "multimodal-model"}
+
+    def test_annotation_only_filter_accepts_ratings_capability(self, service):
+        """ratings は batch annotation 対象 capability として扱う"""
+        ratings_model = SimpleNamespace(
+            name="ratings-model",
+            provider="local",
+            capabilities=["ratings"],
+            is_recommended=False,
+            available=True,
+        )
+        upscaler_model = SimpleNamespace(
+            name="upscaler-model",
+            provider="local",
+            capabilities=["upscaler"],
+            is_recommended=False,
+            available=True,
+        )
+        service._all_models = [ratings_model, upscaler_model]
+
+        filtered = service.filter_models(ModelSelectionCriteria(annotation_only=True))
+
+        assert [model.name for model in filtered] == ["ratings-model"]
 
     # create_model_tooltip, create_model_display_name, _is_recommended_model メソッドは
     # DB中心アーキテクチャでWidgetに移動されたため、テストを削除


### PR DESCRIPTION
## Summary
- reorder batch annotation filters so execution environment is first
- rename capability controls to local model filtering and add ratings support
- disable local capability filtering outside local-only mode
- show a Web API placeholder instead of local model rows in batch annotation
- add annotation-only filtering so pure upscaler models are excluded

Fixes #340
Fixes #341
Fixes #342
Part of #339

## Tests
- uv run ruff check src/lorairo/gui/widgets/annotation_filter_widget.py src/lorairo/gui/widgets/model_selection_widget.py src/lorairo/gui/services/widget_setup_service.py src/lorairo/services/model_selection_service.py tests/unit/gui/widgets/test_annotation_filter_widget.py tests/unit/gui/widgets/test_model_selection_widget.py tests/unit/gui/services/test_widget_setup_service.py tests/unit/services/test_model_selection_service.py
- uv run pytest tests/unit/gui/widgets/test_annotation_filter_widget.py tests/unit/gui/widgets/test_model_selection_widget.py tests/unit/gui/services/test_widget_setup_service.py tests/unit/services/test_model_selection_service.py