### PR TITLE
fix(annotations): map TaskCapability.RATINGS in adapter capability table

### DIFF
--- a/src/lorairo/annotations/annotator_adapter.py
+++ b/src/lorairo/annotations/annotator_adapter.py
@@ -38,6 +38,7 @@ _CAPABILITY_VALUES: dict[TaskCapability, str] = {
     TaskCapability.CAPTIONS: "captions",
     TaskCapability.SCORES: "scores",
     TaskCapability.SCORE_LABELS: "score_labels",
+    TaskCapability.RATINGS: "ratings",
 }
 
 __all__ = ["AnnotatorLibraryAdapter"]

--- a/tests/unit/gui/workers/test_annotation_worker.py
+++ b/tests/unit/gui/workers/test_annotation_worker.py
@@ -653,3 +653,109 @@ class TestApplyRefusalPrefilter:
         worker._apply_refusal_prefilter()
 
         assert worker.image_paths == ["/path/img1.jpg", "/path/img2.jpg"]
+
+
+class TestRefusalPrefilterRatingsCapability:
+    """Issue #367 回帰防止: ratings capability を含むモデル選択で
+    `selection_includes_webapi_model()` が KeyError を投げず、refusal prefilter
+    が "Model registry lookup failed" warning なしに正常判定されることを検証する。
+
+    Issue #366 の `_CAPABILITY_VALUES` 欠落が adapter 経路で表面化したのは
+    statistics 構築 (`_build_model_statistics`) と refusal prefilter
+    (`selection_includes_webapi_model` 経由の `get_available_models`) の双方。
+    本テストは後者の経路を ratings capability 含むモデル情報で固定する。
+    """
+
+    @staticmethod
+    def _ratings_model_info(name: str, requires_api_key: bool, *, litellm_model_id: str | None = None):
+        """`ModelInfo` 互換 Mock。capabilities に "ratings" を含める。"""
+        info = Mock()
+        info.name = name
+        info.requires_api_key = requires_api_key
+        info.litellm_model_id = litellm_model_id or name
+        info.capabilities = ["ratings", "tags"]
+        return info
+
+    @pytest.mark.unit
+    def test_selection_includes_webapi_model_handles_ratings_capability_local_only(self, caplog):
+        """ratings capability を含むローカルモデルのみの選択で warning が出ず False を返す。"""
+        import logging
+
+        from lorairo.services.model_registry_protocol import selection_includes_webapi_model
+
+        registry = Mock()
+        registry.get_available_models.return_value = [
+            self._ratings_model_info("wd-rating-v3", requires_api_key=False),
+        ]
+
+        with caplog.at_level(logging.WARNING):
+            result = selection_includes_webapi_model(["wd-rating-v3"], registry)
+
+        assert result is False
+        # registry lookup が成功しているので prefilter skip warning は出ない
+        assert "Model registry lookup failed" not in caplog.text
+
+    @pytest.mark.unit
+    def test_selection_includes_webapi_model_handles_ratings_capability_with_webapi(self, caplog):
+        """ratings capability を含むモデルと WebAPI モデルの混在で True を返し warning なし。"""
+        import logging
+
+        from lorairo.services.model_registry_protocol import selection_includes_webapi_model
+
+        registry = Mock()
+        registry.get_available_models.return_value = [
+            self._ratings_model_info("wd-rating-v3", requires_api_key=False),
+            self._ratings_model_info("openai/gpt-4o", requires_api_key=True),
+        ]
+
+        with caplog.at_level(logging.WARNING):
+            result = selection_includes_webapi_model(
+                ["wd-rating-v3", "openai/gpt-4o"],
+                registry,
+            )
+
+        assert result is True
+        assert "Model registry lookup failed" not in caplog.text
+
+    @pytest.mark.unit
+    def test_apply_refusal_prefilter_does_not_skip_for_ratings_local_only(
+        self, mock_annotation_logic, monkeypatch, caplog
+    ):
+        """ratings capability を含むローカル単独選択で prefilter skip warning が出ない。
+
+        Issue #367 の元症状 (`Model registry lookup failed; refusal prefilter を
+        skip して annotation 続行: <TaskCapability.RATINGS: 'ratings'>`) を回帰防止。
+        """
+        import logging
+
+        from lorairo.gui.workers import annotation_worker as aw_mod
+
+        registry = Mock()
+        registry.get_available_models.return_value = [
+            TestRefusalPrefilterRatingsCapability._ratings_model_info(
+                "wd-rating-v3", requires_api_key=False
+            ),
+        ]
+
+        mock_db = Mock()
+        mock_db.repository = Mock()
+
+        mock_save_service = Mock()
+        mock_save_service.filter_refused_image_paths = Mock()
+        monkeypatch.setattr(aw_mod, "AnnotationSaveService", lambda repo: mock_save_service)
+
+        worker = AnnotationWorker(
+            annotation_logic=mock_annotation_logic,
+            image_paths=["/path/img1.jpg"],
+            litellm_model_ids=["wd-rating-v3"],
+            db_manager=mock_db,
+            model_registry=registry,
+        )
+
+        with caplog.at_level(logging.WARNING):
+            worker._apply_refusal_prefilter()
+
+        # ローカル単独 → filter スキップ (ただし registry lookup 失敗 warning は出さない)
+        mock_save_service.filter_refused_image_paths.assert_not_called()
+        assert worker.image_paths == ["/path/img1.jpg"]
+        assert "Model registry lookup failed" not in caplog.text

--- a/tests/unit/test_annotator_adapter_model_registry.py
+++ b/tests/unit/test_annotator_adapter_model_registry.py
@@ -167,3 +167,45 @@ def test_get_available_models_with_metadata_alias() -> None:
 
     with patch("lorairo.annotations.annotator_adapter.list_annotator_info", return_value=[]):
         assert adapter.get_available_models_with_metadata() == adapter.get_available_models()
+
+
+# ---- Issue #366 regression: TaskCapability.RATINGS mapping ----
+
+
+@pytest.mark.unit
+def test_capability_values_includes_ratings() -> None:
+    """`_CAPABILITY_VALUES` に `TaskCapability.RATINGS` mapping が存在することを保証する。
+
+    Issue #366 回帰防止: ratings capability を宣言するモデル (canonical rater 等) で
+    `_to_model_info()` が KeyError を投げ、`get_available_models()` が落ちて
+    annotation 全体が degraded mode に入る事象を防ぐ。
+    """
+    from lorairo.annotations.annotator_adapter import _CAPABILITY_VALUES
+
+    assert _CAPABILITY_VALUES[TaskCapability.RATINGS] == "ratings"
+
+
+@pytest.mark.unit
+def test_get_available_models_includes_ratings_capability() -> None:
+    """ratings capability を含む AnnotatorInfo が KeyError なく ModelInfo へ変換される。
+
+    Issue #366 回帰防止: `AnnotatorInfo.capabilities = {RATINGS, TAGS}` の
+    フィクスチャを与え、`get_available_models()` が例外を出さず
+    `ModelInfo.capabilities` に `"ratings"` を含むことを assert する。
+    """
+    adapter = AnnotatorLibraryAdapter(MagicMock())
+    fake_infos = [
+        _make_info(
+            "wd-rating-v3",
+            is_api=False,
+            model_type="tagger",
+            capabilities={TaskCapability.RATINGS, TaskCapability.TAGS},
+            provider="smilingwolf",
+        )
+    ]
+
+    with patch("lorairo.annotations.annotator_adapter.list_annotator_info", return_value=fake_infos):
+        models = adapter.get_available_models()
+
+    assert len(models) == 1
+    assert set(models[0].capabilities) == {"ratings", "tags"}


### PR DESCRIPTION
## Summary

CI-EQUIV-TESTED

`_CAPABILITY_VALUES` in `src/lorairo/annotations/annotator_adapter.py` was missing `TaskCapability.RATINGS`. When the annotator returned a model declaring the ratings capability (canonical raters such as `wd-rating-v3`), `_to_model_info()` raised `KeyError` and `get_available_models()` failed wholesale. This surfaced in the Windows native GUI batch annotation log as two repeated warnings:

- `モデルメタデータ取得エラー: <TaskCapability.RATINGS: 'ratings'>` (#366) — emitted from `AnnotationWorker._build_model_statistics()`.
- `Model registry lookup failed; refusal prefilter を skip して annotation 続行: <TaskCapability.RATINGS: 'ratings'>` (#367) — emitted from `AnnotationWorker._apply_refusal_prefilter()` via `selection_includes_webapi_model()`. Local-only selections only paid a logging cost, but WebAPI-mixed selections lost refusal filtering entirely.

## Fix

- Add `TaskCapability.RATINGS: "ratings"` to `_CAPABILITY_VALUES` in iam-lib `TaskCapability` declaration order (TAGS, CAPTIONS, SCORES, SCORE_LABELS, RATINGS).
- Production code in `annotation_worker.py` is left untouched; graceful-degrade branches remain as a safety net for future unknown capabilities.

## Regression tests

- `tests/unit/test_annotator_adapter_model_registry.py`
  - `test_capability_values_includes_ratings` — pins the mapping at the adapter table level.
  - `test_get_available_models_includes_ratings_capability` — verifies that a ratings-capable `AnnotatorInfo` no longer raises `KeyError` and `ModelInfo.capabilities` includes `"ratings"`.
- `tests/unit/gui/workers/test_annotation_worker.py` (new class `TestRefusalPrefilterRatingsCapability`)
  - Verifies `selection_includes_webapi_model()` returns expected results for ratings-capable models without emitting the prefilter-skip warning.
  - Verifies `AnnotationWorker._apply_refusal_prefilter()` does not log `Model registry lookup failed` for local-only ratings selections.

## Verification

```bash
UV_PROJECT_ENVIRONMENT=/workspaces/LoRAIro/.venv uv run --no-sync pytest \
  tests/unit/test_annotator_adapter_model_registry.py tests/unit/gui/workers/ \
  -m "not gui_show and not calls_real_webapi and not downloads_and_runs_model and not slow" \
  --timeout=60
# → 91 passed in 0.50s
```

Closes #366
Closes #367
Refs #364

🤖 Generated with [Claude Code](https://claude.com/claude-code)