### PR TITLE
test(bdd): scaffold AnnotationWorker failure propagation scenarios (#406)

### DIFF
--- a/tests/bdd/features/annotation_worker_failure_propagation.feature
+++ b/tests/bdd/features/annotation_worker_failure_propagation.feature
@@ -1,0 +1,40 @@
+# language: ja
+機能: AnnotationWorker の部分失敗階層伝播
+  ADR 0033 Decision 2 / 3 / 4 に従い、AnnotationWorker は失敗を 3 階層に分類する。
+  L1 (lib `result.error` で表現される期待された失敗) は `error_records` に保存せず、
+  L2 (lib 呼び出しの想定外例外) と L3 (Worker 自身の前提崩れ) のみを記録する。
+  内部整合性違反は `error_type='integrity_violation'` で別カテゴリとして記録する。
+
+  背景:
+    前提 AnnotationWorker が 2 モデル × 3 画像のタスクで初期化されている
+    かつ db_manager および model_registry が利用可能である
+
+  シナリオ: L1 - lib が result.error で rate_limited を返す
+    前提 image-annotator-lib がモデル "model-a" で全画像に対し result.error="rate_limited" を返す
+    かつ モデル "model-b" は全画像で成功する
+    もし AnnotationWorker を実行する
+    ならば error_records テーブルに該当 row は追加されない
+    かつ model_statistics の "model-a" の error_count は 3 である
+    かつ model_statistics の "model-b" の success_count は 3 である
+    かつ サマリーダイアログの model_errors に "model-a" のエラーが含まれる
+
+  シナリオ: L2 - モデルの lib 呼び出しが RuntimeError を raise
+    前提 image-annotator-lib がモデル "model-b" の呼び出しで RuntimeError を raise する
+    かつ モデル "model-a" は全画像で成功する
+    もし AnnotationWorker を実行する
+    ならば error_records テーブルに 3 行追加される (対象モデル="model-b")
+    かつ 各 row の error_type は "lib_call_exception" または例外型名である
+    かつ モデル "model-a" の処理は完了する
+
+  シナリオ: L3 - refusal filter で致命例外が発生してバッチ中断
+    前提 refusal filter が ValueError を raise する
+    もし AnnotationWorker を実行する
+    ならば error_records テーブルに 3 行追加される (model_name は NULL)
+    かつ 各 row の error_type は "fatal" または例外型名である
+    かつ Worker は失敗 Signal を emit する
+
+  シナリオ: integrity_violation - 想定外の model_id が結果に含まれる
+    前提 image-annotator-lib が litellm_model_ids に含まれない model_id "unknown-model" を結果に混入させる
+    もし AnnotationWorker を実行する
+    ならば error_records テーブルに該当 row が追加され error_type は "integrity_violation" である
+    かつ サマリーダイアログの integrity_violation 専用セクションに該当エントリが表示される

--- a/tests/bdd/steps/test_annotation_worker_failure_propagation.py
+++ b/tests/bdd/steps/test_annotation_worker_failure_propagation.py
@@ -1,0 +1,118 @@
+"""AnnotationWorker 部分失敗階層伝播 BDD step skeleton (ADR 0033 #406).
+
+Worker 側の修正 (#399-#403) が未完了の段階では各 step が `pytest.skip` で保留される。
+Worker 側 PR が main に merge されたら、対応する step を実装に置き換える。
+"""
+
+from pathlib import Path
+
+import pytest
+from pytest_bdd import given, parsers, scenarios, then, when
+
+_FEATURE_FILE = Path(__file__).parent.parent / "features" / "annotation_worker_failure_propagation.feature"
+scenarios(str(_FEATURE_FILE))
+
+_PENDING_MESSAGE = (
+    "pending: AnnotationWorker 部分失敗階層伝播の実装 (ADR 0033 #400/#401/#402/#403) 完了待ち"
+)
+
+
+@given("AnnotationWorker が 2 モデル × 3 画像のタスクで初期化されている", target_fixture="worker_ctx")
+def given_worker_initialized() -> dict[str, object]:
+    pytest.skip(_PENDING_MESSAGE)
+
+
+@given("db_manager および model_registry が利用可能である")
+def given_db_and_registry() -> None:
+    pytest.skip(_PENDING_MESSAGE)
+
+
+@given(
+    parsers.parse('image-annotator-lib がモデル "{model}" で全画像に対し result.error="{message}" を返す')
+)
+def given_lib_returns_result_error(model: str, message: str) -> None:
+    pytest.skip(_PENDING_MESSAGE)
+
+
+@given(parsers.parse('モデル "{model}" は全画像で成功する'))
+def given_model_succeeds(model: str) -> None:
+    pytest.skip(_PENDING_MESSAGE)
+
+
+@given(parsers.parse('image-annotator-lib がモデル "{model}" の呼び出しで {exc_type} を raise する'))
+def given_lib_raises_exception(model: str, exc_type: str) -> None:
+    pytest.skip(_PENDING_MESSAGE)
+
+
+@given(parsers.parse("refusal filter が {exc_type} を raise する"))
+def given_refusal_filter_raises(exc_type: str) -> None:
+    pytest.skip(_PENDING_MESSAGE)
+
+
+@given(
+    parsers.parse(
+        'image-annotator-lib が litellm_model_ids に含まれない model_id "{model_id}" を結果に混入させる'
+    )
+)
+def given_lib_inserts_unknown_model_id(model_id: str) -> None:
+    pytest.skip(_PENDING_MESSAGE)
+
+
+@when("AnnotationWorker を実行する")
+def when_run_worker() -> None:
+    pytest.skip(_PENDING_MESSAGE)
+
+
+@then("error_records テーブルに該当 row は追加されない")
+def then_no_error_records_added() -> None:
+    pytest.skip(_PENDING_MESSAGE)
+
+
+@then(parsers.parse('model_statistics の "{model}" の error_count は {count:d} である'))
+def then_error_count_equals(model: str, count: int) -> None:
+    pytest.skip(_PENDING_MESSAGE)
+
+
+@then(parsers.parse('model_statistics の "{model}" の success_count は {count:d} である'))
+def then_success_count_equals(model: str, count: int) -> None:
+    pytest.skip(_PENDING_MESSAGE)
+
+
+@then(parsers.parse('サマリーダイアログの model_errors に "{model}" のエラーが含まれる'))
+def then_summary_includes_model_error(model: str) -> None:
+    pytest.skip(_PENDING_MESSAGE)
+
+
+@then(parsers.parse('error_records テーブルに {count:d} 行追加される (対象モデル="{model}")'))
+def then_error_records_added_for_model(count: int, model: str) -> None:
+    pytest.skip(_PENDING_MESSAGE)
+
+
+@then(parsers.parse('各 row の error_type は "{expected}" または例外型名である'))
+def then_error_type_matches(expected: str) -> None:
+    pytest.skip(_PENDING_MESSAGE)
+
+
+@then(parsers.parse('モデル "{model}" の処理は完了する'))
+def then_model_completes(model: str) -> None:
+    pytest.skip(_PENDING_MESSAGE)
+
+
+@then(parsers.parse("error_records テーブルに {count:d} 行追加される (model_name は NULL)"))
+def then_error_records_added_no_model(count: int) -> None:
+    pytest.skip(_PENDING_MESSAGE)
+
+
+@then("Worker は失敗 Signal を emit する")
+def then_worker_emits_failure_signal() -> None:
+    pytest.skip(_PENDING_MESSAGE)
+
+
+@then(parsers.parse('error_records テーブルに該当 row が追加され error_type は "{expected}" である'))
+def then_integrity_violation_recorded(expected: str) -> None:
+    pytest.skip(_PENDING_MESSAGE)
+
+
+@then("サマリーダイアログの integrity_violation 専用セクションに該当エントリが表示される")
+def then_integrity_violation_displayed() -> None:
+    pytest.skip(_PENDING_MESSAGE)


### PR DESCRIPTION
ADR 0033 Decision 2/3/4 の 3 階層失敗伝播 (L1/L2/L3 + integrity_violation) を BDD scenarios として skeleton 化する。Worker 側修正 (#400-#403) の完了を待って step を実装する段階的アプローチ。

## Summary

- 新規 feature: `tests/bdd/features/annotation_worker_failure_propagation.feature` — Gherkin で 4 scenarios
- 新規 step skeleton: `tests/bdd/steps/test_annotation_worker_failure_propagation.py` — 全 step が `pytest.skip` で pending
- Worker 修正 PR merge 後、対応する step を実装で置き換える

## Scenarios

1. **L1**: lib が `result.error="rate_limited"` を返す → error_records 追加なし、model_statistics.error_count++ のみ
2. **L2**: lib 呼び出しが RuntimeError raise → error_records に `lib_call_exception` 記録、他モデル続行
3. **L3**: refusal filter で ValueError → error_records に `fatal` 記録、Worker 失敗 Signal
4. **integrity_violation**: 想定外 model_id 混入 → `error_type='integrity_violation'` で記録、Dialog 専用セクション

## Test plan

- [x] `pytest tests/bdd/steps/test_annotation_worker_failure_propagation.py -v` → 4 scenarios collected, 全 skipped (期待挙動)
- [x] `ruff format` / `ruff check` クリア
- [ ] Worker 修正 PR merge 後、step 実装に置き換え (本 PR では skeleton のみ)

## 関連

- Closes #406
- ADR 0033 Decision 2/3/4
- 依存: PR-B (Worker 統合、未起票) merge 後に step 実装フォローアップ

🤖 Generated with [Claude Code](https://claude.com/claude-code)