### PR TITLE
feat(db): ADR 0033 schema migrations (legacy sentinel + retry_count drop)

### DIFF
--- a/src/lorairo/database/db_repository.py
+++ b/src/lorairo/database/db_repository.py
@@ -3333,7 +3333,6 @@ class ImageRepository:
                     stack_trace=stack_trace,
                     file_path=file_path,
                     model_name=model_name,
-                    retry_count=0,
                 )
                 session.add(record)
                 session.flush()

--- a/src/lorairo/database/migrations/versions/a3b4c5d6e7f8_drop_legacy_sentinel_models.py
+++ b/src/lorairo/database/migrations/versions/a3b4c5d6e7f8_drop_legacy_sentinel_models.py
@@ -31,11 +31,14 @@ down_revision: str | None = "f1b2c3d4e5f6"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 
-# SQL LIKE では `_` が任意 1 文字にマッチするため、リテラル比較するには ESCAPE が必要。
-# `mylegacy-model` 等の非 sentinel ID が誤マッチしないよう、`_` をすべて `\_` でエスケープし
-# 末尾に `%` を付ける (旧形式 `__legacy_<id>__` の前方一致)。
-_LEGACY_LIKE = r"\_\_legacy\_%"
+# 正規 sentinel 形式は `__legacy_<digits>__` (ADR 0023 Phase 1.11 / Worker 側
+# `_is_legacy_sentinel_model_id` と一致)。SQL `LIKE` の `_` ワイルドカードを ESCAPE で
+# literal 化し、prefix と suffix の両方を pattern に含める。`<digits>` 部分は LIKE では
+# 厳密に表現できないので、SELECT 後 Python 側で `.isdecimal()` post-filter する。
+_LEGACY_LIKE = r"\_\_legacy\_%\_\_"
 _LEGACY_ESCAPE = "\\"
+_LEGACY_PREFIX = "__legacy_"
+_LEGACY_SUFFIX = "__"
 
 # 子テーブル削除順 (FK 整合性のため models DELETE 前にすべて消す)
 _CHILD_DELETE_TABLES: tuple[str, ...] = (
@@ -48,6 +51,23 @@ _CHILD_DELETE_TABLES: tuple[str, ...] = (
 )
 
 
+def _is_canonical_sentinel(model_id: str) -> bool:
+    """`__legacy_<digits>__` 形式のみ canonical sentinel と判定する。
+
+    Worker 側 `AnnotationWorker._is_legacy_sentinel_model_id` と完全に一致させる。
+    LIKE pattern (prefix `\\_\\_legacy\\_%\\_\\_` + ESCAPE) で suffix `__` までは絞り込み
+    済みだが、`<digits>` 部分の数字限定は SQL では厳密に表現できないため Python 側で
+    検査する。例:
+        `__legacy_22__`       → True
+        `__legacy_foo__`      → False (middle が数字でない)
+        `__legacy_22_extra__` → False (middle に `_` を含む)
+    """
+    if not (model_id.startswith(_LEGACY_PREFIX) and model_id.endswith(_LEGACY_SUFFIX)):
+        return False
+    middle = model_id[len(_LEGACY_PREFIX) : -len(_LEGACY_SUFFIX)]
+    return middle.isdecimal()
+
+
 def upgrade() -> None:
     bind = op.get_bind()
     inspector = inspect(bind)
@@ -55,11 +75,14 @@ def upgrade() -> None:
     if "models" not in existing_tables:
         return
 
-    result = bind.execute(
-        text("SELECT id FROM models WHERE litellm_model_id LIKE :pat ESCAPE :esc"),
+    candidate_rows = bind.execute(
+        text("SELECT id, litellm_model_id FROM models WHERE litellm_model_id LIKE :pat ESCAPE :esc"),
         {"pat": _LEGACY_LIKE, "esc": _LEGACY_ESCAPE},
-    )
-    legacy_ids: list[int] = [row[0] for row in result]
+    ).fetchall()
+    legacy_ids: list[int] = [row[0] for row in candidate_rows if _is_canonical_sentinel(row[1])]
+    skipped = [row[1] for row in candidate_rows if not _is_canonical_sentinel(row[1])]
+    if skipped:
+        print(f"[migration a3b4c5d6e7f8] LIKE 候補で除外 (canonical sentinel ではない): {skipped}")
     if not legacy_ids:
         print("[migration a3b4c5d6e7f8] legacy sentinel 行なし、no-op")
         return
@@ -77,21 +100,21 @@ def upgrade() -> None:
             bind.execute(text(f"DELETE FROM {table} WHERE model_id IN ({ids_csv})"))
             print(f"[migration a3b4c5d6e7f8] {table}: {count} 行削除")
 
-    # error_records は model_name 文字列ベース (FK なし)
+    # error_records は model_name 文字列ベース (FK なし)。models と同じ canonical filter
+    # で `__legacy_<digits>__` のみに絞る (SELECT 後 Python post-filter で id を取得)。
     if "error_records" in existing_tables:
-        er_count = (
-            bind.execute(
-                text("SELECT COUNT(*) FROM error_records WHERE model_name LIKE :pat ESCAPE :esc"),
-                {"pat": _LEGACY_LIKE, "esc": _LEGACY_ESCAPE},
-            ).scalar()
-            or 0
-        )
-        if er_count:
-            bind.execute(
-                text("DELETE FROM error_records WHERE model_name LIKE :pat ESCAPE :esc"),
-                {"pat": _LEGACY_LIKE, "esc": _LEGACY_ESCAPE},
-            )
-            print(f"[migration a3b4c5d6e7f8] error_records: {er_count} 行削除")
+        er_candidates = bind.execute(
+            text("SELECT id, model_name FROM error_records WHERE model_name LIKE :pat ESCAPE :esc"),
+            {"pat": _LEGACY_LIKE, "esc": _LEGACY_ESCAPE},
+        ).fetchall()
+        er_ids = [row[0] for row in er_candidates if _is_canonical_sentinel(row[1])]
+        er_skipped = [row[1] for row in er_candidates if not _is_canonical_sentinel(row[1])]
+        if er_skipped:
+            print(f"[migration a3b4c5d6e7f8] error_records LIKE 候補で除外: {er_skipped}")
+        if er_ids:
+            er_ids_csv = ", ".join(str(i) for i in er_ids)
+            bind.execute(text(f"DELETE FROM error_records WHERE id IN ({er_ids_csv})"))
+            print(f"[migration a3b4c5d6e7f8] error_records: {len(er_ids)} 行削除")
 
     bind.execute(text(f"DELETE FROM models WHERE id IN ({ids_csv})"))
     print(f"[migration a3b4c5d6e7f8] models: {len(legacy_ids)} 行削除")

--- a/src/lorairo/database/migrations/versions/a3b4c5d6e7f8_drop_legacy_sentinel_models.py
+++ b/src/lorairo/database/migrations/versions/a3b4c5d6e7f8_drop_legacy_sentinel_models.py
@@ -1,0 +1,110 @@
+"""Drop legacy sentinel models and child references (ADR 0033 Decision 7).
+
+ADR 0023 Phase 1.11 で導入された `litellm_model_id="__legacy_<id>__"` 用 sentinel
+行を models テーブルから削除する。ADR 0033 で「過去 DB 互換は不要」と判断し、
+履歴行として残す運用契約を撤回した。
+
+FK 設定:
+- tags / captions / scores: ondelete=SET NULL
+- score_labels / ratings: ondelete=CASCADE
+- model_function_associations: ondelete 未設定 (明示 DELETE 必須)
+- error_records.model_name: FK ではなく文字列、`__legacy_%` で明示 DELETE
+
+ADR 0033 Decision 7 に従い「該当行も同 migration 内で削除」を一律明示 DELETE で行う。
+SET NULL 設定のテーブルも履歴ごと消す (整合性リスク排除を優先)。
+
+Downgrade: 削除データは復元不可。downgrade は no-op (必要なら backup から手動復元)。
+
+Revision ID: a3b4c5d6e7f8
+Revises: f1b2c3d4e5f6
+Create Date: 2026-05-23
+
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+from sqlalchemy import inspect, text
+
+revision: str = "a3b4c5d6e7f8"
+down_revision: str | None = "f1b2c3d4e5f6"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+# SQL LIKE では `_` が任意 1 文字にマッチするため、リテラル比較するには ESCAPE が必要。
+# `mylegacy-model` 等の非 sentinel ID が誤マッチしないよう、`_` をすべて `\_` でエスケープし
+# 末尾に `%` を付ける (旧形式 `__legacy_<id>__` の前方一致)。
+_LEGACY_LIKE = r"\_\_legacy\_%"
+_LEGACY_ESCAPE = "\\"
+
+# 子テーブル削除順 (FK 整合性のため models DELETE 前にすべて消す)
+_CHILD_DELETE_TABLES: tuple[str, ...] = (
+    "tags",
+    "captions",
+    "scores",
+    "score_labels",
+    "ratings",
+    "model_function_associations",
+)
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = inspect(bind)
+    existing_tables = set(inspector.get_table_names())
+    if "models" not in existing_tables:
+        return
+
+    result = bind.execute(
+        text("SELECT id FROM models WHERE litellm_model_id LIKE :pat ESCAPE :esc"),
+        {"pat": _LEGACY_LIKE, "esc": _LEGACY_ESCAPE},
+    )
+    legacy_ids: list[int] = [row[0] for row in result]
+    if not legacy_ids:
+        print("[migration a3b4c5d6e7f8] legacy sentinel 行なし、no-op")
+        return
+
+    ids_csv = ", ".join(str(i) for i in legacy_ids)
+    print(f"[migration a3b4c5d6e7f8] 対象 models.id=[{ids_csv}] ({len(legacy_ids)} 件)")
+
+    for table in _CHILD_DELETE_TABLES:
+        if table not in existing_tables:
+            continue
+        count = (
+            bind.execute(text(f"SELECT COUNT(*) FROM {table} WHERE model_id IN ({ids_csv})")).scalar() or 0
+        )
+        if count:
+            bind.execute(text(f"DELETE FROM {table} WHERE model_id IN ({ids_csv})"))
+            print(f"[migration a3b4c5d6e7f8] {table}: {count} 行削除")
+
+    # error_records は model_name 文字列ベース (FK なし)
+    if "error_records" in existing_tables:
+        er_count = (
+            bind.execute(
+                text("SELECT COUNT(*) FROM error_records WHERE model_name LIKE :pat ESCAPE :esc"),
+                {"pat": _LEGACY_LIKE, "esc": _LEGACY_ESCAPE},
+            ).scalar()
+            or 0
+        )
+        if er_count:
+            bind.execute(
+                text("DELETE FROM error_records WHERE model_name LIKE :pat ESCAPE :esc"),
+                {"pat": _LEGACY_LIKE, "esc": _LEGACY_ESCAPE},
+            )
+            print(f"[migration a3b4c5d6e7f8] error_records: {er_count} 行削除")
+
+    bind.execute(text(f"DELETE FROM models WHERE id IN ({ids_csv})"))
+    print(f"[migration a3b4c5d6e7f8] models: {len(legacy_ids)} 行削除")
+
+
+def downgrade() -> None:
+    """legacy sentinel データは復元不可。downgrade は no-op。
+
+    元の状態に戻す必要がある場合は、migration 適用前の backup から手動復元する。
+    ADR 0033 で「過去 DB 互換不要」と判断した結果のため、downgrade で sentinel を
+    再生成する意味はない。
+    """
+    print(
+        "[migration a3b4c5d6e7f8 downgrade] no-op: legacy sentinel データは復元不可。"
+        " 必要なら backup から手動復元してください。"
+    )

--- a/src/lorairo/database/migrations/versions/b4c5d6e7f8a9_drop_error_records_retry_count.py
+++ b/src/lorairo/database/migrations/versions/b4c5d6e7f8a9_drop_error_records_retry_count.py
@@ -1,0 +1,61 @@
+"""Drop ErrorRecord.retry_count column (ADR 0033 Decision 8).
+
+ADR 0033 Decision 8 (2026-05-23 訂正版) に従い、`error_records.retry_count`
+カラムを削除する。当初は `resolved_at` も削除対象だったが、Error Log Viewer /
+Error Detail Dialog の手動「解決済みマーク」UX が live のため削除対象外。
+
+`retry_count` は「LoRAIro 側で retry 管理する」設計仮説の遺物で、現状は
+`retry_count=0` 固定 INSERT のみで参照箇所が存在しない。Decision 2 で
+「LoRAIro 側で自動 retry はしない」と確定したため、永続的に未使用。
+
+Downgrade: カラムを INTEGER DEFAULT 0 NOT NULL で再追加する。過去データの
+復元はできない (delete 時点で値は 0 のみだったため、復元する意味もない)。
+
+Revision ID: b4c5d6e7f8a9
+Revises: a3b4c5d6e7f8
+Create Date: 2026-05-23
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy import inspect
+
+revision: str = "b4c5d6e7f8a9"
+down_revision: str | None = "a3b4c5d6e7f8"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def _table_exists(table: str) -> bool:
+    return table in inspect(op.get_bind()).get_table_names()
+
+
+def _has_column(table: str, column: str) -> bool:
+    if not _table_exists(table):
+        return False
+    return any(col["name"] == column for col in inspect(op.get_bind()).get_columns(table))
+
+
+def upgrade() -> None:
+    if not _has_column("error_records", "retry_count"):
+        return
+    with op.batch_alter_table("error_records") as batch_op:
+        batch_op.drop_column("retry_count")
+
+
+def downgrade() -> None:
+    # テーブル不在 or カラムが既に存在する場合は no-op
+    if not _table_exists("error_records") or _has_column("error_records", "retry_count"):
+        return
+    with op.batch_alter_table("error_records") as batch_op:
+        batch_op.add_column(
+            sa.Column(
+                "retry_count",
+                sa.Integer(),
+                nullable=False,
+                server_default="0",
+            )
+        )

--- a/src/lorairo/database/schema.py
+++ b/src/lorairo/database/schema.py
@@ -446,8 +446,8 @@ class ErrorRecord(Base):
     file_path: Mapped[str | None] = mapped_column(String)
     model_name: Mapped[str | None] = mapped_column(String)
 
-    # 再試行管理
-    retry_count: Mapped[int] = mapped_column(Integer, default=0, nullable=False)
+    # 手動「解決済みマーク」管理 (Error Log Viewer / Detail Dialog で利用)
+    # ADR 0033 Decision 8: retry_count は drop 済み (LoRAIro 側で自動 retry はしない)
     resolved_at: Mapped[datetime.datetime | None] = mapped_column(TIMESTAMP(timezone=True))
 
     # タイムスタンプ
@@ -611,6 +611,5 @@ class ErrorRecordData(TypedDict):
     stack_trace: NotRequired[str | None]
     file_path: NotRequired[str | None]
     model_name: NotRequired[str | None]
-    retry_count: NotRequired[int]
     resolved_at: NotRequired[datetime.datetime | None]
     created_at: NotRequired[datetime.datetime]

--- a/src/lorairo/gui/designer/ErrorDetailDialog.ui
+++ b/src/lorairo/gui/designer/ErrorDetailDialog.ui
@@ -132,27 +132,13 @@
        </widget>
       </item>
       <item row="6" column="0">
-       <widget class="QLabel" name="labelRetryCountText">
-        <property name="text">
-         <string>再試行回数:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="6" column="1">
-       <widget class="QLineEdit" name="lineEditRetryCount">
-        <property name="readOnly">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
-      <item row="7" column="0">
        <widget class="QLabel" name="labelResolvedAtText">
         <property name="text">
          <string>解決日時:</string>
         </property>
        </widget>
       </item>
-      <item row="7" column="1">
+      <item row="6" column="1">
        <widget class="QLineEdit" name="lineEditResolvedAt">
         <property name="readOnly">
          <bool>true</bool>

--- a/src/lorairo/gui/designer/ErrorDetailDialog_ui.py
+++ b/src/lorairo/gui/designer/ErrorDetailDialog_ui.py
@@ -102,27 +102,16 @@ class Ui_ErrorDetailDialog(object):
 
         self.formLayoutBasicInfo.setWidget(5, QFormLayout.ItemRole.FieldRole, self.lineEditCreatedAt)
 
-        self.labelRetryCountText = QLabel(self.groupBoxBasicInfo)
-        self.labelRetryCountText.setObjectName(u"labelRetryCountText")
-
-        self.formLayoutBasicInfo.setWidget(6, QFormLayout.ItemRole.LabelRole, self.labelRetryCountText)
-
-        self.lineEditRetryCount = QLineEdit(self.groupBoxBasicInfo)
-        self.lineEditRetryCount.setObjectName(u"lineEditRetryCount")
-        self.lineEditRetryCount.setReadOnly(True)
-
-        self.formLayoutBasicInfo.setWidget(6, QFormLayout.ItemRole.FieldRole, self.lineEditRetryCount)
-
         self.labelResolvedAtText = QLabel(self.groupBoxBasicInfo)
         self.labelResolvedAtText.setObjectName(u"labelResolvedAtText")
 
-        self.formLayoutBasicInfo.setWidget(7, QFormLayout.ItemRole.LabelRole, self.labelResolvedAtText)
+        self.formLayoutBasicInfo.setWidget(6, QFormLayout.ItemRole.LabelRole, self.labelResolvedAtText)
 
         self.lineEditResolvedAt = QLineEdit(self.groupBoxBasicInfo)
         self.lineEditResolvedAt.setObjectName(u"lineEditResolvedAt")
         self.lineEditResolvedAt.setReadOnly(True)
 
-        self.formLayoutBasicInfo.setWidget(7, QFormLayout.ItemRole.FieldRole, self.lineEditResolvedAt)
+        self.formLayoutBasicInfo.setWidget(6, QFormLayout.ItemRole.FieldRole, self.lineEditResolvedAt)
 
 
         self.verticalLayoutMain.addWidget(self.groupBoxBasicInfo)
@@ -192,7 +181,6 @@ class Ui_ErrorDetailDialog(object):
         self.labelFilePathText.setText(QCoreApplication.translate("ErrorDetailDialog", u"\u753b\u50cf\u30d1\u30b9:", None))
         self.labelModelNameText.setText(QCoreApplication.translate("ErrorDetailDialog", u"\u30e2\u30c7\u30eb\u540d:", None))
         self.labelCreatedAtText.setText(QCoreApplication.translate("ErrorDetailDialog", u"\u4f5c\u6210\u65e5\u6642:", None))
-        self.labelRetryCountText.setText(QCoreApplication.translate("ErrorDetailDialog", u"\u518d\u8a66\u884c\u56de\u6570:", None))
         self.labelResolvedAtText.setText(QCoreApplication.translate("ErrorDetailDialog", u"\u89e3\u6c7a\u65e5\u6642:", None))
         self.groupBoxStackTrace.setTitle(QCoreApplication.translate("ErrorDetailDialog", u"\u30b9\u30bf\u30c3\u30af\u30c8\u30ec\u30fc\u30b9", None))
         self.groupBoxImagePreview.setTitle(QCoreApplication.translate("ErrorDetailDialog", u"\u753b\u50cf\u30d7\u30ec\u30d3\u30e5\u30fc", None))
@@ -200,3 +188,4 @@ class Ui_ErrorDetailDialog(object):
         self.buttonMarkResolved.setText(QCoreApplication.translate("ErrorDetailDialog", u"\u89e3\u6c7a\u6e08\u307f\u306b\u30de\u30fc\u30af", None))
         self.buttonClose.setText(QCoreApplication.translate("ErrorDetailDialog", u"\u9589\u3058\u308b", None))
     # retranslateUi
+

--- a/src/lorairo/gui/widgets/error_detail_dialog.py
+++ b/src/lorairo/gui/widgets/error_detail_dialog.py
@@ -108,7 +108,6 @@ class ErrorDetailDialog(QDialog, Ui_ErrorDetailDialog):
         self.lineEditFilePath.setText(record.file_path if record.file_path else "N/A")
         self.lineEditModelName.setText(record.model_name if record.model_name else "N/A")
         self.lineEditCreatedAt.setText(record.created_at.strftime("%Y-%m-%d %H:%M:%S"))
-        self.lineEditRetryCount.setText(str(record.retry_count))
 
         # 解決日時
         if record.resolved_at:

--- a/tests/unit/database/test_migration_a3b4c5d6e7f8_drop_legacy_sentinel.py
+++ b/tests/unit/database/test_migration_a3b4c5d6e7f8_drop_legacy_sentinel.py
@@ -51,16 +51,16 @@ def test_sentinel_rows_are_removed_and_non_sentinel_preserved(tmp_path: Path) ->
                 """
             )
         )
-        # 削除対象: legacy sentinel
+        # 削除対象: canonical sentinel (`__legacy_<digits>__`)
         conn.execute(
             text("INSERT INTO models (id, name, litellm_model_id) VALUES (1, 'a', '__legacy_17__')")
         )
         conn.execute(
             text("INSERT INTO models (id, name, litellm_model_id) VALUES (2, 'b', '__legacy_22__')")
         )
-        # 削除されてはいけない: `_` をワイルドカード扱いすると `__legacy_` プレフィックス
-        # でないが `_` 含む ID が誤マッチする可能性。これらが残ることで ESCAPE が効いている
-        # ことを保証する (Codex P1-1 regression test)。
+        # 削除されてはいけない (Codex P1-1 / P2 regression):
+        # - `_` をワイルドカード扱いすると `mylegacy-foo` 等が誤マッチ (P1-1)
+        # - 末尾 `__` を見ない / middle が digits 以外でも誤マッチ (P2)
         conn.execute(
             text("INSERT INTO models (id, name, litellm_model_id) VALUES (3, 'c', 'mylegacy-model')")
         )
@@ -69,6 +69,14 @@ def test_sentinel_rows_are_removed_and_non_sentinel_preserved(tmp_path: Path) ->
         )
         conn.execute(
             text("INSERT INTO models (id, name, litellm_model_id) VALUES (5, 'e', 'openai/gpt-4o')")
+        )
+        # P2: prefix だけ満たすが non-canonical (suffix `__` 無し / middle が non-digit)
+        conn.execute(
+            text("INSERT INTO models (id, name, litellm_model_id) VALUES (6, 'f', '__legacy_foo__')")
+        )
+        conn.execute(text("INSERT INTO models (id, name, litellm_model_id) VALUES (7, 'g', '__legacy_99')"))
+        conn.execute(
+            text("INSERT INTO models (id, name, litellm_model_id) VALUES (8, 'h', '__legacy_22_extra__')")
         )
         # alembic_version を `f1b2c3d4e5f6` (a3b4c5d6e7f8 の down_revision) に
         # 直接スタンプして、対象 migration だけを走らせる
@@ -85,10 +93,14 @@ def test_sentinel_rows_are_removed_and_non_sentinel_preserved(tmp_path: Path) ->
         }
     engine.dispose()
 
-    # legacy sentinel は両方削除
+    # canonical sentinel は削除
     assert "__legacy_17__" not in remaining
     assert "__legacy_22__" not in remaining
-    # 非 sentinel は残る (ESCAPE で wildcard 誤マッチを防ぐ)
+    # 非 sentinel は残る (P1-1: ESCAPE wildcard / P2: canonical filter)
     assert "mylegacy-model" in remaining
     assert "xxlegacyZmodel" in remaining
     assert "openai/gpt-4o" in remaining
+    # P2: prefix だけ満たすが non-canonical (middle non-digit / 末尾 __ 無し / extra _)
+    assert "__legacy_foo__" in remaining
+    assert "__legacy_99" in remaining
+    assert "__legacy_22_extra__" in remaining

--- a/tests/unit/database/test_migration_a3b4c5d6e7f8_drop_legacy_sentinel.py
+++ b/tests/unit/database/test_migration_a3b4c5d6e7f8_drop_legacy_sentinel.py
@@ -1,0 +1,94 @@
+"""Alembic migration `a3b4c5d6e7f8` legacy sentinel removal checks.
+
+ADR 0033 Decision 7 で導入された `__legacy_<id>__` sentinel 行削除 migration の
+verification。Codex P1-1 指摘 (LIKE wildcard 誤マッチ) の regression 防止も含む。
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from alembic import command
+from alembic.config import Config
+from sqlalchemy import create_engine, text
+
+
+def _make_alembic_config(db_path: Path) -> Config:
+    project_root = Path(__file__).resolve().parents[3]
+    cfg = Config(str(project_root / "alembic.ini"))
+    cfg.set_main_option("script_location", str(project_root / "src/lorairo/database/migrations"))
+    cfg.set_main_option("sqlalchemy.url", f"sqlite:///{db_path}")
+    return cfg
+
+
+@pytest.mark.unit
+def test_sentinel_rows_are_removed_and_non_sentinel_preserved(tmp_path: Path) -> None:
+    """`__legacy_<id>__` sentinel のみ削除され、非 sentinel 行は残る。
+
+    Codex P1-1 (PR #407) で指摘された LIKE wildcard 誤マッチを防ぐ。
+    SQL LIKE で `_` がワイルドカード扱いされると `mylegacy-foo` 等も削除対象になる
+    可能性があったため、ESCAPE 句で literal 化していることを保証する。
+    """
+    db = tmp_path / "legacy.db"
+    engine = create_engine(f"sqlite:///{db}")
+    with engine.begin() as conn:
+        conn.execute(
+            text(
+                """
+                CREATE TABLE models (
+                    id INTEGER NOT NULL PRIMARY KEY,
+                    name VARCHAR NOT NULL,
+                    provider VARCHAR,
+                    discontinued_at TIMESTAMP,
+                    litellm_model_id VARCHAR NOT NULL,
+                    estimated_size_gb FLOAT,
+                    requires_api_key BOOLEAN DEFAULT '0' NOT NULL,
+                    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
+                    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
+                    UNIQUE (litellm_model_id)
+                )
+                """
+            )
+        )
+        # 削除対象: legacy sentinel
+        conn.execute(
+            text("INSERT INTO models (id, name, litellm_model_id) VALUES (1, 'a', '__legacy_17__')")
+        )
+        conn.execute(
+            text("INSERT INTO models (id, name, litellm_model_id) VALUES (2, 'b', '__legacy_22__')")
+        )
+        # 削除されてはいけない: `_` をワイルドカード扱いすると `__legacy_` プレフィックス
+        # でないが `_` 含む ID が誤マッチする可能性。これらが残ることで ESCAPE が効いている
+        # ことを保証する (Codex P1-1 regression test)。
+        conn.execute(
+            text("INSERT INTO models (id, name, litellm_model_id) VALUES (3, 'c', 'mylegacy-model')")
+        )
+        conn.execute(
+            text("INSERT INTO models (id, name, litellm_model_id) VALUES (4, 'd', 'xxlegacyZmodel')")
+        )
+        conn.execute(
+            text("INSERT INTO models (id, name, litellm_model_id) VALUES (5, 'e', 'openai/gpt-4o')")
+        )
+        # alembic_version を `f1b2c3d4e5f6` (a3b4c5d6e7f8 の down_revision) に
+        # 直接スタンプして、対象 migration だけを走らせる
+        conn.execute(text("CREATE TABLE alembic_version (version_num VARCHAR(32) PRIMARY KEY)"))
+        conn.execute(text("INSERT INTO alembic_version (version_num) VALUES ('f1b2c3d4e5f6')"))
+    engine.dispose()
+
+    command.upgrade(_make_alembic_config(db), "a3b4c5d6e7f8")
+
+    engine = create_engine(f"sqlite:///{db}")
+    with engine.connect() as conn:
+        remaining = {
+            row.litellm_model_id for row in conn.execute(text("SELECT litellm_model_id FROM models"))
+        }
+    engine.dispose()
+
+    # legacy sentinel は両方削除
+    assert "__legacy_17__" not in remaining
+    assert "__legacy_22__" not in remaining
+    # 非 sentinel は残る (ESCAPE で wildcard 誤マッチを防ぐ)
+    assert "mylegacy-model" in remaining
+    assert "xxlegacyZmodel" in remaining
+    assert "openai/gpt-4o" in remaining

--- a/tests/unit/database/test_migration_a7b8c9d0e1f2_score_labels.py
+++ b/tests/unit/database/test_migration_a7b8c9d0e1f2_score_labels.py
@@ -121,7 +121,7 @@ def test_score_labels_migration_converges_when_table_was_precreated(tmp_path: Pa
         version = conn.execute(text("SELECT version_num FROM alembic_version")).scalar_one()
     engine.dispose()
 
-    assert version == "a3b4c5d6e7f8"
+    assert version == "b4c5d6e7f8a9"
     assert "ix_score_labels_image_id" in indexes
 
 
@@ -142,7 +142,7 @@ def test_project_database_prepare_upgrades_alembic_managed_db(tmp_path: Path) ->
         score_label_count = conn.execute(text("SELECT count(*) FROM score_labels")).scalar_one()
     engine.dispose()
 
-    assert version == "a3b4c5d6e7f8"
+    assert version == "b4c5d6e7f8a9"
     assert score_label_count == 0
 
 

--- a/tests/unit/database/test_migration_a7b8c9d0e1f2_score_labels.py
+++ b/tests/unit/database/test_migration_a7b8c9d0e1f2_score_labels.py
@@ -121,7 +121,7 @@ def test_score_labels_migration_converges_when_table_was_precreated(tmp_path: Pa
         version = conn.execute(text("SELECT version_num FROM alembic_version")).scalar_one()
     engine.dispose()
 
-    assert version == "f1b2c3d4e5f6"
+    assert version == "a3b4c5d6e7f8"
     assert "ix_score_labels_image_id" in indexes
 
 
@@ -142,7 +142,7 @@ def test_project_database_prepare_upgrades_alembic_managed_db(tmp_path: Path) ->
         score_label_count = conn.execute(text("SELECT count(*) FROM score_labels")).scalar_one()
     engine.dispose()
 
-    assert version == "f1b2c3d4e5f6"
+    assert version == "a3b4c5d6e7f8"
     assert score_label_count == 0
 
 

--- a/tests/unit/database/test_migration_d8e9f0a1b2c3_litellm_unique.py
+++ b/tests/unit/database/test_migration_d8e9f0a1b2c3_litellm_unique.py
@@ -201,7 +201,11 @@ class TestLitellmModelIdMigration:
         engine.dispose()
 
     def test_unknown_provider_falls_back_to_legacy_sentinel(self, tmp_path: Path) -> None:
-        """ローカル ML モデル (`provider=None`/`xinntao` 等) は `__legacy_<id>__` sentinel に落ちる。"""
+        """ローカル ML モデル (`provider=None`/`xinntao` 等) は `__legacy_<id>__` sentinel に落ちる。
+
+        Note: ADR 0033 Decision 7 (migration a3b4c5d6e7f8) で legacy sentinel 行は最終的に
+        削除されるため、本テストでは d8e9f0a1b2c3 までの状態で sentinel 割り当てを検証する。
+        """
         db = tmp_path / "test.db"
         _create_legacy_schema(db)
         engine = create_engine(f"sqlite:///{db}")
@@ -212,7 +216,8 @@ class TestLitellmModelIdMigration:
             )
         engine.dispose()
 
-        _upgrade_to_head(db)
+        # d8e9f0a1b2c3 まで upgrade (legacy sentinel が割り当てられる時点で停止)
+        command.upgrade(_make_alembic_config(db), "d8e9f0a1b2c3")
 
         engine = create_engine(f"sqlite:///{db}")
         with engine.connect() as conn:
@@ -232,6 +237,9 @@ class TestLitellmModelIdMigration:
         `name='openai/gpt-4o'` (slash) と `name='gpt-4o', provider='openai'` (bare) が
         共存していた場合、Step 2/4 で両行が同じ `litellm_model_id='openai/gpt-4o'` を持つ。
         Step 5.5 (dedup) で最古 (id 最小) のみ正規 ID を保持し、残りは sentinel に変換される。
+
+        Note: ADR 0033 Decision 7 (migration a3b4c5d6e7f8) で sentinel 行は最終的に削除される。
+        本テストでは衝突解消挙動 (d8e9f0a1b2c3) を検証するため、d8 までで停止する。
         """
         db = tmp_path / "test.db"
         _create_legacy_schema(db)
@@ -242,7 +250,8 @@ class TestLitellmModelIdMigration:
             conn.execute(text("INSERT INTO models (id, name, provider) VALUES (2, 'gpt-4o', 'openai')"))
         engine.dispose()
 
-        _upgrade_to_head(db)
+        # d8e9f0a1b2c3 まで upgrade (sentinel 衝突解消挙動を保持)
+        command.upgrade(_make_alembic_config(db), "d8e9f0a1b2c3")
 
         engine = create_engine(f"sqlite:///{db}")
         with engine.connect() as conn:

--- a/tests/unit/database/test_migration_f1b2c3d4e5f6_ratings_backfill.py
+++ b/tests/unit/database/test_migration_f1b2c3d4e5f6_ratings_backfill.py
@@ -113,7 +113,7 @@ def test_ratings_backfill_adds_associations_for_known_rating_models(tmp_path: Pa
         version = conn.execute(text("SELECT version_num FROM alembic_version")).scalar_one()
     engine.dispose()
 
-    assert version == "f1b2c3d4e5f6"
+    assert version == "a3b4c5d6e7f8"
     assert rows == [
         ("wd-vit-tagger-v3", "tags,ratings"),
         ("Z3D-E621-Convnext", "tags,ratings"),

--- a/tests/unit/database/test_migration_f1b2c3d4e5f6_ratings_backfill.py
+++ b/tests/unit/database/test_migration_f1b2c3d4e5f6_ratings_backfill.py
@@ -113,7 +113,7 @@ def test_ratings_backfill_adds_associations_for_known_rating_models(tmp_path: Pa
         version = conn.execute(text("SELECT version_num FROM alembic_version")).scalar_one()
     engine.dispose()
 
-    assert version == "a3b4c5d6e7f8"
+    assert version == "b4c5d6e7f8a9"
     assert rows == [
         ("wd-vit-tagger-v3", "tags,ratings"),
         ("Z3D-E621-Convnext", "tags,ratings"),

--- a/tests/unit/gui/widgets/test_error_detail_dialog.py
+++ b/tests/unit/gui/widgets/test_error_detail_dialog.py
@@ -32,7 +32,6 @@ def sample_error_record():
         error_message="Test error message for unit testing",
         file_path="/path/to/test_image.jpg",
         model_name="test-model-v1",
-        retry_count=2,
         resolved_at=None,
         created_at=datetime.datetime(2025, 11, 24, 12, 0, 0),
         stack_trace="Traceback (most recent call last):\n  File test.py, line 10\n    raise APIError()",
@@ -49,7 +48,6 @@ def resolved_error_record():
         error_message="File not accessible",
         file_path="/path/to/missing.jpg",
         model_name=None,
-        retry_count=0,
         resolved_at=datetime.datetime(2025, 11, 24, 13, 0, 0),
         created_at=datetime.datetime(2025, 11, 24, 12, 30, 0),
         stack_trace=None,
@@ -113,7 +111,6 @@ class TestErrorDetailDialogUIUpdate:
         assert dialog.lineEditErrorType.text() == "APIError"
         assert dialog.lineEditFilePath.text() == "/path/to/test_image.jpg"
         assert dialog.lineEditModelName.text() == "test-model-v1"
-        assert dialog.lineEditRetryCount.text() == "2"
         assert dialog.lineEditResolvedAt.text() == "未解決"
 
         # 解決マークボタン有効確認
@@ -225,7 +222,6 @@ class TestErrorDetailDialogImagePreview:
             error_message="No file path",
             file_path=None,
             model_name=None,
-            retry_count=0,
             resolved_at=None,
             created_at=datetime.datetime(2025, 11, 24, 12, 0, 0),
         )

--- a/tests/unit/gui/widgets/test_error_log_viewer_widget.py
+++ b/tests/unit/gui/widgets/test_error_log_viewer_widget.py
@@ -42,7 +42,6 @@ def sample_error_record():
         error_message="Test error message",
         file_path="/path/to/image.jpg",
         model_name="test-model",
-        retry_count=0,
         resolved_at=None,
         created_at=datetime.datetime(2025, 11, 24, 12, 0, 0),
     )
@@ -248,7 +247,6 @@ class TestErrorLogViewerWidgetActions:
             error_message="Resolved error",
             file_path="/path/to/file.jpg",
             model_name=None,
-            retry_count=0,
             resolved_at=datetime.datetime(2025, 11, 24, 13, 0, 0),
             created_at=datetime.datetime(2025, 11, 24, 12, 0, 0),
         )
@@ -302,7 +300,6 @@ class TestMarkResolvedMultiSelect:
             error_message="Second error message",
             file_path=None,
             model_name=None,
-            retry_count=0,
             resolved_at=None,
             created_at=datetime.datetime(2025, 11, 25, 12, 0, 0),
         )
@@ -432,7 +429,6 @@ class TestErrorLogViewerWidgetTableDisplay:
             error_message="File not found",
             file_path="/path/to/missing.jpg",
             model_name=None,
-            retry_count=1,
             resolved_at=datetime.datetime(2025, 11, 24, 13, 0, 0),
             created_at=datetime.datetime(2025, 11, 24, 12, 0, 0),
         )


### PR DESCRIPTION
ADR 0033 Decision 7 / 8 (amended) の DB schema 変更を実装。Wave 1 / PR-A。

CI-EQUIV-TESTED

## Summary

- **migration `a3b4c5d6e7f8`**: `__legacy_<id>__` sentinel models と子テーブル参照行を削除 (#397)
- **migration `b4c5d6e7f8a9`**: `error_records.retry_count` カラムを drop (#398)
- 関連 schema (`ErrorRecord`, `ErrorRecordData`) / UI (`ErrorDetailDialog.ui`, `_ui.py`) / Dialog コード / unit tests を整合させる
- `resolved_at` は **GUI 機能 (Error Log Viewer の手動「解決済みマーク」) で live のため保持**。ADR 0033 Decision 8 を 2026-05-23 に訂正済み (commit `f09417c2`)

## Codex P1-1 fix (migration A LIKE wildcard)

修正前: `litellm_model_id LIKE '__legacy_%'`
- SQL では `_` が任意 1 文字ワイルドカード
- `mylegacy-model`, `xxlegacyZ...`, `12legacyfoo` 等の非 sentinel ID も誤マッチ

修正後: `litellm_model_id LIKE :pat ESCAPE :esc` with `pat='\_\_legacy\_%', esc='\\'`
- `\_` は literal `_` を意味し、ワイルドカード扱いされない
- 新規 regression test `test_sentinel_rows_are_removed_and_non_sentinel_preserved` で look-alike ID が残ることを保証

## Codex P1-2 (unmanaged legacy DB) — 却下

Codex 指摘: `_prepare_project_database()` が `alembic_version` テーブル不在の DB に対し migration skip するため、`retry_count` 削除後に `save_error_record` が NOT NULL 違反で破綻する。

**判断**: 却下。**ADR 0033 Decision 7 で「過去 DB 互換は不要」と明示的に方針決定済み** (LoRAIro は開発フェーズ、過去アノテーション履歴を保持する業務要件なし)。Decision 8 (`retry_count` drop) も同じ互換切り捨て方針の一部。

unmanaged DB ユーザーは LoRAIro 側で救済しない (alembic 管理に変換するか、新規 DB 作成して再構築するか自己責任)。LoRAIro は alembic 管理 DB のみを公式サポート対象とする。

## Migration 詳細

### `a3b4c5d6e7f8_drop_legacy_sentinel_models`

- 対象: `models WHERE litellm_model_id LIKE '\_\_legacy\_%' ESCAPE '\\'`
- 子テーブル削除 (FK 設定が SET NULL / CASCADE / no-action と異種なので、整合性のため全て明示 DELETE):
  - `tags`, `captions`, `scores`, `score_labels`, `ratings`, `model_function_associations`
  - `error_records` (`model_name LIKE '\_\_legacy\_%' ESCAPE '\\'`)
- テーブル存在チェック付き (古いマイグレーション断面でも no-op 動作)
- downgrade: no-op (削除データは復元不可)

### `b4c5d6e7f8a9_drop_error_records_retry_count`

- `error_records.retry_count` カラムを `batch_alter_table` で drop
- カラム存在チェック付き (テスト断面に retry_count が無いケースで no-op)
- downgrade: `INTEGER DEFAULT 0 NOT NULL` で再追加

## Test plan

- [x] CI-equivalent filter: `pytest -m "not gui_show and not calls_real_webapi and not downloads_and_runs_model and not slow"` → **2569 passed, 2 skipped, 1 deselected**
- [x] `test_migration_d8e9f0a1b2c3_litellm_unique` の sentinel 関連テストは `d8e9f0a1b2c3` までで stop するよう調整
- [x] `test_migration_a7b8c9d0e1f2_score_labels`, `test_migration_f1b2c3d4e5f6_ratings_backfill` の `version_num` assertion を新 head (`b4c5d6e7f8a9`) に更新
- [x] 新規 ESCAPE regression test `test_sentinel_rows_are_removed_and_non_sentinel_preserved` pass
- [x] `ruff format` / `ruff check` クリア

## 関連

- Closes #397
- Closes #398
- ADR 0033 Decision 7 / 8 (amended `f09417c2`)
- 前提: ADR 0023 Phase 1.11 (撤回対象、後続 PR-C で明記)

🤖 Generated with [Claude Code](https://claude.com/claude-code)