### PR TITLE
fix: improve web api model display names

### DIFF
--- a/src/lorairo/cli/commands/models.py
+++ b/src/lorairo/cli/commands/models.py
@@ -15,10 +15,8 @@ if TYPE_CHECKING:
     from rich.console import Console
 from lorairo.services.model_route_service import (
     build_available_providers,
-    canonical_key,
-    detect_route,
+    build_model_route_identity,
     parse_route_preference,
-    required_provider_for,
 )
 from lorairo.services.service_container import get_service_container
 from lorairo.utils.log import logger
@@ -313,8 +311,7 @@ def _group_rows_by_canonical_key(
     grouped: dict[str, list[dict[str, str | bool]]] = {}
     order: list[str] = []
     for row in rows:
-        litellm_id = str(row["litellm_id"])
-        ckey = canonical_key(litellm_id)
+        ckey = str(row["canonical_key"])
         if ckey not in grouped:
             grouped[ckey] = []
             order.append(ckey)
@@ -356,25 +353,36 @@ def _build_rows_from_infos(
 
         type_label = "webapi" if info.is_api else "local"
         litellm_id = info.litellm_model_id or info.name
-        row_route = detect_route(litellm_id)
-        row_required = required_provider_for(litellm_id, info.provider)
+        identity = build_model_route_identity(
+            litellm_id,
+            info.name,
+            info.provider,
+            info.is_api,
+        )
         # Provider 列は LiteLLM の raw prefix ではなく、実際に必要な API key provider を表示する。
-        provider_label = "local" if info.is_local else row_required
+        provider_label = "local" if info.is_local else identity.required_provider
         # Issue #249: ローカル ML モデルは API key 不要のため常に available。
         # info.is_local も加味する: provider 未設定 + slash 入り bare ID のローカルモデル
         # (例: "some/local-tagger") は required_provider_for だと "some" になるため、
         # info.is_local フラグを優先して available 判定する。
-        row_available = info.is_local or row_required == "local" or row_required in available_providers
+        row_available = (
+            info.is_local
+            or identity.required_provider == "local"
+            or identity.required_provider in available_providers
+        )
         rows.append(
             {
                 "name": info.name,
                 "provider": provider_label,
                 "litellm_id": litellm_id,
+                "canonical_key": identity.canonical_key,
+                "display_name": identity.display_name,
+                "display_family": identity.display_family,
                 "type_label": type_label,
                 "category": info.model_type,
                 "deprecated": deprecated,
-                "route": row_route,
-                "required_provider": row_required,
+                "route": identity.route,
+                "required_provider": identity.required_provider,
                 "available": row_available,
             }
         )

--- a/src/lorairo/gui/widgets/model_checkbox_widget.py
+++ b/src/lorairo/gui/widgets/model_checkbox_widget.py
@@ -29,10 +29,11 @@ class ModelInfo:
     同 `name` で `provider` が異なる行 (migration 経由 OpenRouter vs 新規 sync 直接版)
     が共存しうるため、内部キーは `litellm_model_id` を使うこと。
 
-    Issue #241: 同一モデルが direct / openrouter 経路で別エントリ登録される
-    仕様 (image-annotator-lib #39 / #51 / #52) に対し、UI 表示は preferred route の
-    1 行に畳む。``route`` は preferred の経路 ("direct" / "openrouter")、
-    ``alternatives`` は同一 canonical key の代替 route の litellm_model_id 群。
+    Issue #241/#343: 同一モデルが direct / openrouter 経路で別エントリ登録される
+    仕様に対し、UI 表示は preferred route の 1 行に畳む。``route`` は preferred
+    の経路 ("direct" / "openrouter")、``alternatives`` は同一 canonical key の
+    代替 route の litellm_model_id 群。OpenRouter は実行経路なので primary label
+    には出さず、tooltip に raw ID と route 情報を載せる。
     """
 
     name: str
@@ -121,24 +122,23 @@ class ModelCheckboxWidget(QWidget, Ui_ModelCheckboxWidget):
     def _setup_model_display(self) -> None:
         """モデル情報をUIに表示
 
-        Issue #245: 同じ表示名 `Model.name` を持つ行が異なる `provider`/route で
-        共存しうる (migration 経由 OpenRouter vs 新規 sync 直接版)。視覚的に
-        区別できるよう、ラベル末尾に `(provider)` を併記し、tooltip に正規
-        ルーティングキー `litellm_model_id` を載せる。
+        Issue #245: 同じ表示名 `Model.name` を持つ行が異なる `provider`/family で
+        共存しうるため、ラベル末尾に `(provider)` を併記する。
 
-        Issue #241: 同一モデルの 2 経路を 1 行に畳んだ後、preferred が OpenRouter
-        経由の場合は ``[openrouter]`` badge をラベルに付与し、tooltip に
-        ``Alternative: <litellm_id>`` 行を追加して代替 route を提示する。
+        Issue #343: direct/openrouter は execution route metadata であり annotation
+        capability ではないため、primary label には ``[openrouter]`` を出さない。
+        raw ``litellm_model_id`` と route/via 情報は tooltip に載せる。
         """
         try:
-            # モデル名設定 (provider 併記 + Issue #241: openrouter 経路の場合は badge)
+            # モデル名設定 (provider/family 併記)
             base_label = f"{self.model_info.name} ({self.model_info.provider})"
-            if self.model_info.route == "openrouter":
-                base_label = f"{base_label} [openrouter]"
             self.labelModelName.setText(base_label)
 
-            # tooltip: litellm_model_id + alternatives
-            tooltip_lines = [self.model_info.litellm_model_id]
+            # tooltip: raw litellm_model_id + route/via + alternatives
+            tooltip_lines = [
+                f"Model ID: {self.model_info.litellm_model_id}",
+                f"Route: {self._format_route_tooltip(self.model_info.route)}",
+            ]
             for alt_id in self.model_info.alternatives:
                 tooltip_lines.append(f"Alternative: {alt_id}")
             self.labelModelName.setToolTip("\n".join(tooltip_lines))
@@ -160,6 +160,13 @@ class ModelCheckboxWidget(QWidget, Ui_ModelCheckboxWidget):
 
         except Exception as e:
             logger.error(f"Error setting up model display for {self.model_info.name}: {e}", exc_info=True)
+
+    @staticmethod
+    def _format_route_tooltip(route: str) -> str:
+        """tooltip 用の route/via 表記を返す。"""
+        if route == "openrouter":
+            return "openrouter via OpenRouter"
+        return route
 
     def _apply_provider_styling(self, provider_display: str) -> None:
         """プロバイダー別スタイリング適用（辞書ベース）"""

--- a/src/lorairo/gui/widgets/model_selection_widget.py
+++ b/src/lorairo/gui/widgets/model_selection_widget.py
@@ -334,7 +334,7 @@ if not __name__ == "__main__":
             # プレースホルダーを非表示
             self.placeholderLabel.setVisible(False)
 
-            # プロバイダー別にグループ化して表示 (preferred の表示プロバイダー基準)
+            # プロバイダー/family 別にグループ化して表示
             provider_groups = self._group_options_by_provider(options)
 
             for provider, group_options in provider_groups.items():
@@ -435,14 +435,14 @@ if not __name__ == "__main__":
         def _group_options_by_provider(
             self, options: list[DisplayModelOption]
         ) -> dict[str, list[DisplayModelOption]]:
-            """Issue #241: DisplayModelOption を preferred の表示 provider 別にグループ化。
+            """DisplayModelOption を表示 family/provider 別にグループ化。
 
-            表示用 provider は ``preferred.model.provider`` を使う (UI ラベル
-            "OpenAI Models" などの分類軸として既存の表示挙動を維持)。
+            OpenRouter は execution route なので、Web API 表示では
+            ``openrouter`` ではなく canonical provider/family (例: Qwen) で分類する。
             """
             groups: dict[str, list[DisplayModelOption]] = {}
             for option in options:
-                provider = option.preferred.model.provider or "local"
+                provider = option.display_family or "local"
                 groups.setdefault(provider, []).append(option)
             return groups
 
@@ -479,14 +479,13 @@ if not __name__ == "__main__":
         def _convert_option_to_info(self, option: DisplayModelOption) -> ModelInfo:
             """Issue #241: DisplayModelOption (route 畳み込み済み) を ModelInfo に変換。
 
-            表示名は ``preferred.model.name``、内部キーは ``preferred.litellm_model_id``。
-            ``route`` / ``alternatives`` を ModelInfo に伝搬し、UI で badge と
-            tooltip を構築する。
+            表示名は ``option.display_name``、内部キーは ``preferred.litellm_model_id``。
+            ``route`` / ``alternatives`` を ModelInfo に伝搬し、UI で tooltip を構築する。
             """
             model = option.preferred.model
             return ModelInfo(
-                name=model.name,
-                provider=model.provider or "local",
+                name=option.display_name,
+                provider=option.display_family or model.provider or "local",
                 capabilities=list(option.capabilities),
                 litellm_model_id=option.preferred.litellm_model_id,
                 is_local=not model.requires_api_key,

--- a/src/lorairo/services/model_route_service.py
+++ b/src/lorairo/services/model_route_service.py
@@ -48,6 +48,11 @@ _PROVIDER_ALIAS_MAP: dict[str, str] = {
     "vertex_ai": "google",
 }
 
+_DISPLAY_FAMILY_NAMES: dict[str, str] = {
+    "openai": "OpenAI",
+    "qwen": "Qwen",
+}
+
 
 def detect_route(litellm_model_id: str) -> Route:
     """litellm_model_id の prefix から route を判定。
@@ -73,6 +78,41 @@ def canonical_key(litellm_model_id: str) -> str:
         prefix を除去した文字列。例 ``"anthropic/claude-3-5-sonnet"``。
     """
     return litellm_model_id.removeprefix(_OPENROUTER_PREFIX)
+
+
+def is_webapi_model_id(litellm_model_id: str) -> bool:
+    """litellm_model_id が Web API 経路 ID かを slash 有無で判定する。"""
+    return "/" in litellm_model_id
+
+
+def display_model_name_for(litellm_model_id: str, fallback_name: str) -> str:
+    """UI の primary label に使う短いモデル名を返す。
+
+    Web API モデルは ``provider/model`` または ``openrouter/provider/model``
+    形式のため、実行経路を含む raw ID ではなく最後の segment を表示する。
+    slash 無しのローカルモデルは既存表示を維持する。
+    """
+    if not is_webapi_model_id(litellm_model_id):
+        return fallback_name
+    _, _, model_name = canonical_key(litellm_model_id).rpartition("/")
+    return model_name or fallback_name
+
+
+def display_family_for(litellm_model_id: str, provider_hint: str | None = None) -> str:
+    """UI grouping/provider label に使う capability family 名を返す。
+
+    OpenRouter は実行経路なので family には出さず、canonical ID の provider
+    segment (例: ``openrouter/qwen/...`` -> ``Qwen``) を使う。
+    ローカルモデルは従来どおり local として扱う。
+    """
+    if not is_webapi_model_id(litellm_model_id):
+        return provider_hint or _LOCAL_PROVIDER
+
+    family_key, _, _ = canonical_key(litellm_model_id).partition("/")
+    family_key = family_key.strip().lower()
+    if not family_key:
+        return provider_hint or _LOCAL_PROVIDER
+    return _DISPLAY_FAMILY_NAMES.get(family_key, family_key.title())
 
 
 def required_provider_for(litellm_model_id: str, provider_hint: str | None = None) -> str:
@@ -129,6 +169,7 @@ class DisplayModelOption:
 
     canonical_key: str
     display_name: str
+    display_family: str
     capabilities: tuple[str, ...]
     preferred: ModelRouteCandidate
     alternatives: tuple[ModelRouteCandidate, ...] = field(default_factory=tuple)
@@ -291,7 +332,14 @@ def build_display_options(
         options.append(
             DisplayModelOption(
                 canonical_key=ckey,
-                display_name=preferred.model.name,
+                display_name=display_model_name_for(
+                    preferred.litellm_model_id,
+                    preferred.model.name,
+                ),
+                display_family=display_family_for(
+                    preferred.litellm_model_id,
+                    preferred.model.provider,
+                ),
                 capabilities=preferred_caps,
                 preferred=preferred,
                 alternatives=alternatives,
@@ -380,7 +428,10 @@ __all__ = [
     "build_display_options",
     "canonical_key",
     "detect_route",
+    "display_family_for",
+    "display_model_name_for",
     "group_model_routes",
+    "is_webapi_model_id",
     "parse_route_preference",
     "required_provider_for",
     "select_preferred_route",

--- a/src/lorairo/services/model_route_service.py
+++ b/src/lorairo/services/model_route_service.py
@@ -81,6 +81,23 @@ def canonical_key(litellm_model_id: str) -> str:
     return litellm_model_id.removeprefix(_OPENROUTER_PREFIX)
 
 
+@dataclass(frozen=True)
+class ModelRouteIdentity:
+    """1 モデル行の route / provider / display 解釈結果。
+
+    `litellm_model_id` の文字列解析と `Model.provider` / `requires_api_key`
+    による補正を一箇所に集約し、GUI / CLI の表示判定を揃える。
+    """
+
+    litellm_model_id: str
+    route: Route
+    canonical_key: str
+    required_provider: str
+    display_name: str
+    display_family: str
+    is_webapi: bool
+
+
 def _normalized_provider_hint(provider_hint: str | None) -> str | None:
     """信頼できる provider hint を lowercase で返す。unknown/空は None。"""
     if not isinstance(provider_hint, str):
@@ -130,6 +147,58 @@ def display_family_name_for(provider_key: str) -> str:
     return _DISPLAY_FAMILY_NAMES.get(family_key, family_key.title())
 
 
+def build_model_route_identity(
+    litellm_model_id: str,
+    name: str,
+    provider_hint: str | None = None,
+    requires_api_key: bool | None = None,
+) -> ModelRouteIdentity:
+    """1 モデル行の route / canonical / display identity を構築する。
+
+    `requires_api_key` が分かる場合は local/WebAPI 判定の一次情報として扱う。
+    slash の有無は WebAPI 判定には使わず、WebAPI と判定された後の表示 key
+    解析にだけ使う。
+    """
+    route = detect_route(litellm_model_id)
+    ckey = canonical_key(litellm_model_id)
+    normalized_provider = _normalized_provider_hint(provider_hint)
+    is_webapi = is_webapi_model_id(litellm_model_id, provider_hint, requires_api_key)
+
+    if not is_webapi:
+        return ModelRouteIdentity(
+            litellm_model_id=litellm_model_id,
+            route=route,
+            canonical_key=ckey,
+            required_provider=_LOCAL_PROVIDER,
+            display_name=name,
+            display_family=_LOCAL_PROVIDER,
+            is_webapi=False,
+        )
+
+    required_provider = required_provider_for(litellm_model_id, provider_hint)
+    display_key = display_key_for(litellm_model_id)
+    provider_for_display = normalized_provider or required_provider
+
+    if "/" not in display_key:
+        display_name = name
+        display_family = display_family_name_for(provider_for_display)
+    else:
+        family_key, _, _ = display_key.partition("/")
+        _, _, model_name = display_key.rpartition("/")
+        display_name = model_name or name
+        display_family = display_family_name_for(family_key or provider_for_display)
+
+    return ModelRouteIdentity(
+        litellm_model_id=litellm_model_id,
+        route=route,
+        canonical_key=ckey,
+        required_provider=required_provider,
+        display_name=display_name,
+        display_family=display_family,
+        is_webapi=True,
+    )
+
+
 def display_model_name_for(
     litellm_model_id: str,
     fallback_name: str,
@@ -142,13 +211,12 @@ def display_model_name_for(
     実行経路を含む raw ID ではなく最後の segment を表示する。ローカルモデルは slash
     付き namespace を持つ可能性があるため既存表示を維持する。
     """
-    if not is_webapi_model_id(litellm_model_id, provider_hint, requires_api_key):
-        return fallback_name
-    display_key = display_key_for(litellm_model_id)
-    if "/" not in display_key:
-        return fallback_name
-    _, _, model_name = display_key.rpartition("/")
-    return model_name or fallback_name
+    return build_model_route_identity(
+        litellm_model_id,
+        fallback_name,
+        provider_hint,
+        requires_api_key,
+    ).display_name
 
 
 def display_family_for(
@@ -162,17 +230,12 @@ def display_family_for(
     実モデル側の provider segment (例: ``openrouter/qwen/...`` -> ``Qwen``) を使う。
     ローカルモデルは従来どおり provider hint/local として扱う。
     """
-    if not is_webapi_model_id(litellm_model_id, provider_hint, requires_api_key):
-        return provider_hint or _LOCAL_PROVIDER
-
-    display_key = display_key_for(litellm_model_id)
-    if "/" not in display_key:
-        return display_family_name_for(provider_hint or _LOCAL_PROVIDER)
-
-    family_key, _, _ = display_key.partition("/")
-    if not family_key:
-        return display_family_name_for(provider_hint or _LOCAL_PROVIDER)
-    return display_family_name_for(family_key)
+    return build_model_route_identity(
+        litellm_model_id,
+        litellm_model_id,
+        provider_hint,
+        requires_api_key,
+    ).display_family
 
 
 def required_provider_for(litellm_model_id: str, provider_hint: str | None = None) -> str:
@@ -220,6 +283,7 @@ class ModelRouteCandidate:
     litellm_model_id: str
     route: Route
     required_provider: str
+    identity: ModelRouteIdentity
     model: Model
 
 
@@ -270,15 +334,20 @@ def group_model_routes(models: Iterable[Model]) -> dict[str, list[ModelRouteCand
     """
     grouped: dict[str, list[ModelRouteCandidate]] = {}
     for model in models:
-        route = detect_route(model.litellm_model_id)
-        required = required_provider_for(model.litellm_model_id, model.provider)
+        identity = build_model_route_identity(
+            model.litellm_model_id,
+            model.name,
+            model.provider,
+            model.requires_api_key,
+        )
         candidate = ModelRouteCandidate(
             litellm_model_id=model.litellm_model_id,
-            route=route,
-            required_provider=required,
+            route=identity.route,
+            required_provider=identity.required_provider,
+            identity=identity,
             model=model,
         )
-        grouped.setdefault(canonical_key(model.litellm_model_id), []).append(candidate)
+        grouped.setdefault(identity.canonical_key, []).append(candidate)
 
     # direct -> openrouter の順に並べる (UI 表示と select_preferred_route の挙動を安定させる)
     for candidates in grouped.values():
@@ -392,17 +461,8 @@ def build_display_options(
         options.append(
             DisplayModelOption(
                 canonical_key=ckey,
-                display_name=display_model_name_for(
-                    preferred.litellm_model_id,
-                    preferred.model.name,
-                    preferred.model.provider,
-                    preferred.model.requires_api_key,
-                ),
-                display_family=display_family_for(
-                    preferred.litellm_model_id,
-                    preferred.model.provider,
-                    preferred.model.requires_api_key,
-                ),
+                display_name=preferred.identity.display_name,
+                display_family=preferred.identity.display_family,
                 capabilities=preferred_caps,
                 preferred=preferred,
                 alternatives=alternatives,
@@ -485,10 +545,12 @@ def validate_api_keys_for_models(
 __all__ = [
     "DisplayModelOption",
     "ModelRouteCandidate",
+    "ModelRouteIdentity",
     "Route",
     "RoutePreference",
     "build_available_providers",
     "build_display_options",
+    "build_model_route_identity",
     "canonical_key",
     "detect_route",
     "display_family_for",

--- a/src/lorairo/services/model_route_service.py
+++ b/src/lorairo/services/model_route_service.py
@@ -122,6 +122,14 @@ def display_key_for(litellm_model_id: str) -> str:
     return display_key
 
 
+def display_family_name_for(provider_key: str) -> str:
+    """provider key を UI 表示用 family 名へ正規化する。"""
+    family_key = provider_key.strip().lower()
+    if not family_key:
+        return _LOCAL_PROVIDER
+    return _DISPLAY_FAMILY_NAMES.get(family_key, family_key.title())
+
+
 def display_model_name_for(
     litellm_model_id: str,
     fallback_name: str,
@@ -159,13 +167,12 @@ def display_family_for(
 
     display_key = display_key_for(litellm_model_id)
     if "/" not in display_key:
-        return provider_hint or _LOCAL_PROVIDER
+        return display_family_name_for(provider_hint or _LOCAL_PROVIDER)
 
     family_key, _, _ = display_key.partition("/")
-    family_key = family_key.strip().lower()
     if not family_key:
-        return provider_hint or _LOCAL_PROVIDER
-    return _DISPLAY_FAMILY_NAMES.get(family_key, family_key.title())
+        return display_family_name_for(provider_hint or _LOCAL_PROVIDER)
+    return display_family_name_for(family_key)
 
 
 def required_provider_for(litellm_model_id: str, provider_hint: str | None = None) -> str:

--- a/src/lorairo/services/model_route_service.py
+++ b/src/lorairo/services/model_route_service.py
@@ -136,7 +136,10 @@ def display_model_name_for(
     """
     if not is_webapi_model_id(litellm_model_id, provider_hint, requires_api_key):
         return fallback_name
-    _, _, model_name = display_key_for(litellm_model_id).rpartition("/")
+    display_key = display_key_for(litellm_model_id)
+    if "/" not in display_key:
+        return fallback_name
+    _, _, model_name = display_key.rpartition("/")
     return model_name or fallback_name
 
 
@@ -154,7 +157,11 @@ def display_family_for(
     if not is_webapi_model_id(litellm_model_id, provider_hint, requires_api_key):
         return provider_hint or _LOCAL_PROVIDER
 
-    family_key, _, _ = display_key_for(litellm_model_id).partition("/")
+    display_key = display_key_for(litellm_model_id)
+    if "/" not in display_key:
+        return provider_hint or _LOCAL_PROVIDER
+
+    family_key, _, _ = display_key.partition("/")
     family_key = family_key.strip().lower()
     if not family_key:
         return provider_hint or _LOCAL_PROVIDER

--- a/src/lorairo/services/model_route_service.py
+++ b/src/lorairo/services/model_route_service.py
@@ -36,6 +36,7 @@ Route = Literal["direct", "openrouter"]
 RoutePreference = Literal["auto", "direct", "openrouter", "all"]
 
 _OPENROUTER_PREFIX = "openrouter/"
+_DISPLAY_GATEWAY_PREFIXES = frozenset({"openrouter", "vercel_ai_gateway"})
 _LOCAL_PROVIDER = "local"
 _UNKNOWN_PROVIDERS = frozenset({"", "unknown"})
 # Issue #249: parse_route_preference の validation 集合 (Literal 値域と完全一致)
@@ -80,35 +81,80 @@ def canonical_key(litellm_model_id: str) -> str:
     return litellm_model_id.removeprefix(_OPENROUTER_PREFIX)
 
 
-def is_webapi_model_id(litellm_model_id: str) -> bool:
-    """litellm_model_id が Web API 経路 ID かを slash 有無で判定する。"""
+def _normalized_provider_hint(provider_hint: str | None) -> str | None:
+    """信頼できる provider hint を lowercase で返す。unknown/空は None。"""
+    if not isinstance(provider_hint, str):
+        return None
+    normalized = provider_hint.strip().lower()
+    if normalized in _UNKNOWN_PROVIDERS:
+        return None
+    return normalized
+
+
+def is_webapi_model_id(
+    litellm_model_id: str,
+    provider_hint: str | None = None,
+    requires_api_key: bool | None = None,
+) -> bool:
+    """litellm_model_id が Web API 経路 ID かを判定する。
+
+    ``requires_api_key`` が分かる caller ではそれを一次ソースにする。local model の
+    ``info.name`` には slash 付き namespace が入り得るため、slash の有無だけでは判定しない。
+    """
+    if requires_api_key is not None:
+        return requires_api_key
+
+    normalized_provider = _normalized_provider_hint(provider_hint)
+    if normalized_provider == _LOCAL_PROVIDER:
+        return False
+    if normalized_provider is not None:
+        return True
+
     return "/" in litellm_model_id
 
 
-def display_model_name_for(litellm_model_id: str, fallback_name: str) -> str:
+def display_key_for(litellm_model_id: str) -> str:
+    """UI 表示用に execution gateway prefix を除いた model key を返す。"""
+    display_key = canonical_key(litellm_model_id)
+    head, sep, tail = display_key.partition("/")
+    if sep and head.strip().lower() in _DISPLAY_GATEWAY_PREFIXES:
+        return tail
+    return display_key
+
+
+def display_model_name_for(
+    litellm_model_id: str,
+    fallback_name: str,
+    provider_hint: str | None = None,
+    requires_api_key: bool | None = None,
+) -> str:
     """UI の primary label に使う短いモデル名を返す。
 
-    Web API モデルは ``provider/model`` または ``openrouter/provider/model``
-    形式のため、実行経路を含む raw ID ではなく最後の segment を表示する。
-    slash 無しのローカルモデルは既存表示を維持する。
+    Web API モデルは ``provider/model`` または ``gateway/provider/model`` 形式のため、
+    実行経路を含む raw ID ではなく最後の segment を表示する。ローカルモデルは slash
+    付き namespace を持つ可能性があるため既存表示を維持する。
     """
-    if not is_webapi_model_id(litellm_model_id):
+    if not is_webapi_model_id(litellm_model_id, provider_hint, requires_api_key):
         return fallback_name
-    _, _, model_name = canonical_key(litellm_model_id).rpartition("/")
+    _, _, model_name = display_key_for(litellm_model_id).rpartition("/")
     return model_name or fallback_name
 
 
-def display_family_for(litellm_model_id: str, provider_hint: str | None = None) -> str:
+def display_family_for(
+    litellm_model_id: str,
+    provider_hint: str | None = None,
+    requires_api_key: bool | None = None,
+) -> str:
     """UI grouping/provider label に使う capability family 名を返す。
 
-    OpenRouter は実行経路なので family には出さず、canonical ID の provider
-    segment (例: ``openrouter/qwen/...`` -> ``Qwen``) を使う。
-    ローカルモデルは従来どおり local として扱う。
+    OpenRouter / Vercel AI Gateway などの execution gateway は family には出さず、
+    実モデル側の provider segment (例: ``openrouter/qwen/...`` -> ``Qwen``) を使う。
+    ローカルモデルは従来どおり provider hint/local として扱う。
     """
-    if not is_webapi_model_id(litellm_model_id):
+    if not is_webapi_model_id(litellm_model_id, provider_hint, requires_api_key):
         return provider_hint or _LOCAL_PROVIDER
 
-    family_key, _, _ = canonical_key(litellm_model_id).partition("/")
+    family_key, _, _ = display_key_for(litellm_model_id).partition("/")
     family_key = family_key.strip().lower()
     if not family_key:
         return provider_hint or _LOCAL_PROVIDER
@@ -335,10 +381,13 @@ def build_display_options(
                 display_name=display_model_name_for(
                     preferred.litellm_model_id,
                     preferred.model.name,
+                    preferred.model.provider,
+                    preferred.model.requires_api_key,
                 ),
                 display_family=display_family_for(
                     preferred.litellm_model_id,
                     preferred.model.provider,
+                    preferred.model.requires_api_key,
                 ),
                 capabilities=preferred_caps,
                 preferred=preferred,

--- a/tests/unit/cli/test_commands_models.py
+++ b/tests/unit/cli/test_commands_models.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from typer.testing import CliRunner
 
+from lorairo.cli.commands.models import ModelCategoryFilter, ModelTypeFilter, _build_rows_from_infos
 from lorairo.cli.main import app
 
 
@@ -669,6 +670,49 @@ def test_models_list_long_model_names_keep_columns_visible(mock_get_container) -
     assert "ready" in result.stdout
     assert "missing_key" in result.stdout
     assert "2 model(s)" in result.stdout
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+def test_models_list_rows_use_shared_identity_for_display_metadata() -> None:
+    """CLI row 生成も GUI と同じ identity 解析を使う。"""
+    infos = [
+        _FakeAnnotatorInfo(
+            name="GPT-4o Vision",
+            model_type="vision",
+            is_local=False,
+            is_api=True,
+            provider="openai",
+            litellm_model_id="gpt-4o",
+        ),
+        _FakeAnnotatorInfo(
+            name="some/very/deep/namespace/local-tagger",
+            model_type="tagger",
+            is_local=True,
+            is_api=False,
+            device="cuda",
+        ),
+    ]
+    annotator = MagicMock()
+    annotator.is_model_deprecated.return_value = False
+
+    rows = _build_rows_from_infos(
+        infos=infos,
+        type_filter=ModelTypeFilter.all,
+        category=ModelCategoryFilter.all,
+        include_deprecated=False,
+        annotator=annotator,
+        available_providers={"openai"},
+    )
+
+    assert rows[0]["display_name"] == "GPT-4o Vision"
+    assert rows[0]["display_family"] == "OpenAI"
+    assert rows[0]["required_provider"] == "openai"
+    assert rows[0]["available"] is True
+    assert rows[1]["display_name"] == "some/very/deep/namespace/local-tagger"
+    assert rows[1]["display_family"] == "local"
+    assert rows[1]["required_provider"] == "local"
+    assert rows[1]["available"] is True
 
 
 # --- Issue #253: 0 件 hint + DEBUG diagnostic ---

--- a/tests/unit/gui/widgets/test_model_checkbox_widget.py
+++ b/tests/unit/gui/widgets/test_model_checkbox_widget.py
@@ -85,7 +85,8 @@ class TestModelCheckboxWidget:
 
     def test_model_name_tooltip_is_litellm_id(self, widget_openai):
         """tooltip には正規ルーティングキー (litellm_model_id) が出る (Issue #245)"""
-        assert widget_openai.labelModelName.toolTip() == "openai/gpt-4-vision-preview"
+        assert "Model ID: openai/gpt-4-vision-preview" in widget_openai.labelModelName.toolTip()
+        assert "Route: direct" in widget_openai.labelModelName.toolTip()
 
     def test_label_distinguishes_same_name_different_provider(self, qtbot):
         """同 name 異 provider の行が UI 上で視覚的に区別できる (Issue #245)"""
@@ -275,11 +276,11 @@ class TestModelCheckboxWidget:
 
     # --- Issue #241: route badge / alternative tooltip ---
 
-    def test_route_badge_shown_for_openrouter_route(self, qtbot):
-        """preferred route が openrouter の場合、ラベル末尾に [openrouter] badge"""
+    def test_route_badge_not_shown_for_openrouter_route(self, qtbot):
+        """preferred route が openrouter の場合も primary label に route badge を出さない"""
         info = ModelInfo(
             name="claude-3-5-sonnet",
-            provider="openrouter",
+            provider="Anthropic",
             capabilities=["caption"],
             litellm_model_id="openrouter/anthropic/claude-3-5-sonnet",
             is_local=False,
@@ -288,7 +289,9 @@ class TestModelCheckboxWidget:
         )
         widget = ModelCheckboxWidget(info)
         qtbot.addWidget(widget)
-        assert "[openrouter]" in widget.labelModelName.text()
+        assert widget.labelModelName.text() == "claude-3-5-sonnet (Anthropic)"
+        assert "[openrouter]" not in widget.labelModelName.text()
+        assert "Route: openrouter via OpenRouter" in widget.labelModelName.toolTip()
 
     def test_route_badge_absent_for_direct_route(self, widget_openai):
         """direct route はラベルに badge が付かない (Issue #245 の表記を維持)"""
@@ -310,12 +313,32 @@ class TestModelCheckboxWidget:
         widget = ModelCheckboxWidget(info)
         qtbot.addWidget(widget)
         tooltip = widget.labelModelName.toolTip()
-        assert "anthropic/claude-3-5-sonnet-20241022" in tooltip
+        assert "Model ID: anthropic/claude-3-5-sonnet-20241022" in tooltip
         assert "Alternative: openrouter/anthropic/claude-3-5-sonnet-20241022" in tooltip
 
-    def test_tooltip_without_alternatives_is_just_litellm_id(self, widget_openai):
-        """alternatives が空の場合、tooltip は litellm_model_id のみ"""
-        assert widget_openai.labelModelName.toolTip() == "openai/gpt-4-vision-preview"
+    def test_tooltip_without_alternatives_has_model_id_and_route(self, widget_openai):
+        """alternatives が空の場合も tooltip は raw ID と route を含む"""
+        assert widget_openai.labelModelName.toolTip() == (
+            "Model ID: openai/gpt-4-vision-preview\nRoute: direct"
+        )
+
+    def test_openrouter_raw_id_not_primary_visible_name(self, qtbot):
+        """長い OpenRouter raw ID は primary visible name に使わない (Issue #343)"""
+        info = ModelInfo(
+            name="qwen3.7-max",
+            provider="Qwen",
+            capabilities=["caption"],
+            litellm_model_id="openrouter/qwen/qwen3.7-max",
+            is_local=False,
+            requires_api_key=True,
+            route="openrouter",
+        )
+        widget = ModelCheckboxWidget(info)
+        qtbot.addWidget(widget)
+
+        assert widget.labelModelName.text() == "qwen3.7-max (Qwen)"
+        assert "openrouter/qwen/qwen3.7-max" not in widget.labelModelName.text()
+        assert "Model ID: openrouter/qwen/qwen3.7-max" in widget.labelModelName.toolTip()
 
 
 class TestProviderStylesConstant:

--- a/tests/unit/gui/widgets/test_model_selection_widget.py
+++ b/tests/unit/gui/widgets/test_model_selection_widget.py
@@ -230,6 +230,57 @@ class TestModelSelectionWidgetLitellmIdKeying:
         assert migration_route.litellm_model_id not in selected
 
 
+class TestModelSelectionWidgetWebApiDisplay:
+    """Issue #343: Web API の primary display は raw route ID ではなく表示名/family を使う。"""
+
+    def test_openrouter_qwen_display_name_and_group_use_canonical_model_family(
+        self, qtbot, mock_model_service
+    ) -> None:
+        model = _fake_db_model(
+            name="openrouter/qwen/qwen3.7-max",
+            provider="openrouter",
+            litellm_model_id="openrouter/qwen/qwen3.7-max",
+            is_recommended=True,
+        )
+        mock_model_service.load_models.return_value = [model]
+        mock_model_service.get_recommended_models.return_value = [model]
+
+        w = ModelSelectionWidget(model_selection_service=mock_model_service, mode="simple")
+        qtbot.addWidget(w)
+
+        checkbox = w.model_checkbox_widgets["openrouter/qwen/qwen3.7-max"]
+        assert checkbox.labelModelName.text() == "qwen3.7-max (Qwen)"
+        assert "openrouter/qwen/qwen3.7-max" not in checkbox.labelModelName.text()
+        assert "Model ID: openrouter/qwen/qwen3.7-max" in checkbox.labelModelName.toolTip()
+        assert "Route: openrouter via OpenRouter" in checkbox.labelModelName.toolTip()
+
+        group_labels = [
+            w.dynamicContentLayout.itemAt(i).widget().text()
+            for i in range(w.dynamicContentLayout.count())
+            if w.dynamicContentLayout.itemAt(i).widget()
+            and hasattr(w.dynamicContentLayout.itemAt(i).widget(), "text")
+        ]
+        assert any("Qwen Models" in label for label in group_labels)
+
+    def test_selection_still_returns_raw_litellm_id_for_short_display_name(
+        self, qtbot, mock_model_service
+    ) -> None:
+        model = _fake_db_model(
+            name="openrouter/qwen/qwen3.7-max",
+            provider="openrouter",
+            litellm_model_id="openrouter/qwen/qwen3.7-max",
+            is_recommended=True,
+        )
+        mock_model_service.load_models.return_value = [model]
+        mock_model_service.get_recommended_models.return_value = [model]
+
+        w = ModelSelectionWidget(model_selection_service=mock_model_service, mode="simple")
+        qtbot.addWidget(w)
+        w.set_selected_models(["openrouter/qwen/qwen3.7-max"])
+
+        assert w.get_selected_models() == ["openrouter/qwen/qwen3.7-max"]
+
+
 class TestModelSelectionWidgetRoutePreference:
     """Issue #249: route_preference を config から読み込む挙動。"""
 

--- a/tests/unit/services/test_model_route_service.py
+++ b/tests/unit/services/test_model_route_service.py
@@ -109,6 +109,9 @@ class TestDisplayHelpers:
             == "Local Tagger"
         )
 
+    def test_bare_webapi_display_name_uses_fallback_name(self) -> None:
+        assert display_model_name_for("gpt-4o", "GPT-4o", "openai", True) == "GPT-4o"
+
     def test_openrouter_family_uses_canonical_provider(self) -> None:
         assert display_family_for("openrouter/qwen/qwen3.7-max", "openrouter", True) == "Qwen"
 
@@ -117,6 +120,9 @@ class TestDisplayHelpers:
 
     def test_direct_webapi_family_uses_provider_segment(self) -> None:
         assert display_family_for("openai/gpt-4o", "openai", True) == "OpenAI"
+
+    def test_bare_webapi_family_uses_provider_hint(self) -> None:
+        assert display_family_for("gpt-4o", "openai", True) == "openai"
 
     def test_local_family_uses_provider_hint(self) -> None:
         assert display_family_for("wd-v1-4-tagger", "local", False) == "local"
@@ -335,6 +341,16 @@ class TestBuildDisplayOptions:
         options = build_display_options([m], None, "auto")
         assert options[0].display_name == "o1-very-long-model-name-2025-04-16"
         assert options[0].display_family == "OpenAI"
+
+    def test_bare_webapi_id_keeps_curated_name_and_provider_family(self) -> None:
+        m = _fake_model(
+            "gpt-4o",
+            "GPT-4o Vision",
+            "openai",
+        )
+        options = build_display_options([m], {"openai"}, "auto")
+        assert options[0].display_name == "GPT-4o Vision"
+        assert options[0].display_family == "openai"
 
     def test_slash_qualified_local_model_keeps_library_name(self) -> None:
         m = _fake_model(

--- a/tests/unit/services/test_model_route_service.py
+++ b/tests/unit/services/test_model_route_service.py
@@ -122,7 +122,7 @@ class TestDisplayHelpers:
         assert display_family_for("openai/gpt-4o", "openai", True) == "OpenAI"
 
     def test_bare_webapi_family_uses_provider_hint(self) -> None:
-        assert display_family_for("gpt-4o", "openai", True) == "openai"
+        assert display_family_for("gpt-4o", "openai", True) == "OpenAI"
 
     def test_local_family_uses_provider_hint(self) -> None:
         assert display_family_for("wd-v1-4-tagger", "local", False) == "local"
@@ -350,7 +350,7 @@ class TestBuildDisplayOptions:
         )
         options = build_display_options([m], {"openai"}, "auto")
         assert options[0].display_name == "GPT-4o Vision"
-        assert options[0].display_family == "openai"
+        assert options[0].display_family == "OpenAI"
 
     def test_slash_qualified_local_model_keeps_library_name(self) -> None:
         m = _fake_model(

--- a/tests/unit/services/test_model_route_service.py
+++ b/tests/unit/services/test_model_route_service.py
@@ -15,6 +15,7 @@ from lorairo.services.model_route_service import (
     ModelRouteCandidate,
     build_available_providers,
     build_display_options,
+    build_model_route_identity,
     canonical_key,
     detect_route,
     display_family_for,
@@ -137,6 +138,149 @@ class TestDisplayHelpers:
 
 
 @pytest.mark.unit
+class TestBuildModelRouteIdentity:
+    @pytest.mark.parametrize(
+        (
+            "litellm_id",
+            "name",
+            "provider",
+            "requires_api_key",
+            "expected",
+        ),
+        [
+            (
+                "wd-v1-4-tagger",
+                "WD Tagger",
+                "local",
+                False,
+                {
+                    "route": "direct",
+                    "canonical_key": "wd-v1-4-tagger",
+                    "required_provider": "local",
+                    "display_name": "WD Tagger",
+                    "display_family": "local",
+                    "is_webapi": False,
+                },
+            ),
+            (
+                "some/very/deep/local-tagger",
+                "Namespaced Local Tagger",
+                "local",
+                False,
+                {
+                    "route": "direct",
+                    "canonical_key": "some/very/deep/local-tagger",
+                    "required_provider": "local",
+                    "display_name": "Namespaced Local Tagger",
+                    "display_family": "local",
+                    "is_webapi": False,
+                },
+            ),
+            (
+                "gpt-4o",
+                "GPT-4o Vision",
+                "openai",
+                True,
+                {
+                    "route": "direct",
+                    "canonical_key": "gpt-4o",
+                    "required_provider": "openai",
+                    "display_name": "GPT-4o Vision",
+                    "display_family": "OpenAI",
+                    "is_webapi": True,
+                },
+            ),
+            (
+                "openai/gpt-4o",
+                "openai/gpt-4o",
+                "openai",
+                True,
+                {
+                    "route": "direct",
+                    "canonical_key": "openai/gpt-4o",
+                    "required_provider": "openai",
+                    "display_name": "gpt-4o",
+                    "display_family": "OpenAI",
+                    "is_webapi": True,
+                },
+            ),
+            (
+                "openrouter/openai/gpt-4o",
+                "openrouter/openai/gpt-4o",
+                "openrouter",
+                True,
+                {
+                    "route": "openrouter",
+                    "canonical_key": "openai/gpt-4o",
+                    "required_provider": "openrouter",
+                    "display_name": "gpt-4o",
+                    "display_family": "OpenAI",
+                    "is_webapi": True,
+                },
+            ),
+            (
+                "vercel_ai_gateway/openai/o1",
+                "vercel_ai_gateway/openai/o1",
+                "vercel_ai_gateway",
+                True,
+                {
+                    "route": "direct",
+                    "canonical_key": "vercel_ai_gateway/openai/o1",
+                    "required_provider": "vercel_ai_gateway",
+                    "display_name": "o1",
+                    "display_family": "OpenAI",
+                    "is_webapi": True,
+                },
+            ),
+            (
+                "gemini/gemini-2.5-pro",
+                "gemini/gemini-2.5-pro",
+                "Gemini",
+                True,
+                {
+                    "route": "direct",
+                    "canonical_key": "gemini/gemini-2.5-pro",
+                    "required_provider": "google",
+                    "display_name": "gemini-2.5-pro",
+                    "display_family": "Gemini",
+                    "is_webapi": True,
+                },
+            ),
+            (
+                "vertex_ai/gemini-pro",
+                "vertex_ai/gemini-pro",
+                None,
+                True,
+                {
+                    "route": "direct",
+                    "canonical_key": "vertex_ai/gemini-pro",
+                    "required_provider": "google",
+                    "display_name": "gemini-pro",
+                    "display_family": "Vertex_Ai",
+                    "is_webapi": True,
+                },
+            ),
+        ],
+    )
+    def test_identity_matrix(
+        self,
+        litellm_id: str,
+        name: str,
+        provider: str | None,
+        requires_api_key: bool,
+        expected: dict[str, str | bool],
+    ) -> None:
+        identity = build_model_route_identity(litellm_id, name, provider, requires_api_key)
+
+        assert identity.route == expected["route"]
+        assert identity.canonical_key == expected["canonical_key"]
+        assert identity.required_provider == expected["required_provider"]
+        assert identity.display_name == expected["display_name"]
+        assert identity.display_family == expected["display_family"]
+        assert identity.is_webapi is expected["is_webapi"]
+
+
+@pytest.mark.unit
 class TestRequiredProviderFor:
     def test_provider_hint_takes_priority(self) -> None:
         """hint があれば信頼する (migration 経由で name と provider が食い違うケース)"""
@@ -238,6 +382,7 @@ class TestSelectPreferredRoute:
                 litellm_model_id=lid,
                 route=r,
                 required_provider=p,
+                identity=build_model_route_identity(lid, "x", p, p != "local"),
                 model=_fake_model(lid, "x", p),
             )
             for lid, r, p in configs
@@ -468,6 +613,7 @@ class TestDisplayModelOptionAvailable:
             litellm_model_id="openai/gpt-4o",
             route="direct",
             required_provider="openai",
+            identity=build_model_route_identity("openai/gpt-4o", "gpt-4o", "openai", True),
             model=m,
         )
         opt = DisplayModelOption(

--- a/tests/unit/services/test_model_route_service.py
+++ b/tests/unit/services/test_model_route_service.py
@@ -98,18 +98,36 @@ class TestDisplayHelpers:
     def test_local_display_name_uses_fallback_name(self) -> None:
         assert display_model_name_for("wd-v1-4-tagger", "WD Tagger") == "WD Tagger"
 
+    def test_local_slash_display_name_uses_fallback_name(self) -> None:
+        assert (
+            display_model_name_for(
+                "some/very/deep/namespace/local-tagger-v3",
+                "Local Tagger",
+                "local",
+                False,
+            )
+            == "Local Tagger"
+        )
+
     def test_openrouter_family_uses_canonical_provider(self) -> None:
-        assert display_family_for("openrouter/qwen/qwen3.7-max", "openrouter") == "Qwen"
+        assert display_family_for("openrouter/qwen/qwen3.7-max", "openrouter", True) == "Qwen"
+
+    def test_gateway_family_uses_real_provider_segment(self) -> None:
+        assert display_family_for("vercel_ai_gateway/openai/o1", "vercel_ai_gateway", True) == "OpenAI"
 
     def test_direct_webapi_family_uses_provider_segment(self) -> None:
-        assert display_family_for("openai/gpt-4o", "openai") == "OpenAI"
+        assert display_family_for("openai/gpt-4o", "openai", True) == "OpenAI"
 
     def test_local_family_uses_provider_hint(self) -> None:
-        assert display_family_for("wd-v1-4-tagger", "local") == "local"
+        assert display_family_for("wd-v1-4-tagger", "local", False) == "local"
 
     def test_is_webapi_model_id_checks_slash(self) -> None:
         assert is_webapi_model_id("openrouter/qwen/qwen3.7-max") is True
         assert is_webapi_model_id("wd-v1-4-tagger") is False
+
+    def test_is_webapi_model_id_prefers_requires_api_key(self) -> None:
+        assert is_webapi_model_id("some/very/deep/local-tagger", "local", False) is False
+        assert is_webapi_model_id("gpt-4o", "openai", True) is True
 
 
 @pytest.mark.unit
@@ -307,6 +325,27 @@ class TestBuildDisplayOptions:
         options = build_display_options([m], {"openrouter"}, "auto")
         assert options[0].display_name == "qwen3.7-max"
         assert options[0].display_family == "Qwen"
+
+    def test_gateway_raw_id_uses_real_family_for_display(self) -> None:
+        m = _fake_model(
+            "vercel_ai_gateway/openai/o1-very-long-model-name-2025-04-16",
+            "vercel_ai_gateway/openai/o1-very-long-model-name-2025-04-16",
+            "vercel_ai_gateway",
+        )
+        options = build_display_options([m], None, "auto")
+        assert options[0].display_name == "o1-very-long-model-name-2025-04-16"
+        assert options[0].display_family == "OpenAI"
+
+    def test_slash_qualified_local_model_keeps_library_name(self) -> None:
+        m = _fake_model(
+            "some/very/deep/namespace/local-tagger-v3",
+            "some/very/deep/namespace/local-tagger-v3",
+            "local",
+            requires_api_key=False,
+        )
+        options = build_display_options([m], set(), "auto")
+        assert options[0].display_name == "some/very/deep/namespace/local-tagger-v3"
+        assert options[0].display_family == "local"
 
     def test_all_candidates_property_returns_preferred_first(self) -> None:
         m_direct = _fake_model("openai/gpt-4o", "gpt-4o", "openai")

--- a/tests/unit/services/test_model_route_service.py
+++ b/tests/unit/services/test_model_route_service.py
@@ -17,7 +17,10 @@ from lorairo.services.model_route_service import (
     build_display_options,
     canonical_key,
     detect_route,
+    display_family_for,
+    display_model_name_for,
     group_model_routes,
+    is_webapi_model_id,
     parse_route_preference,
     required_provider_for,
     select_preferred_route,
@@ -81,6 +84,32 @@ class TestCanonicalKey:
     def test_idempotent(self) -> None:
         """canonical_key を 2 回適用しても同じ結果"""
         assert canonical_key(canonical_key("openrouter/openai/gpt-4o")) == "openai/gpt-4o"
+
+
+@pytest.mark.unit
+class TestDisplayHelpers:
+    def test_webapi_display_name_uses_last_segment(self) -> None:
+        display_name = display_model_name_for(
+            "openrouter/qwen/qwen3.7-max",
+            "openrouter/qwen/qwen3.7-max",
+        )
+        assert display_name == "qwen3.7-max"
+
+    def test_local_display_name_uses_fallback_name(self) -> None:
+        assert display_model_name_for("wd-v1-4-tagger", "WD Tagger") == "WD Tagger"
+
+    def test_openrouter_family_uses_canonical_provider(self) -> None:
+        assert display_family_for("openrouter/qwen/qwen3.7-max", "openrouter") == "Qwen"
+
+    def test_direct_webapi_family_uses_provider_segment(self) -> None:
+        assert display_family_for("openai/gpt-4o", "openai") == "OpenAI"
+
+    def test_local_family_uses_provider_hint(self) -> None:
+        assert display_family_for("wd-v1-4-tagger", "local") == "local"
+
+    def test_is_webapi_model_id_checks_slash(self) -> None:
+        assert is_webapi_model_id("openrouter/qwen/qwen3.7-max") is True
+        assert is_webapi_model_id("wd-v1-4-tagger") is False
 
 
 @pytest.mark.unit
@@ -264,10 +293,20 @@ class TestBuildDisplayOptions:
         assert options[0].preferred.route == "direct"
 
     def test_sorts_by_display_name(self) -> None:
-        m1 = _fake_model("openai/zebra", "zebra", "openai")
-        m2 = _fake_model("openai/alpha", "alpha", "openai")
+        m1 = _fake_model("openai/zebra", "openai/zebra", "openai")
+        m2 = _fake_model("openai/alpha", "openai/alpha", "openai")
         options = build_display_options([m1, m2], None, "auto")
         assert [o.display_name for o in options] == ["alpha", "zebra"]
+
+    def test_openrouter_raw_id_is_not_primary_display_name(self) -> None:
+        m = _fake_model(
+            "openrouter/qwen/qwen3.7-max",
+            "openrouter/qwen/qwen3.7-max",
+            "openrouter",
+        )
+        options = build_display_options([m], {"openrouter"}, "auto")
+        assert options[0].display_name == "qwen3.7-max"
+        assert options[0].display_family == "Qwen"
 
     def test_all_candidates_property_returns_preferred_first(self) -> None:
         m_direct = _fake_model("openai/gpt-4o", "gpt-4o", "openai")
@@ -379,6 +418,7 @@ class TestDisplayModelOptionAvailable:
         opt = DisplayModelOption(
             canonical_key="openai/gpt-4o",
             display_name="gpt-4o",
+            display_family="OpenAI",
             capabilities=(),
             preferred=candidate,
         )


### PR DESCRIPTION
## Summary
- shorten Web API primary model labels so raw route IDs are not the main display text
- group OpenRouter routes by canonical provider/model family such as Qwen
- move raw litellm_model_id and route/via metadata into tooltips
- preserve raw litellm_model_id for selection signals and execution

Fixes #343
Part of #339

## Tests
- uv run pytest tests/unit/services/test_model_route_service.py tests/unit/gui/widgets/test_model_checkbox_widget.py tests/unit/gui/widgets/test_model_selection_widget.py