### PR TITLE
fix(test): test_annotation_logic 型アノテーション追加・mypy エラー解消

### DIFF
--- a/tests/unit/annotations/test_annotation_logic.py
+++ b/tests/unit/annotations/test_annotation_logic.py
@@ -16,7 +16,7 @@ from lorairo.annotations.annotation_logic import AnnotationLogic
 
 
 @pytest.fixture
-def mock_adapter():
+def mock_adapter() -> MagicMock:
     """AnnotatorLibraryAdapter のモック。annotate が pHash→結果辞書を返す。"""
     adapter = MagicMock()
     adapter.annotate.return_value = {"abc123def456": {"tags": ["cat"], "captions": []}}
@@ -24,19 +24,19 @@ def mock_adapter():
 
 
 @pytest.fixture
-def logic(mock_adapter):
+def logic(mock_adapter: MagicMock) -> AnnotationLogic:
     """AnnotationLogic インスタンス（モックアダプター注入済み）。"""
     return AnnotationLogic(annotator_adapter=mock_adapter)
 
 
 @pytest.fixture
-def test_image_dir():
+def test_image_dir() -> Path:
     """テスト用画像ディレクトリのパスを返す。"""
     return Path(__file__).parent.parent.parent / "resources" / "img" / "1_img"
 
 
 @pytest.fixture
-def test_image_path(test_image_dir):
+def test_image_path(test_image_dir: Path) -> Path:
     """テスト用画像のパスを返す（存在しない場合はスキップ）。"""
     image_path = test_image_dir / "file01.webp"
     if not image_path.exists():
@@ -48,7 +48,9 @@ def test_image_path(test_image_dir):
 
 
 @pytest.mark.unit
-def test_execute_annotation_calls_adapter_with_correct_args(logic, mock_adapter, test_image_path):
+def test_execute_annotation_calls_adapter_with_correct_args(
+    logic: AnnotationLogic, mock_adapter: MagicMock, test_image_path: Path
+) -> None:
     """execute_annotation が adapter.annotate を正しい引数で呼ぶことを確認する。"""
     image_paths = [str(test_image_path)]
     model_ids = ["openai/gpt-4o"]
@@ -66,23 +68,26 @@ def test_execute_annotation_calls_adapter_with_correct_args(logic, mock_adapter,
 
 
 @pytest.mark.unit
-def test_execute_annotation_returns_adapter_result(logic, mock_adapter, test_image_path):
+def test_execute_annotation_returns_adapter_result(
+    logic: AnnotationLogic, mock_adapter: MagicMock, test_image_path: Path
+) -> None:
     """execute_annotation が adapter.annotate の戻り値をそのまま返すことを確認する。"""
-    expected = {"abc123def456": {"tags": ["cat"], "captions": []}}
-    mock_adapter.annotate.return_value = expected
     image_paths = [str(test_image_path)]
     model_ids = ["openai/gpt-4o"]
 
     result = logic.execute_annotation(image_paths, model_ids)
 
-    assert result == expected
+    # adapter.annotate の戻り値と同一オブジェクトが返されることを確認
+    assert result is mock_adapter.annotate.return_value
 
 
 # ---- phash_list あり ----
 
 
 @pytest.mark.unit
-def test_execute_annotation_passes_phash_list_to_adapter(logic, mock_adapter, test_image_path):
+def test_execute_annotation_passes_phash_list_to_adapter(
+    logic: AnnotationLogic, mock_adapter: MagicMock, test_image_path: Path
+) -> None:
     """phash_list を渡したとき adapter.annotate に正しく転送されることを確認する。"""
     image_paths = [str(test_image_path)]
     model_ids = ["openai/gpt-4o"]
@@ -98,7 +103,7 @@ def test_execute_annotation_passes_phash_list_to_adapter(logic, mock_adapter, te
 
 
 @pytest.mark.unit
-def test_load_images_raises_file_not_found_for_missing_path(logic):
+def test_load_images_raises_file_not_found_for_missing_path(logic: AnnotationLogic) -> None:
     """存在しないパスを渡すと FileNotFoundError が raise されることを確認する。"""
     nonexistent = "/nonexistent/path/to/image.png"
 
@@ -110,7 +115,7 @@ def test_load_images_raises_file_not_found_for_missing_path(logic):
 
 
 @pytest.mark.unit
-def test_load_images_raises_value_error_for_corrupt_file(logic, tmp_path):
+def test_load_images_raises_value_error_for_corrupt_file(logic: AnnotationLogic, tmp_path: Path) -> None:
     """壊れたファイルを渡すと ValueError が raise されることを確認する。"""
     # 無効な画像データのファイルを作成
     corrupt_file = tmp_path / "corrupt.png"
@@ -124,7 +129,9 @@ def test_load_images_raises_value_error_for_corrupt_file(logic, tmp_path):
 
 
 @pytest.mark.unit
-def test_execute_annotation_reraises_adapter_exception(logic, mock_adapter, test_image_path):
+def test_execute_annotation_reraises_adapter_exception(
+    logic: AnnotationLogic, mock_adapter: MagicMock, test_image_path: Path
+) -> None:
     """adapter.annotate が Exception を raise すると同一例外が re-raise されることを確認する。"""
     mock_adapter.annotate.side_effect = RuntimeError("test error from adapter")
     image_paths = [str(test_image_path)]
@@ -138,7 +145,7 @@ def test_execute_annotation_reraises_adapter_exception(logic, mock_adapter, test
 
 
 @pytest.mark.unit
-def test_execute_annotation_with_empty_image_paths(logic, mock_adapter):
+def test_execute_annotation_with_empty_image_paths(logic: AnnotationLogic, mock_adapter: MagicMock) -> None:
     """空の image_paths を渡しても例外なく結果が返ることを確認する。"""
     mock_adapter.annotate.return_value = {}
 
@@ -155,7 +162,9 @@ def test_execute_annotation_with_empty_image_paths(logic, mock_adapter):
 
 
 @pytest.mark.unit
-def test_execute_annotation_with_multiple_images(logic, mock_adapter, test_image_dir):
+def test_execute_annotation_with_multiple_images(
+    logic: AnnotationLogic, mock_adapter: MagicMock, test_image_dir: Path
+) -> None:
     """複数の画像パスを渡すと全て読み込まれて adapter.annotate に渡されることを確認する。"""
     image_paths_p = sorted(test_image_dir.glob("*.webp"))[:3]
     if len(image_paths_p) < 3:


### PR DESCRIPTION
## Summary

- PR #431 マージ後に IDE mypy 診断で検出された `test_annotation_logic.py` の型アノテーション不足を修正
- 全フィクスチャ・テスト関数に引数・戻り値の型ヒントを追加
- `test_execute_annotation_returns_adapter_result`: `dict` 直比較を `result is mock_adapter.annotate.return_value` に変更し `PHashAnnotationResults vs dict[str, ...]` の mypy `comparison-overlap` エラーを解消

## Test plan

- [x] `uv run mypy tests/unit/annotations/test_annotation_logic.py` — no issues
- [x] `uv run ruff check` — All checks passed
- [x] `uv run pytest tests/unit/annotations/test_annotation_logic.py` — 8 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)