### PR TITLE
fix: backfill rating model associations

### DIFF
--- a/src/lorairo/database/migrations/versions/f1b2c3d4e5f6_backfill_ratings_model_type_associations.py
+++ b/src/lorairo/database/migrations/versions/f1b2c3d4e5f6_backfill_ratings_model_type_associations.py
@@ -1,0 +1,81 @@
+"""Backfill ratings model type associations
+
+Revision ID: f1b2c3d4e5f6
+Revises: f0a1b2c3d4e5
+Create Date: 2026-05-22
+
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+from sqlalchemy import inspect
+
+revision: str = "f1b2c3d4e5f6"
+down_revision: str | None = "f0a1b2c3d4e5"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+RATING_CAPABLE_MODEL_NAMES = (
+    "idolsankaku-eva02-large-tagger-v1",
+    "idolsankaku-swinv2-tagger-v1",
+    "Z3D-E621-Convnext",
+    "anime_rating_mobilenetv3_sce_dist",
+    "anime_rating_caformer_s36_plus",
+    "camie_tagger_initial",
+    "wd-v1-4-convnext-tagger-v2",
+    "wd-v1-4-convnextv2-tagger-v2",
+    "wd-v1-4-moat-tagger-v2",
+    "wd-v1-4-swinv2-tagger-v2",
+    "wd-vit-tagger-v3",
+    "wd-convnext-tagger-v3",
+    "wd-swinv2-tagger-v3",
+    "wd-vit-large-tagger-v3",
+    "wd-eva02-large-tagger-v3",
+)
+
+
+def _quoted_model_names() -> str:
+    return ", ".join(f"'{name}'" for name in RATING_CAPABLE_MODEL_NAMES)
+
+
+def upgrade() -> None:
+    """Attach the `ratings` type to known rating-capable local models."""
+    inspector = inspect(op.get_bind())
+    required_tables = {"models", "model_types", "model_function_associations"}
+    if not required_tables.issubset(set(inspector.get_table_names())):
+        return
+
+    op.execute(
+        """
+        INSERT INTO model_types (name)
+        SELECT 'ratings'
+        WHERE NOT EXISTS (
+            SELECT 1 FROM model_types WHERE name = 'ratings'
+        )
+        """
+    )
+    op.execute(
+        f"""
+        INSERT INTO model_function_associations (model_id, type_id)
+        SELECT m.id, mt.id
+        FROM models AS m
+        JOIN model_types AS mt ON mt.name = 'ratings'
+        WHERE m.name IN ({_quoted_model_names()})
+          AND NOT EXISTS (
+              SELECT 1
+              FROM model_function_associations AS existing
+              WHERE existing.model_id = m.id
+                AND existing.type_id = mt.id
+          )
+        """
+    )
+
+
+def downgrade() -> None:
+    """Leave rating associations intact on downgrade.
+
+    This data migration cannot distinguish rows inserted here from valid
+    associations created by a prior manual backfill or model resync. Preserve
+    data rather than deleting potentially legitimate model capabilities.
+    """

--- a/tests/unit/database/test_migration_a7b8c9d0e1f2_score_labels.py
+++ b/tests/unit/database/test_migration_a7b8c9d0e1f2_score_labels.py
@@ -121,7 +121,7 @@ def test_score_labels_migration_converges_when_table_was_precreated(tmp_path: Pa
         version = conn.execute(text("SELECT version_num FROM alembic_version")).scalar_one()
     engine.dispose()
 
-    assert version == "f0a1b2c3d4e5"
+    assert version == "f1b2c3d4e5f6"
     assert "ix_score_labels_image_id" in indexes
 
 
@@ -142,7 +142,7 @@ def test_project_database_prepare_upgrades_alembic_managed_db(tmp_path: Path) ->
         score_label_count = conn.execute(text("SELECT count(*) FROM score_labels")).scalar_one()
     engine.dispose()
 
-    assert version == "f0a1b2c3d4e5"
+    assert version == "f1b2c3d4e5f6"
     assert score_label_count == 0
 
 

--- a/tests/unit/database/test_migration_f1b2c3d4e5f6_ratings_backfill.py
+++ b/tests/unit/database/test_migration_f1b2c3d4e5f6_ratings_backfill.py
@@ -1,0 +1,200 @@
+"""Alembic migration `f1b2c3d4e5f6` ratings association backfill checks."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from alembic import command
+from alembic.config import Config
+from sqlalchemy import create_engine, text
+
+
+def _make_alembic_config(db_path: Path) -> Config:
+    """Build an Alembic Config that targets the temporary DB."""
+    project_root = Path(__file__).resolve().parents[3]
+    cfg = Config(str(project_root / "alembic.ini"))
+    cfg.set_main_option("script_location", str(project_root / "src/lorairo/database/migrations"))
+    cfg.set_main_option("sqlalchemy.url", f"sqlite:///{db_path}")
+    return cfg
+
+
+def _create_schema_at_f0(db_path: Path) -> None:
+    """Create the minimal schema after f0 ratings model_type migration."""
+    engine = create_engine(f"sqlite:///{db_path}")
+    with engine.begin() as conn:
+        conn.execute(
+            text(
+                """
+                CREATE TABLE models (
+                    id INTEGER NOT NULL PRIMARY KEY,
+                    name VARCHAR NOT NULL,
+                    provider VARCHAR,
+                    discontinued_at TIMESTAMP,
+                    litellm_model_id VARCHAR NOT NULL,
+                    estimated_size_gb FLOAT,
+                    requires_api_key BOOLEAN DEFAULT '0' NOT NULL,
+                    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
+                    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
+                    UNIQUE (litellm_model_id)
+                )
+                """
+            )
+        )
+        conn.execute(
+            text(
+                """
+                CREATE TABLE model_types (
+                    id INTEGER NOT NULL PRIMARY KEY,
+                    name VARCHAR NOT NULL UNIQUE
+                )
+                """
+            )
+        )
+        conn.execute(
+            text(
+                """
+                CREATE TABLE model_function_associations (
+                    model_id INTEGER NOT NULL,
+                    type_id INTEGER NOT NULL,
+                    PRIMARY KEY (model_id, type_id),
+                    FOREIGN KEY(model_id) REFERENCES models (id),
+                    FOREIGN KEY(type_id) REFERENCES model_types (id)
+                )
+                """
+            )
+        )
+        conn.execute(
+            text(
+                "INSERT INTO model_types (id, name) VALUES "
+                "(1, 'tags'), (2, 'scores'), (3, 'caption'), "
+                "(4, 'upscaler'), (5, 'multimodal'), (6, 'ratings')"
+            )
+        )
+        conn.execute(
+            text(
+                "INSERT INTO models (id, name, provider, litellm_model_id) VALUES "
+                "(1, 'wd-vit-tagger-v3', 'local', 'wd-vit-tagger-v3'), "
+                "(2, 'Z3D-E621-Convnext', 'local', 'Z3D-E621-Convnext'), "
+                "(3, 'clip-aesthetic', 'local', 'clip-aesthetic')"
+            )
+        )
+        conn.execute(
+            text(
+                "INSERT INTO model_function_associations (model_id, type_id) VALUES (1, 1), (2, 1), (3, 2)"
+            )
+        )
+        conn.execute(text("CREATE TABLE alembic_version (version_num VARCHAR(32) PRIMARY KEY)"))
+        conn.execute(text("INSERT INTO alembic_version (version_num) VALUES ('f0a1b2c3d4e5')"))
+    engine.dispose()
+
+
+@pytest.mark.unit
+def test_ratings_backfill_adds_associations_for_known_rating_models(tmp_path: Path) -> None:
+    db_path = tmp_path / "ratings-backfill.db"
+    _create_schema_at_f0(db_path)
+
+    command.upgrade(_make_alembic_config(db_path), "head")
+
+    engine = create_engine(f"sqlite:///{db_path}")
+    with engine.connect() as conn:
+        rows = conn.execute(
+            text(
+                """
+                SELECT m.name, group_concat(mt.name)
+                FROM models AS m
+                JOIN model_function_associations AS mfa ON m.id = mfa.model_id
+                JOIN model_types AS mt ON mt.id = mfa.type_id
+                GROUP BY m.id
+                ORDER BY m.id
+                """
+            )
+        ).fetchall()
+        version = conn.execute(text("SELECT version_num FROM alembic_version")).scalar_one()
+    engine.dispose()
+
+    assert version == "f1b2c3d4e5f6"
+    assert rows == [
+        ("wd-vit-tagger-v3", "tags,ratings"),
+        ("Z3D-E621-Convnext", "tags,ratings"),
+        ("clip-aesthetic", "scores"),
+    ]
+
+
+@pytest.mark.unit
+def test_ratings_backfill_is_idempotent(tmp_path: Path) -> None:
+    db_path = tmp_path / "ratings-backfill.db"
+    _create_schema_at_f0(db_path)
+
+    cfg = _make_alembic_config(db_path)
+    command.upgrade(cfg, "head")
+    command.downgrade(cfg, "f0a1b2c3d4e5")
+
+    engine = create_engine(f"sqlite:///{db_path}")
+    with engine.connect() as conn:
+        count_after_downgrade = conn.execute(
+            text(
+                """
+                SELECT count(*)
+                FROM model_function_associations AS mfa
+                JOIN model_types AS mt ON mt.id = mfa.type_id
+                WHERE mt.name = 'ratings'
+                """
+            )
+        ).scalar_one()
+    engine.dispose()
+
+    command.upgrade(cfg, "head")
+
+    engine = create_engine(f"sqlite:///{db_path}")
+    with engine.connect() as conn:
+        count = conn.execute(
+            text(
+                """
+                SELECT count(*)
+                FROM model_function_associations AS mfa
+                JOIN model_types AS mt ON mt.id = mfa.type_id
+                WHERE mt.name = 'ratings'
+                """
+            )
+        ).scalar_one()
+    engine.dispose()
+
+    assert count_after_downgrade == 2
+    assert count == 2
+
+
+@pytest.mark.unit
+def test_downgrade_preserves_preexisting_ratings_associations(tmp_path: Path) -> None:
+    db_path = tmp_path / "ratings-backfill.db"
+    _create_schema_at_f0(db_path)
+    engine = create_engine(f"sqlite:///{db_path}")
+    with engine.begin() as conn:
+        conn.execute(text("INSERT INTO model_function_associations (model_id, type_id) VALUES (3, 6)"))
+    engine.dispose()
+
+    cfg = _make_alembic_config(db_path)
+    command.upgrade(cfg, "head")
+    command.downgrade(cfg, "f0a1b2c3d4e5")
+
+    engine = create_engine(f"sqlite:///{db_path}")
+    with engine.connect() as conn:
+        rows = conn.execute(
+            text(
+                """
+                SELECT m.name
+                FROM models AS m
+                JOIN model_function_associations AS mfa ON m.id = mfa.model_id
+                JOIN model_types AS mt ON mt.id = mfa.type_id
+                WHERE mt.name = 'ratings'
+                ORDER BY m.id
+                """
+            )
+        ).fetchall()
+    engine.dispose()
+
+    assert [row.name for row in rows] == [
+        "wd-vit-tagger-v3",
+        "Z3D-E621-Convnext",
+        "clip-aesthetic",
+    ]


### PR DESCRIPTION
## Summary
- add a follow-up migration that backfills ratings model_type associations for known rating-capable local models already present in existing LoRAIro DBs
- keep the migration idempotent and table-existence guarded for partial migration test schemas
- update migration head expectations and add backfill regression tests

## Root Cause
PR #354 added the canonical ratings model_type and future sync mapping, but existing DB rows still had only tags/scores/etc. because model sync was not automatically re-run after migration. As a result, the GUI rating filter queried ratings and got 0 models.

## Verification
- uv run pytest tests/unit/database/test_migration_f1b2c3d4e5f6_ratings_backfill.py tests/unit/database/test_migration_a7b8c9d0e1f2_score_labels.py tests/unit/database/test_migration_e3f4a5b6c7d8_model_types_rename.py
- uv run pytest tests/unit/test_model_sync_service.py tests/unit/services/test_model_selection_service.py
- uv run ruff check src/lorairo/database/migrations/versions/f1b2c3d4e5f6_backfill_ratings_model_type_associations.py tests/unit/database/test_migration_f1b2c3d4e5f6_ratings_backfill.py tests/unit/database/test_migration_a7b8c9d0e1f2_score_labels.py
- copied current project DB to /tmp/rating-backfill-check.db and upgraded it to head; ratings associations increased from 0 to 24