### PR TITLE
fix: exclude legacy sentinel models from annotation execution (#344/#360)

### DIFF
--- a/src/lorairo/gui/workers/annotation_worker.py
+++ b/src/lorairo/gui/workers/annotation_worker.py
@@ -105,9 +105,9 @@ class AnnotationWorker(LoRAIroWorkerBase["AnnotationExecutionResult"]):
             and model_name.endswith(AnnotationWorker._LEGACY_SENTINEL_SUFFIX)
         ):
             return False
-        body = model_name[len(AnnotationWorker._LEGACY_SENTINEL_PREFIX) : -len(
-            AnnotationWorker._LEGACY_SENTINEL_SUFFIX
-        )]
+        body = model_name[
+            len(AnnotationWorker._LEGACY_SENTINEL_PREFIX) : -len(AnnotationWorker._LEGACY_SENTINEL_SUFFIX)
+        ]
         return body.isdecimal()
 
     def __init__(
@@ -141,9 +141,7 @@ class AnnotationWorker(LoRAIroWorkerBase["AnnotationExecutionResult"]):
         ]
         dropped = len(litellm_model_ids) - len(self.litellm_model_ids)
         if dropped:
-            logger.info(
-                f"AnnotationWorker初期化: legacy sentinel を除外しました: {dropped}件"
-            )
+            logger.info(f"AnnotationWorker初期化: legacy sentinel を除外しました: {dropped}件")
         self.db_manager = db_manager
         self.model_registry = model_registry
 

--- a/src/lorairo/gui/workers/annotation_worker.py
+++ b/src/lorairo/gui/workers/annotation_worker.py
@@ -95,6 +95,20 @@ class AnnotationWorker(LoRAIroWorkerBase["AnnotationExecutionResult"]):
     """
 
     _OPERATION_TYPE = "annotation"
+    _LEGACY_SENTINEL_PREFIX = "__legacy_"
+    _LEGACY_SENTINEL_SUFFIX = "__"
+
+    @staticmethod
+    def _is_legacy_sentinel_model_id(model_name: str) -> bool:
+        if not (
+            model_name.startswith(AnnotationWorker._LEGACY_SENTINEL_PREFIX)
+            and model_name.endswith(AnnotationWorker._LEGACY_SENTINEL_SUFFIX)
+        ):
+            return False
+        body = model_name[len(AnnotationWorker._LEGACY_SENTINEL_PREFIX) : -len(
+            AnnotationWorker._LEGACY_SENTINEL_SUFFIX
+        )]
+        return body.isdecimal()
 
     def __init__(
         self,
@@ -122,7 +136,14 @@ class AnnotationWorker(LoRAIroWorkerBase["AnnotationExecutionResult"]):
 
         self.annotation_logic = annotation_logic
         self.image_paths = image_paths
-        self.litellm_model_ids = litellm_model_ids
+        self.litellm_model_ids = [
+            model_id for model_id in litellm_model_ids if not self._is_legacy_sentinel_model_id(model_id)
+        ]
+        dropped = len(litellm_model_ids) - len(self.litellm_model_ids)
+        if dropped:
+            logger.info(
+                f"AnnotationWorker初期化: legacy sentinel を除外しました: {dropped}件"
+            )
         self.db_manager = db_manager
         self.model_registry = model_registry
 
@@ -586,6 +607,8 @@ class AnnotationWorker(LoRAIroWorkerBase["AnnotationExecutionResult"]):
 
         for annotations in results.values():
             for model_name, unified_result in annotations.items():
+                if self._is_legacy_sentinel_model_id(model_name):
+                    continue
                 if model_name not in model_stats:
                     info = info_map.get(model_name)
                     provider_name = info.provider if info else None

--- a/src/lorairo/services/annotation_save_service.py
+++ b/src/lorairo/services/annotation_save_service.py
@@ -219,6 +219,28 @@ class AnnotationSaveService:
         "ContentPolicyRefusalError:",
     )
 
+    # legacy migration 行の fallback sentinel: __legacy_<id>__.
+    # runtime 保存経路では通常モデルとして扱わず必ずスキップする。
+    _LEGACY_SENTINEL_PREFIX = "__legacy_"
+    _LEGACY_SENTINEL_SUFFIX = "__"
+
+    @classmethod
+    def _is_legacy_sentinel_model_id(cls, model_name: str) -> bool:
+        """モデル名が legacy fallback sentinel (`__legacy_<id>__`) かどうかを判定する。"""
+        if not (
+            model_name.startswith(cls._LEGACY_SENTINEL_PREFIX)
+            and model_name.endswith(cls._LEGACY_SENTINEL_SUFFIX)
+        ):
+            return False
+
+        if len(model_name) <= len(cls._LEGACY_SENTINEL_PREFIX) + len(cls._LEGACY_SENTINEL_SUFFIX):
+            return False
+
+        model_id = model_name[
+            len(cls._LEGACY_SENTINEL_PREFIX) : -len(cls._LEGACY_SENTINEL_SUFFIX)
+        ]
+        return model_id.isdecimal()
+
     @classmethod
     def _detect_refusal_error_type(cls, error: Any) -> str | None:
         """`UnifiedAnnotationResult.error` から refusal exception type 名を抽出する。
@@ -263,6 +285,12 @@ class AnnotationSaveService:
             result: 追記先の AnnotationsDict。
             image_id: 対象画像 ID。refusal を error_records に記録する際に必要。
         """
+        if self._is_legacy_sentinel_model_id(model_name):
+            logger.warning(
+                f"legacy sentinel モデルID {model_name} を保存対象外としてスキップ: image_id={image_id}"
+            )
+            return
+
         error = self._extract_field(unified_result, "error")
         if error:
             refusal_type = self._detect_refusal_error_type(error)
@@ -346,6 +374,8 @@ class AnnotationSaveService:
         all_raw_tags: set[str] = set()
         for phash_annotations in results.values():
             for model_name, unified_result in phash_annotations.items():
+                if self._is_legacy_sentinel_model_id(model_name):
+                    continue
                 if self._extract_field(unified_result, "error"):
                     continue
                 all_model_names.add(model_name)

--- a/src/lorairo/services/annotation_save_service.py
+++ b/src/lorairo/services/annotation_save_service.py
@@ -236,9 +236,7 @@ class AnnotationSaveService:
         if len(model_name) <= len(cls._LEGACY_SENTINEL_PREFIX) + len(cls._LEGACY_SENTINEL_SUFFIX):
             return False
 
-        model_id = model_name[
-            len(cls._LEGACY_SENTINEL_PREFIX) : -len(cls._LEGACY_SENTINEL_SUFFIX)
-        ]
+        model_id = model_name[len(cls._LEGACY_SENTINEL_PREFIX) : -len(cls._LEGACY_SENTINEL_SUFFIX)]
         return model_id.isdecimal()
 
     @classmethod

--- a/src/lorairo/services/model_selection_service.py
+++ b/src/lorairo/services/model_selection_service.py
@@ -108,9 +108,11 @@ class ModelSelectionService:
             and model_name.endswith(ModelSelectionService._LEGACY_SENTINEL_SUFFIX)
         ):
             return False
-        body = model_name[len(ModelSelectionService._LEGACY_SENTINEL_PREFIX) : -len(
-            ModelSelectionService._LEGACY_SENTINEL_SUFFIX
-        )]
+        body = model_name[
+            len(ModelSelectionService._LEGACY_SENTINEL_PREFIX) : -len(
+                ModelSelectionService._LEGACY_SENTINEL_SUFFIX
+            )
+        ]
         return body.isdecimal()
 
     @staticmethod

--- a/src/lorairo/services/model_selection_service.py
+++ b/src/lorairo/services/model_selection_service.py
@@ -39,6 +39,9 @@ class ModelSelectionService:
         self._all_models: list[Model] = []
         self._cached_models: list[Model] | None = None
 
+    _LEGACY_SENTINEL_PREFIX = "__legacy_"
+    _LEGACY_SENTINEL_SUFFIX = "__"
+
     @classmethod
     def create(cls, db_repository: ImageRepository) -> ModelSelectionService:
         """Create ModelSelectionService with DB-centric architecture."""
@@ -96,6 +99,21 @@ class ModelSelectionService:
         return provider.lower()
 
     @staticmethod
+    def _is_legacy_sentinel_model_name(model_name: str | None) -> bool:
+        """legacy fallback sentinel (`__legacy_<id>__`) モデル名か判定する。"""
+        if not isinstance(model_name, str):
+            return False
+        if not (
+            model_name.startswith(ModelSelectionService._LEGACY_SENTINEL_PREFIX)
+            and model_name.endswith(ModelSelectionService._LEGACY_SENTINEL_SUFFIX)
+        ):
+            return False
+        body = model_name[len(ModelSelectionService._LEGACY_SENTINEL_PREFIX) : -len(
+            ModelSelectionService._LEGACY_SENTINEL_SUFFIX
+        )]
+        return body.isdecimal()
+
+    @staticmethod
     def _model_capability_names(model: Model) -> set[str]:
         """Model capabilities/model_types から構造化された capability 名を取得する。"""
         capabilities = getattr(model, "capabilities", None)
@@ -112,6 +130,8 @@ class ModelSelectionService:
     @classmethod
     def _is_annotation_eligible_model(cls, model: Model) -> bool:
         """Batch annotation に使える model_types/capabilities を持つか判定する。"""
+        if cls._is_legacy_sentinel_model_name(model.name):
+            return False
         annotation_types = {"caption", "tags", "scores", "ratings", "multimodal"}
         return bool(cls._model_capability_names(model) & annotation_types)
 

--- a/tests/unit/gui/workers/test_annotation_worker.py
+++ b/tests/unit/gui/workers/test_annotation_worker.py
@@ -66,6 +66,24 @@ class TestAnnotationWorkerInitialization:
         assert worker.db_manager is mock_db_manager
         assert worker.model_registry is mock_model_registry
 
+    def test_initialization_filters_legacy_sentinel_models(
+        self, mock_annotation_logic, mock_model_registry
+    ):
+        """legacy sentinel を受け取ると初期化時に除外して保持する。"""
+        image_paths = ["/path/to/image1.jpg"]
+        models = ["__legacy_17__", "gpt-4o-mini"]
+        mock_db_manager = Mock()
+
+        worker = AnnotationWorker(
+            annotation_logic=mock_annotation_logic,
+            image_paths=image_paths,
+            litellm_model_ids=models,
+            db_manager=mock_db_manager,
+            model_registry=mock_model_registry,
+        )
+
+        assert worker.litellm_model_ids == ["gpt-4o-mini"]
+
 
 class TestAnnotationWorkerExecute:
     """AnnotationWorker execute()テスト"""
@@ -156,6 +174,30 @@ class TestAnnotationWorkerExecute:
         assert "claude-3-haiku-20240307" in result.results["phash1"]
         assert result.total_images == 1
         assert result.models_used == ["gpt-4o-mini", "claude-3-haiku-20240307"]
+
+    def test_execute_skips_legacy_sentinel_models(self, mock_annotation_logic, mock_model_registry):
+        """legacy sentinel は execute 時の対象モデルから除外される。"""
+        image_paths = ["/path/to/image.jpg"]
+        models = ["__legacy_17__", "gpt-4o-mini"]
+
+        mock_db_manager = Mock()
+        mock_db_manager.repository.find_image_ids_by_phashes.return_value = {"phash1": 1}
+        mock_db_manager.repository.get_models_by_litellm_ids.return_value = {"gpt-4o-mini": Mock(id=1)}
+        mock_db_manager.repository.save_annotations = Mock()
+
+        worker = AnnotationWorker(
+            annotation_logic=mock_annotation_logic,
+            image_paths=image_paths,
+            litellm_model_ids=models,
+            db_manager=mock_db_manager,
+            model_registry=mock_model_registry,
+        )
+        result = worker.execute()
+
+        mock_annotation_logic.execute_annotation.assert_called_once()
+        assert result.models_used == ["gpt-4o-mini"]
+        called_kwargs = mock_annotation_logic.execute_annotation.call_args.kwargs
+        assert called_kwargs["litellm_model_ids"] == ["gpt-4o-mini"]
 
     def test_execute_model_error_partial_success(self, mock_annotation_logic, mock_model_registry):
         """モデルエラー時の部分的成功"""

--- a/tests/unit/services/test_annotation_save_service.py
+++ b/tests/unit/services/test_annotation_save_service.py
@@ -1,7 +1,7 @@
 """AnnotationSaveService ユニットテスト。"""
 
 from types import SimpleNamespace
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -113,6 +113,69 @@ def test_save_annotation_results_with_unknown_phash_skips_silently(
 
 
 @pytest.mark.unit
+def test_save_annotation_results_excludes_legacy_sentinel_from_lookup(
+    service: AnnotationSaveService,
+    mock_repository: MagicMock,
+) -> None:
+    """sentinel モデルは lookup 対象外になり、通常モデルのみ保存する。"""
+    mock_model = MagicMock()
+    mock_model.id = 10
+
+    mock_repository.find_image_ids_by_phashes.return_value = {"phash001": 1}
+    mock_repository.get_models_by_litellm_ids.return_value = {"wdtagger": mock_model}
+    mock_repository.batch_resolve_tag_ids.return_value = {}
+
+    results = {
+        "phash001": {
+            "__legacy_17__": _make_success_result(tags=["legacy"]),
+            "wdtagger": _make_success_result(tags=["tag1"]),
+        },
+    }
+
+    result = service.save_annotation_results(results)
+
+    assert result.success_count == 1
+    assert result.skip_count == 0
+    assert result.error_count == 0
+    assert result.total_count == 1
+    mock_repository.get_models_by_litellm_ids.assert_called_once_with({"wdtagger"})
+    mock_repository.save_annotations.assert_called_once()
+    annotations_dict = mock_repository.save_annotations.call_args[0][1]
+    assert annotations_dict["tags"] == [
+        {
+            "model_id": 10,
+            "tag": "tag1",
+            "existing": False,
+            "is_edited_manually": False,
+            "confidence_score": None,
+            "tag_id": None,
+        }
+    ]
+
+
+@pytest.mark.unit
+def test_save_annotation_results_legacy_sentinel_only_is_skipped(
+    service: AnnotationSaveService,
+    mock_repository: MagicMock,
+) -> None:
+    """legacy sentinel のみなら保存対象がなく、スキップ件数に集計される。"""
+    mock_repository.find_image_ids_by_phashes.return_value = {"phash001": 1}
+    mock_repository.get_models_by_litellm_ids.return_value = {}
+    mock_repository.batch_resolve_tag_ids.return_value = {}
+
+    results = {"phash001": {"__legacy_17__": _make_success_result(tags=["legacy"])}}
+
+    result = service.save_annotation_results(results)
+
+    assert result.success_count == 0
+    assert result.skip_count == 1
+    assert result.error_count == 0
+    assert result.total_count == 1
+    mock_repository.get_models_by_litellm_ids.assert_called_once_with(set())
+    mock_repository.save_annotations.assert_not_called()
+
+
+@pytest.mark.unit
 def test_save_annotation_results_handles_partial_save_failure(
     service: AnnotationSaveService,
     mock_repository: MagicMock,
@@ -135,6 +198,33 @@ def test_save_annotation_results_handles_partial_save_failure(
     assert result.skip_count == 0
     assert len(result.error_details) == 1
     assert "phash001" in result.error_details[0]
+
+
+@pytest.mark.unit
+def test_process_model_result_legacy_sentinel_is_skipped_with_warning(
+    service: AnnotationSaveService,
+    mock_repository: MagicMock,
+) -> None:
+    """legacy sentinel は refusal/error 処理を経ず警告してスキップする。"""
+    unified_result = MagicMock()
+    unified_result.error = "ApiTimeoutError: timeout"
+    result_dict = {"scores": [], "score_labels": [], "tags": [], "captions": [], "ratings": []}
+
+    with patch("lorairo.services.annotation_save_service.logger.warning") as warn_mock:
+        service._process_model_result(
+            "__legacy_17__",
+            unified_result,
+            {},
+            result_dict,
+            image_id=1,
+        )
+        assert warn_mock.call_count >= 1
+        warn_mock.assert_any_call(
+            "legacy sentinel モデルID __legacy_17__ を保存対象外としてスキップ: image_id=1"
+        )
+
+    mock_repository.save_error_record.assert_not_called()
+    assert result_dict["tags"] == []
 
 
 @pytest.mark.unit

--- a/tests/unit/services/test_model_selection_service.py
+++ b/tests/unit/services/test_model_selection_service.py
@@ -298,6 +298,44 @@ class TestModelSelectionService:
 
         assert [model.name for model in filtered] == ["ratings-model"]
 
+    def test_annotation_only_filter_excludes_legacy_sentinel(self, service):
+        """legacy sentinel 命名 (`__legacy_*__`) は annotation 用フィルタで除外する。"""
+        legacy_model = SimpleNamespace(
+            name="__legacy_17__",
+            provider="openai",
+            capabilities=["caption"],
+            is_recommended=False,
+            available=True,
+        )
+        normal_model = SimpleNamespace(
+            name="caption-model",
+            provider="local",
+            capabilities=["caption"],
+            is_recommended=False,
+            available=True,
+        )
+        service._all_models = [legacy_model, normal_model]
+
+        filtered = service.filter_models(ModelSelectionCriteria(annotation_only=True))
+
+        assert len(filtered) == 1
+        assert filtered[0].name == "caption-model"
+
+    def test_annotation_only_false_keeps_legacy_sentinel(self, service):
+        """annotation_only が false の場合は legacy sentinel も現状仕様どおり残す。"""
+        legacy_model = SimpleNamespace(
+            name="__legacy_17__",
+            provider="openai",
+            capabilities=[],
+            is_recommended=False,
+            available=True,
+        )
+        service._all_models = [legacy_model]
+
+        filtered = service.filter_models(ModelSelectionCriteria(annotation_only=False))
+
+        assert filtered[0].name == "__legacy_17__"
+
     def test_local_ratings_filter_matches_model_types(self, service):
         """ローカル + ratings 条件は DB model_types に ratings を持つモデルを返す"""
         ratings_model = SimpleNamespace(


### PR DESCRIPTION
## Summary
- Exclude __legacy_<id>__ sentinel rows from batch annotation eligibility at selection stage.
- Strip legacy sentinel IDs from AnnotationWorker execution input and worker-level statistics.
- Add regression coverage for service and worker paths.

## Related
- Closes #344
- Addresses #360