### PR TITLE
feat: copy preview image to clipboard

### DIFF
--- a/src/lorairo/gui/widgets/image_preview.py
+++ b/src/lorairo/gui/widgets/image_preview.py
@@ -30,7 +30,6 @@ class ImagePreviewWidget(QWidget, Ui_ImagePreviewWidget):
         )
         self.pixmap_item: QGraphicsPixmapItem | None = None
         self._current_image_path: Path | None = None
-        self._current_stored_image_path: str | None = None
         self._current_pixmap: QPixmap | None = None
 
         self.previewGraphicsView.setContextMenuPolicy(Qt.ContextMenuPolicy.CustomContextMenu)
@@ -49,6 +48,9 @@ class ImagePreviewWidget(QWidget, Ui_ImagePreviewWidget):
         try:
             # 画像を読み込み
             pixmap = QPixmap(str(image_path))
+            if pixmap.isNull():
+                logger.warning(f"画像の読み込みに失敗しました（null pixmap）: {image_path}")
+                return
 
             # 画像をシーンに追加
             self.pixmap_item = self.graphics_scene.addPixmap(pixmap)
@@ -82,7 +84,6 @@ class ImagePreviewWidget(QWidget, Ui_ImagePreviewWidget):
             # 画像をシーンに追加
             self.pixmap_item = self.graphics_scene.addPixmap(pixmap)
             self._current_image_path = None
-            self._current_stored_image_path = None
             self._current_pixmap = pixmap
 
             # シーンの矩形を画像のサイズに設定
@@ -135,7 +136,7 @@ class ImagePreviewWidget(QWidget, Ui_ImagePreviewWidget):
 
     def _has_current_image(self) -> bool:
         """コピー可能な画像状態があるか判定する"""
-        return self._current_image_path is not None or self._current_pixmap is not None
+        return self._current_pixmap is not None and not self._current_pixmap.isNull()
 
     def copy_current_image_to_clipboard(self) -> bool:
         """現在表示中の画像をクリップボードへコピーする"""
@@ -157,22 +158,13 @@ class ImagePreviewWidget(QWidget, Ui_ImagePreviewWidget):
 
     def _load_current_original_pixmap(self) -> QPixmap | None:
         """保存パスから元画像を読み直す。失敗時は None を返す。"""
-        image_path = self._resolve_current_image_path()
-        if image_path is None or not image_path.exists():
+        if self._current_image_path is None or not self._current_image_path.exists():
             return None
 
-        pixmap = QPixmap(str(image_path))
+        pixmap = QPixmap(str(self._current_image_path))
         if pixmap.isNull():
             return None
         return pixmap
-
-    def _resolve_current_image_path(self) -> Path | None:
-        """現在画像の保存パスをLoRAIro標準パス解決で取得する。"""
-        if self._current_stored_image_path:
-            from ...database.db_core import resolve_stored_path
-
-            return resolve_stored_path(self._current_stored_image_path)
-        return self._current_image_path
 
     # resizeEvent をオーバーライドしてウィンドウサイズ変更時にサイズ調整
     def resizeEvent(self, event: QResizeEvent) -> None:
@@ -257,7 +249,6 @@ class ImagePreviewWidget(QWidget, Ui_ImagePreviewWidget):
                 return
 
             self.load_image(image_path)
-            self._current_stored_image_path = image_path_str
 
             logger.info(
                 f"✅ プレビュー表示成功: ID={image_id}, path={image_path.name} - Enhanced Event-Driven Pattern 完全動作"
@@ -279,7 +270,6 @@ class ImagePreviewWidget(QWidget, Ui_ImagePreviewWidget):
             # PixmapItemの参照もクリア
             self.pixmap_item = None
             self._current_image_path = None
-            self._current_stored_image_path = None
             self._current_pixmap = None
 
             logger.debug("Preview cleared and memory optimized")

--- a/src/lorairo/gui/widgets/image_preview.py
+++ b/src/lorairo/gui/widgets/image_preview.py
@@ -2,9 +2,9 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from PIL import Image
-from PySide6.QtCore import Qt, QTimer, Slot
-from PySide6.QtGui import QPainter, QPixmap, QResizeEvent, QShowEvent
-from PySide6.QtWidgets import QGraphicsPixmapItem, QGraphicsScene, QWidget
+from PySide6.QtCore import QPoint, Qt, QTimer, Slot
+from PySide6.QtGui import QAction, QPainter, QPixmap, QResizeEvent, QShowEvent
+from PySide6.QtWidgets import QApplication, QGraphicsPixmapItem, QGraphicsScene, QMenu, QWidget
 
 from ...gui.designer.ImagePreviewWidget_ui import Ui_ImagePreviewWidget
 from ...utils.log import logger
@@ -29,6 +29,12 @@ class ImagePreviewWidget(QWidget, Ui_ImagePreviewWidget):
             QPainter.RenderHint.Antialiasing | QPainter.RenderHint.SmoothPixmapTransform
         )
         self.pixmap_item: QGraphicsPixmapItem | None = None
+        self._current_image_path: Path | None = None
+        self._current_stored_image_path: str | None = None
+        self._current_pixmap: QPixmap | None = None
+
+        self.previewGraphicsView.setContextMenuPolicy(Qt.ContextMenuPolicy.CustomContextMenu)
+        self.previewGraphicsView.customContextMenuRequested.connect(self._show_preview_context_menu)
 
         # Phase 3.3: Enhanced Event-Driven Pattern (状態管理なし)
 
@@ -46,6 +52,8 @@ class ImagePreviewWidget(QWidget, Ui_ImagePreviewWidget):
 
             # 画像をシーンに追加
             self.pixmap_item = self.graphics_scene.addPixmap(pixmap)
+            self._current_image_path = image_path
+            self._current_pixmap = pixmap
 
             # シーンの矩形を画像のサイズに設定
             self.graphics_scene.setSceneRect(pixmap.rect())
@@ -73,6 +81,9 @@ class ImagePreviewWidget(QWidget, Ui_ImagePreviewWidget):
 
             # 画像をシーンに追加
             self.pixmap_item = self.graphics_scene.addPixmap(pixmap)
+            self._current_image_path = None
+            self._current_stored_image_path = None
+            self._current_pixmap = pixmap
 
             # シーンの矩形を画像のサイズに設定
             self.graphics_scene.setSceneRect(pixmap.rect())
@@ -108,6 +119,60 @@ class ImagePreviewWidget(QWidget, Ui_ImagePreviewWidget):
             self.previewGraphicsView.fitInView(
                 self.graphics_scene.sceneRect(), Qt.AspectRatioMode.KeepAspectRatio
             )
+
+    def _show_preview_context_menu(self, position: QPoint) -> None:
+        """プレビュー用コンテキストメニューを表示する"""
+        menu = QMenu(self.previewGraphicsView)
+        menu.addAction(self._create_copy_image_action(menu))
+        menu.exec(self.previewGraphicsView.mapToGlobal(position))
+
+    def _create_copy_image_action(self, parent: QWidget) -> QAction:
+        """現在画像コピー用アクションを作成する"""
+        copy_action = QAction("画像をコピー", parent)
+        copy_action.setEnabled(self._has_current_image())
+        copy_action.triggered.connect(self.copy_current_image_to_clipboard)
+        return copy_action
+
+    def _has_current_image(self) -> bool:
+        """コピー可能な画像状態があるか判定する"""
+        return self._current_image_path is not None or self._current_pixmap is not None
+
+    def copy_current_image_to_clipboard(self) -> bool:
+        """現在表示中の画像をクリップボードへコピーする"""
+        if not self._has_current_image():
+            logger.debug("Copy preview image requested without a current image")
+            return False
+
+        pixmap = self._load_current_original_pixmap()
+        if pixmap is None and self._current_pixmap is not None and not self._current_pixmap.isNull():
+            pixmap = self._current_pixmap
+
+        if pixmap is None or pixmap.isNull():
+            logger.debug("Copy preview image skipped because no valid pixmap is available")
+            return False
+
+        QApplication.clipboard().setPixmap(pixmap)
+        logger.debug("Current preview image copied to clipboard")
+        return True
+
+    def _load_current_original_pixmap(self) -> QPixmap | None:
+        """保存パスから元画像を読み直す。失敗時は None を返す。"""
+        image_path = self._resolve_current_image_path()
+        if image_path is None or not image_path.exists():
+            return None
+
+        pixmap = QPixmap(str(image_path))
+        if pixmap.isNull():
+            return None
+        return pixmap
+
+    def _resolve_current_image_path(self) -> Path | None:
+        """現在画像の保存パスをLoRAIro標準パス解決で取得する。"""
+        if self._current_stored_image_path:
+            from ...database.db_core import resolve_stored_path
+
+            return resolve_stored_path(self._current_stored_image_path)
+        return self._current_image_path
 
     # resizeEvent をオーバーライドしてウィンドウサイズ変更時にサイズ調整
     def resizeEvent(self, event: QResizeEvent) -> None:
@@ -192,6 +257,7 @@ class ImagePreviewWidget(QWidget, Ui_ImagePreviewWidget):
                 return
 
             self.load_image(image_path)
+            self._current_stored_image_path = image_path_str
 
             logger.info(
                 f"✅ プレビュー表示成功: ID={image_id}, path={image_path.name} - Enhanced Event-Driven Pattern 完全動作"
@@ -212,6 +278,9 @@ class ImagePreviewWidget(QWidget, Ui_ImagePreviewWidget):
 
             # PixmapItemの参照もクリア
             self.pixmap_item = None
+            self._current_image_path = None
+            self._current_stored_image_path = None
+            self._current_pixmap = None
 
             logger.debug("Preview cleared and memory optimized")
 

--- a/tests/unit/gui/widgets/test_image_preview_widget.py
+++ b/tests/unit/gui/widgets/test_image_preview_widget.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from unittest.mock import Mock, patch
 
 import pytest
+from PySide6.QtCore import Qt
 
 from lorairo.gui.widgets.image_preview import ImagePreviewWidget
 
@@ -23,6 +24,7 @@ class TestImagePreviewWidget:
         assert widget.pixmap_item is None
         assert hasattr(widget, "graphics_scene")
         assert hasattr(widget, "previewGraphicsView")
+        assert widget.previewGraphicsView.contextMenuPolicy() == Qt.ContextMenuPolicy.CustomContextMenu
 
     def test_adjust_view_size_skips_when_no_pixmap(self, widget):
         """Issue #52リグレッション: pixmap_item が None の場合は fitInView を呼ばない"""
@@ -49,6 +51,9 @@ class TestImagePreviewWidget:
         """プレビュークリア・メモリ最適化テスト"""
         # テストデータ設定
         widget.pixmap_item = Mock()
+        widget._current_image_path = Path("/test/image.jpg")
+        widget._current_stored_image_path = "image.jpg"
+        widget._current_pixmap = Mock()
 
         with patch("lorairo.gui.widgets.image_preview.logger") as mock_logger:
             widget._clear_preview()
@@ -58,6 +63,9 @@ class TestImagePreviewWidget:
 
             # PixmapItemがクリアされる
             assert widget.pixmap_item is None
+            assert widget._current_image_path is None
+            assert widget._current_stored_image_path is None
+            assert widget._current_pixmap is None
 
             # ログ確認
             mock_logger.debug.assert_called_with("Preview cleared and memory optimized")
@@ -142,6 +150,7 @@ class TestImagePreviewWidget:
                 widget._on_image_data_received(image_data)
 
                 mock_load.assert_called_once_with(mock_path)
+                assert widget._current_stored_image_path == "/valid/image.jpg"
 
     def test_load_image_success(self, widget):
         """画像読み込み成功テスト"""
@@ -161,6 +170,8 @@ class TestImagePreviewWidget:
 
                 # pixmap_item が設定される
                 assert widget.pixmap_item is not None
+                assert widget._current_image_path == test_path
+                assert widget._current_pixmap is mock_pixmap
 
     def test_load_image_clears_before_loading(self, widget):
         """新しい画像読み込み前に既存をクリアするテスト"""
@@ -172,6 +183,71 @@ class TestImagePreviewWidget:
 
                 # クリアが呼ばれる
                 mock_clear.assert_called()
+
+    def test_copy_current_image_to_clipboard_no_image_noops(self, widget):
+        """画像未表示時はクリップボードへコピーしない"""
+        with patch("lorairo.gui.widgets.image_preview.QApplication.clipboard") as mock_clipboard:
+            assert widget.copy_current_image_to_clipboard() is False
+
+            mock_clipboard.assert_not_called()
+
+    def test_copy_current_image_to_clipboard_prefers_resolved_original(self, widget):
+        """保存パス解決で元画像が取得できる場合は元画像をコピーする"""
+        resolved_path = Mock()
+        resolved_path.exists.return_value = True
+
+        original_pixmap = Mock()
+        original_pixmap.isNull.return_value = False
+        displayed_pixmap = Mock()
+        displayed_pixmap.isNull.return_value = False
+        clipboard = Mock()
+
+        widget._current_stored_image_path = "stored/image.jpg"
+        widget._current_pixmap = displayed_pixmap
+
+        with (
+            patch(
+                "lorairo.database.db_core.resolve_stored_path", return_value=resolved_path
+            ) as mock_resolve,
+            patch(
+                "lorairo.gui.widgets.image_preview.QPixmap", return_value=original_pixmap
+            ) as mock_qpixmap,
+            patch("lorairo.gui.widgets.image_preview.QApplication.clipboard", return_value=clipboard),
+        ):
+            assert widget.copy_current_image_to_clipboard() is True
+
+        mock_resolve.assert_called_once_with("stored/image.jpg")
+        mock_qpixmap.assert_called_once_with(str(resolved_path))
+        clipboard.setPixmap.assert_called_once_with(original_pixmap)
+
+    def test_copy_current_image_to_clipboard_falls_back_to_displayed_pixmap(self, widget):
+        """元画像が使えない場合は表示中のpixmapをコピーする"""
+        resolved_path = Mock()
+        resolved_path.exists.return_value = False
+
+        displayed_pixmap = Mock()
+        displayed_pixmap.isNull.return_value = False
+        clipboard = Mock()
+
+        widget._current_stored_image_path = "stored/missing.jpg"
+        widget._current_pixmap = displayed_pixmap
+
+        with (
+            patch("lorairo.database.db_core.resolve_stored_path", return_value=resolved_path),
+            patch("lorairo.gui.widgets.image_preview.QPixmap") as mock_qpixmap,
+            patch("lorairo.gui.widgets.image_preview.QApplication.clipboard", return_value=clipboard),
+        ):
+            assert widget.copy_current_image_to_clipboard() is True
+
+        mock_qpixmap.assert_not_called()
+        clipboard.setPixmap.assert_called_once_with(displayed_pixmap)
+
+    def test_copy_image_action_disabled_without_image(self, widget):
+        """画像未表示時のコンテキストメニュー用コピー操作を無効化する"""
+        action = widget._create_copy_image_action(widget)
+
+        assert action.text() == "画像をコピー"
+        assert action.isEnabled() is False
 
     def test_load_image_exception(self, widget):
         """画像読み込み例外処理テスト"""

--- a/tests/unit/gui/widgets/test_image_preview_widget.py
+++ b/tests/unit/gui/widgets/test_image_preview_widget.py
@@ -52,7 +52,6 @@ class TestImagePreviewWidget:
         # テストデータ設定
         widget.pixmap_item = Mock()
         widget._current_image_path = Path("/test/image.jpg")
-        widget._current_stored_image_path = "image.jpg"
         widget._current_pixmap = Mock()
 
         with patch("lorairo.gui.widgets.image_preview.logger") as mock_logger:
@@ -64,7 +63,6 @@ class TestImagePreviewWidget:
             # PixmapItemがクリアされる
             assert widget.pixmap_item is None
             assert widget._current_image_path is None
-            assert widget._current_stored_image_path is None
             assert widget._current_pixmap is None
 
             # ログ確認
@@ -150,7 +148,6 @@ class TestImagePreviewWidget:
                 widget._on_image_data_received(image_data)
 
                 mock_load.assert_called_once_with(mock_path)
-                assert widget._current_stored_image_path == "/valid/image.jpg"
 
     def test_load_image_success(self, widget):
         """画像読み込み成功テスト"""
@@ -159,6 +156,7 @@ class TestImagePreviewWidget:
         test_path = Path("/test/image.jpg")
 
         mock_pixmap = Mock()
+        mock_pixmap.isNull.return_value = False
         mock_pixmap.rect.return_value = QRectF(0, 0, 100, 100)
 
         with patch("lorairo.gui.widgets.image_preview.QPixmap", return_value=mock_pixmap):
@@ -176,13 +174,32 @@ class TestImagePreviewWidget:
     def test_load_image_clears_before_loading(self, widget):
         """新しい画像読み込み前に既存をクリアするテスト"""
         test_path = Path("/test/image.jpg")
+        mock_pixmap = Mock()
+        mock_pixmap.isNull.return_value = False
 
         with patch.object(widget, "_clear_preview") as mock_clear:
-            with patch("lorairo.gui.widgets.image_preview.QPixmap", return_value=Mock()):
+            with patch("lorairo.gui.widgets.image_preview.QPixmap", return_value=mock_pixmap):
                 widget.load_image(test_path)
 
                 # クリアが呼ばれる
                 mock_clear.assert_called()
+
+    def test_load_image_null_pixmap_keeps_copy_disabled(self, widget):
+        """読み込み結果がnull pixmapならコピー可能状態にしない"""
+        test_path = Path("/test/corrupt.jpg")
+
+        mock_pixmap = Mock()
+        mock_pixmap.isNull.return_value = True
+
+        with patch("lorairo.gui.widgets.image_preview.QPixmap", return_value=mock_pixmap):
+            with patch.object(widget.graphics_scene, "addPixmap") as mock_add:
+                widget.load_image(test_path)
+
+        mock_add.assert_not_called()
+        assert widget.pixmap_item is None
+        assert widget._current_image_path is None
+        assert widget._current_pixmap is None
+        assert widget._create_copy_image_action(widget).isEnabled() is False
 
     def test_copy_current_image_to_clipboard_no_image_noops(self, widget):
         """画像未表示時はクリップボードへコピーしない"""
@@ -191,8 +208,8 @@ class TestImagePreviewWidget:
 
             mock_clipboard.assert_not_called()
 
-    def test_copy_current_image_to_clipboard_prefers_resolved_original(self, widget):
-        """保存パス解決で元画像が取得できる場合は元画像をコピーする"""
+    def test_copy_current_image_to_clipboard_prefers_loaded_original_path(self, widget):
+        """表示時に保持したresolved pathから元画像をコピーする"""
         resolved_path = Mock()
         resolved_path.exists.return_value = True
 
@@ -202,13 +219,10 @@ class TestImagePreviewWidget:
         displayed_pixmap.isNull.return_value = False
         clipboard = Mock()
 
-        widget._current_stored_image_path = "stored/image.jpg"
+        widget._current_image_path = resolved_path
         widget._current_pixmap = displayed_pixmap
 
         with (
-            patch(
-                "lorairo.database.db_core.resolve_stored_path", return_value=resolved_path
-            ) as mock_resolve,
             patch(
                 "lorairo.gui.widgets.image_preview.QPixmap", return_value=original_pixmap
             ) as mock_qpixmap,
@@ -216,7 +230,6 @@ class TestImagePreviewWidget:
         ):
             assert widget.copy_current_image_to_clipboard() is True
 
-        mock_resolve.assert_called_once_with("stored/image.jpg")
         mock_qpixmap.assert_called_once_with(str(resolved_path))
         clipboard.setPixmap.assert_called_once_with(original_pixmap)
 
@@ -229,11 +242,10 @@ class TestImagePreviewWidget:
         displayed_pixmap.isNull.return_value = False
         clipboard = Mock()
 
-        widget._current_stored_image_path = "stored/missing.jpg"
+        widget._current_image_path = resolved_path
         widget._current_pixmap = displayed_pixmap
 
         with (
-            patch("lorairo.database.db_core.resolve_stored_path", return_value=resolved_path),
             patch("lorairo.gui.widgets.image_preview.QPixmap") as mock_qpixmap,
             patch("lorairo.gui.widgets.image_preview.QApplication.clipboard", return_value=clipboard),
         ):


### PR DESCRIPTION
## Summary
- Add preview image clipboard copy from the context menu
- Prefer copying the original resolved stored image and fall back to the displayed pixmap
- Keep copy disabled/no-op when no valid image is available

Closes #375

## Tests
- uv run ruff check src/lorairo/gui/widgets/image_preview.py tests/unit/gui/widgets/test_image_preview_widget.py
- uv run pytest tests/unit/gui/widgets/test_image_preview_widget.py