### PR TITLE
feat: copy selected image details

### DIFF
--- a/src/lorairo/gui/widgets/annotation_data_display_widget.py
+++ b/src/lorairo/gui/widgets/annotation_data_display_widget.py
@@ -8,13 +8,16 @@ Annotation Data Display Widget
 from dataclasses import dataclass, field
 from typing import Any
 
-from PySide6.QtCore import Qt, Signal, Slot
+from PySide6.QtCore import QPoint, Qt, Signal, Slot
 from PySide6.QtGui import QResizeEvent
 from PySide6.QtWidgets import (
+    QAbstractItemView,
     QAbstractScrollArea,
+    QApplication,
     QComboBox,
     QHBoxLayout,
     QLabel,
+    QMenu,
     QSizePolicy,
     QTableWidgetItem,
     QWidget,
@@ -105,7 +108,13 @@ class AnnotationDataDisplayWidget(QWidget, Ui_AnnotationDataDisplayWidget):
         self.textEditCaption.setReadOnly(True)
         self.tableWidgetTags.setSizeAdjustPolicy(QAbstractScrollArea.SizeAdjustPolicy.AdjustToContents)
         self.tableWidgetTags.setVerticalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
+        self.tableWidgetTags.setSelectionMode(QAbstractItemView.SelectionMode.ExtendedSelection)
+        self.tableWidgetTags.setSelectionBehavior(QAbstractItemView.SelectionBehavior.SelectItems)
+        self.tableWidgetTags.setContextMenuPolicy(Qt.ContextMenuPolicy.CustomContextMenu)
+        self.tableWidgetTags.customContextMenuRequested.connect(self._show_tags_table_context_menu)
         self.textEditCaption.setVerticalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
+        self._make_label_copyable(self.labelScoreTypeValue)
+        self._make_label_copyable(self.labelOverallValue)
 
     def _setup_tags_compact_view(self) -> None:
         # 言語切り替えバー（コンボボックス付き）を先頭に動的追加
@@ -124,6 +133,7 @@ class AnnotationDataDisplayWidget(QWidget, Ui_AnnotationDataDisplayWidget):
         self._tags_compact_label.setWordWrap(True)
         self._tags_compact_label.setText("-")
         self._tags_compact_label.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum)
+        self._make_label_copyable(self._tags_compact_label)
         self.verticalLayoutTags.insertWidget(1, self._tags_compact_label)
 
         self.tableWidgetTags.setVisible(False)
@@ -133,6 +143,7 @@ class AnnotationDataDisplayWidget(QWidget, Ui_AnnotationDataDisplayWidget):
         self._caption_compact_label.setWordWrap(True)
         self._caption_compact_label.setText("キャプションが表示されます")
         self._caption_compact_label.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum)
+        self._make_label_copyable(self._caption_compact_label)
         self.verticalLayoutCaption.insertWidget(0, self._caption_compact_label)
         self.textEditCaption.setVisible(False)
 
@@ -160,8 +171,54 @@ class AnnotationDataDisplayWidget(QWidget, Ui_AnnotationDataDisplayWidget):
         self._quality_tier_label = QLabel(self.groupBoxScoreLabels)
         self._quality_tier_label.setText("品質: -")
         self._quality_tier_label.setVisible(False)
+        self._make_label_copyable(self._quality_tier_label)
         # pill コンテナの前 (上) に挿入
         self.verticalLayoutScoreLabels.insertWidget(0, self._quality_tier_label)
+
+    def _make_label_copyable(self, label: QLabel) -> None:
+        """読み取り専用 QLabel を選択・コピー可能にする。"""
+        label.setTextInteractionFlags(
+            Qt.TextInteractionFlag.TextSelectableByMouse | Qt.TextInteractionFlag.TextSelectableByKeyboard
+        )
+        label.setFocusPolicy(Qt.FocusPolicy.StrongFocus)
+        label.setContextMenuPolicy(Qt.ContextMenuPolicy.CustomContextMenu)
+        label.customContextMenuRequested.connect(
+            lambda position, target=label: self._show_label_context_menu(target, position)
+        )
+
+    def _show_label_context_menu(self, label: QLabel, position: QPoint) -> None:
+        menu = QMenu(label)
+        copy_action = menu.addAction("コピー")
+        copy_action.setEnabled(bool(label.text()))
+        copy_action.triggered.connect(lambda: QApplication.clipboard().setText(label.text()))
+        menu.exec(label.mapToGlobal(position))
+
+    @Slot(QPoint)
+    def _show_tags_table_context_menu(self, position: QPoint) -> None:
+        menu = QMenu(self.tableWidgetTags)
+        copy_action = menu.addAction("選択範囲をコピー")
+        copy_action.setEnabled(bool(self.tableWidgetTags.selectedRanges()))
+        copy_action.triggered.connect(self.copy_selected_tag_cells_to_clipboard)
+        menu.exec(self.tableWidgetTags.viewport().mapToGlobal(position))
+
+    @Slot()
+    def copy_selected_tag_cells_to_clipboard(self) -> bool:
+        """タグテーブルの選択セルを TSV としてクリップボードへコピーする。"""
+        ranges = self.tableWidgetTags.selectedRanges()
+        if not ranges:
+            return False
+
+        lines: list[str] = []
+        for selected_range in ranges:
+            for row in range(selected_range.topRow(), selected_range.bottomRow() + 1):
+                values: list[str] = []
+                for column in range(selected_range.leftColumn(), selected_range.rightColumn() + 1):
+                    item = self.tableWidgetTags.item(row, column)
+                    values.append(item.text() if item is not None else "")
+                lines.append("\t".join(values))
+
+        QApplication.clipboard().setText("\n".join(lines))
+        return True
 
     def update_data(self, data: AnnotationData) -> None:
         """アノテーションデータで表示を更新"""
@@ -379,6 +436,7 @@ class AnnotationDataDisplayWidget(QWidget, Ui_AnnotationDataDisplayWidget):
                 model = entry.get("model", "Unknown")
                 label = entry.get("label", "-")
                 pill = QLabel(f"[{model}] {label}", self._score_labels_container)
+                self._make_label_copyable(pill)
                 pill.setStyleSheet(
                     "QLabel { "
                     "background-color: palette(light); "

--- a/src/lorairo/gui/widgets/annotation_data_display_widget.py
+++ b/src/lorairo/gui/widgets/annotation_data_display_widget.py
@@ -201,6 +201,10 @@ class AnnotationDataDisplayWidget(QWidget, Ui_AnnotationDataDisplayWidget):
         selected_text = label.selectedText()
         return selected_text if selected_text else label.text()
 
+    def displayed_tags_text(self) -> str:
+        """現在の言語選択で表示されているタグ文字列を返す。"""
+        return self._tags_compact_label.text()
+
     @Slot(QPoint)
     def _show_tags_table_context_menu(self, position: QPoint) -> None:
         menu = QMenu(self.tableWidgetTags)

--- a/src/lorairo/gui/widgets/annotation_data_display_widget.py
+++ b/src/lorairo/gui/widgets/annotation_data_display_widget.py
@@ -189,9 +189,17 @@ class AnnotationDataDisplayWidget(QWidget, Ui_AnnotationDataDisplayWidget):
     def _show_label_context_menu(self, label: QLabel, position: QPoint) -> None:
         menu = QMenu(label)
         copy_action = menu.addAction("コピー")
-        copy_action.setEnabled(bool(label.text()))
-        copy_action.triggered.connect(lambda: QApplication.clipboard().setText(label.text()))
+        copy_action.setEnabled(bool(self._label_clipboard_text(label)))
+        copy_action.triggered.connect(
+            lambda: QApplication.clipboard().setText(self._label_clipboard_text(label))
+        )
         menu.exec(label.mapToGlobal(position))
+
+    @staticmethod
+    def _label_clipboard_text(label: QLabel) -> str:
+        """QLabel の選択テキストを優先し、未選択時は全テキストを返す。"""
+        selected_text = label.selectedText()
+        return selected_text if selected_text else label.text()
 
     @Slot(QPoint)
     def _show_tags_table_context_menu(self, position: QPoint) -> None:

--- a/src/lorairo/gui/widgets/annotation_data_display_widget.py
+++ b/src/lorairo/gui/widgets/annotation_data_display_widget.py
@@ -226,11 +226,20 @@ class AnnotationDataDisplayWidget(QWidget, Ui_AnnotationDataDisplayWidget):
                 values: list[str] = []
                 for column in range(selected_range.leftColumn(), selected_range.rightColumn() + 1):
                     item = self.tableWidgetTags.item(row, column)
-                    values.append(item.text() if item is not None else "")
+                    values.append(self._tag_table_item_clipboard_text(item, column))
                 lines.append("\t".join(values))
 
         QApplication.clipboard().setText("\n".join(lines))
         return True
+
+    @staticmethod
+    def _tag_table_item_clipboard_text(item: QTableWidgetItem | None, column: int) -> str:
+        """タグテーブルセルのコピー用文字列を返す。"""
+        if item is None:
+            return ""
+        if column == 4:
+            return "true" if item.checkState() == Qt.CheckState.Checked else "false"
+        return item.text()
 
     def update_data(self, data: AnnotationData) -> None:
         """アノテーションデータで表示を更新"""

--- a/src/lorairo/gui/widgets/selected_image_details_widget.py
+++ b/src/lorairo/gui/widgets/selected_image_details_widget.py
@@ -684,6 +684,7 @@ class SelectedImageDetailsWidget(QWidget):
                 self.current_details,
                 rating_value=rating_value,
                 score_value=score_value,
+                tags_value=self.annotation_display.displayed_tags_text(),
             )
         )
         logger.debug(f"画像詳細をクリップボードへコピー: image_id={self.current_details.image_id}")
@@ -702,9 +703,11 @@ class SelectedImageDetailsWidget(QWidget):
         *,
         rating_value: str | None = None,
         score_value: str | int | float | None = None,
+        tags_value: str | None = None,
     ) -> str:
         display_rating = details.rating_value if rating_value is None else rating_value
         display_score = details.score_value if score_value is None else score_value
+        display_tags = details.tags if tags_value is None else tags_value
         lines = [
             f"Image ID: {details.image_id if details.image_id is not None else '-'}",
             f"File name: {details.file_name or '-'}",
@@ -730,7 +733,7 @@ class SelectedImageDetailsWidget(QWidget):
 
         lines.extend(
             [
-                f"Tags: {details.tags or '-'}",
+                f"Tags: {display_tags or '-'}",
                 f"Caption: {details.caption or '-'}",
             ]
         )

--- a/src/lorairo/gui/widgets/selected_image_details_widget.py
+++ b/src/lorairo/gui/widgets/selected_image_details_widget.py
@@ -670,12 +670,33 @@ class SelectedImageDetailsWidget(QWidget):
             logger.debug("詳細コピー要求: current_details がありません")
             return False
 
-        QApplication.clipboard().setText(self._format_current_details_for_clipboard(self.current_details))
+        rating_value, score_value = self._get_live_rating_score_for_clipboard()
+        QApplication.clipboard().setText(
+            self._format_current_details_for_clipboard(
+                self.current_details,
+                rating_value=rating_value,
+                score_value=score_value,
+            )
+        )
         logger.debug(f"画像詳細をクリップボードへコピー: image_id={self.current_details.image_id}")
         return True
 
+    def _get_live_rating_score_for_clipboard(self) -> tuple[str, int]:
+        """現在表示中のRating/Score編集ウィジェット値をコピー用に取得する。"""
+        rating = self._rating_score_widget.ui.comboBoxRating.currentText()
+        if rating == RatingScoreEditWidget._NO_RATING_TEXT:
+            rating = ""
+        return rating, self._rating_score_widget.ui.sliderScore.value()
+
     @staticmethod
-    def _format_current_details_for_clipboard(details: ImageDetails) -> str:
+    def _format_current_details_for_clipboard(
+        details: ImageDetails,
+        *,
+        rating_value: str | None = None,
+        score_value: int | None = None,
+    ) -> str:
+        display_rating = details.rating_value if rating_value is None else rating_value
+        display_score = details.score_value if score_value is None else score_value
         lines = [
             f"Image ID: {details.image_id if details.image_id is not None else '-'}",
             f"File name: {details.file_name or '-'}",
@@ -683,8 +704,8 @@ class SelectedImageDetailsWidget(QWidget):
             f"Resolution: {details.image_size or '-'}",
             f"File size: {details.file_size or '-'}",
             f"Created date: {details.created_date or '-'}",
-            f"Rating: {details.rating_value or '-'}",
-            f"Score: {details.score_value if details.score_value is not None else '-'}",
+            f"Rating: {display_rating or '-'}",
+            f"Score: {display_score if display_score is not None else '-'}",
         ]
 
         if details.annotation_data is not None:

--- a/src/lorairo/gui/widgets/selected_image_details_widget.py
+++ b/src/lorairo/gui/widgets/selected_image_details_widget.py
@@ -19,8 +19,18 @@ DatasetStateManager.current_image_data_changedを正規経路としてUI更新�
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-from PySide6.QtCore import Qt, Signal, Slot
-from PySide6.QtWidgets import QFrame, QScrollArea, QSizePolicy, QToolButton, QVBoxLayout, QWidget
+from PySide6.QtCore import QPoint, Qt, Signal, Slot
+from PySide6.QtWidgets import (
+    QApplication,
+    QFrame,
+    QLabel,
+    QMenu,
+    QScrollArea,
+    QSizePolicy,
+    QToolButton,
+    QVBoxLayout,
+    QWidget,
+)
 
 from ...gui.designer.SelectedImageDetailsWidget_ui import Ui_SelectedImageDetailsWidget
 from ...services.date_formatter import format_datetime_for_display
@@ -105,6 +115,7 @@ class SelectedImageDetailsWidget(QWidget):
         self.current_image_id: int | None = None
         self._summary_layout: QVBoxLayout | None = None
         self._image_info_toggle: QToolButton | None = None
+        self._copy_details_button: QToolButton | None = None
 
         # UI設定
         self.ui = Ui_SelectedImageDetailsWidget()
@@ -141,6 +152,7 @@ class SelectedImageDetailsWidget(QWidget):
     def _apply_readable_layout(self) -> None:
         """読みやすさ優先のレイアウトに調整する。"""
         self._align_summary_labels()
+        self._setup_copyable_summary_labels()
 
         container = QWidget(self)
         layout = QVBoxLayout(container)
@@ -158,17 +170,25 @@ class SelectedImageDetailsWidget(QWidget):
         self._image_info_toggle.setStyleSheet("text-align: left;")
         self._image_info_toggle.toggled.connect(self._toggle_image_info_section)
 
+        self._copy_details_button = QToolButton(container)
+        self._copy_details_button.setText("詳細をコピー")
+        self._copy_details_button.setToolButtonStyle(Qt.ToolButtonStyle.ToolButtonTextOnly)
+        self._copy_details_button.setEnabled(False)
+        self._copy_details_button.clicked.connect(self.copy_current_details_to_clipboard)
+
         self.ui.groupBoxImageInfo.setTitle("")
         self.ui.groupBoxImageInfo.setVisible(False)
 
         layout.addWidget(self._image_info_toggle)
+        layout.addWidget(self._copy_details_button)
         layout.addWidget(self.ui.groupBoxImageInfo)
         layout.addWidget(self.ui.annotationDataDisplay)
         layout.addWidget(self._rating_score_widget)
         layout.setStretch(0, 0)  # _image_info_toggle
-        layout.setStretch(1, 0)  # groupBoxImageInfo
-        layout.setStretch(2, 1)  # annotationDataDisplay
-        layout.setStretch(3, 0)  # _rating_score_widget
+        layout.setStretch(1, 0)  # _copy_details_button
+        layout.setStretch(2, 0)  # groupBoxImageInfo
+        layout.setStretch(3, 1)  # annotationDataDisplay
+        layout.setStretch(4, 0)  # _rating_score_widget
 
         scroll_area = QScrollArea(self)
         scroll_area.setFrameShape(QFrame.Shape.NoFrame)
@@ -218,6 +238,35 @@ class SelectedImageDetailsWidget(QWidget):
         if hasattr(self.annotation_display, "verticalLayoutMain"):
             self.annotation_display.verticalLayoutMain.setContentsMargins(0, 0, 0, 0)
             self.annotation_display.verticalLayoutMain.setSpacing(4)
+
+    def _setup_copyable_summary_labels(self) -> None:
+        for label in (
+            self.ui.labelFileNameValue,
+            self.ui.labelImageSizeValue,
+            self.ui.labelFileSizeValue,
+            self.ui.labelCreatedDateValue,
+            self.ui.labelTagsContent,
+        ):
+            self._make_label_copyable(label)
+
+        self.ui.textEditCaptionsContent.setReadOnly(True)
+
+    def _make_label_copyable(self, label: QLabel) -> None:
+        label.setTextInteractionFlags(
+            Qt.TextInteractionFlag.TextSelectableByMouse | Qt.TextInteractionFlag.TextSelectableByKeyboard
+        )
+        label.setFocusPolicy(Qt.FocusPolicy.StrongFocus)
+        label.setContextMenuPolicy(Qt.ContextMenuPolicy.CustomContextMenu)
+        label.customContextMenuRequested.connect(
+            lambda position, target=label: self._show_label_context_menu(target, position)
+        )
+
+    def _show_label_context_menu(self, label: QLabel, position: QPoint) -> None:
+        menu = QMenu(label)
+        copy_action = menu.addAction("コピー")
+        copy_action.setEnabled(bool(label.text()))
+        copy_action.triggered.connect(lambda: QApplication.clipboard().setText(label.text()))
+        menu.exec(label.mapToGlobal(position))
 
     def _toggle_image_info_section(self, expanded: bool) -> None:
         if self._image_info_toggle:
@@ -536,6 +585,8 @@ class SelectedImageDetailsWidget(QWidget):
             self.annotation_display.update_data(details.annotation_data)
 
         logger.info(f"✅ SelectedImageDetailsWidget表示更新完了: image_id={details.image_id}")
+        if self._copy_details_button:
+            self._copy_details_button.setEnabled(True)
         self.image_details_loaded.emit(details)
 
     def _update_rating_score_display(self, details: ImageDetails) -> None:
@@ -603,12 +654,58 @@ class SelectedImageDetailsWidget(QWidget):
 
         # AnnotationDataDisplayWidgetのクリア
         self.annotation_display.clear_data()
+        if self._copy_details_button:
+            self._copy_details_button.setEnabled(False)
 
         logger.debug("SelectedImageDetailsWidget display cleared")
 
     def get_current_details(self) -> ImageDetails | None:
         """現在表示中の画像詳細情報を返す"""
         return self.current_details
+
+    @Slot()
+    def copy_current_details_to_clipboard(self) -> bool:
+        """現在表示中の画像詳細全体をクリップボードへコピーする。"""
+        if self.current_details is None:
+            logger.debug("詳細コピー要求: current_details がありません")
+            return False
+
+        QApplication.clipboard().setText(self._format_current_details_for_clipboard(self.current_details))
+        logger.debug(f"画像詳細をクリップボードへコピー: image_id={self.current_details.image_id}")
+        return True
+
+    @staticmethod
+    def _format_current_details_for_clipboard(details: ImageDetails) -> str:
+        lines = [
+            f"Image ID: {details.image_id if details.image_id is not None else '-'}",
+            f"File name: {details.file_name or '-'}",
+            f"File path: {details.file_path or '-'}",
+            f"Resolution: {details.image_size or '-'}",
+            f"File size: {details.file_size or '-'}",
+            f"Created date: {details.created_date or '-'}",
+            f"Rating: {details.rating_value or '-'}",
+            f"Score: {details.score_value if details.score_value is not None else '-'}",
+        ]
+
+        if details.annotation_data is not None:
+            quality_tier = details.annotation_data.quality_summary.get("tier")
+            if quality_tier:
+                lines.append(f"Quality tier: {quality_tier}")
+
+            if details.annotation_data.score_labels:
+                score_labels = [
+                    f"{entry.get('model', 'Unknown')}: {entry.get('label', '-')}"
+                    for entry in details.annotation_data.score_labels
+                ]
+                lines.append(f"Score labels: {', '.join(score_labels)}")
+
+        lines.extend(
+            [
+                f"Tags: {details.tags or '-'}",
+                f"Caption: {details.caption or '-'}",
+            ]
+        )
+        return "\n".join(lines)
 
 
 if __name__ == "__main__":

--- a/src/lorairo/gui/widgets/selected_image_details_widget.py
+++ b/src/lorairo/gui/widgets/selected_image_details_widget.py
@@ -264,9 +264,17 @@ class SelectedImageDetailsWidget(QWidget):
     def _show_label_context_menu(self, label: QLabel, position: QPoint) -> None:
         menu = QMenu(label)
         copy_action = menu.addAction("コピー")
-        copy_action.setEnabled(bool(label.text()))
-        copy_action.triggered.connect(lambda: QApplication.clipboard().setText(label.text()))
+        copy_action.setEnabled(bool(self._label_clipboard_text(label)))
+        copy_action.triggered.connect(
+            lambda: QApplication.clipboard().setText(self._label_clipboard_text(label))
+        )
         menu.exec(label.mapToGlobal(position))
+
+    @staticmethod
+    def _label_clipboard_text(label: QLabel) -> str:
+        """QLabel の選択テキストを優先し、未選択時は全テキストを返す。"""
+        selected_text = label.selectedText()
+        return selected_text if selected_text else label.text()
 
     def _toggle_image_info_section(self, expanded: bool) -> None:
         if self._image_info_toggle:
@@ -681,19 +689,19 @@ class SelectedImageDetailsWidget(QWidget):
         logger.debug(f"画像詳細をクリップボードへコピー: image_id={self.current_details.image_id}")
         return True
 
-    def _get_live_rating_score_for_clipboard(self) -> tuple[str, int]:
+    def _get_live_rating_score_for_clipboard(self) -> tuple[str, str]:
         """現在表示中のRating/Score編集ウィジェット値をコピー用に取得する。"""
         rating = self._rating_score_widget.ui.comboBoxRating.currentText()
         if rating == RatingScoreEditWidget._NO_RATING_TEXT:
             rating = ""
-        return rating, self._rating_score_widget.ui.sliderScore.value()
+        return rating, self._rating_score_widget.ui.labelScoreValue.text()
 
     @staticmethod
     def _format_current_details_for_clipboard(
         details: ImageDetails,
         *,
         rating_value: str | None = None,
-        score_value: int | None = None,
+        score_value: str | int | float | None = None,
     ) -> str:
         display_rating = details.rating_value if rating_value is None else rating_value
         display_score = details.score_value if score_value is None else score_value

--- a/tests/unit/gui/widgets/test_annotation_data_display_widget.py
+++ b/tests/unit/gui/widgets/test_annotation_data_display_widget.py
@@ -1,6 +1,8 @@
 # tests/unit/gui/widgets/test_annotation_data_display_widget.py
 
 import pytest
+from PySide6.QtCore import Qt
+from PySide6.QtWidgets import QApplication, QTableWidgetSelectionRange
 
 from lorairo.gui.widgets.annotation_data_display_widget import AnnotationData, AnnotationDataDisplayWidget
 
@@ -87,6 +89,25 @@ class TestAnnotationDataDisplayWidget:
         widget.update_data(data)
         assert "1girl" in widget._tags_compact_label.text()
         assert "flower" in widget._tags_compact_label.text()
+
+    def test_compact_labels_are_selectable(self, widget):
+        """compact表示のQLabelは選択・コピー可能であること"""
+        flags = (
+            Qt.TextInteractionFlag.TextSelectableByMouse | Qt.TextInteractionFlag.TextSelectableByKeyboard
+        )
+
+        assert widget._tags_compact_label.textInteractionFlags() & flags == flags
+        assert widget._caption_compact_label.textInteractionFlags() & flags == flags
+        assert widget._tags_compact_label.focusPolicy() == Qt.FocusPolicy.StrongFocus
+        assert widget._caption_compact_label.focusPolicy() == Qt.FocusPolicy.StrongFocus
+
+    def test_copy_selected_tag_cells_to_clipboard(self, widget, sample_tags):
+        """タグテーブル選択範囲をTSVとしてコピーできること"""
+        widget.update_data(AnnotationData(tags=sample_tags))
+        widget.tableWidgetTags.setRangeSelected(QTableWidgetSelectionRange(0, 0, 1, 1), True)
+
+        assert widget.copy_selected_tag_cells_to_clipboard() is True
+        assert QApplication.clipboard().text() == "1girl\twd\nflower\twd"
 
     def test_compact_label_switches_to_japanese(self, widget, sample_tags):
         """japanese選択でラベルが翻訳テキストに切り替わること"""

--- a/tests/unit/gui/widgets/test_annotation_data_display_widget.py
+++ b/tests/unit/gui/widgets/test_annotation_data_display_widget.py
@@ -130,6 +130,16 @@ class TestAnnotationDataDisplayWidget:
         assert widget.copy_selected_tag_cells_to_clipboard() is True
         assert QApplication.clipboard().text() == "1girl\twd\nflower\twd"
 
+    def test_copy_selected_tag_cells_exports_edited_checkbox_state(self, widget, sample_tags):
+        """Edited列はcheckbox状態をTSVへ出力すること"""
+        sample_tags[0]["is_edited_manually"] = True
+        sample_tags[1]["is_edited_manually"] = False
+        widget.update_data(AnnotationData(tags=sample_tags))
+        widget.tableWidgetTags.setRangeSelected(QTableWidgetSelectionRange(0, 4, 1, 4), True)
+
+        assert widget.copy_selected_tag_cells_to_clipboard() is True
+        assert QApplication.clipboard().text() == "true\nfalse"
+
     def test_compact_label_switches_to_japanese(self, widget, sample_tags):
         """japanese選択でラベルが翻訳テキストに切り替わること"""
         translations = {10: {"japanese": "1人の女の子"}, 20: {"japanese": "花"}}

--- a/tests/unit/gui/widgets/test_annotation_data_display_widget.py
+++ b/tests/unit/gui/widgets/test_annotation_data_display_widget.py
@@ -101,6 +101,13 @@ class TestAnnotationDataDisplayWidget:
         assert widget._tags_compact_label.focusPolicy() == Qt.FocusPolicy.StrongFocus
         assert widget._caption_compact_label.focusPolicy() == Qt.FocusPolicy.StrongFocus
 
+    def test_label_clipboard_text_prefers_selected_text(self, widget):
+        """QLabelのcontext copyは選択範囲を優先すること"""
+        widget._tags_compact_label.setText("1girl, flower, solo")
+        widget._tags_compact_label.setSelection(7, 6)
+
+        assert widget._label_clipboard_text(widget._tags_compact_label) == "flower"
+
     def test_copy_selected_tag_cells_to_clipboard(self, widget, sample_tags):
         """タグテーブル選択範囲をTSVとしてコピーできること"""
         widget.update_data(AnnotationData(tags=sample_tags))

--- a/tests/unit/gui/widgets/test_annotation_data_display_widget.py
+++ b/tests/unit/gui/widgets/test_annotation_data_display_widget.py
@@ -108,6 +108,20 @@ class TestAnnotationDataDisplayWidget:
 
         assert widget._label_clipboard_text(widget._tags_compact_label) == "flower"
 
+    def test_displayed_tags_text_returns_current_compact_label(self, widget, sample_tags):
+        """現在表示中のタグ文字列を取得できること"""
+        translations = {10: {"japanese": "1人の女の子"}, 20: {"japanese": "花"}}
+        data = AnnotationData(
+            tags=sample_tags,
+            tag_translations=translations,
+            available_languages=["japanese"],
+        )
+        widget.update_data(data)
+        widget.initialize_language_selector(["japanese"])
+        widget._lang_combo.setCurrentText("japanese")
+
+        assert widget.displayed_tags_text() == "1人の女の子, 花, solo"
+
     def test_copy_selected_tag_cells_to_clipboard(self, widget, sample_tags):
         """タグテーブル選択範囲をTSVとしてコピーできること"""
         widget.update_data(AnnotationData(tags=sample_tags))

--- a/tests/unit/gui/widgets/test_selected_image_details_widget.py
+++ b/tests/unit/gui/widgets/test_selected_image_details_widget.py
@@ -153,6 +153,26 @@ class TestSelectedImageDetailsWidget:
         assert "Rating: R" in clipboard_text
         assert "Score: 9.20" in clipboard_text
 
+    def test_copy_current_details_uses_displayed_tag_language(self, widget, sample_image_details):
+        """言語切り替え後は表示中のタグ言語で詳細をコピーすること"""
+        sample_image_details.annotation_data.tag_translations = {
+            10: {"japanese": "1人の女の子"},
+            20: {"japanese": "長い髪"},
+            30: {"japanese": "青い目"},
+        }
+        for tag, tag_id in zip(sample_image_details.annotation_data.tags, (10, 20, 30), strict=True):
+            tag["tag_id"] = tag_id
+        sample_image_details.annotation_data.available_languages = ["japanese"]
+
+        widget._update_details_display(sample_image_details)
+        widget.annotation_display.initialize_language_selector(["japanese"])
+        widget.annotation_display._lang_combo.setCurrentText("japanese")
+
+        assert widget.copy_current_details_to_clipboard() is True
+        clipboard_text = QApplication.clipboard().text()
+        assert "Tags: 1人の女の子, 長い髪, 青い目" in clipboard_text
+        assert "Tags: 1girl, long hair, blue eyes" not in clipboard_text
+
     def test_copy_current_details_without_selection_noops(self, widget):
         """未選択時は詳細全体コピーを行わないこと"""
         QApplication.clipboard().setText("")

--- a/tests/unit/gui/widgets/test_selected_image_details_widget.py
+++ b/tests/unit/gui/widgets/test_selected_image_details_widget.py
@@ -134,6 +134,17 @@ class TestSelectedImageDetailsWidget:
         assert "Tags: 1girl, long hair, blue eyes" in clipboard_text
         assert "Caption: A beautiful anime girl with long hair" in clipboard_text
 
+    def test_copy_current_details_uses_live_rating_score_widget_values(self, widget, sample_image_details):
+        """編集後metadata refresh前でも表示中のRating/Scoreをコピーすること"""
+        widget._update_details_display(sample_image_details)
+        widget._rating_score_widget.ui.comboBoxRating.setCurrentText("R")
+        widget._rating_score_widget.ui.sliderScore.setValue(920)
+
+        assert widget.copy_current_details_to_clipboard() is True
+        clipboard_text = QApplication.clipboard().text()
+        assert "Rating: R" in clipboard_text
+        assert "Score: 920" in clipboard_text
+
     def test_copy_current_details_without_selection_noops(self, widget):
         """未選択時は詳細全体コピーを行わないこと"""
         QApplication.clipboard().setText("")

--- a/tests/unit/gui/widgets/test_selected_image_details_widget.py
+++ b/tests/unit/gui/widgets/test_selected_image_details_widget.py
@@ -123,6 +123,14 @@ class TestSelectedImageDetailsWidget:
             assert label.textInteractionFlags() & flags == flags
             assert label.focusPolicy() == Qt.FocusPolicy.StrongFocus
 
+    def test_label_clipboard_text_prefers_selected_text(self, widget):
+        """QLabelのcontext copyは選択範囲を優先すること"""
+        label = widget.ui.labelFileNameValue
+        label.setText("sample_image.jpg")
+        label.setSelection(0, 6)
+
+        assert widget._label_clipboard_text(label) == "sample"
+
     def test_copy_current_details_to_clipboard(self, widget, sample_image_details):
         """表示中の詳細情報全体をクリップボードへコピーできること"""
         widget._update_details_display(sample_image_details)
@@ -143,7 +151,7 @@ class TestSelectedImageDetailsWidget:
         assert widget.copy_current_details_to_clipboard() is True
         clipboard_text = QApplication.clipboard().text()
         assert "Rating: R" in clipboard_text
-        assert "Score: 920" in clipboard_text
+        assert "Score: 9.20" in clipboard_text
 
     def test_copy_current_details_without_selection_noops(self, widget):
         """未選択時は詳細全体コピーを行わないこと"""

--- a/tests/unit/gui/widgets/test_selected_image_details_widget.py
+++ b/tests/unit/gui/widgets/test_selected_image_details_widget.py
@@ -4,7 +4,8 @@ from pathlib import Path
 from unittest.mock import Mock, patch
 
 import pytest
-from PySide6.QtCore import QObject, Signal
+from PySide6.QtCore import QObject, Qt, Signal
+from PySide6.QtWidgets import QApplication
 
 from lorairo.gui.widgets.annotation_data_display_widget import AnnotationData, ImageDetails
 from lorairo.gui.widgets.selected_image_details_widget import SelectedImageDetailsWidget
@@ -106,6 +107,39 @@ class TestSelectedImageDetailsWidget:
         # 実際の実装により具体的な検証項目は変わる
         # UIラベルの内容更新等を確認
         pass
+
+    def test_summary_value_labels_are_selectable(self, widget):
+        """画像情報の値ラベルは選択・コピー可能であること"""
+        flags = (
+            Qt.TextInteractionFlag.TextSelectableByMouse | Qt.TextInteractionFlag.TextSelectableByKeyboard
+        )
+
+        for label in (
+            widget.ui.labelFileNameValue,
+            widget.ui.labelImageSizeValue,
+            widget.ui.labelFileSizeValue,
+            widget.ui.labelCreatedDateValue,
+        ):
+            assert label.textInteractionFlags() & flags == flags
+            assert label.focusPolicy() == Qt.FocusPolicy.StrongFocus
+
+    def test_copy_current_details_to_clipboard(self, widget, sample_image_details):
+        """表示中の詳細情報全体をクリップボードへコピーできること"""
+        widget._update_details_display(sample_image_details)
+
+        assert widget.copy_current_details_to_clipboard() is True
+        clipboard_text = QApplication.clipboard().text()
+        assert "Image ID: 123" in clipboard_text
+        assert "File name: sample_image.jpg" in clipboard_text
+        assert "Tags: 1girl, long hair, blue eyes" in clipboard_text
+        assert "Caption: A beautiful anime girl with long hair" in clipboard_text
+
+    def test_copy_current_details_without_selection_noops(self, widget):
+        """未選択時は詳細全体コピーを行わないこと"""
+        QApplication.clipboard().setText("")
+
+        assert widget.copy_current_details_to_clipboard() is False
+        assert QApplication.clipboard().text() == ""
 
     def test_annotation_data_loaded_slot(self, widget):
         """アノテーションデータ読み込み完了スロットテスト"""


### PR DESCRIPTION
## Summary
- Make selected image detail labels, compact annotation labels, score labels, and tag table content copyable
- Add a detail-wide clipboard copy action in SelectedImageDetailsWidget
- Add tests for selectable labels, TSV tag-table copy, and whole-details copy

Depends on #376 branch fix/376-details-metadata.
Refs #374

## Tests
- uv run ruff check src/lorairo/gui/widgets/selected_image_details_widget.py src/lorairo/gui/widgets/annotation_data_display_widget.py tests/unit/gui/widgets/test_selected_image_details_widget.py tests/unit/gui/widgets/test_annotation_data_display_widget.py
- uv run pytest tests/unit/gui/widgets/test_annotation_data_display_widget.py tests/unit/gui/widgets/test_selected_image_details_widget.py (with temporary ignored RatingScoreEditWidget_ui.py generated from .ui for collection)