### PR TITLE
fix: show selected image file metadata

### DIFF
--- a/src/lorairo/gui/widgets/selected_image_details_widget.py
+++ b/src/lorairo/gui/widgets/selected_image_details_widget.py
@@ -22,6 +22,7 @@ from typing import TYPE_CHECKING, Any
 from PySide6.QtCore import Qt, Signal, Slot
 from PySide6.QtWidgets import QFrame, QScrollArea, QSizePolicy, QToolButton, QVBoxLayout, QWidget
 
+from ...database.db_core import resolve_stored_path
 from ...gui.designer.SelectedImageDetailsWidget_ui import Ui_SelectedImageDetailsWidget
 from ...services.date_formatter import format_datetime_for_display
 from ...utils.log import logger
@@ -353,15 +354,15 @@ class SelectedImageDetailsWidget(QWidget):
         """
         # 基本情報
         image_id = metadata.get("id")
-        file_path_str = metadata.get("file_path", "")
+        file_path_str = self._get_display_file_path(metadata)
         file_name = Path(file_path_str).name if file_path_str else ""
 
         width = metadata.get("width", 0)
         height = metadata.get("height", 0)
         image_size = f"{width} x {height}" if width and height else ""
 
-        file_size = metadata.get("file_size", 0)
-        if file_size:
+        file_size = self._get_file_size_bytes(metadata, image_id)
+        if file_size is not None and file_size > 0:
             size_kb = file_size / 1024
             file_size_str = f"{size_kb / 1024:.2f} MB" if size_kb >= 1024 else f"{size_kb:.2f} KB"
         else:
@@ -427,6 +428,60 @@ class SelectedImageDetailsWidget(QWidget):
         )
 
         return details
+
+    @staticmethod
+    def _get_display_file_path(metadata: dict[str, Any]) -> str:
+        """表示用ファイルパスを metadata から取得する。
+
+        DatasetStateManager の正規キーは stored_image_path。file_path は旧経路との
+        互換 fallback として扱う。
+        """
+        stored_path = metadata.get("stored_image_path")
+        if stored_path:
+            return str(stored_path)
+
+        file_path = metadata.get("file_path")
+        if file_path:
+            logger.debug(
+                "metadata に stored_image_path が無いため file_path を使用: "
+                f"image_id={metadata.get('id')}, file_path={file_path}"
+            )
+            return str(file_path)
+
+        logger.debug(
+            "metadata に表示可能な画像パスがありません: "
+            f"image_id={metadata.get('id')}, keys={list(metadata.keys())}"
+        )
+        return ""
+
+    @staticmethod
+    def _get_file_size_bytes(metadata: dict[str, Any], image_id: Any) -> int | None:
+        """metadata または stored_image_path の実ファイルからファイルサイズを取得する。"""
+        raw_file_size = metadata.get("file_size")
+        if isinstance(raw_file_size, int | float) and raw_file_size > 0:
+            return int(raw_file_size)
+
+        stored_path = metadata.get("stored_image_path")
+        if not stored_path:
+            logger.debug(
+                "file_size 補完不可: stored_image_path がありません: "
+                f"image_id={image_id}, keys={list(metadata.keys())}"
+            )
+            return None
+
+        try:
+            resolved_path = resolve_stored_path(str(stored_path))
+            if resolved_path.exists():
+                return resolved_path.stat().st_size
+            logger.debug(
+                f"file_size 補完不可: ファイルが存在しません: image_id={image_id}, path={resolved_path}"
+            )
+        except OSError as e:
+            logger.debug(
+                f"file_size 補完不可: stat 失敗: image_id={image_id}, path={stored_path}, error={e}"
+            )
+
+        return None
 
     def _update_details_display(self, details: ImageDetails) -> None:
         """

--- a/src/lorairo/gui/widgets/selected_image_details_widget.py
+++ b/src/lorairo/gui/widgets/selected_image_details_widget.py
@@ -22,7 +22,6 @@ from typing import TYPE_CHECKING, Any
 from PySide6.QtCore import Qt, Signal, Slot
 from PySide6.QtWidgets import QFrame, QScrollArea, QSizePolicy, QToolButton, QVBoxLayout, QWidget
 
-from ...database.db_core import resolve_stored_path
 from ...gui.designer.SelectedImageDetailsWidget_ui import Ui_SelectedImageDetailsWidget
 from ...services.date_formatter import format_datetime_for_display
 from ...utils.log import logger
@@ -438,7 +437,7 @@ class SelectedImageDetailsWidget(QWidget):
         """
         stored_path = metadata.get("stored_image_path")
         if stored_path:
-            return str(stored_path)
+            return str(stored_path).replace("\\", "/")
 
         file_path = metadata.get("file_path")
         if file_path:
@@ -446,7 +445,7 @@ class SelectedImageDetailsWidget(QWidget):
                 "metadata に stored_image_path が無いため file_path を使用: "
                 f"image_id={metadata.get('id')}, file_path={file_path}"
             )
-            return str(file_path)
+            return str(file_path).replace("\\", "/")
 
         logger.debug(
             "metadata に表示可能な画像パスがありません: "
@@ -470,6 +469,8 @@ class SelectedImageDetailsWidget(QWidget):
             return None
 
         try:
+            from ...database.db_core import resolve_stored_path
+
             resolved_path = resolve_stored_path(str(stored_path))
             if resolved_path.exists():
                 return resolved_path.stat().st_size

--- a/tests/unit/gui/widgets/test_selected_image_details_widget.py
+++ b/tests/unit/gui/widgets/test_selected_image_details_widget.py
@@ -153,6 +153,81 @@ class TestSelectedImageDetailsWidget:
         if widget.current_details.score_value:
             assert widget.current_details.score_value == 750
 
+    def test_build_metadata_uses_stored_image_path_for_file_name(self, widget):
+        """stored_image_path のみでもファイル名が表示されること"""
+        metadata = {
+            "id": 1,
+            "stored_image_path": "/test/dataset/stored_image.webp",
+            "width": 512,
+            "height": 768,
+            "file_size": 2048,
+            "tags": [],
+            "caption_text": "",
+            "tags_text": "",
+            "score_value": 0,
+            "rating_value": "",
+        }
+
+        details = widget._build_image_details_from_metadata(metadata)
+
+        assert details.file_name == "stored_image.webp"
+        assert details.file_path == "/test/dataset/stored_image.webp"
+        assert details.file_size == "2.00 KB"
+
+    def test_build_metadata_falls_back_to_file_path_for_file_name(self, widget):
+        """旧 metadata の file_path fallback が維持されること"""
+        metadata = {
+            "id": 1,
+            "file_path": "/test/dataset/legacy_image.png",
+            "tags": [],
+            "caption_text": "",
+            "tags_text": "",
+            "score_value": 0,
+            "rating_value": "",
+        }
+
+        details = widget._build_image_details_from_metadata(metadata)
+
+        assert details.file_name == "legacy_image.png"
+        assert details.file_path == "/test/dataset/legacy_image.png"
+        assert details.file_size == ""
+
+    def test_build_metadata_uses_stored_path_stat_when_file_size_missing(self, widget, tmp_path):
+        """file_size が無い場合は stored_image_path の実ファイルサイズで補完すること"""
+        image_path = tmp_path / "stat_size_image.jpg"
+        image_path.write_bytes(b"x" * 1536)
+        metadata = {
+            "id": 1,
+            "stored_image_path": str(image_path),
+            "tags": [],
+            "caption_text": "",
+            "tags_text": "",
+            "score_value": 0,
+            "rating_value": "",
+        }
+
+        details = widget._build_image_details_from_metadata(metadata)
+
+        assert details.file_name == "stat_size_image.jpg"
+        assert details.file_size == "1.50 KB"
+
+    def test_build_metadata_file_size_missing_for_missing_file_stays_empty(self, widget, tmp_path):
+        """ファイルサイズが本当に取得できない場合のみ空表示にすること"""
+        metadata = {
+            "id": 1,
+            "stored_image_path": str(tmp_path / "missing.jpg"),
+            "tags": [],
+            "caption_text": "",
+            "tags_text": "",
+            "score_value": 0,
+            "rating_value": "",
+        }
+
+        details = widget._build_image_details_from_metadata(metadata)
+
+        assert details.file_name == "missing.jpg"
+        assert details.file_size == ""
+
     def test_on_image_data_received_empty(self, widget):
         """Enhanced Event-Driven Pattern: 空データ受信テスト"""
         # 初期状態設定

--- a/tests/unit/gui/widgets/test_selected_image_details_widget.py
+++ b/tests/unit/gui/widgets/test_selected_image_details_widget.py
@@ -174,6 +174,24 @@ class TestSelectedImageDetailsWidget:
         assert details.file_path == "/test/dataset/stored_image.webp"
         assert details.file_size == "2.00 KB"
 
+    def test_build_metadata_normalizes_windows_stored_image_path_for_file_name(self, widget):
+        """Windows形式のstored_image_pathでもファイル名だけを表示できること"""
+        metadata = {
+            "id": 1,
+            "stored_image_path": r"C:\test\dataset\windows_image.webp",
+            "file_size": 2048,
+            "tags": [],
+            "caption_text": "",
+            "tags_text": "",
+            "score_value": 0,
+            "rating_value": "",
+        }
+
+        details = widget._build_image_details_from_metadata(metadata)
+
+        assert details.file_name == "windows_image.webp"
+        assert details.file_path == "C:/test/dataset/windows_image.webp"
+
     def test_build_metadata_falls_back_to_file_path_for_file_name(self, widget):
         """旧 metadata の file_path fallback が維持されること"""
         metadata = {


### PR DESCRIPTION
## Summary
- Use stored_image_path as the canonical selected-image path with file_path fallback
- Fill missing file_size from the resolved stored image path when possible
- Add regression coverage for filename and filesize display fallbacks

Closes #376

## Tests
- uv run ruff check src/lorairo/gui/widgets/selected_image_details_widget.py tests/unit/gui/widgets/test_selected_image_details_widget.py
- uv run pytest tests/unit/gui/widgets/test_selected_image_details_widget.py (blocked on main without generated ignored RatingScoreEditWidget_ui.py)