### PR TITLE
fix: improve annotation summary dialog ratings display

### DIFF
--- a/src/lorairo/gui/widgets/annotation_summary_dialog.py
+++ b/src/lorairo/gui/widgets/annotation_summary_dialog.py
@@ -7,6 +7,7 @@
 from typing import Any
 
 from PySide6.QtCore import Qt
+from PySide6.QtGui import QTextOption
 from PySide6.QtWidgets import (
     QDialog,
     QDialogButtonBox,
@@ -18,6 +19,7 @@ from PySide6.QtWidgets import (
     QTableWidgetItem,
     QTabWidget,
     QTextBrowser,
+    QTextEdit,
     QVBoxLayout,
     QWidget,
 )
@@ -63,6 +65,7 @@ class AnnotationSummaryDialog(QDialog):
         tabs.addTab(self._create_tags_tab(), "タグ")
         tabs.addTab(self._create_captions_tab(), "キャプション")
         tabs.addTab(self._create_scores_tab(), "スコア")
+        tabs.addTab(self._create_ratings_tab(), "レーティング")
         tabs.addTab(self._create_model_details_tab(), "モデル詳細")
 
         layout.addWidget(tabs)
@@ -139,7 +142,7 @@ class AnnotationSummaryDialog(QDialog):
         form = QFormLayout(group)
 
         form.addRow("対象画像:", QLabel(f"{self._result.total_images}件"))
-        form.addRow("使用モデル:", QLabel(", ".join(self._result.models_used)))
+        form.addRow("使用モデル:", self._create_models_used_view())
         form.addRow("DB保存成功:", QLabel(f"{self._result.db_save_success}件"))
 
         if self._result.db_save_skip > 0:
@@ -159,6 +162,21 @@ class AnnotationSummaryDialog(QDialog):
 
         return group
 
+    def _create_models_used_view(self) -> QTextBrowser:
+        """使用モデル一覧を横に伸びないスクロール表示で作成する。"""
+        browser = QTextBrowser()
+        browser.setObjectName("modelsUsedView")
+        browser.setPlainText("\n".join(self._result.models_used) if self._result.models_used else "-")
+        browser.setOpenExternalLinks(False)
+        browser.setReadOnly(True)
+        browser.setLineWrapMode(QTextEdit.LineWrapMode.WidgetWidth)
+        browser.setWordWrapMode(QTextOption.WrapMode.WrapAnywhere)
+        browser.setHorizontalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
+        browser.setMaximumHeight(96)
+        browser.setMinimumHeight(48)
+        browser.setToolTip("\n".join(self._result.models_used))
+        return browser
+
     def _create_results_group(self) -> QGroupBox:
         """保存結果一覧セクションを作成する。
 
@@ -172,13 +190,14 @@ class AnnotationSummaryDialog(QDialog):
         group = QGroupBox(f"保存結果一覧 ({total}件)")
         layout = QVBoxLayout(group)
 
-        table = QTableWidget(display_count, 4)
+        table = QTableWidget(display_count, 5)
         table.setObjectName("resultsTable")
-        table.setHorizontalHeaderLabels(["画像名", "タグ数", "キャプション", "スコア"])
+        table.setHorizontalHeaderLabels(["画像名", "タグ数", "キャプション", "スコア", "レーティング"])
         table.horizontalHeader().setSectionResizeMode(0, QHeaderView.ResizeMode.Stretch)
         table.horizontalHeader().setSectionResizeMode(1, QHeaderView.ResizeMode.ResizeToContents)
         table.horizontalHeader().setSectionResizeMode(2, QHeaderView.ResizeMode.ResizeToContents)
         table.horizontalHeader().setSectionResizeMode(3, QHeaderView.ResizeMode.ResizeToContents)
+        table.horizontalHeader().setSectionResizeMode(4, QHeaderView.ResizeMode.ResizeToContents)
         table.verticalHeader().setVisible(False)
         table.setEditTriggers(QTableWidget.EditTrigger.NoEditTriggers)
         table.setSelectionBehavior(QTableWidget.SelectionBehavior.SelectRows)
@@ -199,6 +218,10 @@ class AnnotationSummaryDialog(QDialog):
             score_item = QTableWidgetItem(score_text)
             score_item.setTextAlignment(Qt.AlignmentFlag.AlignCenter)
             table.setItem(row, 3, score_item)
+
+            rating_item = QTableWidgetItem(summary.rating or "-")
+            rating_item.setTextAlignment(Qt.AlignmentFlag.AlignCenter)
+            table.setItem(row, 4, rating_item)
 
         layout.addWidget(table)
 
@@ -267,6 +290,13 @@ class AnnotationSummaryDialog(QDialog):
         if isinstance(result, dict):
             return result.get(key, default)
         return getattr(result, key, default)
+
+    @staticmethod
+    def _get_rating_attr(rating: object, key: str, default: object = None) -> Any:
+        """RatingPrediction相当からキーに対応する値を取得する。"""
+        if isinstance(rating, dict):
+            return rating.get(key, default)
+        return getattr(rating, key, default)
 
     def _create_tags_tab(self) -> QWidget:
         """タグタブを作成する。
@@ -396,6 +426,74 @@ class AnnotationSummaryDialog(QDialog):
             layout.addWidget(QLabel("スコアデータがありません。"))
 
         return widget
+
+    def _create_ratings_tab(self) -> QWidget:
+        """レーティングタブを作成する。
+
+        Returns:
+            レーティングタブウィジェット。
+        """
+        widget = QWidget()
+        layout = QVBoxLayout(widget)
+
+        rating_rows: list[tuple[str, str, str, str, str]] = []
+        for phash, model_results in self._result.results.items():
+            filename = self._result.phash_to_filename.get(phash, phash[:12] + "...")
+            for model_name, result in model_results.items():
+                ratings = self._get_result_attr(result, "ratings", None)
+                for raw_label, source_scheme, confidence in self._iter_rating_rows(ratings):
+                    rating_rows.append((filename, model_name, raw_label, source_scheme, confidence))
+
+        table = QTableWidget(len(rating_rows), 5)
+        table.setObjectName("ratingsTable")
+        table.setHorizontalHeaderLabels(["pHash/ファイル", "モデル名", "raw label", "scheme", "confidence"])
+        table.horizontalHeader().setSectionResizeMode(0, QHeaderView.ResizeMode.ResizeToContents)
+        table.horizontalHeader().setSectionResizeMode(1, QHeaderView.ResizeMode.ResizeToContents)
+        table.horizontalHeader().setSectionResizeMode(2, QHeaderView.ResizeMode.Stretch)
+        table.horizontalHeader().setSectionResizeMode(3, QHeaderView.ResizeMode.ResizeToContents)
+        table.horizontalHeader().setSectionResizeMode(4, QHeaderView.ResizeMode.ResizeToContents)
+        table.verticalHeader().setVisible(False)
+        table.setEditTriggers(QTableWidget.EditTrigger.NoEditTriggers)
+        table.setSelectionBehavior(QTableWidget.SelectionBehavior.SelectRows)
+
+        for row, (filename, model_name, raw_label, source_scheme, confidence) in enumerate(rating_rows):
+            table.setItem(row, 0, QTableWidgetItem(filename))
+            table.setItem(row, 1, QTableWidgetItem(model_name))
+            table.setItem(row, 2, QTableWidgetItem(raw_label))
+            table.setItem(row, 3, QTableWidgetItem(source_scheme))
+            confidence_item = QTableWidgetItem(confidence)
+            confidence_item.setTextAlignment(Qt.AlignmentFlag.AlignRight | Qt.AlignmentFlag.AlignVCenter)
+            table.setItem(row, 4, confidence_item)
+
+        layout.addWidget(table)
+
+        if not rating_rows:
+            layout.addWidget(QLabel("レーティングデータがありません。"))
+
+        return widget
+
+    def _iter_rating_rows(self, ratings: object) -> list[tuple[str, str, str]]:
+        """ratings を詳細タブ表示用の行に変換する。"""
+        if not ratings:
+            return []
+        if isinstance(ratings, str):
+            return [(ratings, "-", "-")]
+
+        candidates = ratings if isinstance(ratings, list) else [ratings]
+        rows: list[tuple[str, str, str]] = []
+        for rating in candidates:
+            if isinstance(rating, str):
+                rows.append((rating, "-", "-"))
+                continue
+
+            raw_label = self._get_rating_attr(rating, "raw_label")
+            if not raw_label:
+                continue
+            source_scheme = self._get_rating_attr(rating, "source_scheme", "-") or "-"
+            confidence = self._get_rating_attr(rating, "confidence_score")
+            confidence_text = f"{float(confidence):.4f}" if confidence is not None else "-"
+            rows.append((str(raw_label), str(source_scheme), confidence_text))
+        return rows
 
     def _create_model_details_tab(self) -> QWidget:
         """モデル詳細タブを作成する。

--- a/src/lorairo/gui/widgets/annotation_summary_dialog.py
+++ b/src/lorairo/gui/widgets/annotation_summary_dialog.py
@@ -440,6 +440,8 @@ class AnnotationSummaryDialog(QDialog):
         for phash, model_results in self._result.results.items():
             filename = self._result.phash_to_filename.get(phash, phash[:12] + "...")
             for model_name, result in model_results.items():
+                if self._get_result_attr(result, "error", None):
+                    continue
                 ratings = self._get_result_attr(result, "ratings", None)
                 for raw_label, source_scheme, confidence in self._iter_rating_rows(ratings):
                     rating_rows.append((filename, model_name, raw_label, source_scheme, confidence))

--- a/src/lorairo/gui/workers/annotation_worker.py
+++ b/src/lorairo/gui/workers/annotation_worker.py
@@ -43,6 +43,7 @@ class ImageResultSummary:
     tag_count: int = 0
     has_caption: bool = False
     score: float | None = None
+    rating: str | None = None
 
 
 @dataclass
@@ -428,6 +429,7 @@ class AnnotationWorker(LoRAIroWorkerBase["AnnotationExecutionResult"]):
         tag_count = 0
         has_caption = False
         score: float | None = None
+        rating: str | None = None
         for unified_result in raw_annotations.values():
             error = (
                 unified_result.get("error")
@@ -458,12 +460,61 @@ class AnnotationWorker(LoRAIroWorkerBase["AnnotationExecutionResult"]):
                 )
                 if isinstance(raw_scores, dict) and raw_scores:
                     score = float(next(iter(raw_scores.values())))
+            if rating is None:
+                raw_ratings = (
+                    unified_result.get("ratings")
+                    if isinstance(unified_result, dict)
+                    else getattr(unified_result, "ratings", None)
+                )
+                rating = AnnotationWorker._format_rating_summary(raw_ratings)
         return ImageResultSummary(
             file_name=file_name,
             tag_count=tag_count,
             has_caption=has_caption,
             score=score,
+            rating=rating,
         )
+
+    @staticmethod
+    def _format_rating_summary(ratings: Any) -> str | None:
+        """ratings から完了ダイアログ用の代表表示を作る。"""
+        prediction = AnnotationWorker._select_first_rating(ratings)
+        if prediction is None:
+            return None
+        if isinstance(prediction, str):
+            return prediction
+
+        raw_label = AnnotationWorker._extract_rating_attr(prediction, "raw_label")
+        if not raw_label:
+            return None
+
+        source_scheme = AnnotationWorker._extract_rating_attr(prediction, "source_scheme")
+        confidence = AnnotationWorker._extract_rating_attr(prediction, "confidence_score")
+        if source_scheme and confidence is not None:
+            return f"{raw_label} ({source_scheme}, {float(confidence):.2f})"
+        if source_scheme:
+            return f"{raw_label} ({source_scheme})"
+        if confidence is not None:
+            return f"{raw_label} ({float(confidence):.2f})"
+        return str(raw_label)
+
+    @staticmethod
+    def _select_first_rating(ratings: Any) -> Any | None:
+        """str / list / structured rating から最初の表示対象を取り出す。"""
+        if not ratings:
+            return None
+        if isinstance(ratings, str):
+            return ratings
+        if isinstance(ratings, list):
+            return ratings[0] if ratings else None
+        return ratings
+
+    @staticmethod
+    def _extract_rating_attr(prediction: Any, name: str) -> Any:
+        """RatingPrediction / dict の両方から属性を読む。"""
+        if isinstance(prediction, dict):
+            return prediction.get(name)
+        return getattr(prediction, name, None)
 
     @staticmethod
     def _extract_field(result: Any, field_name: str) -> Any:

--- a/src/lorairo/gui/workers/annotation_worker.py
+++ b/src/lorairo/gui/workers/annotation_worker.py
@@ -478,7 +478,7 @@ class AnnotationWorker(LoRAIroWorkerBase["AnnotationExecutionResult"]):
     @staticmethod
     def _format_rating_summary(ratings: Any) -> str | None:
         """ratings から完了ダイアログ用の代表表示を作る。"""
-        prediction = AnnotationWorker._select_first_rating(ratings)
+        prediction = AnnotationWorker._select_rating_prediction(ratings)
         if prediction is None:
             return None
         if isinstance(prediction, str):
@@ -499,15 +499,33 @@ class AnnotationWorker(LoRAIroWorkerBase["AnnotationExecutionResult"]):
         return str(raw_label)
 
     @staticmethod
-    def _select_first_rating(ratings: Any) -> Any | None:
-        """str / list / structured rating から最初の表示対象を取り出す。"""
+    def _select_rating_prediction(ratings: Any) -> Any | None:
+        """str / list / structured rating から代表表示対象を取り出す。
+
+        structured rating は保存処理と同じく confidence 最大を代表にする。
+        confidence 欠損は最下位扱いで、同値の場合は先頭を維持する。
+        """
         if not ratings:
             return None
         if isinstance(ratings, str):
             return ratings
-        if isinstance(ratings, list):
-            return ratings[0] if ratings else None
-        return ratings
+        candidates = ratings if isinstance(ratings, list) else [ratings]
+        if candidates and all(isinstance(candidate, str) for candidate in candidates):
+            return candidates[0]
+        predictions = [
+            candidate
+            for candidate in candidates
+            if isinstance(candidate, dict) or hasattr(candidate, "raw_label")
+        ]
+        if not predictions:
+            return None
+        return max(predictions, key=AnnotationWorker._rating_confidence_sort_key)
+
+    @staticmethod
+    def _rating_confidence_sort_key(prediction: Any) -> float:
+        """confidence_score の sort key。None は最下位扱い。"""
+        score = AnnotationWorker._extract_rating_attr(prediction, "confidence_score")
+        return -1.0 if score is None else float(score)
 
     @staticmethod
     def _extract_rating_attr(prediction: Any, name: str) -> Any:

--- a/tests/unit/gui/widgets/test_annotation_summary_dialog.py
+++ b/tests/unit/gui/widgets/test_annotation_summary_dialog.py
@@ -4,7 +4,7 @@
 """
 
 import pytest
-from PySide6.QtWidgets import QGroupBox, QLabel, QTableWidget
+from PySide6.QtWidgets import QGroupBox, QLabel, QTableWidget, QTextBrowser, QTextEdit
 
 from lorairo.gui.widgets.annotation_summary_dialog import AnnotationSummaryDialog
 from lorairo.gui.workers.annotation_worker import (
@@ -25,10 +25,52 @@ def success_result() -> AnnotationExecutionResult:
         db_save_skip=0,
         model_errors=[],
         image_summaries=[
-            ImageResultSummary(file_name="image_001.png", tag_count=15, has_caption=True, score=0.85),
+            ImageResultSummary(
+                file_name="image_001.png",
+                tag_count=15,
+                has_caption=True,
+                score=0.85,
+                rating="safe (danbooru4, 0.98)",
+            ),
             ImageResultSummary(file_name="image_002.png", tag_count=12, has_caption=True, score=None),
             ImageResultSummary(file_name="image_003.png", tag_count=8, has_caption=False, score=0.72),
         ],
+    )
+
+
+@pytest.fixture
+def rating_result() -> AnnotationExecutionResult:
+    """レーティングを含むアノテーション結果"""
+    return AnnotationExecutionResult(
+        results={
+            "phash1": {
+                "wd-tagger": {
+                    "ratings": [
+                        {
+                            "raw_label": "safe",
+                            "source_scheme": "danbooru4",
+                            "confidence_score": 0.9876,
+                        }
+                    ]
+                },
+                "legacy": {"ratings": ["PG"]},
+            }
+        },
+        total_images=1,
+        models_used=["wd-tagger", "legacy"],
+        db_save_success=1,
+        db_save_skip=0,
+        model_errors=[],
+        image_summaries=[
+            ImageResultSummary(
+                file_name="image_001.png",
+                tag_count=10,
+                has_caption=False,
+                score=None,
+                rating="safe (danbooru4, 0.99)",
+            )
+        ],
+        phash_to_filename={"phash1": "image_001.png"},
     )
 
 
@@ -139,9 +181,30 @@ class TestAnnotationSummaryDialogLayout:
         dialog = AnnotationSummaryDialog(partial_error_result)
         qtbot.addWidget(dialog)
 
-        labels = dialog.findChildren(QLabel)
-        label_texts = [label.text() for label in labels]
-        assert any("gpt-4o-mini" in text and "claude-3-haiku" in text for text in label_texts)
+        model_view = dialog.findChild(QTextBrowser, "modelsUsedView")
+        assert model_view is not None
+        assert "gpt-4o-mini" in model_view.toPlainText()
+        assert "claude-3-haiku" in model_view.toPlainText()
+
+    def test_summary_model_names_use_scrollable_view(self, qtbot):
+        """多数の長いモデル名でも概要欄を単一行QLabelにしない"""
+        long_models = [
+            f"openrouter/provider/very-long-model-name-{i:02d}-with-extra-suffix" for i in range(12)
+        ]
+        result = AnnotationExecutionResult(
+            results={},
+            total_images=1,
+            models_used=long_models,
+            db_save_success=0,
+        )
+        dialog = AnnotationSummaryDialog(result)
+        qtbot.addWidget(dialog)
+
+        model_view = dialog.findChild(QTextBrowser, "modelsUsedView")
+        assert model_view is not None
+        assert model_view.lineWrapMode() == QTextEdit.LineWrapMode.WidgetWidth
+        assert model_view.maximumHeight() <= 96
+        assert long_models[0] in model_view.toPlainText()
 
     def test_skip_count_shown_when_nonzero(self, qtbot, partial_error_result):
         """スキップ件数が0でない場合に表示される"""
@@ -251,3 +314,43 @@ class TestAnnotationSummaryDialogResultsTable:
         assert results_table.item(0, 3).text() == "0.85"
         assert results_table.item(1, 3).text() == "-"  # score=None
         assert results_table.item(2, 3).text() == "0.72"
+
+    def test_results_table_has_rating_column(self, qtbot, success_result, find_child_widget):
+        """保存結果テーブルにレーティング列が表示される"""
+        dialog = AnnotationSummaryDialog(success_result)
+        qtbot.addWidget(dialog)
+
+        results_table = find_child_widget(dialog, QTableWidget, "resultsTable")
+        assert results_table.columnCount() == 5
+        assert results_table.horizontalHeaderItem(4).text() == "レーティング"
+        assert results_table.item(0, 4).text() == "safe (danbooru4, 0.98)"
+        assert results_table.item(1, 4).text() == "-"
+
+
+class TestAnnotationSummaryDialogRatingsTab:
+    """レーティングタブのテスト"""
+
+    def test_ratings_table_content(self, qtbot, rating_result, find_child_widget):
+        """レーティングタブに詳細が表示される"""
+        dialog = AnnotationSummaryDialog(rating_result)
+        qtbot.addWidget(dialog)
+
+        table = find_child_widget(dialog, QTableWidget, "ratingsTable")
+        assert table.rowCount() == 2
+        assert table.item(0, 0).text() == "image_001.png"
+        assert table.item(0, 1).text() == "wd-tagger"
+        assert table.item(0, 2).text() == "safe"
+        assert table.item(0, 3).text() == "danbooru4"
+        assert table.item(0, 4).text() == "0.9876"
+        assert table.item(1, 1).text() == "legacy"
+        assert table.item(1, 2).text() == "PG"
+
+    def test_ratings_placeholder_when_empty(self, qtbot, success_result):
+        """レーティングがない場合はプレースホルダーを表示する"""
+        success_result.results = {"phash1": {"gpt-4o-mini": {"tags": ["cat"]}}}
+        dialog = AnnotationSummaryDialog(success_result)
+        qtbot.addWidget(dialog)
+
+        labels = dialog.findChildren(QLabel)
+        label_texts = [label.text() for label in labels]
+        assert "レーティングデータがありません。" in label_texts

--- a/tests/unit/gui/widgets/test_annotation_summary_dialog.py
+++ b/tests/unit/gui/widgets/test_annotation_summary_dialog.py
@@ -345,6 +345,25 @@ class TestAnnotationSummaryDialogRatingsTab:
         assert table.item(1, 1).text() == "legacy"
         assert table.item(1, 2).text() == "PG"
 
+    def test_ratings_table_excludes_errored_results(self, qtbot, rating_result, find_child_widget):
+        """error result の ratings はレーティングタブに表示しない"""
+        rating_result.results["phash1"]["failed-model"] = {
+            "ratings": [
+                {
+                    "raw_label": "questionable",
+                    "source_scheme": "danbooru4",
+                    "confidence_score": 0.9,
+                }
+            ],
+            "error": "model failed",
+        }
+        dialog = AnnotationSummaryDialog(rating_result)
+        qtbot.addWidget(dialog)
+
+        table = find_child_widget(dialog, QTableWidget, "ratingsTable")
+        model_names = [table.item(row, 1).text() for row in range(table.rowCount())]
+        assert model_names == ["wd-tagger", "legacy"]
+
     def test_ratings_placeholder_when_empty(self, qtbot, success_result):
         """レーティングがない場合はプレースホルダーを表示する"""
         success_result.results = {"phash1": {"gpt-4o-mini": {"tags": ["cat"]}}}

--- a/tests/unit/gui/workers/test_annotation_worker.py
+++ b/tests/unit/gui/workers/test_annotation_worker.py
@@ -331,6 +331,32 @@ class TestBuildImageSummary:
         assert summary.tag_count == 1
         assert summary.rating == "safe (danbooru4, 0.99)"
 
+    def test_build_image_summary_uses_highest_confidence_rating(self):
+        """structured ratings は保存処理と同じく confidence 最大を代表表示に使う"""
+        summary = AnnotationWorker._build_image_summary(
+            "phash1",
+            {"phash1": "image_001.png"},
+            {
+                "wd-tagger": {
+                    "ratings": [
+                        {
+                            "raw_label": "general",
+                            "source_scheme": "civitai5",
+                            "confidence_score": 0.12,
+                        },
+                        {
+                            "raw_label": "x",
+                            "source_scheme": "civitai5",
+                            "confidence_score": 0.88,
+                        },
+                    ],
+                    "error": None,
+                }
+            },
+        )
+
+        assert summary.rating == "x (civitai5, 0.88)"
+
     def test_build_image_summary_uses_object_rating(self):
         """RatingPrediction風オブジェクトにも対応する"""
         summary = AnnotationWorker._build_image_summary(

--- a/tests/unit/gui/workers/test_annotation_worker.py
+++ b/tests/unit/gui/workers/test_annotation_worker.py
@@ -302,6 +302,91 @@ class TestExtractField:
         assert worker._extract_field(obj, "nonexistent") is None
 
 
+class TestBuildImageSummary:
+    """_build_image_summary の表示用集計テスト"""
+
+    def test_build_image_summary_uses_structured_rating(self):
+        """structured ratings から代表レーティング表示を作る"""
+        summary = AnnotationWorker._build_image_summary(
+            "phash1",
+            {"phash1": "image_001.png"},
+            {
+                "wd-tagger": {
+                    "tags": ["cat"],
+                    "captions": None,
+                    "scores": None,
+                    "ratings": [
+                        {
+                            "raw_label": "safe",
+                            "source_scheme": "danbooru4",
+                            "confidence_score": 0.9876,
+                        }
+                    ],
+                    "error": None,
+                }
+            },
+        )
+
+        assert summary.file_name == "image_001.png"
+        assert summary.tag_count == 1
+        assert summary.rating == "safe (danbooru4, 0.99)"
+
+    def test_build_image_summary_uses_object_rating(self):
+        """RatingPrediction風オブジェクトにも対応する"""
+        summary = AnnotationWorker._build_image_summary(
+            "phash1",
+            {"phash1": "image_001.png"},
+            {
+                "wd-tagger": SimpleNamespace(
+                    tags=[],
+                    captions=None,
+                    scores=None,
+                    ratings=[
+                        SimpleNamespace(
+                            raw_label="questionable",
+                            source_scheme="danbooru4",
+                            confidence_score=None,
+                        )
+                    ],
+                    error=None,
+                )
+            },
+        )
+
+        assert summary.rating == "questionable (danbooru4)"
+
+    def test_build_image_summary_uses_string_rating(self):
+        """後方互換のstr ratingにも対応する"""
+        summary = AnnotationWorker._build_image_summary(
+            "phash1",
+            {"phash1": "image_001.png"},
+            {"legacy": {"ratings": ["PG"], "error": None}},
+        )
+
+        assert summary.rating == "PG"
+
+    def test_build_image_summary_ignores_error_rating(self):
+        """error result の ratings は代表表示に使わない"""
+        summary = AnnotationWorker._build_image_summary(
+            "phash1",
+            {"phash1": "image_001.png"},
+            {
+                "failed-model": {
+                    "ratings": [
+                        {
+                            "raw_label": "safe",
+                            "source_scheme": "danbooru4",
+                            "confidence_score": 0.9,
+                        }
+                    ],
+                    "error": "model failed",
+                }
+            },
+        )
+
+        assert summary.rating is None
+
+
 # ==============================================================================
 # Test _save_error_records
 # ==============================================================================


### PR DESCRIPTION
## Summary
- keep the annotation completion dialog width stable by replacing the one-line model list with a wrapped scrollable view
- add rating summary values to image result summaries and the save results table
- add a ratings detail tab for per-image/per-model raw label, scheme, and confidence

## Tests
- uv run ruff check src/lorairo/gui/workers/annotation_worker.py src/lorairo/gui/widgets/annotation_summary_dialog.py tests/unit/gui/widgets/test_annotation_summary_dialog.py tests/unit/gui/workers/test_annotation_worker.py
- uv run ruff format --check src/lorairo/gui/workers/annotation_worker.py src/lorairo/gui/widgets/annotation_summary_dialog.py tests/unit/gui/widgets/test_annotation_summary_dialog.py tests/unit/gui/workers/test_annotation_worker.py
- uv run pytest tests/unit/gui/widgets/test_annotation_summary_dialog.py tests/unit/gui/workers/test_annotation_worker.py

Closes #361
Closes #362
Closes #363