### PR TITLE
feat: show model rating details

### DIFF
--- a/src/lorairo/database/db_repository.py
+++ b/src/lorairo/database/db_repository.py
@@ -1566,7 +1566,7 @@ class ImageRepository:
                     select(Image)
                     .where(Image.id == image_id)
                     .options(
-                        selectinload(Image.ratings),
+                        selectinload(Image.ratings).selectinload(Rating.model),
                         selectinload(Image.scores),
                     )
                 )
@@ -1892,11 +1892,17 @@ class ImageRepository:
             フォーマット済み辞書。
 
         """
+        model_name = rating.model.name if rating.model else "Unknown"
+        litellm_model_id = rating.model.litellm_model_id if rating.model else None
+        is_manual = litellm_model_id == MANUAL_EDIT_LITELLM_ID or model_name == MANUAL_EDIT_NAME
         return {
             "id": rating.id,
             "raw_rating_value": rating.raw_rating_value,
             "normalized_rating": rating.normalized_rating,
             "model_id": rating.model_id,
+            "model": model_name,
+            "model_name": model_name,
+            "source": "Manual" if is_manual else "AI",
             "confidence_score": rating.confidence_score,
             "created_at": rating.created_at,
             "updated_at": rating.updated_at,
@@ -1968,7 +1974,7 @@ class ImageRepository:
                         # ADR 0028: score_labels は model 名と組で返すため
                         # ScoreLabel.model も eager load する
                         joinedload(Image.score_labels).joinedload(ScoreLabel.model),
-                        joinedload(Image.ratings),
+                        joinedload(Image.ratings).joinedload(Rating.model),
                         joinedload(Image.processed_images),
                     )
                 )
@@ -2519,18 +2525,7 @@ class ImageRepository:
 
         """
         if image.ratings:
-            annotations["ratings"] = [
-                {
-                    "id": rating.id,
-                    "raw_rating_value": rating.raw_rating_value,
-                    "normalized_rating": rating.normalized_rating,
-                    "model_id": rating.model_id,
-                    "confidence_score": rating.confidence_score,
-                    "created_at": rating.created_at,
-                    "updated_at": rating.updated_at,
-                }
-                for rating in image.ratings
-            ]
+            annotations["ratings"] = [self._format_rating_annotation(rating) for rating in image.ratings]
             latest_rating = max(image.ratings, key=lambda r: r.created_at)
             annotations["rating_value"] = latest_rating.normalized_rating
         else:
@@ -2596,7 +2591,7 @@ class ImageRepository:
                 selectinload(Image.captions).selectinload(Caption.model),
                 selectinload(Image.scores).selectinload(Score.model),
                 selectinload(Image.score_labels).selectinload(ScoreLabel.model),
-                selectinload(Image.ratings),
+                selectinload(Image.ratings).selectinload(Rating.model),
             )
         )
         orig_results: list[Image] = list(session.execute(orig_stmt).scalars().all())
@@ -2639,7 +2634,7 @@ class ImageRepository:
                 selectinload(Image.captions).selectinload(Caption.model),
                 selectinload(Image.scores).selectinload(Score.model),
                 selectinload(Image.score_labels).selectinload(ScoreLabel.model),
-                selectinload(Image.ratings),
+                selectinload(Image.ratings).selectinload(Rating.model),
             )
         )
         orig_images = session.execute(orig_annotations_stmt).scalars().all()
@@ -3450,7 +3445,7 @@ class ImageRepository:
                         joinedload(Image.tags).joinedload(Tag.model),
                         joinedload(Image.captions).joinedload(Caption.model),
                         joinedload(Image.scores).joinedload(Score.model),
-                        joinedload(Image.ratings),
+                        joinedload(Image.ratings).joinedload(Rating.model),
                     )
                 )
                 images = session.execute(stmt).unique().scalars().all()

--- a/src/lorairo/gui/services/image_db_write_service.py
+++ b/src/lorairo/gui/services/image_db_write_service.py
@@ -126,6 +126,9 @@ class ImageDBWriteService:
                 aesthetic_score=aesthetic_score,
                 overall_score=0,
                 score_type="Aesthetic",
+                score_labels=annotations.get("score_labels", []),
+                ratings=annotations.get("ratings", []),
+                quality_summary=annotations.get("quality_summary", {}),
             )
 
             logger.debug(f"Annotation data retrieved for ID: {image_id}")

--- a/src/lorairo/gui/widgets/annotation_data_display_widget.py
+++ b/src/lorairo/gui/widgets/annotation_data_display_widget.py
@@ -9,17 +9,21 @@ from dataclasses import dataclass, field
 from typing import Any
 
 from PySide6.QtCore import QPoint, Qt, Signal, Slot
-from PySide6.QtGui import QResizeEvent
+from PySide6.QtGui import QKeySequence, QResizeEvent, QShortcut
 from PySide6.QtWidgets import (
     QAbstractItemView,
     QAbstractScrollArea,
     QApplication,
     QComboBox,
+    QGroupBox,
     QHBoxLayout,
+    QHeaderView,
     QLabel,
     QMenu,
     QSizePolicy,
+    QTableWidget,
     QTableWidgetItem,
+    QVBoxLayout,
     QWidget,
 )
 
@@ -38,6 +42,8 @@ class AnnotationData:
     score_type: str = "Aesthetic"
     # ADR 0028: canonical scorer の categorical label を {model, label, ...} ペアで保持
     score_labels: list[dict[str, Any]] = field(default_factory=list)
+    # Issue #334: model-native rating record を model 別に保持
+    ratings: list[dict[str, Any]] = field(default_factory=list)
     # ADR 0029: 統一品質 tier (raw annotation からの derived view)
     quality_summary: dict[str, Any] = field(default_factory=dict)
     # 翻訳データ: {tag_id: {language: translated_text}}
@@ -94,6 +100,7 @@ class AnnotationDataDisplayWidget(QWidget, Ui_AnnotationDataDisplayWidget):
         self._setup_caption_compact_view()
         self._setup_score_labels_compact_view()
         self._setup_quality_tier_badge()
+        self._setup_ratings_table_view()
         self._adjust_content_heights()
 
         # 言語コンボボックスのシグナル接続
@@ -175,6 +182,43 @@ class AnnotationDataDisplayWidget(QWidget, Ui_AnnotationDataDisplayWidget):
         # pill コンテナの前 (上) に挿入
         self.verticalLayoutScoreLabels.insertWidget(0, self._quality_tier_label)
 
+    def _setup_ratings_table_view(self) -> None:
+        """モデル別 rating record の read-only table を初期化する (Issue #334)。"""
+        self.groupBoxRatings = QGroupBox("レーティング詳細", self)
+        ratings_layout = QVBoxLayout(self.groupBoxRatings)
+        ratings_layout.setSpacing(4)
+        ratings_layout.setObjectName("verticalLayoutRatings")
+
+        self.labelRatingsPlaceholder = QLabel("-", self.groupBoxRatings)
+        self.labelRatingsPlaceholder.setWordWrap(True)
+        self.labelRatingsPlaceholder.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum)
+        self._make_label_copyable(self.labelRatingsPlaceholder)
+        ratings_layout.addWidget(self.labelRatingsPlaceholder)
+
+        self.tableWidgetRatings = QTableWidget(self.groupBoxRatings)
+        self.tableWidgetRatings.setObjectName("tableWidgetRatings")
+        self.tableWidgetRatings.setColumnCount(5)
+        for column, label in enumerate(["Model", "Normalized", "Raw", "Confidence", "Source"]):
+            self.tableWidgetRatings.setHorizontalHeaderItem(column, QTableWidgetItem(label))
+        self.tableWidgetRatings.setEditTriggers(QAbstractItemView.EditTrigger.NoEditTriggers)
+        self.tableWidgetRatings.setAlternatingRowColors(True)
+        self.tableWidgetRatings.setSelectionMode(QAbstractItemView.SelectionMode.ExtendedSelection)
+        self.tableWidgetRatings.setSelectionBehavior(QAbstractItemView.SelectionBehavior.SelectItems)
+        self.tableWidgetRatings.setSizeAdjustPolicy(QAbstractScrollArea.SizeAdjustPolicy.AdjustToContents)
+        self.tableWidgetRatings.setVerticalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
+        self.tableWidgetRatings.horizontalHeader().setStretchLastSection(True)
+        self.tableWidgetRatings.horizontalHeader().setSectionResizeMode(
+            QHeaderView.ResizeMode.ResizeToContents
+        )
+        self.tableWidgetRatings.setContextMenuPolicy(Qt.ContextMenuPolicy.CustomContextMenu)
+        self.tableWidgetRatings.customContextMenuRequested.connect(self._show_ratings_table_context_menu)
+        self._ratings_copy_shortcut = QShortcut(QKeySequence.StandardKey.Copy, self.tableWidgetRatings)
+        self._ratings_copy_shortcut.activated.connect(self.copy_selected_rating_cells_to_clipboard)
+        self.tableWidgetRatings.setVisible(False)
+        ratings_layout.addWidget(self.tableWidgetRatings)
+
+        self.verticalLayoutMain.addWidget(self.groupBoxRatings)
+
     def _make_label_copyable(self, label: QLabel) -> None:
         """読み取り専用 QLabel を選択・コピー可能にする。"""
         label.setTextInteractionFlags(
@@ -213,10 +257,32 @@ class AnnotationDataDisplayWidget(QWidget, Ui_AnnotationDataDisplayWidget):
         copy_action.triggered.connect(self.copy_selected_tag_cells_to_clipboard)
         menu.exec(self.tableWidgetTags.viewport().mapToGlobal(position))
 
+    @Slot(QPoint)
+    def _show_ratings_table_context_menu(self, position: QPoint) -> None:
+        menu = QMenu(self.tableWidgetRatings)
+        copy_action = menu.addAction("選択範囲をコピー")
+        copy_action.setEnabled(bool(self.tableWidgetRatings.selectedRanges()))
+        copy_action.triggered.connect(self.copy_selected_rating_cells_to_clipboard)
+        menu.exec(self.tableWidgetRatings.viewport().mapToGlobal(position))
+
     @Slot()
     def copy_selected_tag_cells_to_clipboard(self) -> bool:
         """タグテーブルの選択セルを TSV としてクリップボードへコピーする。"""
-        ranges = self.tableWidgetTags.selectedRanges()
+        return self._copy_selected_table_cells_to_clipboard(
+            self.tableWidgetTags, self._tag_table_item_clipboard_text
+        )
+
+    @Slot()
+    def copy_selected_rating_cells_to_clipboard(self) -> bool:
+        """rating 詳細テーブルの選択セルを TSV としてクリップボードへコピーする。"""
+        return self._copy_selected_table_cells_to_clipboard(self.tableWidgetRatings)
+
+    def _copy_selected_table_cells_to_clipboard(
+        self,
+        table: QTableWidget,
+        formatter: Any | None = None,
+    ) -> bool:
+        ranges = table.selectedRanges()
         if not ranges:
             return False
 
@@ -225,8 +291,8 @@ class AnnotationDataDisplayWidget(QWidget, Ui_AnnotationDataDisplayWidget):
             for row in range(selected_range.topRow(), selected_range.bottomRow() + 1):
                 values: list[str] = []
                 for column in range(selected_range.leftColumn(), selected_range.rightColumn() + 1):
-                    item = self.tableWidgetTags.item(row, column)
-                    values.append(self._tag_table_item_clipboard_text(item, column))
+                    item = table.item(row, column)
+                    values.append(formatter(item, column) if formatter else (item.text() if item else ""))
                 lines.append("\t".join(values))
 
         QApplication.clipboard().setText("\n".join(lines))
@@ -258,6 +324,9 @@ class AnnotationDataDisplayWidget(QWidget, Ui_AnnotationDataDisplayWidget):
             # スコアラベル表示更新 (ADR 0028)
             self._update_score_labels_display(data.score_labels)
 
+            # レーティング詳細表示更新 (Issue #334)
+            self._update_ratings_display(data.ratings)
+
             # 品質 tier badge 更新 (ADR 0029)
             self._update_quality_tier_display(data.quality_summary)
 
@@ -266,7 +335,8 @@ class AnnotationDataDisplayWidget(QWidget, Ui_AnnotationDataDisplayWidget):
             self.data_loaded.emit(data)
             logger.debug(
                 f"Annotation data updated - tags: {len(data.tags)}, "
-                f"caption: {bool(data.caption)}, score_labels: {len(data.score_labels)}"
+                f"caption: {bool(data.caption)}, score_labels: {len(data.score_labels)}, "
+                f"ratings: {len(data.ratings)}"
             )
 
         except Exception as e:
@@ -508,6 +578,45 @@ class AnnotationDataDisplayWidget(QWidget, Ui_AnnotationDataDisplayWidget):
         except Exception as e:
             logger.error(f"Error updating quality tier display: {e}")
 
+    def _update_ratings_display(self, ratings: list[dict[str, Any]]) -> None:
+        """モデル別 rating record を table 表示する (Issue #334)。"""
+        try:
+            self.tableWidgetRatings.setRowCount(len(ratings))
+            self.tableWidgetRatings.setSortingEnabled(False)
+
+            if not ratings:
+                self.labelRatingsPlaceholder.setVisible(True)
+                self.tableWidgetRatings.setVisible(False)
+                return
+
+            self.labelRatingsPlaceholder.setVisible(False)
+            self.tableWidgetRatings.setVisible(True)
+
+            for row, entry in enumerate(ratings):
+                confidence = entry.get("confidence_score")
+                confidence_text = f"{confidence:.2f}" if confidence is not None else "-"
+                values = [
+                    entry.get("model") or entry.get("model_name") or "Unknown",
+                    entry.get("normalized_rating") or "-",
+                    entry.get("raw_rating_value") or "-",
+                    confidence_text,
+                    entry.get("source") or "AI",
+                ]
+                for column, value in enumerate(values):
+                    item = QTableWidgetItem(str(value))
+                    if column == 3:
+                        item.setData(Qt.ItemDataRole.UserRole, confidence if confidence is not None else -1)
+                    self.tableWidgetRatings.setItem(row, column, item)
+
+            self.tableWidgetRatings.setSortingEnabled(True)
+            self.tableWidgetRatings.resizeColumnsToContents()
+            self._adjust_ratings_height()
+
+            logger.debug(f"Updated ratings display: {len(ratings)} rows")
+
+        except Exception as e:
+            logger.error(f"Error updating ratings display: {e}")
+
     @Slot()
     def clear_data(self) -> None:
         """表示データをクリア"""
@@ -527,6 +636,7 @@ class AnnotationDataDisplayWidget(QWidget, Ui_AnnotationDataDisplayWidget):
 
             # スコアラベル pill もクリア
             self._update_score_labels_display([])
+            self._update_ratings_display([])
             # 品質 tier badge もクリア (ADR 0029)
             self._update_quality_tier_display({})
 
@@ -554,12 +664,14 @@ class AnnotationDataDisplayWidget(QWidget, Ui_AnnotationDataDisplayWidget):
         caption: bool = True,
         scores: bool = True,
         score_labels: bool = True,
+        ratings: bool = True,
     ) -> None:
-        """各グループボックスの表示/非表示制御 (Issue #284 で score_labels を追加)。"""
+        """各グループボックスの表示/非表示制御 (Issue #284 / #334)。"""
         self.groupBoxTags.setVisible(tags)
         self.groupBoxCaption.setVisible(caption)
         self.groupBoxScores.setVisible(scores)
         self.groupBoxScoreLabels.setVisible(score_labels)
+        self.groupBoxRatings.setVisible(ratings)
 
     def resizeEvent(self, event: QResizeEvent) -> None:
         super().resizeEvent(event)
@@ -568,6 +680,7 @@ class AnnotationDataDisplayWidget(QWidget, Ui_AnnotationDataDisplayWidget):
     def _adjust_content_heights(self) -> None:
         self._adjust_tags_height()
         self._adjust_caption_height()
+        self._adjust_ratings_height()
 
     def _adjust_tags_height(self) -> None:
         if not self.tableWidgetTags.isVisible():
@@ -584,6 +697,22 @@ class AnnotationDataDisplayWidget(QWidget, Ui_AnnotationDataDisplayWidget):
         if target < min_height:
             target = min_height
         self.tableWidgetTags.setFixedHeight(target)
+
+    def _adjust_ratings_height(self) -> None:
+        if not self.tableWidgetRatings.isVisible():
+            return
+        self.tableWidgetRatings.resizeRowsToContents()
+        header_height = self.tableWidgetRatings.horizontalHeader().height()
+        rows_height = sum(
+            self.tableWidgetRatings.rowHeight(row) for row in range(self.tableWidgetRatings.rowCount())
+        )
+        frame = self.tableWidgetRatings.frameWidth() * 2
+        padding = 6
+        target = header_height + rows_height + frame + padding
+        min_height = header_height + frame + padding
+        if target < min_height:
+            target = min_height
+        self.tableWidgetRatings.setFixedHeight(target)
 
     def _adjust_caption_height(self) -> None:
         if not self.textEditCaption.isVisible():

--- a/src/lorairo/gui/widgets/selected_image_details_widget.py
+++ b/src/lorairo/gui/widgets/selected_image_details_widget.py
@@ -438,6 +438,8 @@ class SelectedImageDetailsWidget(QWidget):
         tags_text = metadata.get("tags_text", "")
         # ADR 0028: canonical scorer の score_labels を AnnotationData に渡す
         score_labels_list = metadata.get("score_labels", [])
+        # Issue #334: model 別 rating record を詳細表示へ渡す
+        ratings_list = metadata.get("ratings", [])
         # ADR 0029: 統一品質 tier (derived view) を AnnotationData に渡す
         quality_summary = metadata.get("quality_summary", {})
 
@@ -459,6 +461,7 @@ class SelectedImageDetailsWidget(QWidget):
             aesthetic_score=score_value,
             overall_score=0,  # Rating値は文字列なのでoverall_scoreには使用しない
             score_labels=score_labels_list,
+            ratings=ratings_list,
             quality_summary=quality_summary,
             tag_translations=tag_translations,
             available_languages=self._available_languages,
@@ -730,6 +733,20 @@ class SelectedImageDetailsWidget(QWidget):
                     for entry in details.annotation_data.score_labels
                 ]
                 lines.append(f"Score labels: {', '.join(score_labels)}")
+
+            if details.annotation_data.ratings:
+                ratings = []
+                for entry in details.annotation_data.ratings:
+                    model = entry.get("model") or entry.get("model_name") or "Unknown"
+                    normalized = entry.get("normalized_rating", "-")
+                    raw = entry.get("raw_rating_value", "-")
+                    confidence = entry.get("confidence_score")
+                    confidence_text = f"{confidence:.2f}" if confidence is not None else "-"
+                    source = entry.get("source", "AI")
+                    ratings.append(
+                        f"{model}: {normalized} (raw={raw}, confidence={confidence_text}, source={source})"
+                    )
+                lines.append(f"Ratings: {', '.join(ratings)}")
 
         lines.extend(
             [

--- a/tests/unit/database/test_db_repository_score_labels.py
+++ b/tests/unit/database/test_db_repository_score_labels.py
@@ -423,3 +423,89 @@ class TestGetImageAnnotationsQualitySummary:
 
         assert annotations["quality_summary"]["tier"] == "masterpiece"
         assert annotations["quality_summary"]["known_count"] == 1
+
+
+class TestFormatRatings:
+    """Issue #334: model 別 rating record の formatting 動作テスト。"""
+
+    @pytest.fixture
+    def repository(self) -> ImageRepository:
+        mock_session_factory = Mock()
+        return ImageRepository(session_factory=mock_session_factory)
+
+    def _make_rating(
+        self,
+        rating_id: int,
+        model_id: int,
+        model_name: str,
+        raw_rating_value: str,
+        normalized_rating: str,
+        confidence_score: float | None,
+        litellm_model_id: str = "wd-vit-tagger-v3",
+    ) -> SimpleNamespace:
+        return SimpleNamespace(
+            id=rating_id,
+            image_id=100,
+            model_id=model_id,
+            raw_rating_value=raw_rating_value,
+            normalized_rating=normalized_rating,
+            confidence_score=confidence_score,
+            created_at=datetime.datetime(2026, 5, 21, 10, rating_id, 0),
+            updated_at=datetime.datetime(2026, 5, 21, 10, rating_id, 0),
+            model=SimpleNamespace(name=model_name, litellm_model_id=litellm_model_id),
+        )
+
+    def test_format_ratings_multi_models(self, repository: ImageRepository) -> None:
+        ratings = [
+            self._make_rating(1, 42, "wd-vit-tagger-v3", "questionable", "R", 0.91),
+            self._make_rating(2, 43, "z3d-e621-convnext", "safe", "PG", 0.84),
+        ]
+        image = SimpleNamespace(ratings=ratings)
+        annotations: dict = {}
+
+        repository._format_ratings(image, annotations)
+
+        assert len(annotations["ratings"]) == 2
+        assert annotations["ratings"][0]["model"] == "wd-vit-tagger-v3"
+        assert annotations["ratings"][0]["model_name"] == "wd-vit-tagger-v3"
+        assert annotations["ratings"][0]["raw_rating_value"] == "questionable"
+        assert annotations["ratings"][0]["normalized_rating"] == "R"
+        assert annotations["ratings"][0]["confidence_score"] == 0.91
+        assert annotations["ratings"][0]["source"] == "AI"
+        assert annotations["rating_value"] == "PG"
+
+    def test_format_ratings_manual_edit_source(self, repository: ImageRepository) -> None:
+        rating = self._make_rating(
+            1,
+            1,
+            "MANUAL_EDIT",
+            "PG",
+            "PG",
+            None,
+            litellm_model_id="__manual_edit__",
+        )
+        image = SimpleNamespace(ratings=[rating])
+        annotations: dict = {}
+
+        repository._format_ratings(image, annotations)
+
+        assert annotations["ratings"][0]["source"] == "Manual"
+
+    def test_format_rating_annotation_unknown_model(self, repository: ImageRepository) -> None:
+        rating = SimpleNamespace(
+            id=1,
+            image_id=100,
+            model_id=99,
+            raw_rating_value="explicit",
+            normalized_rating="X",
+            confidence_score=0.88,
+            created_at=datetime.datetime(2026, 5, 21, 10, 0, 0),
+            updated_at=datetime.datetime(2026, 5, 21, 10, 0, 0),
+            model=None,
+        )
+
+        entry = repository._format_rating_annotation(rating)
+
+        assert entry["model"] == "Unknown"
+        assert entry["model_name"] == "Unknown"
+        assert entry["source"] == "AI"

--- a/tests/unit/gui/services/test_image_db_write_service.py
+++ b/tests/unit/gui/services/test_image_db_write_service.py
@@ -49,6 +49,17 @@ class TestImageDBWriteService:
             "tags": [{"content": "1girl"}, {"content": "long hair"}],
             "captions": [{"content": "A beautiful anime girl"}],
             "scores": [{"value": 0.85}],
+            "score_labels": [{"model": "aesthetic_shadow_v1", "label": "aesthetic"}],
+            "ratings": [
+                {
+                    "model": "wd-vit-tagger-v3",
+                    "normalized_rating": "R",
+                    "raw_rating_value": "questionable",
+                    "confidence_score": 0.91,
+                    "source": "AI",
+                }
+            ],
+            "quality_summary": {"tier": "high"},
         }
 
         mock_db_manager.repository.get_image_metadata.return_value = mock_image_metadata
@@ -73,6 +84,19 @@ class TestImageDBWriteService:
         assert result.annotation_data.tags == ["1girl", "long hair"]
         assert result.annotation_data.caption == "A beautiful anime girl"
         assert result.annotation_data.aesthetic_score == 0.85
+        assert result.annotation_data.score_labels == [
+            {"model": "aesthetic_shadow_v1", "label": "aesthetic"}
+        ]
+        assert result.annotation_data.ratings == [
+            {
+                "model": "wd-vit-tagger-v3",
+                "normalized_rating": "R",
+                "raw_rating_value": "questionable",
+                "confidence_score": 0.91,
+                "source": "AI",
+            }
+        ]
+        assert result.annotation_data.quality_summary == {"tier": "high"}
 
         # モックメソッドの呼び出し確認
         mock_db_manager.repository.get_image_metadata.assert_called_once_with(image_id)

--- a/tests/unit/gui/widgets/test_annotation_data_display_widget.py
+++ b/tests/unit/gui/widgets/test_annotation_data_display_widget.py
@@ -326,6 +326,74 @@ class TestAnnotationDataDisplayWidget:
         # score_labels は default で visible 設定 → isHidden() は False
         assert not widget.groupBoxScoreLabels.isHidden()
 
+    @pytest.fixture
+    def sample_ratings(self):
+        """Issue #334: model 別 rating record のデータ形状。"""
+        return [
+            {
+                "model": "wd-vit-tagger-v3",
+                "model_id": 42,
+                "normalized_rating": "R",
+                "raw_rating_value": "questionable",
+                "confidence_score": 0.91,
+                "source": "AI",
+            },
+            {
+                "model": "MANUAL_EDIT",
+                "model_id": 1,
+                "normalized_rating": "PG",
+                "raw_rating_value": "PG",
+                "confidence_score": None,
+                "source": "Manual",
+            },
+        ]
+
+    def test_ratings_empty_shows_placeholder(self, widget):
+        """ratings 空時、table が hidden で placeholder のみ。"""
+        widget.update_data(AnnotationData(ratings=[]))
+
+        assert not widget.labelRatingsPlaceholder.isHidden()
+        assert widget.tableWidgetRatings.isHidden()
+
+    def test_ratings_table_rows(self, widget, sample_ratings):
+        """複数 rating record を model 別 table として表示する。"""
+        widget.update_data(AnnotationData(ratings=sample_ratings))
+
+        assert widget.tableWidgetRatings.rowCount() == 2
+        assert widget.tableWidgetRatings.item(0, 0).text() == "wd-vit-tagger-v3"
+        assert widget.tableWidgetRatings.item(0, 1).text() == "R"
+        assert widget.tableWidgetRatings.item(0, 2).text() == "questionable"
+        assert widget.tableWidgetRatings.item(0, 3).text() == "0.91"
+        assert widget.tableWidgetRatings.item(0, 4).text() == "AI"
+        assert widget.tableWidgetRatings.item(1, 0).text() == "MANUAL_EDIT"
+        assert widget.tableWidgetRatings.item(1, 3).text() == "-"
+        assert widget.tableWidgetRatings.item(1, 4).text() == "Manual"
+        assert not widget.tableWidgetRatings.isHidden()
+        assert widget.labelRatingsPlaceholder.isHidden()
+
+    def test_ratings_re_render_clears_previous(self, widget, sample_ratings):
+        """update_data 再呼出しで前 rating rows がクリアされる。"""
+        widget.update_data(AnnotationData(ratings=sample_ratings))
+        assert widget.tableWidgetRatings.rowCount() == 2
+
+        widget.update_data(AnnotationData(ratings=[sample_ratings[0]]))
+
+        assert widget.tableWidgetRatings.rowCount() == 1
+        assert widget.tableWidgetRatings.item(0, 0).text() == "wd-vit-tagger-v3"
+
+    def test_set_group_box_visibility_ratings_false(self, widget):
+        """ratings=False で groupBoxRatings が hidden になる。"""
+        widget.set_group_box_visibility(ratings=False)
+        assert widget.groupBoxRatings.isHidden()
+
+    def test_copy_selected_rating_cells_to_clipboard(self, widget, sample_ratings):
+        """rating 詳細テーブルの選択セルを TSV としてコピーする。"""
+        widget.update_data(AnnotationData(ratings=sample_ratings))
+        widget.tableWidgetRatings.setRangeSelected(QTableWidgetSelectionRange(0, 0, 0, 2), True)
+
+        assert widget.copy_selected_rating_cells_to_clipboard() is True
+        assert QApplication.clipboard().text() == "wd-vit-tagger-v3\tR\tquestionable"
+
 
 class TestQualityTierBadge:
     """ADR 0029: 統一品質 tier badge の表示挙動。"""

--- a/tests/unit/gui/widgets/test_selected_image_details_widget.py
+++ b/tests/unit/gui/widgets/test_selected_image_details_widget.py
@@ -56,6 +56,15 @@ class TestSelectedImageDetailsWidget:
             aesthetic_score=0.85,
             overall_score=850,
             score_type="Aesthetic",
+            ratings=[
+                {
+                    "model": "wd-vit-tagger-v3",
+                    "normalized_rating": "R",
+                    "raw_rating_value": "questionable",
+                    "confidence_score": 0.91,
+                    "source": "AI",
+                }
+            ],
         )
 
         return ImageDetails(
@@ -139,6 +148,9 @@ class TestSelectedImageDetailsWidget:
         clipboard_text = QApplication.clipboard().text()
         assert "Image ID: 123" in clipboard_text
         assert "File name: sample_image.jpg" in clipboard_text
+        assert (
+            "Ratings: wd-vit-tagger-v3: R (raw=questionable, confidence=0.91, source=AI)" in clipboard_text
+        )
         assert "Tags: 1girl, long hair, blue eyes" in clipboard_text
         assert "Caption: A beautiful anime girl with long hair" in clipboard_text
 


### PR DESCRIPTION
## Summary
- Add model/source metadata to formatted rating records for image details
- Show per-model rating records in the annotation details panel with normalized/raw/confidence/source columns
- Preserve existing canonical rating filter behavior and scalar Rating summary

## Tests
- uv run ruff check src/lorairo/database/db_repository.py src/lorairo/gui/widgets/annotation_data_display_widget.py src/lorairo/gui/widgets/selected_image_details_widget.py src/lorairo/gui/services/image_db_write_service.py tests/unit/database/test_db_repository_score_labels.py tests/unit/gui/widgets/test_annotation_data_display_widget.py tests/unit/gui/widgets/test_selected_image_details_widget.py tests/unit/gui/services/test_image_db_write_service.py
- uv run pytest tests/unit/gui/widgets/test_annotation_data_display_widget.py tests/unit/gui/services/test_image_db_write_service.py tests/unit/database/test_db_repository_score_labels.py

## Notes
- tests/unit/gui/widgets/test_selected_image_details_widget.py currently cannot be collected in this worktree because generated module lorairo.gui.designer.RatingScoreEditWidget_ui is not present on the base branch.

Closes #334