### PR TITLE
fix: treat worker cancellation as non-error

### DIFF
--- a/docs/specs/application/worker_service.md
+++ b/docs/specs/application/worker_service.md
@@ -33,7 +33,7 @@ src/lorairo/gui/
 - **基底クラス:** 全てのワーカーは、`src.lorairo.gui.workers.base.LoRAIroWorkerBase` クラスを継承します。
 - **`LoRAIroWorkerBase` の役割:**
     - `QObject` + `Generic[T]` を継承し、型安全な結果を提供します。
-    - 標準シグナル (`finished(result: T)`, `error(message: str)`) を定義します。
+    - 標準シグナル (`finished(result: T)`, `error_occurred(message: str)`, `canceled()`) を定義します。
     - 進捗報告とキャンセレーション機能を統合します。
     - 基本的なキャンセル処理 (`cancel()` メソッド、`_is_cancelled` フラグ) の枠組みを提供します。
     - スレッドプールまたは個別の `QThread` 上で実行されるエントリーポイント (`run()` メソッド) を提供します。`run()` はキャンセルチェック、抽象メソッド `run_task()` の呼び出し、例外処理、`finished` シグナルの発行を行います。
@@ -44,15 +44,16 @@ src/lorairo/gui/
 - **サービスとの連携:**
     - `WorkerService` は、対応するワーカークラス（例: `AnnotationWorker`, `SearchWorker`）のインスタンスを生成します。
     - `WorkerService` は `WorkerManager` 経由で `QThreadPool` でワーカーを実行します。
-    - ワーカーの `finished` および `progress` シグナルを、`WorkerService` 内の適切なスロット（またはUIコンポーネントのスロット）に接続して、結果や進捗を処理します。
+    - ワーカーの `finished` / `error_occurred` / `canceled` および `progress` シグナルを、`WorkerService` 内の適切なスロット（またはUIコンポーネントのスロット）に接続して、結果や進捗を処理します。
     - `WorkerService` はワーカーの `cancel()` メソッドを呼び出して、タスクの中断を要求できます。
 
 ## 3. 責務
 
 - **タスク実行:** 割り当てられた特定の非同期タスク（AI アノテーション、画像読み込み、設定の保存など）を実行します。
-- **結果通知:** タスク完了時、`finished` シグナルを通じて結果オブジェクトまたは発生した例外をサービスに通知します。
+- **結果通知:** タスク完了時、`finished` / `error_occurred` / `canceled` のいずれか一つの終端シグナルでサービスに通知します。
 - **進捗通知:** (任意) タスク実行中に、`progress` シグナルを通じて進捗状況（通常 0-100 のパーセンテージ）を通知します。
-- **キャンセル処理:** サービスからのキャンセル要求を受け付け、可能な範囲でタスクを安全に中断します。中断した場合も `finished` シグナルは発行されます（結果は `None` や特定のキャンセル状態を示すオブジェクトになる場合があります）。
+- **キャンセル処理:** サービスからのキャンセル要求を受け付け、可能な範囲でタスクを安全に中断します。中断した場合は `canceled` シグナルを発行します。キャンセルは failure ではない第三の終端状態であり、ErrorLogViewer 用のエラーレコードには記録しません。
+    - 将来的に user requested / superseded / shutdown などを区別する必要が出た場合は、`canceled` の横に reason を後付けするのではなく、統一 terminal event と cancel reason の設計を別ADRで検討します。
 
 ## 4. 実装ガイドライン
 
@@ -61,7 +62,8 @@ src/lorairo/gui/
     - 正常完了時は結果オブジェクトを返します。
     - 処理中にエラーが発生した場合は、例外を送出します (`BaseWorker.run` で捕捉されます)。特定のビジネスロジックエラーは、`run_task` 内で捕捉し、エラーを示す特定のオブジェクトを返すことも可能です。
 - **エラーハンドリング:**
-    - `BaseWorker.run()` が一般的な `Exception` を捕捉し、`finished` シグナルで通知します。
+    - `BaseWorker.run()` が一般的な `Exception` を捕捉し、`error_occurred` シグナルで通知します。
+    - キャンセルは `CancellationError` またはキャンセルフラグで検出し、`WorkerStatus.CANCELED` と `canceled` シグナルで通知します。
     - `run_task()` 内で、特定の予期される例外（例: `FileNotFoundError`, `ValueError`）を捕捉し、より具体的なエラー情報を含む結果を返すことも検討します。
 - **状態管理:** ワーカーは自身の状態（実行中、キャンセル済みなど）を管理しますが、サービスやUIに直接依存しないようにします。状態の通知はシグナルを使用します。
 - **リソース管理:** ワーカーがファイルハンドルやネットワーク接続などのリソースを使用する場合、`run_task()` 内または `finally` ブロックで適切に解放するようにします。

--- a/src/lorairo/gui/services/pipeline_control_service.py
+++ b/src/lorairo/gui/services/pipeline_control_service.py
@@ -151,6 +151,31 @@ class PipelineControlService:
         if self.filter_search_panel and hasattr(self.filter_search_panel, "hide_progress_after_completion"):
             self.filter_search_panel.hide_progress_after_completion()
 
+    def on_search_canceled(self, worker_id: str) -> None:
+        """Pipeline検索キャンセル時の処理（エラー扱いしない）"""
+        logger.info(f"Pipeline search canceled: {worker_id}")
+
+        if self.thumbnail_selector and hasattr(self.thumbnail_selector, "clear_thumbnails"):
+            self.thumbnail_selector.clear_thumbnails()
+
+        if self.filter_search_panel and hasattr(self.filter_search_panel, "clear_pipeline_results"):
+            self.filter_search_panel.clear_pipeline_results()
+
+        if self.filter_search_panel and hasattr(self.filter_search_panel, "hide_progress_after_completion"):
+            self.filter_search_panel.hide_progress_after_completion()
+
+    def on_thumbnail_canceled(self, worker_id: str) -> None:
+        """Pipelineサムネイル読み込みキャンセル時の処理（エラー扱いしない）。
+
+        thumbnail worker はページ切替や prefetch 整理でも通常運用としてキャンセルされるため、
+        ここでは検索結果を破棄しない。明示的な pipeline cancel の結果破棄は
+        cancel_current_pipeline() 側で行う。
+        """
+        logger.info(f"Pipeline thumbnail canceled: {worker_id}")
+
+        if self.filter_search_panel and hasattr(self.filter_search_panel, "hide_progress_after_completion"):
+            self.filter_search_panel.hide_progress_after_completion()
+
     # ============================================================
     # 進捗状態管理統合
     # ============================================================
@@ -210,6 +235,9 @@ class PipelineControlService:
             # キャンセル時の結果破棄（要求仕様通り）
             if self.thumbnail_selector and hasattr(self.thumbnail_selector, "clear_thumbnails"):
                 self.thumbnail_selector.clear_thumbnails()
+
+            if self.filter_search_panel and hasattr(self.filter_search_panel, "clear_pipeline_results"):
+                self.filter_search_panel.clear_pipeline_results()
 
             # キャンセル時もプログレスバーを非表示
             if self.filter_search_panel and hasattr(

--- a/src/lorairo/gui/services/progress_state_service.py
+++ b/src/lorairo/gui/services/progress_state_service.py
@@ -70,6 +70,32 @@ class ProgressStateService:
             except Exception as e:
                 logger.debug(f"Status bar update failed: {e}")
 
+    def on_batch_registration_canceled(self, worker_id: str) -> None:
+        """バッチ登録キャンセル時の進捗表示"""
+        logger.info(f"バッチ登録キャンセル: worker_id={worker_id}")
+
+        self._show_canceled_message("バッチ登録")
+
+    def on_batch_annotation_canceled(self, worker_id: str) -> None:
+        """バッチアノテーションキャンセル時の進捗表示"""
+        logger.info(f"バッチアノテーションキャンセル: worker_id={worker_id}")
+
+        self._show_canceled_message("アノテーション処理")
+
+    def on_batch_import_canceled(self, worker_id: str) -> None:
+        """バッチインポートキャンセル時の進捗表示"""
+        logger.info(f"バッチインポートキャンセル: worker_id={worker_id}")
+
+        self._show_canceled_message("バッチインポート")
+
+    def _show_canceled_message(self, operation_name: str) -> None:
+        """キャンセル完了メッセージをステータスバーへ表示する。"""
+        if self.status_bar:
+            try:
+                self.status_bar.showMessage(f"{operation_name}をキャンセルしました", 5000)
+            except Exception as e:
+                logger.debug(f"Status bar update failed: {e}")
+
     # ============================================================
     # Worker進捗管理
     # ============================================================

--- a/src/lorairo/gui/services/worker_service.py
+++ b/src/lorairo/gui/services/worker_service.py
@@ -34,22 +34,27 @@ class WorkerService(QObject):
     batch_registration_started = Signal(str)  # worker_id
     batch_registration_finished = Signal(object)  # DatabaseRegistrationResult
     batch_registration_error = Signal(str)  # error_message
+    batch_registration_canceled = Signal(str)  # worker_id
 
     enhanced_annotation_started = Signal(str)  # worker_id
     enhanced_annotation_finished = Signal(object)  # Enhanced annotation results
     enhanced_annotation_error = Signal(str)  # error_message
+    enhanced_annotation_canceled = Signal(str)  # worker_id
 
     search_started = Signal(str)  # worker_id
     search_finished = Signal(object)  # SearchResult
     search_error = Signal(str)  # error_message
+    search_canceled = Signal(str)  # worker_id
 
     thumbnail_started = Signal(str)  # worker_id
     thumbnail_finished = Signal(object)  # ThumbnailLoadResult
     thumbnail_error = Signal(str)  # error_message
+    thumbnail_canceled = Signal(str)  # worker_id
 
     batch_import_started = Signal(str)  # worker_id
     batch_import_finished = Signal(object)  # BatchImportResult
     batch_import_error = Signal(str)  # error_message
+    batch_import_canceled = Signal(str)  # worker_id
 
     # === 進捗シグナル ===
     worker_progress_updated = Signal(str, object)  # worker_id, WorkerProgress
@@ -85,6 +90,7 @@ class WorkerService(QObject):
         self.worker_manager.worker_started.connect(self._on_worker_started)
         self.worker_manager.worker_finished.connect(self._on_worker_finished)
         self.worker_manager.worker_error.connect(self._on_worker_error)
+        self.worker_manager.worker_canceled.connect(self._on_worker_canceled)
         self.worker_manager.active_worker_count_changed.connect(self.active_worker_count_changed)
         self.worker_manager.all_workers_finished.connect(self.all_workers_finished)
 
@@ -156,6 +162,7 @@ class WorkerService(QObject):
         )
 
         if self.worker_manager.start_worker(worker_id, worker):
+            self.current_registration_worker_id = worker_id
             logger.info(f"バッチ登録開始: {directory} (ID: {worker_id})")
             return worker_id
         else:
@@ -210,6 +217,7 @@ class WorkerService(QObject):
         )
 
         if self.worker_manager.start_worker(worker_id, worker):
+            self.current_annotation_worker_id = worker_id
             logger.info(
                 f"バッチアノテーション開始: {len(image_paths)}画像 (filter 前), "
                 f"{len(litellm_model_ids)}モデル (ID: {worker_id})"
@@ -247,7 +255,6 @@ class WorkerService(QObject):
 
         worker = SearchWorker(self.db_manager, search_conditions)
         worker_id = f"search_{uuid.uuid4().hex[:8]}"
-        self.current_search_worker_id = worker_id
 
         # 進捗シグナル接続
         worker.progress_updated.connect(
@@ -260,6 +267,7 @@ class WorkerService(QObject):
         )
 
         if self.worker_manager.start_worker(worker_id, worker):
+            self.current_search_worker_id = worker_id
             logger.info(f"検索開始: {search_conditions} (ID: {worker_id})")
             return worker_id
         else:
@@ -424,10 +432,12 @@ class WorkerService(QObject):
         )
 
         mode = "DRY-RUN" if dry_run else "LIVE"
-        logger.info(f"バッチインポート開始: {len(jsonl_files)}ファイル ({mode}) (ID: {worker_id})")
-        self.worker_manager.start_worker(worker_id, worker)
-        self.current_batch_import_worker_id = worker_id
-        return worker_id
+        if self.worker_manager.start_worker(worker_id, worker):
+            logger.info(f"バッチインポート開始: {len(jsonl_files)}ファイル ({mode}) (ID: {worker_id})")
+            self.current_batch_import_worker_id = worker_id
+            return worker_id
+
+        raise RuntimeError(f"ワーカー開始失敗: {worker_id}")
 
     def cancel_batch_import(self, worker_id: str) -> None:
         """バッチインポートワーカーをキャンセルする。
@@ -555,3 +565,24 @@ class WorkerService(QObject):
                 setattr(self, attr, None)
 
         logger.info(f"ワーカーエラーとプログレス終了: {worker_id}")
+
+    def _on_worker_canceled(self, worker_id: str) -> None:
+        """ワーカーキャンセルハンドラ - エラー扱いせずプログレスを終了"""
+        logger.info(f"ワーカーキャンセル完了: {worker_id}")
+
+        worker_type = self._resolve_worker_type(worker_id)
+        if worker_type != "thumbnail":
+            self.progress_manager.finish_worker_progress(worker_id, success=False)
+
+        canceled_dispatch: dict[str, tuple[Any, str | None]] = {
+            "batch_reg": (self.batch_registration_canceled, "current_registration_worker_id"),
+            "batch_import": (self.batch_import_canceled, "current_batch_import_worker_id"),
+            "annotation": (self.enhanced_annotation_canceled, "current_annotation_worker_id"),
+            "search": (self.search_canceled, "current_search_worker_id"),
+            "thumbnail": (self.thumbnail_canceled, "current_thumbnail_worker_id"),
+        }
+        if worker_type in canceled_dispatch:
+            signal, attr = canceled_dispatch[worker_type]
+            signal.emit(worker_id)
+            if attr and getattr(self, attr) == worker_id:
+                setattr(self, attr, None)

--- a/src/lorairo/gui/widgets/filter_search_panel.py
+++ b/src/lorairo/gui/widgets/filter_search_panel.py
@@ -735,6 +735,7 @@ class FilterSearchPanel(QScrollArea):
         if self.worker_service:
             self.worker_service.search_finished.connect(self._on_search_finished)
             self.worker_service.search_error.connect(self._on_search_error)
+            self.worker_service.search_canceled.connect(self._on_search_canceled)
 
             # Option B: バッチ進捗シグナル接続を追加
             self.worker_service.worker_batch_progress.connect(self._on_worker_batch_progress)
@@ -791,6 +792,13 @@ class FilterSearchPanel(QScrollArea):
         self._transition_to_state(PipelineState.ERROR)
 
         self.search_completed.emit({"results": [], "count": 0, "error": error})
+
+    def _on_search_canceled(self, worker_id: str) -> None:
+        """検索キャンセルイベント処理"""
+        logger.info(f"検索キャンセル: {worker_id}")
+        self._current_search_worker_id = None
+        self._transition_to_state(PipelineState.CANCELED)
+        self.search_completed.emit({"results": [], "count": 0, "canceled": True})
 
     def _on_worker_batch_progress(self, worker_id: str, current: int, total: int, filename: str) -> None:
         """ワーカーのバッチ進捗処理（Option B: 動的進捗計算）"""

--- a/src/lorairo/gui/window/main_window.py
+++ b/src/lorairo/gui/window/main_window.py
@@ -647,14 +647,21 @@ class MainWindow(QMainWindow, Ui_MainWindow):
             "search_finished",
             "search_started",
             "search_error",
+            "search_canceled",
             "thumbnail_finished",
             "thumbnail_started",
             "thumbnail_error",
+            "thumbnail_canceled",
             "batch_registration_started",
             "batch_registration_finished",
             "batch_registration_error",
+            "batch_registration_canceled",
+            "batch_import_finished",
+            "batch_import_error",
+            "batch_import_canceled",
             "enhanced_annotation_finished",
             "enhanced_annotation_error",
+            "enhanced_annotation_canceled",
             "worker_progress_updated",
             "worker_batch_progress",
         ]
@@ -678,25 +685,30 @@ class MainWindow(QMainWindow, Ui_MainWindow):
         # Error handling connections
         self.worker_service.search_error.connect(self._on_pipeline_search_error)
         self.worker_service.thumbnail_error.connect(self._on_pipeline_thumbnail_error)
+        self.worker_service.search_canceled.connect(self._on_pipeline_search_canceled)
+        self.worker_service.thumbnail_canceled.connect(self._on_pipeline_thumbnail_canceled)
 
         # Batch registration connections
         self.worker_service.batch_registration_started.connect(self._on_batch_registration_started)
         self.worker_service.batch_registration_finished.connect(self._on_batch_registration_finished)
         self.worker_service.batch_registration_error.connect(self._on_batch_registration_error)
+        self.worker_service.batch_registration_canceled.connect(self._on_batch_registration_canceled)
 
         # Batch import connections
         self.worker_service.batch_import_finished.connect(self._on_batch_import_finished)
         self.worker_service.batch_import_error.connect(self._on_batch_import_error)
+        self.worker_service.batch_import_canceled.connect(self._on_batch_import_canceled)
 
         # Annotation connections
         self.worker_service.enhanced_annotation_finished.connect(self._on_annotation_finished)
         self.worker_service.enhanced_annotation_error.connect(self._on_annotation_error)
+        self.worker_service.enhanced_annotation_canceled.connect(self._on_annotation_canceled)
 
         # Progress feedback connections
         self.worker_service.worker_progress_updated.connect(self._on_worker_progress_updated)
         self.worker_service.worker_batch_progress.connect(self._on_worker_batch_progress)
 
-        logger.info("WorkerService pipeline signals connected (15 connections)")
+        logger.info("WorkerService pipeline signals connected (18 connections)")
 
     def _delegate_to_pipeline_control(self, method_name: str, *args: Any) -> None:
         """PipelineControlServiceへのイベント委譲ヘルパー"""
@@ -728,6 +740,12 @@ class MainWindow(QMainWindow, Ui_MainWindow):
         # エラー通知Widget更新
         if self.error_notification_widget:
             self.error_notification_widget.update_error_count()
+
+    def _on_pipeline_search_canceled(self, worker_id: str) -> None:
+        self._delegate_to_pipeline_control("on_search_canceled", worker_id)
+
+    def _on_pipeline_thumbnail_canceled(self, worker_id: str) -> None:
+        self._delegate_to_pipeline_control("on_thumbnail_canceled", worker_id)
 
     def _delegate_to_progress_state(self, method_name: str, *args: Any) -> None:
         """ProgressStateServiceへのイベント委譲ヘルパー"""
@@ -763,6 +781,10 @@ class MainWindow(QMainWindow, Ui_MainWindow):
         # エラー通知Widget更新
         if self.error_notification_widget:
             self.error_notification_widget.update_error_count()
+
+    def _on_batch_registration_canceled(self, worker_id: str) -> None:
+        """Batch registration canceled signal handler（エラー通知は出さない）"""
+        self._delegate_to_progress_state("on_batch_registration_canceled", worker_id)
 
     def _on_worker_progress_updated(self, worker_id: str, progress: Any) -> None:
         self._delegate_to_progress_state("on_worker_progress_updated", worker_id, progress)
@@ -836,6 +858,10 @@ class MainWindow(QMainWindow, Ui_MainWindow):
         # エラー通知Widget更新
         if self.error_notification_widget:
             self.error_notification_widget.update_error_count()
+
+    def _on_annotation_canceled(self, worker_id: str) -> None:
+        """Annotation canceled signal handler（エラー通知は出さない）"""
+        self._delegate_to_progress_state("on_batch_annotation_canceled", worker_id)
 
     def _on_batch_annotation_finished(self, result: Any) -> None:
         self._delegate_to_result_handler(
@@ -1851,3 +1877,7 @@ class MainWindow(QMainWindow, Ui_MainWindow):
         )
         if self.error_notification_widget:
             self.error_notification_widget.update_error_count()
+
+    def _on_batch_import_canceled(self, worker_id: str) -> None:
+        """バッチインポートキャンセルハンドラ（エラー通知は出さない）。"""
+        self._delegate_to_progress_state("on_batch_import_canceled", worker_id)

--- a/src/lorairo/gui/workers/annotation_worker.py
+++ b/src/lorairo/gui/workers/annotation_worker.py
@@ -20,7 +20,7 @@ from lorairo.services.model_registry_protocol import (
 )
 from lorairo.utils.log import logger
 
-from .base import LoRAIroWorkerBase
+from .base import CancellationError, LoRAIroWorkerBase
 
 if TYPE_CHECKING:
     from lorairo.database.db_manager import ImageDatabaseManager
@@ -230,6 +230,10 @@ class AnnotationWorker(LoRAIroWorkerBase["AnnotationExecutionResult"]):
                     f"マージ後合計={len(merged_results)}件"
                 )
 
+            except CancellationError:
+                logger.info(f"モデル {litellm_model_id} のアノテーション処理がキャンセルされました")
+                raise
+
             except Exception as e:
                 logger.error(f"モデル {litellm_model_id} でエラー: {e}", exc_info=True)
                 self._save_error_records(e, self.image_paths, model_name=litellm_model_id)
@@ -322,6 +326,10 @@ class AnnotationWorker(LoRAIroWorkerBase["AnnotationExecutionResult"]):
                 phash_to_filename=phash_to_filename,
                 total_processing_time_sec=0.0,
             )
+
+        except CancellationError:
+            logger.info("アノテーション処理がキャンセルされました")
+            raise
 
         except Exception as e:
             logger.error(f"アノテーション処理エラー: {e}", exc_info=True)

--- a/src/lorairo/gui/workers/base.py
+++ b/src/lorairo/gui/workers/base.py
@@ -23,6 +23,7 @@ class WorkerStatus(Enum):
     CANCELING = "canceling"
     COMPLETED = "completed"
     FAILED = "failed"
+    CANCELED = "canceled"
 
 
 @dataclass
@@ -53,6 +54,10 @@ class CancellationController:
     def reset(self) -> None:
         """キャンセル状態リセット"""
         self._is_canceled = False
+
+
+class CancellationError(Exception):
+    """ユーザー操作によるワーカーキャンセルを表す例外。"""
 
 
 class ProgressReporter(QObject):
@@ -100,6 +105,7 @@ class LoRAIroWorkerBase[T](QObject):
     status_changed = Signal(WorkerStatus)
     finished = Signal(object)  # result: T
     error_occurred = Signal(str)
+    canceled = Signal()
 
     _OPERATION_TYPE: ClassVar[str] = ""
 
@@ -140,7 +146,14 @@ class LoRAIroWorkerBase[T](QObject):
                 self.finished.emit(result)
                 logger.info(f"ワーカー実行完了: {self.__class__.__name__}")
             else:
+                self._set_status(WorkerStatus.CANCELED)
+                self.canceled.emit()
                 logger.info(f"ワーカー実行キャンセル: {self.__class__.__name__}")
+
+        except CancellationError as e:
+            logger.info(f"ワーカー実行キャンセル: {self.__class__.__name__}: {e}")
+            self._set_status(WorkerStatus.CANCELED)
+            self.canceled.emit()
 
         except Exception as e:
             self._set_status(WorkerStatus.FAILED)
@@ -185,7 +198,7 @@ class LoRAIroWorkerBase[T](QObject):
     def _check_cancellation(self) -> None:
         """キャンセルチェック（サブクラスで使用）"""
         if self.cancellation.is_canceled():
-            raise RuntimeError("処理がキャンセルされました")
+            raise CancellationError("処理がキャンセルされました")
 
     def _report_progress(
         self,

--- a/src/lorairo/gui/workers/manager.py
+++ b/src/lorairo/gui/workers/manager.py
@@ -2,7 +2,7 @@
 
 from typing import Any
 
-from PySide6.QtCore import QObject, QThread, Signal
+from PySide6.QtCore import QCoreApplication, QObject, QThread, Signal
 
 from ...utils.log import logger
 from .base import LoRAIroWorkerBase
@@ -60,12 +60,15 @@ class WorkerManager(QObject):
         thread.started.connect(worker.run)
         worker.finished.connect(lambda result: self._on_worker_finished(worker_id, result))
         worker.error_occurred.connect(lambda error: self._on_worker_error(worker_id, error))
+        worker.canceled.connect(lambda: self._on_worker_canceled(worker_id))
 
         if auto_cleanup:
             worker.finished.connect(thread.quit)
             worker.finished.connect(worker.deleteLater)
             worker.error_occurred.connect(thread.quit)
             worker.error_occurred.connect(worker.deleteLater)
+            worker.canceled.connect(thread.quit)
+            worker.canceled.connect(worker.deleteLater)
             # スレッドの適切な終了処理
             thread.finished.connect(lambda: self._cleanup_thread(worker_id, thread))
             thread.finished.connect(thread.deleteLater)
@@ -105,12 +108,15 @@ class WorkerManager(QObject):
         thread = worker_info["thread"]
         if thread.isRunning():
             thread.quit()
-            if not thread.wait(2000):  # 2秒待機
+            if thread.wait(2000):  # 2秒待機
+                self._finalize_canceled_if_no_terminal_signal(worker_id)
+            else:
                 logger.warning(f"キャンセルされたワーカーの終了タイムアウト: {worker_id}")
                 thread.terminate()
-                thread.wait(1000)  # 強制終了後も1秒待機
-
-        self.worker_canceled.emit(worker_id)
+                if thread.wait(1000):  # 強制終了後も1秒待機
+                    self._finalize_canceled_if_no_terminal_signal(worker_id)
+                else:
+                    logger.error(f"キャンセルされたワーカーの強制終了失敗: {worker_id}")
 
         logger.info(f"ワーカーキャンセル: {worker_id}")
         return True
@@ -184,15 +190,8 @@ class WorkerManager(QObject):
 
     def _on_worker_finished(self, worker_id: str, result: Any) -> None:
         """ワーカー完了イベントハンドラー"""
-        if worker_id in self.active_workers:
-            self.active_workers.pop(worker_id)
+        if self._pop_active_worker(worker_id):
             self.worker_finished.emit(worker_id, result)
-            self.active_worker_count_changed.emit(len(self.active_workers))
-
-            # 全ワーカー完了チェック
-            if len(self.active_workers) == 0:
-                self.all_workers_finished.emit()
-
             logger.info(f"ワーカー完了: {worker_id}")
 
     def _cleanup_thread(self, worker_id: str, thread: QThread) -> None:
@@ -210,16 +209,37 @@ class WorkerManager(QObject):
 
     def _on_worker_error(self, worker_id: str, error: str) -> None:
         """ワーカーエラーイベントハンドラー"""
-        if worker_id in self.active_workers:
-            self.active_workers.pop(worker_id)
+        if self._pop_active_worker(worker_id):
             self.worker_error.emit(worker_id, error)
-            self.active_worker_count_changed.emit(len(self.active_workers))
-
-            # 全ワーカー完了チェック
-            if len(self.active_workers) == 0:
-                self.all_workers_finished.emit()
-
             logger.error(f"ワーカーエラー: {worker_id} - {error}")
+
+    def _on_worker_canceled(self, worker_id: str) -> None:
+        """ワーカーキャンセル完了イベントハンドラー"""
+        if self._pop_active_worker(worker_id):
+            self.worker_canceled.emit(worker_id)
+            logger.info(f"ワーカーキャンセル完了: {worker_id}")
+
+    def _finalize_canceled_if_no_terminal_signal(self, worker_id: str) -> None:
+        """queued terminal signal を優先し、未確定なら cancel fallback で終端する。"""
+        app = QCoreApplication.instance()
+        if app is not None:
+            app.processEvents()
+
+        if worker_id in self.active_workers:
+            self._on_worker_canceled(worker_id)
+
+    def _pop_active_worker(self, worker_id: str) -> bool:
+        """ワーカー終端を一度だけ確定し、管理状態を更新する。"""
+        if worker_id not in self.active_workers:
+            return False
+
+        self.active_workers.pop(worker_id)
+        self.active_worker_count_changed.emit(len(self.active_workers))
+
+        if len(self.active_workers) == 0:
+            self.all_workers_finished.emit()
+
+        return True
 
     # === Utility Methods ===
 

--- a/src/lorairo/gui/workers/search_worker.py
+++ b/src/lorairo/gui/workers/search_worker.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING, Any
 
 from ...services.search_criteria_processor import SearchCriteriaProcessor
 from ...utils.log import logger
-from .base import LoRAIroWorkerBase
+from .base import CancellationError, LoRAIroWorkerBase
 
 if TYPE_CHECKING:
     from ...database.db_manager import ImageDatabaseManager
@@ -83,6 +83,10 @@ class SearchWorker(LoRAIroWorkerBase[SearchResult]):
             logger.info(f"検索完了: {total_count}件, 処理時間={search_time:.3f}秒")
 
             return result
+
+        except CancellationError:
+            logger.info("検索処理がキャンセルされました")
+            raise
 
         except Exception as e:
             logger.error(f"検索処理エラー: {e}", exc_info=True)

--- a/tests/integration/gui/workers/test_worker_error_recording.py
+++ b/tests/integration/gui/workers/test_worker_error_recording.py
@@ -21,6 +21,7 @@ from lorairo.annotations.annotation_logic import AnnotationLogic
 from lorairo.database.db_core import create_db_engine, create_session_factory
 from lorairo.database.db_manager import ImageDatabaseManager
 from lorairo.database.db_repository import ImageRepository
+from lorairo.gui.workers.base import CancellationError
 from lorairo.gui.workers.registration_worker import DatabaseRegistrationWorker
 from lorairo.gui.workers.search_worker import SearchResult, SearchWorker
 from lorairo.gui.workers.thumbnail_worker import ThumbnailWorker
@@ -310,6 +311,22 @@ class TestSearchWorkerErrorRecording:
         assert len(error_records) > 0
         assert error_records[0].error_type == "Exception"
         assert "Database Error" in error_records[0].error_message
+
+    def test_search_cancellation_does_not_create_error_record(self, db_manager):
+        """検索キャンセル時はエラーレコードを作成しない"""
+        conditions = SearchConditions(
+            search_type="tags",
+            keywords=[],
+            tag_logic="and",
+        )
+        worker = SearchWorker(db_manager=db_manager, search_conditions=conditions)
+        worker.cancel()
+
+        with pytest.raises(CancellationError, match="処理がキャンセルされました"):
+            worker.execute()
+
+        error_count = db_manager.repository.get_error_count_unresolved(operation_type="search")
+        assert error_count == 0
 
 
 class TestBatchImportWorkerErrorRecording:

--- a/tests/unit/gui/services/test_pipeline_control_service.py
+++ b/tests/unit/gui/services/test_pipeline_control_service.py
@@ -36,6 +36,7 @@ def mock_filter_panel():
     """フィルターパネルのモック"""
     panel = Mock()
     panel.hide_progress_after_completion = Mock()
+    panel.clear_pipeline_results = Mock()
     return panel
 
 
@@ -87,6 +88,7 @@ class TestCancelCurrentPipeline:
         mock_worker_service.cancel_search.assert_called_once_with("search-123")
         mock_worker_service.cancel_thumbnail_load.assert_called_once_with("thumb-456")
         mock_thumbnail_selector.clear_thumbnails.assert_called_once()
+        mock_filter_panel.clear_pipeline_results.assert_called_once()
         mock_filter_panel.hide_progress_after_completion.assert_called_once()
 
     def test_cancel_pipeline_without_worker_service(self, mock_thumbnail_selector, mock_filter_panel):
@@ -123,6 +125,7 @@ class TestCancelCurrentPipeline:
         mock_worker_service.cancel_search.assert_not_called()
         mock_worker_service.cancel_thumbnail_load.assert_not_called()
         mock_thumbnail_selector.clear_thumbnails.assert_called_once()
+        mock_filter_panel.clear_pipeline_results.assert_called_once()
 
     def test_cancel_pipeline_without_thumbnail_selector(self, mock_worker_service, mock_filter_panel):
         """サムネイルセレクター無し"""
@@ -184,4 +187,22 @@ class TestPipelineFlow:
         service.on_thumbnail_completed(thumbnail_result)
 
         mock_thumbnail_selector.handle_thumbnail_page_result.assert_called_once_with(thumbnail_result)
+        mock_filter_panel.hide_progress_after_completion.assert_called_once()
+
+    def test_on_search_canceled_clears_results_without_error(
+        self, service, mock_thumbnail_selector, mock_filter_panel
+    ):
+        service.on_search_canceled("search-123")
+
+        mock_thumbnail_selector.clear_thumbnails.assert_called_once()
+        mock_filter_panel.clear_pipeline_results.assert_called_once()
+        mock_filter_panel.hide_progress_after_completion.assert_called_once()
+
+    def test_on_thumbnail_canceled_keeps_pipeline_results_without_error(
+        self, service, mock_thumbnail_selector, mock_filter_panel
+    ):
+        service.on_thumbnail_canceled("thumbnail-123")
+
+        mock_thumbnail_selector.clear_thumbnails.assert_not_called()
+        mock_filter_panel.clear_pipeline_results.assert_not_called()
         mock_filter_panel.hide_progress_after_completion.assert_called_once()

--- a/tests/unit/gui/services/test_progress_state_service.py
+++ b/tests/unit/gui/services/test_progress_state_service.py
@@ -53,6 +53,34 @@ class TestBatchRegistrationError:
         assert "テストエラー" in args[0]
 
 
+class TestBatchRegistrationCanceled:
+    @pytest.mark.parametrize(
+        "method_name",
+        [
+            "on_batch_registration_canceled",
+            "on_batch_annotation_canceled",
+            "on_batch_import_canceled",
+        ],
+    )
+    def test_no_statusbar(self, service_no_statusbar, method_name):
+        getattr(service_no_statusbar, method_name)("worker_001")
+
+    @pytest.mark.parametrize(
+        "method_name",
+        [
+            "on_batch_registration_canceled",
+            "on_batch_annotation_canceled",
+            "on_batch_import_canceled",
+        ],
+    )
+    def test_with_statusbar(self, service_with_statusbar, mock_statusbar, method_name):
+        getattr(service_with_statusbar, method_name)("worker_001")
+        mock_statusbar.showMessage.assert_called_once()
+        args = mock_statusbar.showMessage.call_args[0]
+        assert "キャンセル" in args[0]
+        assert args[1] == 5000
+
+
 class TestWorkerProgressUpdated:
     def test_no_statusbar_returns_early(self, service_no_statusbar):
         progress = SimpleNamespace(current=5, total=10)

--- a/tests/unit/gui/services/test_worker_service.py
+++ b/tests/unit/gui/services/test_worker_service.py
@@ -47,6 +47,7 @@ class TestWorkerService:
         assert worker_service.current_registration_worker_id is None
         assert worker_service.current_annotation_worker_id is None
         assert worker_service.current_thumbnail_worker_id is None
+        assert worker_service.current_batch_import_worker_id is None
 
     def test_signal_definitions(self, worker_service):
         """シグナル定義テスト"""
@@ -54,18 +55,27 @@ class TestWorkerService:
         assert hasattr(worker_service, "batch_registration_started")
         assert hasattr(worker_service, "batch_registration_finished")
         assert hasattr(worker_service, "batch_registration_error")
+        assert hasattr(worker_service, "batch_registration_canceled")
 
         assert hasattr(worker_service, "enhanced_annotation_started")
         assert hasattr(worker_service, "enhanced_annotation_finished")
         assert hasattr(worker_service, "enhanced_annotation_error")
+        assert hasattr(worker_service, "enhanced_annotation_canceled")
 
         assert hasattr(worker_service, "search_started")
         assert hasattr(worker_service, "search_finished")
         assert hasattr(worker_service, "search_error")
+        assert hasattr(worker_service, "search_canceled")
 
         assert hasattr(worker_service, "thumbnail_started")
         assert hasattr(worker_service, "thumbnail_finished")
         assert hasattr(worker_service, "thumbnail_error")
+        assert hasattr(worker_service, "thumbnail_canceled")
+
+        assert hasattr(worker_service, "batch_import_started")
+        assert hasattr(worker_service, "batch_import_finished")
+        assert hasattr(worker_service, "batch_import_error")
+        assert hasattr(worker_service, "batch_import_canceled")
 
         # 進捗・管理シグナル
         assert hasattr(worker_service, "worker_progress_updated")
@@ -99,6 +109,7 @@ class TestWorkerService:
         assert worker_id.startswith("batch_reg_")
         suffix = worker_id.split("_")[-1]
         assert len(suffix) == 8 and bool(re.match(r"^[0-9a-f]{8}$", suffix))
+        assert worker_service.current_registration_worker_id == worker_id
 
     @patch("lorairo.gui.services.worker_service.DatabaseRegistrationWorker")
     def test_start_batch_registration_failure(self, mock_worker_class, worker_service):
@@ -107,12 +118,15 @@ class TestWorkerService:
         mock_worker = Mock()
         mock_worker_class.return_value = mock_worker
         worker_service.worker_manager.start_worker.return_value = False
+        worker_service.current_registration_worker_id = "batch_reg_existing"
 
         directory = Path("/test/directory")
 
         # 例外発生確認
         with pytest.raises(RuntimeError, match="ワーカー開始失敗"):
             worker_service.start_batch_registration(directory)
+
+        assert worker_service.current_registration_worker_id == "batch_reg_existing"
 
     def test_cancel_batch_registration(self, worker_service):
         """バッチ登録キャンセルテスト"""
@@ -161,6 +175,22 @@ class TestWorkerService:
 
         # 現在の検索ワーカーID設定確認
         assert worker_service.current_search_worker_id == worker_id
+
+    @patch("lorairo.gui.services.worker_service.SearchWorker")
+    def test_start_search_failure_after_cancel_clears_current_worker_id(
+        self, mock_worker_class, worker_service
+    ):
+        """既存検索キャンセル後の検索開始失敗時は stale id を残さない"""
+        mock_worker_class.return_value = Mock()
+        worker_service.worker_manager.start_worker.return_value = False
+        worker_service.current_search_worker_id = "search_existing"
+
+        with pytest.raises(RuntimeError, match="ワーカー開始失敗"):
+            worker_service.start_search(
+                SearchConditions(search_type="tags", keywords=["test"], tag_logic="and")
+            )
+
+        assert worker_service.current_search_worker_id is None
 
     @patch("lorairo.gui.services.worker_service.SearchWorker")
     def test_start_search_cancels_existing(self, mock_worker_class, worker_service):
@@ -379,6 +409,24 @@ class TestWorkerService:
         assert hasattr(worker_service, "_on_worker_started")
         assert hasattr(worker_service, "_on_worker_finished")
         assert hasattr(worker_service, "_on_worker_error")
+        assert hasattr(worker_service, "_on_worker_canceled")
+
+    def test_on_worker_canceled_clears_current_id_and_finishes_progress(self, worker_service):
+        """キャンセル完了時はエラーシグナルなしで進捗とcurrent idを片付ける"""
+        worker_id = "search_cancelled"
+        worker_service.current_search_worker_id = worker_id
+        error_mock = Mock()
+        canceled_mock = Mock()
+        worker_service.search_error.connect(error_mock)
+        worker_service.search_canceled.connect(canceled_mock)
+
+        with patch.object(worker_service.progress_manager, "finish_worker_progress") as mock_finish:
+            worker_service._on_worker_canceled(worker_id)
+
+        mock_finish.assert_called_once_with(worker_id, success=False)
+        assert worker_service.current_search_worker_id is None
+        error_mock.assert_not_called()
+        canceled_mock.assert_called_once_with(worker_id)
 
     def test_worker_id_uniqueness(self, worker_service):
         """ワーカーID一意性テスト"""
@@ -452,6 +500,7 @@ class TestWorkerService:
         assert worker_service.current_registration_worker_id is None
         assert worker_service.current_annotation_worker_id is None
         assert worker_service.current_thumbnail_worker_id is None
+        assert worker_service.current_batch_import_worker_id is None
 
     @patch("lorairo.gui.services.worker_service.AnnotationWorker")
     @patch.object(WorkerService, "annotation_logic", create=True)
@@ -490,6 +539,162 @@ class TestWorkerService:
 
         # 進捗シグナル接続確認
         mock_worker.progress_updated.connect.assert_called()
+        assert worker_service.current_annotation_worker_id == worker_id
+
+    @patch("lorairo.gui.services.worker_service.AnnotationWorker")
+    @patch.object(WorkerService, "annotation_logic", create=True)
+    def test_start_enhanced_batch_annotation_failure_keeps_current_worker_id(
+        self, mock_annotation_logic, mock_worker_class, worker_service
+    ):
+        """アノテーション開始失敗時に current_annotation_worker_id を上書きしない"""
+        mock_worker_class.return_value = Mock()
+        worker_service.worker_manager.start_worker.return_value = False
+        worker_service.current_annotation_worker_id = "annotation_existing"
+
+        with pytest.raises(RuntimeError, match="アノテーションワーカー開始失敗"):
+            worker_service.start_enhanced_batch_annotation(
+                image_paths=["/path/to/image.jpg"], litellm_model_ids=["gpt-4o-mini"]
+            )
+
+        assert worker_service.current_annotation_worker_id == "annotation_existing"
+
+    @patch("lorairo.gui.services.worker_service.get_service_container")
+    @patch("lorairo.gui.workers.batch_import_worker.BatchImportWorker")
+    def test_start_batch_import_success_sets_current_worker_id(
+        self, mock_worker_class, mock_container, worker_service
+    ):
+        """バッチインポート開始成功時にcurrent worker idを設定する"""
+        mock_container.return_value.image_repository = Mock()
+        mock_worker = Mock()
+        mock_worker_class.return_value = mock_worker
+        worker_service.worker_manager.start_worker.return_value = True
+
+        worker_id = worker_service.start_batch_import([Path("/tmp/test.jsonl")], dry_run=True)
+
+        assert worker_id.startswith("batch_import_")
+        assert worker_service.current_batch_import_worker_id == worker_id
+        worker_service.worker_manager.start_worker.assert_called_once_with(worker_id, mock_worker)
+
+    @patch("lorairo.gui.services.worker_service.get_service_container")
+    @patch("lorairo.gui.workers.batch_import_worker.BatchImportWorker")
+    def test_start_batch_import_failure_keeps_current_worker_id(
+        self, mock_worker_class, mock_container, worker_service
+    ):
+        """バッチインポート開始失敗時に current_batch_import_worker_id を上書きしない"""
+        mock_container.return_value.image_repository = Mock()
+        mock_worker_class.return_value = Mock()
+        worker_service.worker_manager.start_worker.return_value = False
+        worker_service.current_batch_import_worker_id = "batch_import_existing"
+
+        with pytest.raises(RuntimeError, match="ワーカー開始失敗"):
+            worker_service.start_batch_import([Path("/tmp/test.jsonl")])
+
+        assert worker_service.current_batch_import_worker_id == "batch_import_existing"
+
+    @pytest.mark.parametrize(
+        ("worker_id", "terminal", "signal_name", "current_attr", "payload"),
+        [
+            (
+                "batch_reg_abc12345",
+                "finished",
+                "batch_registration_finished",
+                "current_registration_worker_id",
+                {"ok": True},
+            ),
+            (
+                "batch_reg_abc12345",
+                "error",
+                "batch_registration_error",
+                "current_registration_worker_id",
+                "boom",
+            ),
+            (
+                "batch_reg_abc12345",
+                "canceled",
+                "batch_registration_canceled",
+                "current_registration_worker_id",
+                None,
+            ),
+            (
+                "batch_import_abc12345",
+                "finished",
+                "batch_import_finished",
+                "current_batch_import_worker_id",
+                {"ok": True},
+            ),
+            (
+                "batch_import_abc12345",
+                "error",
+                "batch_import_error",
+                "current_batch_import_worker_id",
+                "boom",
+            ),
+            (
+                "batch_import_abc12345",
+                "canceled",
+                "batch_import_canceled",
+                "current_batch_import_worker_id",
+                None,
+            ),
+            (
+                "annotation_abc12345",
+                "finished",
+                "enhanced_annotation_finished",
+                "current_annotation_worker_id",
+                {"ok": True},
+            ),
+            (
+                "annotation_abc12345",
+                "error",
+                "enhanced_annotation_error",
+                "current_annotation_worker_id",
+                "boom",
+            ),
+            (
+                "annotation_abc12345",
+                "canceled",
+                "enhanced_annotation_canceled",
+                "current_annotation_worker_id",
+                None,
+            ),
+            ("search_abc12345", "finished", "search_finished", "current_search_worker_id", {"ok": True}),
+            ("search_abc12345", "error", "search_error", "current_search_worker_id", "boom"),
+            ("search_abc12345", "canceled", "search_canceled", "current_search_worker_id", None),
+            (
+                "thumbnail_abc12345",
+                "finished",
+                "thumbnail_finished",
+                "current_thumbnail_worker_id",
+                {"ok": True},
+            ),
+            ("thumbnail_abc12345", "error", "thumbnail_error", "current_thumbnail_worker_id", "boom"),
+            ("thumbnail_abc12345", "canceled", "thumbnail_canceled", "current_thumbnail_worker_id", None),
+        ],
+    )
+    def test_worker_terminal_dispatch_table(
+        self, worker_service, worker_id, terminal, signal_name, current_attr, payload
+    ):
+        """全worker種別の終端signalとcurrent id cleanupを表で検証する"""
+        setattr(worker_service, current_attr, worker_id)
+        terminal_mock = Mock()
+        getattr(worker_service, signal_name).connect(terminal_mock)
+
+        with patch.object(worker_service.progress_manager, "finish_worker_progress") as mock_finish:
+            if terminal == "finished":
+                worker_service._on_worker_finished(worker_id, payload)
+                terminal_mock.assert_called_once_with(payload)
+            elif terminal == "error":
+                worker_service._on_worker_error(worker_id, payload)
+                terminal_mock.assert_called_once_with(payload)
+            else:
+                worker_service._on_worker_canceled(worker_id)
+                terminal_mock.assert_called_once_with(worker_id)
+
+        assert getattr(worker_service, current_attr) is None
+        if not worker_id.startswith("thumbnail_"):
+            mock_finish.assert_called_once()
+        else:
+            mock_finish.assert_not_called()
 
     def test_modern_progress_manager_integration(self, worker_service):
         """ModernProgressManager統合検証

--- a/tests/unit/gui/widgets/test_custom_range_slider.py
+++ b/tests/unit/gui/widgets/test_custom_range_slider.py
@@ -6,7 +6,7 @@ import pytest
 from PySide6.QtWidgets import QWidget
 
 from lorairo.gui.widgets.custom_range_slider import CustomRangeSlider
-from lorairo.gui.widgets.filter_search_panel import FilterSearchPanel
+from lorairo.gui.widgets.filter_search_panel import FilterSearchPanel, PipelineState
 
 
 class TestCustomRangeSlider:
@@ -335,6 +335,18 @@ class TestFilterSearchPanel:
         assert hasattr(filter_panel, "date_range_slider")
         assert hasattr(filter_panel, "logic_button_group")  # 新機能
         assert hasattr(filter_panel, "filter_applied")
+
+    def test_on_search_canceled_emits_terminal_result(self, filter_panel):
+        """検索キャンセル時にUI状態と検索完了通知が終端することを確認"""
+        results = []
+        filter_panel.search_completed.connect(results.append)
+        filter_panel._current_search_worker_id = "search-123"
+
+        filter_panel._on_search_canceled("search-123")
+
+        assert filter_panel._current_search_worker_id is None
+        assert filter_panel.get_current_pipeline_state() == PipelineState.CANCELED
+        assert results == [{"results": [], "count": 0, "canceled": True}]
 
     def test_get_filter_conditions_basic_search(self, filter_panel):
         """基本検索条件取得テスト"""

--- a/tests/unit/gui/window/test_main_window.py
+++ b/tests/unit/gui/window/test_main_window.py
@@ -318,14 +318,21 @@ class TestMainWindowAnnotationCompletion:
             "search_finished",
             "search_started",
             "search_error",
+            "search_canceled",
             "thumbnail_finished",
             "thumbnail_started",
             "thumbnail_error",
+            "thumbnail_canceled",
             "batch_registration_started",
             "batch_registration_finished",
             "batch_registration_error",
+            "batch_registration_canceled",
+            "batch_import_finished",
+            "batch_import_error",
+            "batch_import_canceled",
             "enhanced_annotation_finished",
             "enhanced_annotation_error",
+            "enhanced_annotation_canceled",
             "worker_progress_updated",
             "worker_batch_progress",
         ]:
@@ -334,11 +341,29 @@ class TestMainWindowAnnotationCompletion:
         with patch("lorairo.gui.window.main_window.logger"):
             MainWindow._setup_worker_pipeline_signals(mock_window)
 
-            # enhanced_annotation_finished シグナルが接続される
-            mock_window.worker_service.enhanced_annotation_finished.connect.assert_called_once()
-
-            # enhanced_annotation_error シグナルが接続される
-            mock_window.worker_service.enhanced_annotation_error.connect.assert_called_once()
+            for signal_name in [
+                "search_finished",
+                "search_started",
+                "search_error",
+                "search_canceled",
+                "thumbnail_finished",
+                "thumbnail_started",
+                "thumbnail_error",
+                "thumbnail_canceled",
+                "batch_registration_started",
+                "batch_registration_finished",
+                "batch_registration_error",
+                "batch_registration_canceled",
+                "batch_import_finished",
+                "batch_import_error",
+                "batch_import_canceled",
+                "enhanced_annotation_finished",
+                "enhanced_annotation_error",
+                "enhanced_annotation_canceled",
+                "worker_progress_updated",
+                "worker_batch_progress",
+            ]:
+                getattr(mock_window.worker_service, signal_name).connect.assert_called_once()
 
 
 class TestMainWindowTagAddFeedback:

--- a/tests/unit/gui/window/test_main_window_coverage.py
+++ b/tests/unit/gui/window/test_main_window_coverage.py
@@ -117,6 +117,15 @@ class TestPipelineEventHandlers:
         mock_window.error_notification_widget = None
         MainWindow._on_pipeline_search_error(mock_window, "search error")
 
+    def test_on_pipeline_search_canceled_delegates_without_error_notification(self):
+        from lorairo.gui.window.main_window import MainWindow
+
+        mock_window = Mock()
+        MainWindow._on_pipeline_search_canceled(mock_window, "search-123")
+        mock_window._delegate_to_pipeline_control.assert_called_once_with(
+            "on_search_canceled", "search-123"
+        )
+
     def test_on_pipeline_thumbnail_error_updates_notification_widget(self):
         from lorairo.gui.window.main_window import MainWindow
 
@@ -127,6 +136,15 @@ class TestPipelineEventHandlers:
             "on_thumbnail_error", "thumb error"
         )
         mock_window.error_notification_widget.update_error_count.assert_called_once()
+
+    def test_on_pipeline_thumbnail_canceled_delegates_without_error_notification(self):
+        from lorairo.gui.window.main_window import MainWindow
+
+        mock_window = Mock()
+        MainWindow._on_pipeline_thumbnail_canceled(mock_window, "thumbnail-123")
+        mock_window._delegate_to_pipeline_control.assert_called_once_with(
+            "on_thumbnail_canceled", "thumbnail-123"
+        )
 
 
 class TestBatchRegistrationHandlers:
@@ -180,6 +198,15 @@ class TestBatchRegistrationHandlers:
         with patch("lorairo.gui.window.main_window.QMessageBox"):
             MainWindow._on_batch_registration_error(mock_window, "エラー")
         mock_window.error_notification_widget.update_error_count.assert_called_once()
+
+    def test_on_batch_registration_canceled_delegates_without_error_notification(self):
+        from lorairo.gui.window.main_window import MainWindow
+
+        mock_window = Mock()
+        MainWindow._on_batch_registration_canceled(mock_window, "worker_1")
+        mock_window._delegate_to_progress_state.assert_called_once_with(
+            "on_batch_registration_canceled", "worker_1"
+        )
 
 
 class TestWorkerProgressHandlers:
@@ -238,6 +265,15 @@ class TestResultHandlerDelegates:
         mock_window = Mock()
         mock_window.error_notification_widget = None
         MainWindow._on_annotation_error(mock_window, "エラー")
+
+    def test_on_annotation_canceled_delegates_without_error_notification(self):
+        from lorairo.gui.window.main_window import MainWindow
+
+        mock_window = Mock()
+        MainWindow._on_annotation_canceled(mock_window, "annotation_123")
+        mock_window._delegate_to_progress_state.assert_called_once_with(
+            "on_batch_annotation_canceled", "annotation_123"
+        )
 
     def test_on_batch_annotation_finished_delegates(self):
         from lorairo.gui.window.main_window import MainWindow
@@ -952,6 +988,15 @@ class TestErrorHandlers:
         mock_window.error_notification_widget = None
         with patch("lorairo.gui.window.main_window.QMessageBox"):
             MainWindow._on_batch_import_error(mock_window, "エラー")
+
+    def test_on_batch_import_canceled_delegates_without_error_notification(self):
+        from lorairo.gui.window.main_window import MainWindow
+
+        mock_window = Mock()
+        MainWindow._on_batch_import_canceled(mock_window, "batch_import_123")
+        mock_window._delegate_to_progress_state.assert_called_once_with(
+            "on_batch_import_canceled", "batch_import_123"
+        )
 
 
 class TestDatabaseStatusLabel:

--- a/tests/unit/gui/workers/test_base_worker.py
+++ b/tests/unit/gui/workers/test_base_worker.py
@@ -8,6 +8,7 @@ from PySide6.QtCore import QObject, QThread
 
 from lorairo.gui.workers.base import (
     CancellationController,
+    CancellationError,
     LoRAIroWorkerBase,
     ProgressReporter,
     WorkerProgress,
@@ -53,6 +54,7 @@ class TestWorkerStatus:
         assert WorkerStatus.CANCELING.value == "canceling"
         assert WorkerStatus.COMPLETED.value == "completed"
         assert WorkerStatus.FAILED.value == "failed"
+        assert WorkerStatus.CANCELED.value == "canceled"
 
 
 class TestCancellationController:
@@ -234,7 +236,7 @@ class TestLoRAIroWorkerBase:
 
         # キャンセル後は例外発生
         worker.cancel()
-        with pytest.raises(RuntimeError, match="処理がキャンセルされました"):
+        with pytest.raises(CancellationError, match="処理がキャンセルされました"):
             worker._check_cancellation()
 
     def test_progress_report_helper(self, worker):
@@ -298,6 +300,26 @@ class ConcreteWorkerWithDb(LoRAIroWorkerBase[str]):
         if self.should_fail:
             raise RuntimeError("テスト例外")
         return "completed"
+
+
+class ConcreteWorkerCanceled(LoRAIroWorkerBase[str]):
+    """キャンセル例外を発生させるテスト用ワーカー"""
+
+    _OPERATION_TYPE = "test_cancel"
+
+    def __init__(self, db_manager=None):
+        super().__init__(db_manager=db_manager)
+
+    def execute(self) -> str:
+        raise CancellationError("処理がキャンセルされました")
+
+
+class ConcreteWorkerReturnsAfterCancel(LoRAIroWorkerBase[str]):
+    """キャンセルフラグ設定後に値を返すテスト用ワーカー"""
+
+    def execute(self) -> str:
+        self.cancellation.cancel()
+        return "ignored"
 
 
 class ConcreteWorkerPreRecords(LoRAIroWorkerBase[str]):
@@ -378,6 +400,44 @@ class TestLoRAIroWorkerBaseUnhandledError:
         worker.run()
 
         assert mock_db.save_error_record.call_count == 1
+
+    def test_run_treats_cancellation_as_non_error(self):
+        """CancellationError はエラーシグナルやDB記録を発生させない"""
+        mock_db = Mock()
+        worker = ConcreteWorkerCanceled(db_manager=mock_db)
+        error_mock = Mock()
+        canceled_mock = Mock()
+        status_mock = Mock()
+        worker.error_occurred.connect(error_mock)
+        worker.canceled.connect(canceled_mock)
+        worker.status_changed.connect(status_mock)
+
+        worker.run()
+
+        error_mock.assert_not_called()
+        canceled_mock.assert_called_once()
+        mock_db.save_error_record.assert_not_called()
+        status_calls = [call[0][0] for call in status_mock.call_args_list]
+        assert WorkerStatus.CANCELED in status_calls
+        assert WorkerStatus.FAILED not in status_calls
+
+    def test_run_treats_return_after_cancel_as_canceled_terminal(self):
+        """キャンセルフラグ後にexecuteが戻ってもfinishedではなくcanceledを発行する"""
+        worker = ConcreteWorkerReturnsAfterCancel()
+        finished_mock = Mock()
+        canceled_mock = Mock()
+        status_mock = Mock()
+        worker.finished.connect(finished_mock)
+        worker.canceled.connect(canceled_mock)
+        worker.status_changed.connect(status_mock)
+
+        worker.run()
+
+        finished_mock.assert_not_called()
+        canceled_mock.assert_called_once()
+        assert worker.status == WorkerStatus.CANCELED
+        status_calls = [call[0][0] for call in status_mock.call_args_list]
+        assert WorkerStatus.CANCELED in status_calls
 
 
 class TestLoRAIroWorkerBaseAlias:

--- a/tests/unit/gui/workers/test_manager.py
+++ b/tests/unit/gui/workers/test_manager.py
@@ -1,5 +1,7 @@
 """WorkerManager ユニットテスト（スレッド不要のシンプルなメソッド中心）。"""
 
+from unittest.mock import Mock
+
 import pytest
 
 from lorairo.gui.workers.manager import WorkerManager
@@ -47,3 +49,139 @@ class TestWorkerManagerEmptyOperations:
     def test_wait_for_all_workers_when_empty(self, manager):
         result = manager.wait_for_all_workers()
         assert result is True
+
+
+class TestWorkerManagerCancellation:
+    def test_cancel_worker_wait_success_finalizes_canceled_when_no_terminal_signal(self, manager):
+        worker = Mock()
+        thread = Mock()
+        thread.isRunning.return_value = True
+        thread.wait.return_value = True
+        manager.active_workers["worker-1"] = {"worker": worker, "thread": thread, "auto_cleanup": True}
+        canceled_mock = Mock()
+        manager.worker_canceled.connect(canceled_mock)
+
+        result = manager.cancel_worker("worker-1")
+
+        assert result is True
+        worker.cancel.assert_called_once()
+        thread.quit.assert_called_once()
+        thread.wait.assert_called_once_with(2000)
+        canceled_mock.assert_called_once_with("worker-1")
+        assert "worker-1" not in manager.active_workers
+
+    def test_cancel_worker_wait_success_prefers_queued_finished_signal(self, manager, monkeypatch):
+        worker = Mock()
+        thread = Mock()
+        thread.isRunning.return_value = True
+        thread.wait.return_value = True
+        manager.active_workers["worker-1"] = {"worker": worker, "thread": thread, "auto_cleanup": True}
+        finished_mock = Mock()
+        canceled_mock = Mock()
+        manager.worker_finished.connect(finished_mock)
+        manager.worker_canceled.connect(canceled_mock)
+        app = Mock()
+        app.processEvents.side_effect = lambda: manager._on_worker_finished("worker-1", {"ok": True})
+        monkeypatch.setattr("lorairo.gui.workers.manager.QCoreApplication.instance", Mock(return_value=app))
+
+        result = manager.cancel_worker("worker-1")
+
+        assert result is True
+        finished_mock.assert_called_once_with("worker-1", {"ok": True})
+        canceled_mock.assert_not_called()
+        assert "worker-1" not in manager.active_workers
+
+    def test_cancel_worker_wait_success_prefers_queued_error_signal(self, manager, monkeypatch):
+        worker = Mock()
+        thread = Mock()
+        thread.isRunning.return_value = True
+        thread.wait.return_value = True
+        manager.active_workers["worker-1"] = {"worker": worker, "thread": thread, "auto_cleanup": True}
+        error_mock = Mock()
+        canceled_mock = Mock()
+        manager.worker_error.connect(error_mock)
+        manager.worker_canceled.connect(canceled_mock)
+        app = Mock()
+        app.processEvents.side_effect = lambda: manager._on_worker_error("worker-1", "boom")
+        monkeypatch.setattr("lorairo.gui.workers.manager.QCoreApplication.instance", Mock(return_value=app))
+
+        result = manager.cancel_worker("worker-1")
+
+        assert result is True
+        error_mock.assert_called_once_with("worker-1", "boom")
+        canceled_mock.assert_not_called()
+        assert "worker-1" not in manager.active_workers
+
+    def test_finished_after_cancel_request_wins_over_canceled(self, manager):
+        manager.active_workers["worker-1"] = {"worker": Mock(), "thread": Mock(), "auto_cleanup": True}
+        finished_mock = Mock()
+        canceled_mock = Mock()
+        manager.worker_finished.connect(finished_mock)
+        manager.worker_canceled.connect(canceled_mock)
+
+        manager._on_worker_finished("worker-1", {"ok": True})
+        manager._on_worker_canceled("worker-1")
+
+        finished_mock.assert_called_once_with("worker-1", {"ok": True})
+        canceled_mock.assert_not_called()
+
+    def test_error_after_cancel_request_wins_over_canceled(self, manager):
+        manager.active_workers["worker-1"] = {"worker": Mock(), "thread": Mock(), "auto_cleanup": True}
+        error_mock = Mock()
+        canceled_mock = Mock()
+        manager.worker_error.connect(error_mock)
+        manager.worker_canceled.connect(canceled_mock)
+
+        manager._on_worker_error("worker-1", "boom")
+        manager._on_worker_canceled("worker-1")
+
+        error_mock.assert_called_once_with("worker-1", "boom")
+        canceled_mock.assert_not_called()
+
+    def test_cancel_worker_timeout_forces_canceled_cleanup(self, manager):
+        worker = Mock()
+        thread = Mock()
+        thread.isRunning.return_value = True
+        thread.wait.side_effect = [False, True]
+        manager.active_workers["worker-1"] = {"worker": worker, "thread": thread, "auto_cleanup": True}
+        canceled_mock = Mock()
+        manager.worker_canceled.connect(canceled_mock)
+
+        result = manager.cancel_worker("worker-1")
+
+        assert result is True
+        thread.terminate.assert_called_once()
+        canceled_mock.assert_called_once_with("worker-1")
+        assert "worker-1" not in manager.active_workers
+
+    def test_cancel_worker_timeout_does_not_finalize_when_terminate_wait_fails(self, manager):
+        worker = Mock()
+        thread = Mock()
+        thread.isRunning.return_value = True
+        thread.wait.side_effect = [False, False]
+        manager.active_workers["worker-1"] = {"worker": worker, "thread": thread, "auto_cleanup": True}
+        canceled_mock = Mock()
+        manager.worker_canceled.connect(canceled_mock)
+
+        result = manager.cancel_worker("worker-1")
+
+        assert result is True
+        thread.terminate.assert_called_once()
+        canceled_mock.assert_not_called()
+        assert "worker-1" in manager.active_workers
+
+    def test_on_worker_canceled_removes_active_worker_and_emits_terminal_signals(self, manager):
+        manager.active_workers["worker-1"] = {"worker": Mock(), "thread": Mock(), "auto_cleanup": True}
+        canceled_mock = Mock()
+        count_mock = Mock()
+        all_finished_mock = Mock()
+        manager.worker_canceled.connect(canceled_mock)
+        manager.active_worker_count_changed.connect(count_mock)
+        manager.all_workers_finished.connect(all_finished_mock)
+
+        manager._on_worker_canceled("worker-1")
+
+        assert manager.active_workers == {}
+        canceled_mock.assert_called_once_with("worker-1")
+        count_mock.assert_called_once_with(0)
+        all_finished_mock.assert_called_once()

--- a/tests/unit/workers/test_database_related_workers.py
+++ b/tests/unit/workers/test_database_related_workers.py
@@ -13,6 +13,7 @@ import pytest
 
 from lorairo.database.db_manager import ImageDatabaseManager
 from lorairo.database.db_repository import ImageRepository
+from lorairo.gui.workers.base import CancellationError
 from lorairo.gui.workers.registration_worker import (
     DatabaseRegistrationResult,
     DatabaseRegistrationWorker,
@@ -167,7 +168,7 @@ class TestDatabaseRegistrationWorker:
         worker = DatabaseRegistrationWorker(temp_dir, real_db_manager, mock_fsm)
         worker.cancel()
 
-        with pytest.raises(RuntimeError, match="処理がキャンセルされました"):
+        with pytest.raises(CancellationError, match="処理がキャンセルされました"):
             worker.execute()
 
     def test_empty_directory_handling(self, temp_dir, real_db_manager):
@@ -313,7 +314,7 @@ class TestSearchWorker:
         worker = SearchWorker(real_db_manager, search_conditions)
         worker.cancel()
 
-        with pytest.raises(RuntimeError, match="処理がキャンセルされました"):
+        with pytest.raises(CancellationError, match="処理がキャンセルされました"):
             worker.execute()
 
     def test_empty_search_result_handling(self, real_db_manager, search_conditions):
@@ -852,11 +853,11 @@ class TestRegistrationErrorHandling:
         return worker, real_db_manager, mock_fsm
 
     def test_cancellation_during_execution(self, worker_setup):
-        """キャンセル実行時にRuntimeErrorが発生することを確認"""
+        """キャンセル実行時にCancellationErrorが発生することを確認"""
         worker, _, _ = worker_setup
         worker.cancel()
 
-        with pytest.raises(RuntimeError, match="処理がキャンセルされました"):
+        with pytest.raises(CancellationError, match="処理がキャンセルされました"):
             worker.execute()
 
     def test_cancellation_mid_loop(self, temp_dir, real_db_manager, mock_fsm):
@@ -883,11 +884,11 @@ class TestRegistrationErrorHandling:
             # 2回目のチェック時にキャンセル
             def cancel_on_second_call():
                 if mock_cancel.call_count >= 2:
-                    raise RuntimeError("処理がキャンセルされました")
+                    raise CancellationError("処理がキャンセルされました")
 
             mock_cancel.side_effect = cancel_on_second_call
 
-            with pytest.raises(RuntimeError, match="処理がキャンセルされました"):
+            with pytest.raises(CancellationError, match="処理がキャンセルされました"):
                 worker.execute()
 
     def test_exception_in_db_registration(self, temp_dir, real_db_manager, mock_fsm):


### PR DESCRIPTION
## Summary

- Add a dedicated `CancellationError` for normal worker cancellation flow
- Prevent search and annotation cancellations from being recorded as ErrorLogViewer entries
- Keep real worker/search failures recorded in `error_records`

## Root Cause

Worker cancellation used `RuntimeError("処理がキャンセルされました")`, so generic `except Exception` handlers treated normal user cancellation as an application error and persisted it to `error_records`.

## Validation

- `uv run pytest tests/unit/gui/workers/test_base_worker.py`
- `uv run pytest tests/integration/gui/workers/test_worker_error_recording.py`
- `uv run pytest tests/unit/workers/test_database_related_workers.py`
- `uv run ruff check src/lorairo/gui/workers/base.py src/lorairo/gui/workers/search_worker.py src/lorairo/gui/workers/annotation_worker.py tests/unit/gui/workers/test_base_worker.py tests/unit/workers/test_database_related_workers.py tests/integration/gui/workers/test_worker_error_recording.py`
- `uv run mypy -p lorairo`

Closes #412