### PR TITLE
fix: sync rating model capabilities

### DIFF
--- a/src/lorairo/database/db_core.py
+++ b/src/lorairo/database/db_core.py
@@ -292,7 +292,7 @@ def _ensure_model_types_seeded(engine: Engine) -> None:
 
     from .schema import ModelType
 
-    canonical_model_types = ("tags", "scores", "caption", "upscaler", "multimodal")
+    canonical_model_types = ("tags", "scores", "caption", "upscaler", "multimodal", "ratings")
     session_factory = create_session_factory(engine)
     with session_factory() as session:
         existing = set(session.execute(select(ModelType.name)).scalars())

--- a/src/lorairo/database/db_repository.py
+++ b/src/lorairo/database/db_repository.py
@@ -366,7 +366,7 @@ class ImageRepository:
             provider: ルーティング元プロバイダー (例: `openai`, `anthropic`,
                 `openrouter`)。ローカル ML モデルは None。
             model_types: LoRAIro の model_type リスト (`["caption"]`,
-                `["multimodal"]`, `["scores"]`, `["tags"]`, `["upscaler"]` のいずれか)。
+                `["multimodal"]`, `["scores"]`, `["tags"]`, `["upscaler"]`, `["ratings"]` など)。
             litellm_model_id: registry key (UNIQUE)。WebAPI では LiteLLM 完全 ID
                 (`openai/gpt-4o`)、ローカル ML では bare name (`wd-vit-tagger-v3`)。
             estimated_size_gb: ローカルモデルの推定サイズ (GB)。

--- a/src/lorairo/database/migrations/versions/f0a1b2c3d4e5_add_ratings_model_type.py
+++ b/src/lorairo/database/migrations/versions/f0a1b2c3d4e5_add_ratings_model_type.py
@@ -1,0 +1,52 @@
+"""Add ratings model type
+
+Revision ID: f0a1b2c3d4e5
+Revises: a7b8c9d0e1f2
+Create Date: 2026-05-22
+
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+from sqlalchemy import inspect
+
+revision: str = "f0a1b2c3d4e5"
+down_revision: str | None = "a7b8c9d0e1f2"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Ensure the canonical `ratings` model type exists."""
+    inspector = inspect(op.get_bind())
+    if not inspector.has_table("model_types"):
+        return
+
+    op.execute(
+        """
+        INSERT INTO model_types (name)
+        SELECT 'ratings'
+        WHERE NOT EXISTS (
+            SELECT 1 FROM model_types WHERE name = 'ratings'
+        )
+        """
+    )
+
+
+def downgrade() -> None:
+    """Remove the `ratings` model type and its associations."""
+    inspector = inspect(op.get_bind())
+    if not inspector.has_table("model_types"):
+        return
+
+    if inspector.has_table("model_function_associations"):
+        op.execute(
+            """
+            DELETE FROM model_function_associations
+            WHERE type_id IN (
+                SELECT id FROM model_types WHERE name = 'ratings'
+            )
+            """
+        )
+    op.execute("DELETE FROM model_types WHERE name = 'ratings'")

--- a/src/lorairo/services/model_sync_service.py
+++ b/src/lorairo/services/model_sync_service.py
@@ -175,7 +175,7 @@ class ModelSyncService:
         """`AnnotatorInfo.model_type` を LoRAIro DB の `model_types` リストに変換する。
 
         Issue #243 (Phase 1.11 後続): DB `model_types` テーブルの SSoT 値
-        (`tags` / `scores` / `caption` / `upscaler` / `multimodal`) に揃える。
+        (`tags` / `scores` / `caption` / `upscaler` / `multimodal` / `ratings`) に揃える。
         旧マッピング (`llm` / `captioner` / `score` / `tagger`) は ADR 0017 の
         正規化以前の値で、`models_function_associations` を介した FK 制約に違反していた。
 
@@ -190,21 +190,28 @@ class ModelSyncService:
             - "captioner" → ["caption"]
             - "scorer" → ["scores"]
             - "tagger" → ["tags"]
+            - TaskCapability.RATINGS を持つモデルは上記に加えて "ratings" を付与
             - その他 → ["caption"] (警告ログ付き)
         """
         model_type = info.model_type
         if model_type == "vision":
             # WebAPI vision モデル (PydanticAI 経由) は LLM + Vision を兼ねるため
             # DB の `multimodal` カテゴリに該当する
-            return ["multimodal"]
-        if model_type == "captioner":
-            return ["caption"]
-        if model_type == "scorer":
-            return ["scores"]
-        if model_type == "tagger":
-            return ["tags"]
-        logger.warning(f"Unknown library model_type: {model_type}, defaulting to ['caption']")
-        return ["caption"]
+            db_model_types = ["multimodal"]
+        elif model_type == "captioner":
+            db_model_types = ["caption"]
+        elif model_type == "scorer":
+            db_model_types = ["scores"]
+        elif model_type == "tagger":
+            db_model_types = ["tags"]
+        else:
+            logger.warning(f"Unknown library model_type: {model_type}, defaulting to ['caption']")
+            db_model_types = ["caption"]
+
+        if TaskCapability.RATINGS in info.capabilities and "ratings" not in db_model_types:
+            db_model_types.append("ratings")
+
+        return db_model_types
 
     def sync_available_models(self) -> ModelSyncResult:
         """利用可能モデルの自動同期

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -300,7 +300,7 @@ def test_engine_with_schema(test_db_url: str):
             # --- ModelType の初期データ挿入 ---
             print("[test_engine_with_schema] Inserting initial model types...")
             # Issue #243: model_types テーブルの SSoT 値は migration `e3f4a5b6c7d8`
-            # 適用後と同じ `tags` / `scores` / `caption` / `upscaler` / `multimodal`。
+            # 適用後と同じ `tags` / `scores` / `caption` / `upscaler` / `multimodal` / `ratings`。
             # 旧名 (`tagger`, `score`, `captioner`, `llm`, `rating`) は本番 DB に存在しない。
             initial_model_types = [
                 "tags",
@@ -308,6 +308,7 @@ def test_engine_with_schema(test_db_url: str):
                 "caption",
                 "upscaler",
                 "multimodal",
+                "ratings",
             ]
             type_map: dict[str, ModelType] = {}
             for type_name in initial_model_types:

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -53,13 +53,14 @@ def test_engine_with_schema(test_db_url: str):
     # 初期 ModelType データ挿入
     SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
     with SessionLocal() as session:
-        # Issue #243: 本番 SSoT に揃える (5 値、`rating`/`llm` は廃止)
+        # Issue #243 + rating capability: 本番 SSoT に揃える (`rating`/`llm` は廃止)
         initial_model_types = [
             "tags",
             "scores",
             "caption",
             "upscaler",
             "multimodal",
+            "ratings",
         ]
 
         for type_name in initial_model_types:

--- a/tests/unit/database/test_migration_a7b8c9d0e1f2_score_labels.py
+++ b/tests/unit/database/test_migration_a7b8c9d0e1f2_score_labels.py
@@ -121,7 +121,7 @@ def test_score_labels_migration_converges_when_table_was_precreated(tmp_path: Pa
         version = conn.execute(text("SELECT version_num FROM alembic_version")).scalar_one()
     engine.dispose()
 
-    assert version == "a7b8c9d0e1f2"
+    assert version == "f0a1b2c3d4e5"
     assert "ix_score_labels_image_id" in indexes
 
 
@@ -142,7 +142,7 @@ def test_project_database_prepare_upgrades_alembic_managed_db(tmp_path: Path) ->
         score_label_count = conn.execute(text("SELECT count(*) FROM score_labels")).scalar_one()
     engine.dispose()
 
-    assert version == "a7b8c9d0e1f2"
+    assert version == "f0a1b2c3d4e5"
     assert score_label_count == 0
 
 

--- a/tests/unit/database/test_migration_e3f4a5b6c7d8_model_types_rename.py
+++ b/tests/unit/database/test_migration_e3f4a5b6c7d8_model_types_rename.py
@@ -91,7 +91,7 @@ class TestModelTypesRenameMigration:
         with engine.connect() as conn:
             rows = conn.execute(text("SELECT name FROM model_types ORDER BY id")).fetchall()
             names = [row.name for row in rows]
-            assert names == ["tags", "scores", "caption", "upscaler", "multimodal"]
+            assert names == ["tags", "scores", "caption", "upscaler", "multimodal", "ratings"]
         engine.dispose()
 
     def test_already_normalized_db_is_noop(self, tmp_path: Path) -> None:
@@ -115,7 +115,7 @@ class TestModelTypesRenameMigration:
         with engine.connect() as conn:
             rows = conn.execute(text("SELECT name FROM model_types ORDER BY id")).fetchall()
             names = [row.name for row in rows]
-            assert names == ["tags", "scores", "caption", "upscaler", "multimodal"]
+            assert names == ["tags", "scores", "caption", "upscaler", "multimodal", "ratings"]
         engine.dispose()
 
     def test_downgrade_restores_legacy_names(self, tmp_path: Path) -> None:

--- a/tests/unit/services/test_model_selection_service.py
+++ b/tests/unit/services/test_model_selection_service.py
@@ -298,6 +298,36 @@ class TestModelSelectionService:
 
         assert [model.name for model in filtered] == ["ratings-model"]
 
+    def test_local_ratings_filter_matches_model_types(self, service):
+        """ローカル + ratings 条件は DB model_types に ratings を持つモデルを返す"""
+        ratings_model = SimpleNamespace(
+            name="ratings-model",
+            provider=None,
+            requires_api_key=False,
+            model_types=[SimpleNamespace(name="scores"), SimpleNamespace(name="ratings")],
+            is_recommended=False,
+            available=True,
+        )
+        tags_model = SimpleNamespace(
+            name="tags-model",
+            provider=None,
+            requires_api_key=False,
+            model_types=[SimpleNamespace(name="tags")],
+            is_recommended=False,
+            available=True,
+        )
+        service._all_models = [ratings_model, tags_model]
+
+        filtered = service.filter_models(
+            ModelSelectionCriteria(
+                execution_env="ローカルモデルのみ",
+                capabilities=["ratings"],
+                annotation_only=True,
+            )
+        )
+
+        assert [model.name for model in filtered] == ["ratings-model"]
+
     # create_model_tooltip, create_model_display_name, _is_recommended_model メソッドは
     # DB中心アーキテクチャでWidgetに移動されたため、テストを削除
 

--- a/tests/unit/test_model_sync_service.py
+++ b/tests/unit/test_model_sync_service.py
@@ -161,10 +161,25 @@ class TestModelTypeMapping:
         info = _info("aesthetic", "scorer", is_api=False, capabilities={TaskCapability.SCORES})
         assert service_with_mock._map_library_model_type_to_db(info) == ["scores"]
 
+    def test_scorer_with_ratings_capability_maps_to_scores_and_ratings(self, service_with_mock):
+        """ratings capability を持つ scorer は rating フィルタ対象にもなる。"""
+        info = _info("anime-rating", "scorer", is_api=False, capabilities={TaskCapability.RATINGS})
+        assert service_with_mock._map_library_model_type_to_db(info) == ["scores", "ratings"]
+
     def test_tagger_maps_to_tags(self, service_with_mock):
         """tagger タイプは DB の `tags` (複数) にマッピングされる (Issue #243)。"""
         info = _info("wd-tagger", "tagger", is_api=False, capabilities={TaskCapability.TAGS})
         assert service_with_mock._map_library_model_type_to_db(info) == ["tags"]
+
+    def test_tagger_with_ratings_capability_maps_to_tags_and_ratings(self, service_with_mock):
+        """WD系など rating も返す tagger は tags と ratings の両方に分類される。"""
+        info = _info(
+            "wd-tagger",
+            "tagger",
+            is_api=False,
+            capabilities={TaskCapability.TAGS, TaskCapability.RATINGS},
+        )
+        assert service_with_mock._map_library_model_type_to_db(info) == ["tags", "ratings"]
 
     def test_unknown_type_falls_back_to_caption(self, service_with_mock):
         """未知のタイプは ['caption'] にフォールバック (警告ログ付き、Issue #243)。"""


### PR DESCRIPTION
## Summary
- add canonical ratings model_type seed and migration
- map image-annotator-lib TaskCapability.RATINGS into LoRAIro DB model_types
- add regression coverage for rating model sync and local rating filtering

## Tests
- uv run pytest tests/unit/test_model_sync_service.py tests/unit/services/test_model_selection_service.py
- uv run ruff check src/lorairo/services/model_sync_service.py src/lorairo/database/db_core.py src/lorairo/database/db_repository.py tests/unit/test_model_sync_service.py tests/unit/services/test_model_selection_service.py tests/conftest.py tests/integration/conftest.py src/lorairo/database/migrations/versions/f0a1b2c3d4e5_add_ratings_model_type.py
- uv run alembic heads