### PR TITLE
test(bdd): タグ検索・お気に入りフィルタの BDD 仕様化 (#350, #351)

### DIFF
--- a/tests/bdd/features/favorite_filter_workflow.feature
+++ b/tests/bdd/features/favorite_filter_workflow.feature
@@ -1,0 +1,28 @@
+# language: ja
+機能: お気に入りフィルタの保存と再適用
+  FavoriteFiltersService（JSON 永続化）と SearchFilterService（条件構築）を
+  横断したフローを仕様化する。保存したフィルタ条件で再検索したとき、
+  保存前と同じ検索結果が得られることを検証する。
+
+  責務分離（database_management.feature との非重複）:
+  - database_management.feature は DB 登録・検索（Repository 層）のみを扱う。
+  - 本 feature は ~/.config/lorairo/favorite_filters.json への JSON 設定
+    永続化と、復元した条件での再検索フローを検証する。データストアが異なる。
+
+  注意:
+  - FavoriteFiltersService と SearchFilterService に直接の連携コードは無いため、
+    dict ⇄ SearchConditions の変換はステップ定義内で明示的に組む。
+  - SearchConditions の datetime フィールド（date_range_start/end）は JSON 直列化
+    できないため、本 feature のシナリオ対象外とする。保存する filter_dict は
+    キーワード・タグロジック・アスペクト比・bool フラグに限定する。
+  - 保存先 Path.home() はテストで tmp_path にリダイレクトし、実ユーザー設定を
+    汚染しない。
+
+  シナリオ: お気に入りフィルタを保存して再適用すると同じ結果が得られる
+    前提 FavoriteFiltersService が一時ディレクトリで初期化されている
+    かつ DB フィルタが同一条件に対して常に同じ結果を返す
+    もし タグ検索条件を組み立てて "my_favorite" として保存する
+    かつ 保存前の検索を実行して結果を記録する
+    かつ "my_favorite" を読み込んで検索条件を再構築する
+    ならば 保存した条件と復元した条件が一致する
+    かつ 復元後の検索結果が保存前の検索結果と一致する

--- a/tests/bdd/features/tag_search_filter.feature
+++ b/tests/bdd/features/tag_search_filter.feature
@@ -1,0 +1,33 @@
+# language: ja
+機能: タグ検索とフロントエンドフィルタ
+  SearchFilterService の UI 入力解析（除外キーワード構文 `-tag`）と
+  SearchCriteriaProcessor のフロントエンドフィルタ（アスペクト比・重複除外）の
+  振る舞いを仕様化する。
+
+  責務分離（database_management.feature との非重複）:
+  - database_management.feature は Repository / DB 層の SQL レベル検索を検証する。
+  - 本 feature は GUI サービス層の入力解析と、DB では処理しないメモリ内
+    フロントエンドフィルタ（アスペクト比・重複除外）の振る舞いを検証する。
+  - 除外タグ（`-tag` 構文）は search_type が "tags" のときのみ有効。
+    caption 検索では破棄されるため、シナリオはタグ検索に限定する。
+
+  シナリオ: 除外キーワード付きタグ検索 (-tag 構文)
+    前提 SearchFilterService が初期化されている
+    もし タグ検索入力 "1girl, -1boy, blue_eyes, -smile" を解析して検索条件を作成する
+    ならば 通常キーワードは "1girl, blue_eyes" になる
+    かつ 除外キーワードは "1boy, smile" になる
+    かつ フィルタ条件の除外タグは "1boy, smile" になる
+
+  シナリオ: アスペクト比フィルタ適用時の件数報告
+    前提 SearchCriteriaProcessor が初期化されている
+    かつ DB フィルタが幅と高さを持つ 4 件の画像を返す
+    もし アスペクト比 "1:1 (正方形)" を指定して検索を実行する
+    ならば 報告件数はフィルタ後の件数と一致する
+    かつ 報告件数は 2 になる
+
+  シナリオ: 重複画像を除外した検索
+    前提 SearchCriteriaProcessor が初期化されている
+    かつ DB フィルタが pHash 重複を含む 4 件の画像を返す
+    もし 重複除外を有効にして検索を実行する
+    ならば 報告件数はフィルタ後の件数と一致する
+    かつ 報告件数は 3 になる

--- a/tests/bdd/steps/test_favorite_filter_workflow.py
+++ b/tests/bdd/steps/test_favorite_filter_workflow.py
@@ -1,0 +1,154 @@
+"""お気に入りフィルタの保存・再適用フローの BDD ステップ定義。
+
+FavoriteFiltersService（JSON 永続化）と SearchFilterService（条件構築）を
+横断し、保存した条件で再検索したとき保存前と同じ結果が得られることを検証する。
+
+FavoriteFiltersService と SearchFilterService に直接の連携コードは無いため、
+dict ⇄ SearchConditions の変換はステップ定義内で明示的に組む（src は変更しない）。
+datetime フィールドは JSON 直列化できないためシナリオ対象外。
+"""
+
+from pathlib import Path
+from typing import Any
+from unittest.mock import Mock
+
+import pytest
+from pytest_bdd import given, scenarios, then, when
+
+from lorairo.gui.services.search_filter_service import SearchFilterService
+from lorairo.services.favorite_filters_service import FavoriteFiltersService
+from lorairo.services.search_criteria_processor import SearchCriteriaProcessor
+
+_FEATURE_FILE = Path(__file__).parent.parent / "features" / "favorite_filter_workflow.feature"
+scenarios(str(_FEATURE_FILE))
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def mock_db_manager() -> Mock:
+    return Mock()
+
+
+@pytest.fixture
+def search_filter_service(mock_db_manager: Mock) -> SearchFilterService:
+    return SearchFilterService(
+        db_manager=mock_db_manager,
+        model_selection_service=Mock(),
+    )
+
+
+@pytest.fixture
+def criteria_processor(mock_db_manager: Mock) -> SearchCriteriaProcessor:
+    return SearchCriteriaProcessor(db_manager=mock_db_manager)
+
+
+# ---------------------------------------------------------------------------
+# Given
+# ---------------------------------------------------------------------------
+
+
+@given("FavoriteFiltersService が一時ディレクトリで初期化されている", target_fixture="ctx")
+def given_favorite_service_initialized(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    search_filter_service: SearchFilterService,
+    criteria_processor: SearchCriteriaProcessor,
+) -> dict[str, Any]:
+    # Path.home() を tmp_path にリダイレクトし実ユーザー設定を汚染しない
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    favorite_service = FavoriteFiltersService()
+    return {
+        "favorite_service": favorite_service,
+        "search_filter_service": search_filter_service,
+        "criteria_processor": criteria_processor,
+    }
+
+
+@given("DB フィルタが同一条件に対して常に同じ結果を返す")
+def given_db_returns_consistent_result(ctx: dict[str, Any], mock_db_manager: Mock) -> None:
+    # 1:1 フィルタ（保存条件の aspect_ratio_filter）で 2 件が残るよう width/height を設定
+    images = [
+        {"id": 1, "phash": "aaaa", "width": 1024, "height": 1024},  # 1:1
+        {"id": 2, "phash": "bbbb", "width": 512, "height": 512},  # 1:1
+        {"id": 3, "phash": "cccc", "width": 1920, "height": 1080},  # 16:9
+    ]
+    # 同一条件の 2 回呼び出しで常に同じ戻り値
+    mock_db_manager.get_images_by_filter.return_value = (images, len(images))
+
+
+# ---------------------------------------------------------------------------
+# When
+# ---------------------------------------------------------------------------
+
+
+@when('タグ検索条件を組み立てて "my_favorite" として保存する')
+def when_build_and_save_filter(ctx: dict[str, Any]) -> None:
+    # datetime を含まない素朴な dict（JSON ラウンドトリップ安全）
+    filter_dict: dict[str, Any] = {
+        "search_type": "tags",
+        "keywords": ["1girl", "blue_eyes"],
+        "excluded_keywords": ["1boy"],
+        "tag_logic": "and",
+        "aspect_ratio_filter": "1:1 (正方形)",
+        "exclude_duplicates": False,
+        "only_untagged": False,
+    }
+    favorite_service: FavoriteFiltersService = ctx["favorite_service"]
+    saved = favorite_service.save_filter("my_favorite", filter_dict)
+    assert saved is True
+    ctx["saved_dict"] = filter_dict
+
+
+@when("保存前の検索を実行して結果を記録する")
+def when_search_before_save(ctx: dict[str, Any]) -> None:
+    search_service: SearchFilterService = ctx["search_filter_service"]
+    processor: SearchCriteriaProcessor = ctx["criteria_processor"]
+    conditions = search_service.create_search_conditions(**ctx["saved_dict"])
+    images, reported_count = processor.execute_search_with_filters(conditions)
+    ctx["before_conditions"] = conditions
+    ctx["before_result"] = (images, reported_count)
+
+
+@when('"my_favorite" を読み込んで検索条件を再構築する')
+def when_load_and_rebuild(ctx: dict[str, Any]) -> None:
+    favorite_service: FavoriteFiltersService = ctx["favorite_service"]
+    search_service: SearchFilterService = ctx["search_filter_service"]
+    processor: SearchCriteriaProcessor = ctx["criteria_processor"]
+
+    loaded_dict = favorite_service.load_filter("my_favorite")
+    assert loaded_dict is not None
+    ctx["loaded_dict"] = loaded_dict
+
+    conditions = search_service.create_search_conditions(**loaded_dict)
+    images, reported_count = processor.execute_search_with_filters(conditions)
+    ctx["after_conditions"] = conditions
+    ctx["after_result"] = (images, reported_count)
+
+
+# ---------------------------------------------------------------------------
+# Then
+# ---------------------------------------------------------------------------
+
+
+@then("保存した条件と復元した条件が一致する")
+def then_dicts_match(ctx: dict[str, Any]) -> None:
+    assert ctx["loaded_dict"] == ctx["saved_dict"]
+    before = ctx["before_conditions"]
+    after = ctx["after_conditions"]
+    assert after.search_type == before.search_type
+    assert after.keywords == before.keywords
+    assert after.excluded_keywords == before.excluded_keywords
+    assert after.tag_logic == before.tag_logic
+    assert after.aspect_ratio_filter == before.aspect_ratio_filter
+
+
+@then("復元後の検索結果が保存前の検索結果と一致する")
+def then_results_match(ctx: dict[str, Any]) -> None:
+    before_images, before_count = ctx["before_result"]
+    after_images, after_count = ctx["after_result"]
+    assert after_images == before_images
+    assert after_count == before_count

--- a/tests/bdd/steps/test_tag_search_filter.py
+++ b/tests/bdd/steps/test_tag_search_filter.py
@@ -1,0 +1,173 @@
+"""タグ検索・フロントエンドフィルタの BDD ステップ定義。
+
+SearchFilterService の UI 入力解析（除外キーワード構文）と
+SearchCriteriaProcessor のフロントエンドフィルタ（アスペクト比・重複除外）の
+振る舞いを検証する。
+"""
+
+from pathlib import Path
+from typing import Any
+from unittest.mock import Mock
+
+import pytest
+from pytest_bdd import given, parsers, scenarios, then, when
+
+from lorairo.gui.services.search_filter_service import SearchFilterService
+from lorairo.services.search_criteria_processor import SearchCriteriaProcessor
+from lorairo.services.search_models import SearchConditions
+
+_FEATURE_FILE = Path(__file__).parent.parent / "features" / "tag_search_filter.feature"
+scenarios(str(_FEATURE_FILE))
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def mock_db_manager() -> Mock:
+    return Mock()
+
+
+@pytest.fixture
+def search_filter_service(mock_db_manager: Mock) -> SearchFilterService:
+    return SearchFilterService(
+        db_manager=mock_db_manager,
+        model_selection_service=Mock(),
+    )
+
+
+@pytest.fixture
+def criteria_processor(mock_db_manager: Mock) -> SearchCriteriaProcessor:
+    return SearchCriteriaProcessor(db_manager=mock_db_manager)
+
+
+# ---------------------------------------------------------------------------
+# Given
+# ---------------------------------------------------------------------------
+
+
+@given("SearchFilterService が初期化されている", target_fixture="ctx")
+def given_search_filter_service_initialized(
+    search_filter_service: SearchFilterService,
+) -> dict[str, Any]:
+    assert search_filter_service is not None
+    return {"service": search_filter_service}
+
+
+@given("SearchCriteriaProcessor が初期化されている", target_fixture="ctx")
+def given_criteria_processor_initialized(
+    criteria_processor: SearchCriteriaProcessor,
+) -> dict[str, Any]:
+    assert criteria_processor is not None
+    return {"processor": criteria_processor}
+
+
+@given("DB フィルタが幅と高さを持つ 4 件の画像を返す")
+def given_db_returns_images_with_dimensions(mock_db_manager: Mock) -> None:
+    # 1:1 が 2 件、それ以外が 2 件
+    images = [
+        {"id": 1, "width": 1024, "height": 1024},  # 1:1
+        {"id": 2, "width": 512, "height": 512},  # 1:1
+        {"id": 3, "width": 1920, "height": 1080},  # 16:9
+        {"id": 4, "width": 720, "height": 1280},  # 9:16
+    ]
+    mock_db_manager.get_images_by_filter.return_value = (images, len(images))
+
+
+@given("DB フィルタが pHash 重複を含む 4 件の画像を返す")
+def given_db_returns_images_with_duplicate_phash(mock_db_manager: Mock) -> None:
+    # phash "aaaa" が 2 件 -> 重複除外で 1 件に集約され、結果は 3 件
+    images = [
+        {"id": 1, "phash": "aaaa"},
+        {"id": 2, "phash": "bbbb"},
+        {"id": 3, "phash": "aaaa"},
+        {"id": 4, "phash": "cccc"},
+    ]
+    mock_db_manager.get_images_by_filter.return_value = (images, len(images))
+
+
+# ---------------------------------------------------------------------------
+# When
+# ---------------------------------------------------------------------------
+
+
+@when(
+    parsers.parse('タグ検索入力 "{input_text}" を解析して検索条件を作成する'),
+)
+def when_parse_and_create_conditions(ctx: dict[str, Any], input_text: str) -> None:
+    service: SearchFilterService = ctx["service"]
+    keywords, excluded_keywords = service.parse_search_input(input_text)
+    conditions = service.create_search_conditions(
+        search_type="tags",
+        keywords=keywords,
+        excluded_keywords=excluded_keywords,
+        tag_logic="and",
+    )
+    ctx["keywords"] = keywords
+    ctx["excluded_keywords"] = excluded_keywords
+    ctx["conditions"] = conditions
+    ctx["filter_criteria"] = conditions.to_filter_criteria()
+
+
+@when(parsers.parse('アスペクト比 "{aspect_ratio}" を指定して検索を実行する'))
+def when_search_with_aspect_ratio(ctx: dict[str, Any], aspect_ratio: str) -> None:
+    processor: SearchCriteriaProcessor = ctx["processor"]
+    conditions = SearchConditions(
+        search_type="tags",
+        keywords=[],
+        tag_logic="and",
+        aspect_ratio_filter=aspect_ratio,
+    )
+    images, reported_count = processor.execute_search_with_filters(conditions)
+    ctx["images"] = images
+    ctx["reported_count"] = reported_count
+
+
+@when("重複除外を有効にして検索を実行する")
+def when_search_with_duplicate_exclusion(ctx: dict[str, Any]) -> None:
+    processor: SearchCriteriaProcessor = ctx["processor"]
+    conditions = SearchConditions(
+        search_type="tags",
+        keywords=[],
+        tag_logic="and",
+        exclude_duplicates=True,
+    )
+    images, reported_count = processor.execute_search_with_filters(conditions)
+    ctx["images"] = images
+    ctx["reported_count"] = reported_count
+
+
+# ---------------------------------------------------------------------------
+# Then
+# ---------------------------------------------------------------------------
+
+
+def _parse_keyword_list(text: str) -> list[str]:
+    return [k.strip() for k in text.split(",") if k.strip()]
+
+
+@then(parsers.parse('通常キーワードは "{expected}" になる'))
+def then_keywords_match(ctx: dict[str, Any], expected: str) -> None:
+    assert ctx["keywords"] == _parse_keyword_list(expected)
+
+
+@then(parsers.parse('除外キーワードは "{expected}" になる'))
+def then_excluded_keywords_match(ctx: dict[str, Any], expected: str) -> None:
+    assert ctx["excluded_keywords"] == _parse_keyword_list(expected)
+
+
+@then(parsers.parse('フィルタ条件の除外タグは "{expected}" になる'))
+def then_filter_criteria_excluded_tags_match(ctx: dict[str, Any], expected: str) -> None:
+    assert ctx["filter_criteria"].excluded_tags == _parse_keyword_list(expected)
+
+
+@then("報告件数はフィルタ後の件数と一致する")
+def then_reported_count_matches_filtered(ctx: dict[str, Any]) -> None:
+    assert ctx["reported_count"] == len(ctx["images"])
+
+
+@then(parsers.parse("報告件数は {expected:d} になる"))
+def then_reported_count_is(ctx: dict[str, Any], expected: int) -> None:
+    assert ctx["reported_count"] == expected

--- a/tests/unit/gui/services/test_search_filter_service.py
+++ b/tests/unit/gui/services/test_search_filter_service.py
@@ -342,6 +342,128 @@ class TestSearchFilterServiceDatabase:
         assert service_with_db.current_conditions is None
 
 
+class TestSearchFilterServiceValidateUiInputs:
+    """SearchFilterService.validate_ui_inputs のユニットテスト
+
+    検索条件未指定時の警告は BDD 対象外（内部ロジック）のため unit テストで代替する。
+    """
+
+    @pytest.fixture
+    def service(self):
+        from unittest.mock import Mock
+
+        return SearchFilterService(db_manager=Mock(), model_selection_service=Mock())
+
+    def test_validate_ui_inputs_no_conditions_returns_warning(self, service):
+        """検索条件未指定時は警告を返し is_valid は True"""
+        result = service.validate_ui_inputs({"keywords": []})
+
+        assert result.is_valid is True
+        assert result.warnings is not None
+        assert any("検索条件が指定されていません" in w for w in result.warnings)
+        assert result.errors == []
+
+    def test_validate_ui_inputs_with_keywords_no_warning(self, service):
+        """キーワード指定時は警告を出さない"""
+        result = service.validate_ui_inputs({"keywords": ["1girl"]})
+
+        assert result.is_valid is True
+        assert result.warnings == []
+        assert result.errors == []
+
+    def test_validate_ui_inputs_only_untagged_suppresses_warning(self, service):
+        """キーワードが無くても only_untagged 指定時は警告を出さない"""
+        result = service.validate_ui_inputs({"keywords": [], "only_untagged": True})
+
+        assert result.is_valid is True
+        assert result.warnings == []
+
+    def test_validate_ui_inputs_resolution_filter_suppresses_warning(self, service):
+        """キーワードが無くても resolution_filter 指定時は警告を出さない"""
+        result = service.validate_ui_inputs({"keywords": [], "resolution_filter": "1024x1024"})
+
+        assert result.is_valid is True
+        assert result.warnings == []
+
+    def test_validate_ui_inputs_invalid_date_range_returns_error(self, service):
+        """開始日付が終了日付より後の場合はエラーを返し is_valid は False"""
+        result = service.validate_ui_inputs(
+            {
+                "keywords": ["tag"],
+                "date_filter_enabled": True,
+                "date_range_start": datetime(2023, 12, 31),
+                "date_range_end": datetime(2023, 1, 1),
+            }
+        )
+
+        assert result.is_valid is False
+        assert result.errors is not None
+        assert any("開始日付は終了日付より前" in e for e in result.errors)
+
+    def test_validate_ui_inputs_valid_date_range_no_error(self, service):
+        """開始日付が終了日付より前の場合はエラーを出さない"""
+        result = service.validate_ui_inputs(
+            {
+                "keywords": ["tag"],
+                "date_filter_enabled": True,
+                "date_range_start": datetime(2023, 1, 1),
+                "date_range_end": datetime(2023, 12, 31),
+            }
+        )
+
+        assert result.is_valid is True
+        assert result.errors == []
+
+
+class TestSearchFilterServiceGetEstimatedCount:
+    """SearchFilterService.get_estimated_count のユニットテスト"""
+
+    def test_get_estimated_count_returns_db_count(self):
+        """DB マネージャーの件数をそのまま返す"""
+        from unittest.mock import Mock
+
+        mock_db_manager = Mock()
+        mock_db_manager.get_images_count_only.return_value = 42
+        service = SearchFilterService(db_manager=mock_db_manager, model_selection_service=Mock())
+        conditions = SearchConditions(search_type="tags", keywords=["1girl"], tag_logic="and")
+
+        count = service.get_estimated_count(conditions)
+
+        assert count == 42
+        mock_db_manager.get_images_count_only.assert_called_once()
+
+    def test_get_estimated_count_passes_filter_criteria(self):
+        """to_filter_criteria() の結果が criteria 引数として渡される"""
+        from unittest.mock import Mock
+
+        mock_db_manager = Mock()
+        mock_db_manager.get_images_count_only.return_value = 0
+        service = SearchFilterService(db_manager=mock_db_manager, model_selection_service=Mock())
+        conditions = SearchConditions(
+            search_type="tags", keywords=["cat"], tag_logic="and", excluded_keywords=["dog"]
+        )
+
+        service.get_estimated_count(conditions)
+
+        _, kwargs = mock_db_manager.get_images_count_only.call_args
+        criteria = kwargs["criteria"]
+        assert criteria.tags == ["cat"]
+        assert criteria.excluded_tags == ["dog"]
+
+    def test_get_estimated_count_returns_zero_on_error(self):
+        """DB エラー時は 0 を返す（例外を伝播しない）"""
+        from unittest.mock import Mock
+
+        mock_db_manager = Mock()
+        mock_db_manager.get_images_count_only.side_effect = RuntimeError("DB error")
+        service = SearchFilterService(db_manager=mock_db_manager, model_selection_service=Mock())
+        conditions = SearchConditions(search_type="tags", keywords=["tag"], tag_logic="and")
+
+        count = service.get_estimated_count(conditions)
+
+        assert count == 0
+
+
 class TestSearchFilterServiceAnnotation:
     """SearchFilterService のアノテーション系機能テスト（Phase 2拡張）"""
 


### PR DESCRIPTION
## 概要

親 issue #331「Service 層・ユーザー向けフローの BDD カバレッジ不足」のサブ issue #350 / #351 に対応。タグ検索・フロントエンドフィルタ・お気に入りフィルタの振る舞いを日本語 Gherkin で仕様化する。

## 追加 BDD シナリオ

### `tests/bdd/features/tag_search_filter.feature` (#350)
- 除外キーワード付きタグ検索 (`-tag` 構文) — `parse_search_input` → `create_search_conditions` → `to_filter_criteria` の `excluded_tags` を検証（`search_type="tags"` 限定）
- アスペクト比フィルタ適用時の件数報告 — フロントエンドフィルタ適用時 `reported_count == len(filtered)`（4→2 件）
- 重複画像を除外した検索 — pHash 重複が除外され件数に反映（4→3 件）

### `tests/bdd/features/favorite_filter_workflow.feature` (#351)
- お気に入りフィルタを保存して再適用すると同じ結果が得られる — `save_filter` → `load_filter` → `create_search_conditions(**dict)` 再構築 → `execute_search_with_filters` の結果が保存前と一致。`Path.home()` を `tmp_path` にリダイレクトし実ユーザー設定を汚染しない

## 追加 unit テスト

`tests/unit/gui/services/test_search_filter_service.py` に「検索条件未指定時の警告」（BDD 対象外＝内部ロジック）の代替として追記:
- `validate_ui_inputs`: 条件未指定の警告、キーワード/フラグ指定時の警告抑制、日付範囲の前後逆転エラー（計 6 件）
- `get_estimated_count`: DB 件数の返却、`to_filter_criteria` 引数の伝播、DB エラー時 0 返却（計 3 件）

## テスト結果

- 新規 BDD 4 シナリオ: 全 pass（xfail 0）
- 追加 unit 9 件含む `test_search_filter_service.py` 29 件: 全 pass
- BDD 全体回帰（CI-equivalent filter）: 37 passed

## 責務分離

両 feature 冒頭コメントで `database_management.feature`（DB / Repository 層の SQL 検索）との非重複を明記。本 PR は GUI サービス層の入力解析・メモリ内フロントエンドフィルタ・JSON 設定永続化を対象とする。

## 発見した実バグ

なし。

Closes #350
Closes #351
Refs #331

🤖 Generated with [Claude Code](https://claude.com/claude-code)