### PR TITLE
feat: add worker terminal event contract

### DIFF
--- a/docs/specs/application/worker_service.md
+++ b/docs/specs/application/worker_service.md
@@ -1,15 +1,15 @@
 # GUI ワーカーサービス 仕様書
 
-version: "2.0.0" (Updated: 2025/07/19)
+version: "2.1.0" (Updated: 2026/05/24)
 
 ## 1. 目的
 
-本仕様書は、`lorairo` アプリケーションのGUI層 (`src/lorairo/gui`) におけるQt QRunnable/QThreadPoolベースの非同期処理システムの設計と実装に関する仕様を定義します。
+本仕様書は、`lorairo` アプリケーションのGUI層 (`src/lorairo/gui`) における `QThread` + `QObject.moveToThread()` ベースの非同期処理システムの設計と実装に関する仕様を定義します。
 
 主な目的は以下の通りです。
 
 - UIスレッドをブロックすることなく、時間のかかるタスク（DB登録、AI処理、検索、サムネイル読み込み）を実行する。
-- Qt標準のQRunnable/QThreadPoolを活用した効率的なリソース管理を提供する。
+- Qt標準の `QThread` を活用した明示的なワーカーライフサイクル管理を提供する。
 - 統一的な進捗報告、エラーハンドリング、キャンセレーション機能を実現する。
 
 ## 2. アーキテクチャ設計
@@ -21,7 +21,8 @@ src/lorairo/gui/
 │   └── worker_service.py      # GUI向け高レベルAPI
 └── workers/
     ├── base.py               # 基底クラスとQt統合
-    ├── manager.py            # QThreadPool管理
+    ├── manager.py            # QThread管理
+    ├── terminal.py           # 終端 outcome / cancel reason / terminal event
     ├── registration_worker.py # DB登録ワーカー
     ├── search_worker.py       # DB検索ワーカー
     ├── thumbnail_worker.py    # サムネイル読み込みワーカー
@@ -36,37 +37,45 @@ src/lorairo/gui/
     - 標準シグナル (`finished(result: T)`, `error_occurred(message: str)`, `canceled()`) を定義します。
     - 進捗報告とキャンセレーション機能を統合します。
     - 基本的なキャンセル処理 (`cancel()` メソッド、`_is_cancelled` フラグ) の枠組みを提供します。
-    - スレッドプールまたは個別の `QThread` 上で実行されるエントリーポイント (`run()` メソッド) を提供します。`run()` はキャンセルチェック、抽象メソッド `run_task()` の呼び出し、例外処理、`finished` シグナルの発行を行います。
+    - 個別の `QThread` 上で実行されるエントリーポイント (`run()` メソッド) を提供します。`run()` はキャンセルチェック、抽象メソッド `execute()` の呼び出し、例外処理、`finished` / `error_occurred` / `canceled` シグナルの発行を行います。
 - **サブクラスの役割:**
-    - `BaseWorker` を継承し、具体的な非同期タスクを `run_task()` メソッド内に実装します。
+    - `LoRAIroWorkerBase` を継承し、具体的な非同期タスクを `execute()` メソッド内に実装します。
     - 必要に応じて `progress` シグナルを発行します。
     - 必要に応じて `cancel()` メソッドをオーバーライドし、タスク固有のキャンセルロジックを追加します（例: 実行中プロセスの停止、ループの中断）。オーバーライドする場合は `super().cancel()` を呼び出す必要があります。
 - **サービスとの連携:**
     - `WorkerService` は、対応するワーカークラス（例: `AnnotationWorker`, `SearchWorker`）のインスタンスを生成します。
-    - `WorkerService` は `WorkerManager` 経由で `QThreadPool` でワーカーを実行します。
-    - ワーカーの `finished` / `error_occurred` / `canceled` および `progress` シグナルを、`WorkerService` 内の適切なスロット（またはUIコンポーネントのスロット）に接続して、結果や進捗を処理します。
+    - `WorkerService` は `WorkerManager` 経由でワーカーを個別の `QThread` に移動して実行します。
+    - `WorkerManager` はワーカーの `finished` / `error_occurred` / `canceled` を `WorkerTerminalEvent` に変換し、`WorkerService` はその event を UI 向け signal へ dispatch します。
     - `WorkerService` はワーカーの `cancel()` メソッドを呼び出して、タスクの中断を要求できます。
 
 ## 3. 責務
 
 - **タスク実行:** 割り当てられた特定の非同期タスク（AI アノテーション、画像読み込み、設定の保存など）を実行します。
-- **結果通知:** タスク完了時、`finished` / `error_occurred` / `canceled` のいずれか一つの終端シグナルでサービスに通知します。
+- **結果通知:** タスク完了時、`WorkerManager.worker_terminal` が `WorkerTerminalEvent` を一度だけ通知します。既存の `worker_finished` / `worker_error` / `worker_canceled` は互換用 signal です。
 - **進捗通知:** (任意) タスク実行中に、`progress` シグナルを通じて進捗状況（通常 0-100 のパーセンテージ）を通知します。
-- **キャンセル処理:** サービスからのキャンセル要求を受け付け、可能な範囲でタスクを安全に中断します。中断した場合は `canceled` シグナルを発行します。キャンセルは failure ではない第三の終端状態であり、ErrorLogViewer 用のエラーレコードには記録しません。
-    - 将来的に user requested / superseded / shutdown などを区別する必要が出た場合は、`canceled` の横に reason を後付けするのではなく、統一 terminal event と cancel reason の設計を別ADRで検討します。
+- **キャンセル処理:** サービスからのキャンセル要求を受け付け、可能な範囲でタスクを安全に中断します。通常キャンセルは failure ではなく、ErrorLogViewer 用のエラーレコードには記録しません。キャンセル要求は `CancelReason` を持ち、UI は user requested / pipeline cancel / worker replacement / prefetch cleanup / progress dialog / shutdown を区別できます。
+- **強制終了:** cancel wait timeout 後に `thread.terminate()` を使った場合、通常キャンセルとは扱いません。停止確認できた場合は `TERMINATED`、停止確認できない場合は `UNRESPONSIVE` として terminal event に記録します。
+
+### 3.1 Terminal Contract
+
+- `WorkerTerminalEvent` は `worker_id`, `worker_type`, `outcome`, `result`, `error`, `cancel_reason` を持ちます。
+- `WorkerOutcome` は `SUCCEEDED`, `FAILED`, `CANCELED`, `CANCEL_TIMEOUT`, `TERMINATED`, `UNRESPONSIVE` を定義します。
+- `CancelReason` は `USER_REQUESTED`, `PIPELINE_CANCEL`, `SEARCH_REPLACED`, `THUMBNAIL_REPLACED`, `PREFETCH_REPLACED`, `PROGRESS_DIALOG`, `SHUTDOWN`, `TIMEOUT_FALLBACK` を定義します。
+- `WorkerManager` は worker ごとに terminal event を一度だけ確定します。cancel 要求後に queued `finished` / `error_occurred` が届いている場合は、その terminal を cancel fallback より優先します。
+- thumbnail replacement / prefetch cancellation は検索結果を破棄しません。明示的な pipeline cancel は検索結果とサムネイル表示を破棄します。
 
 ## 4. 実装ガイドライン
 
-- **`run_task()` の実装:**
+- **`execute()` の実装:**
     - 具体的な処理ロジックを実装します。
     - 正常完了時は結果オブジェクトを返します。
-    - 処理中にエラーが発生した場合は、例外を送出します (`BaseWorker.run` で捕捉されます)。特定のビジネスロジックエラーは、`run_task` 内で捕捉し、エラーを示す特定のオブジェクトを返すことも可能です。
+    - 処理中にエラーが発生した場合は、例外を送出します (`LoRAIroWorkerBase.run` で捕捉されます)。特定のビジネスロジックエラーは、`execute()` 内で捕捉し、エラーを示す特定のオブジェクトを返すことも可能です。
 - **エラーハンドリング:**
     - `BaseWorker.run()` が一般的な `Exception` を捕捉し、`error_occurred` シグナルで通知します。
     - キャンセルは `CancellationError` またはキャンセルフラグで検出し、`WorkerStatus.CANCELED` と `canceled` シグナルで通知します。
-    - `run_task()` 内で、特定の予期される例外（例: `FileNotFoundError`, `ValueError`）を捕捉し、より具体的なエラー情報を含む結果を返すことも検討します。
+    - `execute()` 内で、特定の予期される例外（例: `FileNotFoundError`, `ValueError`）を捕捉し、より具体的なエラー情報を含む結果を返すことも検討します。
 - **状態管理:** ワーカーは自身の状態（実行中、キャンセル済みなど）を管理しますが、サービスやUIに直接依存しないようにします。状態の通知はシグナルを使用します。
-- **リソース管理:** ワーカーがファイルハンドルやネットワーク接続などのリソースを使用する場合、`run_task()` 内または `finally` ブロックで適切に解放するようにします。
+- **リソース管理:** ワーカーがファイルハンドルやネットワーク接続などのリソースを使用する場合、`execute()` 内または `finally` ブロックで適切に解放するようにします。
 - **UI非依存:** ワーカークラスはUIコンポーネントに直接アクセスしません。UIとのやり取りは、サービス層を経由してシグナル/スロットで行います。
 
 ## 5. 命名規則
@@ -75,4 +84,5 @@ src/lorairo/gui/
 
 ## 6. 改訂履歴
 
+- 2.1.0 (2026-05-24): `QThread` 実装に合わせて更新し、`WorkerTerminalEvent` / `WorkerOutcome` / `CancelReason` による終端 contract を追加
 - 1.0.0 (2025-04-18): 初版作成

--- a/src/lorairo/gui/designer/RatingScoreEditWidget_ui.py
+++ b/src/lorairo/gui/designer/RatingScoreEditWidget_ui.py
@@ -1,0 +1,145 @@
+# -*- coding: utf-8 -*-
+
+################################################################################
+## Form generated from reading UI file 'RatingScoreEditWidget.ui'
+##
+## Created by: Qt User Interface Compiler version 6.11.1
+##
+## WARNING! All changes made in this file will be lost when recompiling UI file!
+################################################################################
+
+from PySide6.QtCore import (QCoreApplication, QDate, QDateTime, QLocale,
+    QMetaObject, QObject, QPoint, QRect,
+    QSize, QTime, QUrl, Qt)
+from PySide6.QtGui import (QBrush, QColor, QConicalGradient, QCursor,
+    QFont, QFontDatabase, QGradient, QIcon,
+    QImage, QKeySequence, QLinearGradient, QPainter,
+    QPalette, QPixmap, QRadialGradient, QTransform)
+from PySide6.QtWidgets import (QApplication, QComboBox, QGridLayout, QGroupBox,
+    QHBoxLayout, QLabel, QPushButton, QSizePolicy,
+    QSlider, QSpacerItem, QVBoxLayout, QWidget)
+
+class Ui_RatingScoreEditWidget(object):
+    def setupUi(self, RatingScoreEditWidget: QWidget) -> None:
+        if not RatingScoreEditWidget.objectName():
+            RatingScoreEditWidget.setObjectName(u"RatingScoreEditWidget")
+        RatingScoreEditWidget.resize(250, 200)
+        self.verticalLayoutMain = QVBoxLayout(RatingScoreEditWidget)
+        self.verticalLayoutMain.setSpacing(8)
+        self.verticalLayoutMain.setObjectName(u"verticalLayoutMain")
+        self.verticalLayoutMain.setContentsMargins(8, 8, 8, 8)
+        self.groupBoxRatingScore = QGroupBox(RatingScoreEditWidget)
+        self.groupBoxRatingScore.setObjectName(u"groupBoxRatingScore")
+        self.gridLayoutRatingScore = QGridLayout(self.groupBoxRatingScore)
+        self.gridLayoutRatingScore.setSpacing(6)
+        self.gridLayoutRatingScore.setObjectName(u"gridLayoutRatingScore")
+        self.labelRating = QLabel(self.groupBoxRatingScore)
+        self.labelRating.setObjectName(u"labelRating")
+        sizePolicy = QSizePolicy(QSizePolicy.Policy.Preferred, QSizePolicy.Policy.Fixed)
+        sizePolicy.setHorizontalStretch(0)
+        sizePolicy.setVerticalStretch(0)
+        sizePolicy.setHeightForWidth(self.labelRating.sizePolicy().hasHeightForWidth())
+        self.labelRating.setSizePolicy(sizePolicy)
+
+        self.gridLayoutRatingScore.addWidget(self.labelRating, 0, 0, 1, 1)
+
+        self.comboBoxRating = QComboBox(self.groupBoxRatingScore)
+        self.comboBoxRating.addItem("")
+        self.comboBoxRating.addItem("")
+        self.comboBoxRating.addItem("")
+        self.comboBoxRating.addItem("")
+        self.comboBoxRating.addItem("")
+        self.comboBoxRating.setObjectName(u"comboBoxRating")
+        sizePolicy1 = QSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed)
+        sizePolicy1.setHorizontalStretch(0)
+        sizePolicy1.setVerticalStretch(0)
+        sizePolicy1.setHeightForWidth(self.comboBoxRating.sizePolicy().hasHeightForWidth())
+        self.comboBoxRating.setSizePolicy(sizePolicy1)
+
+        self.gridLayoutRatingScore.addWidget(self.comboBoxRating, 0, 1, 1, 1)
+
+        self.labelScore = QLabel(self.groupBoxRatingScore)
+        self.labelScore.setObjectName(u"labelScore")
+        sizePolicy.setHeightForWidth(self.labelScore.sizePolicy().hasHeightForWidth())
+        self.labelScore.setSizePolicy(sizePolicy)
+
+        self.gridLayoutRatingScore.addWidget(self.labelScore, 1, 0, 1, 1)
+
+        self.horizontalLayoutScore = QHBoxLayout()
+        self.horizontalLayoutScore.setSpacing(8)
+        self.horizontalLayoutScore.setObjectName(u"horizontalLayoutScore")
+        self.sliderScore = QSlider(self.groupBoxRatingScore)
+        self.sliderScore.setObjectName(u"sliderScore")
+        self.sliderScore.setMinimum(0)
+        self.sliderScore.setMaximum(1000)
+        self.sliderScore.setValue(500)
+        self.sliderScore.setOrientation(Qt.Orientation.Horizontal)
+        sizePolicy2 = QSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed)
+        sizePolicy2.setHorizontalStretch(1)
+        sizePolicy2.setVerticalStretch(0)
+        sizePolicy2.setHeightForWidth(self.sliderScore.sizePolicy().hasHeightForWidth())
+        self.sliderScore.setSizePolicy(sizePolicy2)
+
+        self.horizontalLayoutScore.addWidget(self.sliderScore)
+
+        self.labelScoreValue = QLabel(self.groupBoxRatingScore)
+        self.labelScoreValue.setObjectName(u"labelScoreValue")
+        self.labelScoreValue.setAlignment(Qt.AlignmentFlag.AlignRight|Qt.AlignmentFlag.AlignVCenter)
+        self.labelScoreValue.setMinimumWidth(40)
+        sizePolicy3 = QSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed)
+        sizePolicy3.setHorizontalStretch(0)
+        sizePolicy3.setVerticalStretch(0)
+        sizePolicy3.setHeightForWidth(self.labelScoreValue.sizePolicy().hasHeightForWidth())
+        self.labelScoreValue.setSizePolicy(sizePolicy3)
+
+        self.horizontalLayoutScore.addWidget(self.labelScoreValue)
+
+
+        self.gridLayoutRatingScore.addLayout(self.horizontalLayoutScore, 1, 1, 1, 1)
+
+
+        self.verticalLayoutMain.addWidget(self.groupBoxRatingScore)
+
+        self.horizontalLayoutButtons = QHBoxLayout()
+        self.horizontalLayoutButtons.setObjectName(u"horizontalLayoutButtons")
+        self.horizontalSpacer = QSpacerItem(40, 20, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum)
+
+        self.horizontalLayoutButtons.addItem(self.horizontalSpacer)
+
+        self.pushButtonSave = QPushButton(RatingScoreEditWidget)
+        self.pushButtonSave.setObjectName(u"pushButtonSave")
+        self.pushButtonSave.setMinimumWidth(80)
+        sizePolicy3.setHeightForWidth(self.pushButtonSave.sizePolicy().hasHeightForWidth())
+        self.pushButtonSave.setSizePolicy(sizePolicy3)
+
+        self.horizontalLayoutButtons.addWidget(self.pushButtonSave)
+
+
+        self.verticalLayoutMain.addLayout(self.horizontalLayoutButtons)
+
+        self.verticalSpacer = QSpacerItem(20, 40, QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Expanding)
+
+        self.verticalLayoutMain.addItem(self.verticalSpacer)
+
+
+        self.retranslateUi(RatingScoreEditWidget)
+        self.pushButtonSave.clicked.connect(RatingScoreEditWidget._on_save_clicked)
+
+        QMetaObject.connectSlotsByName(RatingScoreEditWidget)
+    # setupUi
+
+    def retranslateUi(self, RatingScoreEditWidget: QWidget) -> None:
+        RatingScoreEditWidget.setWindowTitle(QCoreApplication.translate("RatingScoreEditWidget", u"Rating/Score Edit", None))
+        self.groupBoxRatingScore.setTitle(QCoreApplication.translate("RatingScoreEditWidget", u"\u8a55\u4fa1\u30fb\u30b9\u30b3\u30a2\u7de8\u96c6", None))
+        self.labelRating.setText(QCoreApplication.translate("RatingScoreEditWidget", u"Rating:", None))
+        self.comboBoxRating.setItemText(0, QCoreApplication.translate("RatingScoreEditWidget", u"PG", None))
+        self.comboBoxRating.setItemText(1, QCoreApplication.translate("RatingScoreEditWidget", u"PG-13", None))
+        self.comboBoxRating.setItemText(2, QCoreApplication.translate("RatingScoreEditWidget", u"R", None))
+        self.comboBoxRating.setItemText(3, QCoreApplication.translate("RatingScoreEditWidget", u"X", None))
+        self.comboBoxRating.setItemText(4, QCoreApplication.translate("RatingScoreEditWidget", u"XXX", None))
+
+        self.labelScore.setText(QCoreApplication.translate("RatingScoreEditWidget", u"\u30b9\u30b3\u30a2:", None))
+        self.labelScoreValue.setText(QCoreApplication.translate("RatingScoreEditWidget", u"5.00", None))
+        self.pushButtonSave.setText(QCoreApplication.translate("RatingScoreEditWidget", u"\u4fdd\u5b58", None))
+    # retranslateUi
+

--- a/src/lorairo/gui/services/pipeline_control_service.py
+++ b/src/lorairo/gui/services/pipeline_control_service.py
@@ -15,6 +15,7 @@ from loguru import logger
 
 from lorairo.gui.services.worker_service import WorkerService
 from lorairo.gui.workers.search_worker import SearchResult
+from lorairo.gui.workers.terminal import CancelReason, WorkerOutcome, WorkerTerminalEvent
 
 
 class PipelineControlService:
@@ -151,30 +152,84 @@ class PipelineControlService:
         if self.filter_search_panel and hasattr(self.filter_search_panel, "hide_progress_after_completion"):
             self.filter_search_panel.hide_progress_after_completion()
 
-    def on_search_canceled(self, worker_id: str) -> None:
+    def on_search_canceled(self, terminal: str | WorkerTerminalEvent) -> None:
         """Pipeline検索キャンセル時の処理（エラー扱いしない）"""
+        worker_id = terminal.worker_id if isinstance(terminal, WorkerTerminalEvent) else terminal
+        reason = terminal.cancel_reason if isinstance(terminal, WorkerTerminalEvent) else None
         logger.info(f"Pipeline search canceled: {worker_id}")
 
-        if self.thumbnail_selector and hasattr(self.thumbnail_selector, "clear_thumbnails"):
+        should_clear_results = reason in {
+            None,
+            CancelReason.USER_REQUESTED,
+            CancelReason.PIPELINE_CANCEL,
+            CancelReason.PROGRESS_DIALOG,
+            CancelReason.SHUTDOWN,
+        }
+
+        if (
+            should_clear_results
+            and self.thumbnail_selector
+            and hasattr(self.thumbnail_selector, "clear_thumbnails")
+        ):
             self.thumbnail_selector.clear_thumbnails()
 
-        if self.filter_search_panel and hasattr(self.filter_search_panel, "clear_pipeline_results"):
+        if (
+            should_clear_results
+            and self.filter_search_panel
+            and hasattr(self.filter_search_panel, "clear_pipeline_results")
+        ):
             self.filter_search_panel.clear_pipeline_results()
 
         if self.filter_search_panel and hasattr(self.filter_search_panel, "hide_progress_after_completion"):
             self.filter_search_panel.hide_progress_after_completion()
 
-    def on_thumbnail_canceled(self, worker_id: str) -> None:
+    def on_thumbnail_canceled(self, terminal: str | WorkerTerminalEvent) -> None:
         """Pipelineサムネイル読み込みキャンセル時の処理（エラー扱いしない）。
 
         thumbnail worker はページ切替や prefetch 整理でも通常運用としてキャンセルされるため、
         ここでは検索結果を破棄しない。明示的な pipeline cancel の結果破棄は
         cancel_current_pipeline() 側で行う。
         """
+        worker_id = terminal.worker_id if isinstance(terminal, WorkerTerminalEvent) else terminal
         logger.info(f"Pipeline thumbnail canceled: {worker_id}")
 
         if self.filter_search_panel and hasattr(self.filter_search_panel, "hide_progress_after_completion"):
             self.filter_search_panel.hide_progress_after_completion()
+
+    def on_worker_terminal(self, event: WorkerTerminalEvent) -> None:
+        """Handle search/thumbnail terminal events with outcome and cancel reason."""
+        if event.worker_type not in {"search", "thumbnail"}:
+            return
+
+        if event.outcome is WorkerOutcome.CANCELED:
+            if event.worker_type == "search":
+                self.on_search_canceled(event)
+            else:
+                self.on_thumbnail_canceled(event)
+            return
+
+        if event.outcome in {
+            WorkerOutcome.CANCEL_TIMEOUT,
+            WorkerOutcome.TERMINATED,
+            WorkerOutcome.UNRESPONSIVE,
+        }:
+            if event.cancel_reason in {
+                CancelReason.SEARCH_REPLACED,
+                CancelReason.THUMBNAIL_REPLACED,
+                CancelReason.PREFETCH_REPLACED,
+            }:
+                logger.info(
+                    f"Pipeline replacement worker ended abnormally without cleanup: "
+                    f"{event.worker_id}, outcome={event.outcome.value}, "
+                    f"reason={event.cancel_reason.value}"
+                )
+                return
+
+            message = event.error or f"Worker ended abnormally: {event.outcome.value}"
+            if event.worker_type == "search":
+                self.on_search_error(message)
+            else:
+                self.on_thumbnail_error(message)
 
     # ============================================================
     # 進捗状態管理統合
@@ -222,14 +277,20 @@ class PipelineControlService:
                 hasattr(self.worker_service, "current_search_worker_id")
                 and self.worker_service.current_search_worker_id
             ):
-                self.worker_service.cancel_search(self.worker_service.current_search_worker_id)
+                self.worker_service.cancel_search(
+                    self.worker_service.current_search_worker_id,
+                    reason=CancelReason.PIPELINE_CANCEL,
+                )
                 logger.info("Search worker cancelled in pipeline")
 
             if (
                 hasattr(self.worker_service, "current_thumbnail_worker_id")
                 and self.worker_service.current_thumbnail_worker_id
             ):
-                self.worker_service.cancel_thumbnail_load(self.worker_service.current_thumbnail_worker_id)
+                self.worker_service.cancel_thumbnail_load(
+                    self.worker_service.current_thumbnail_worker_id,
+                    reason=CancelReason.PIPELINE_CANCEL,
+                )
                 logger.info("Thumbnail worker cancelled in pipeline")
 
             # キャンセル時の結果破棄（要求仕様通り）

--- a/src/lorairo/gui/services/pipeline_control_service.py
+++ b/src/lorairo/gui/services/pipeline_control_service.py
@@ -225,11 +225,10 @@ class PipelineControlService:
                 )
                 return
 
-            message = event.error or f"Worker ended abnormally: {event.outcome.value}"
-            if event.worker_type == "search":
-                self.on_search_error(message)
-            else:
-                self.on_thumbnail_error(message)
+            logger.debug(
+                f"Pipeline abnormal terminal observed; compat error signal owns cleanup: "
+                f"{event.worker_id}, outcome={event.outcome.value}"
+            )
 
     # ============================================================
     # 進捗状態管理統合

--- a/src/lorairo/gui/services/worker_service.py
+++ b/src/lorairo/gui/services/worker_service.py
@@ -598,6 +598,10 @@ class WorkerService(QObject):
         if event.outcome is WorkerOutcome.SUCCEEDED:
             self._on_worker_finished(event.worker_id, event.result)
         elif event.outcome is WorkerOutcome.FAILED:
+            if self._is_replacement_terminal(event):
+                self._finish_worker_terminal_progress(event, success=False)
+                self._clear_current_worker_id(event.worker_id)
+                return
             self._on_worker_error(event.worker_id, event.error or "")
         elif event.outcome is WorkerOutcome.CANCELED:
             self._on_worker_canceled_event(event)
@@ -638,10 +642,17 @@ class WorkerService(QObject):
             f"reason={event.cancel_reason.value if event.cancel_reason else 'unknown'}, message={message}"
         )
         if self._is_replacement_terminal(event):
+            self._finish_worker_terminal_progress(event, success=False)
             self._clear_current_worker_id(event.worker_id)
             return
 
         self._on_worker_error(event.worker_id, message)
+
+    def _finish_worker_terminal_progress(self, event: WorkerTerminalEvent, *, success: bool) -> None:
+        """Close modal progress for terminal events that intentionally skip compat dispatch."""
+        worker_type = self._resolve_worker_type(event.worker_id)
+        if worker_type != "thumbnail":
+            self.progress_manager.finish_worker_progress(event.worker_id, success=success)
 
     def _should_emit_compat_canceled(self, event: WorkerTerminalEvent) -> bool:
         """Suppress normal UI cancellation signals for replacement-only cancellation."""

--- a/src/lorairo/gui/services/worker_service.py
+++ b/src/lorairo/gui/services/worker_service.py
@@ -21,6 +21,7 @@ from ..workers.manager import WorkerManager
 from ..workers.modern_progress_manager import ModernProgressManager, create_worker_id
 from ..workers.registration_worker import DatabaseRegistrationWorker
 from ..workers.search_worker import SearchResult, SearchWorker
+from ..workers.terminal import CancelReason, WorkerOutcome, WorkerTerminalEvent
 from ..workers.thumbnail_worker import ThumbnailWorker
 
 
@@ -59,6 +60,7 @@ class WorkerService(QObject):
     # === 進捗シグナル ===
     worker_progress_updated = Signal(str, object)  # worker_id, WorkerProgress
     worker_batch_progress = Signal(str, int, int, str)  # worker_id, current, total, filename
+    worker_terminal = Signal(object)  # WorkerTerminalEvent
 
     # === 全体管理シグナル ===
     active_worker_count_changed = Signal(int)
@@ -88,9 +90,7 @@ class WorkerService(QObject):
 
         # ワーカーマネージャーのシグナル接続
         self.worker_manager.worker_started.connect(self._on_worker_started)
-        self.worker_manager.worker_finished.connect(self._on_worker_finished)
-        self.worker_manager.worker_error.connect(self._on_worker_error)
-        self.worker_manager.worker_canceled.connect(self._on_worker_canceled)
+        self.worker_manager.worker_terminal.connect(self._on_worker_terminal)
         self.worker_manager.active_worker_count_changed.connect(self.active_worker_count_changed)
         self.worker_manager.all_workers_finished.connect(self.all_workers_finished)
 
@@ -250,7 +250,10 @@ class WorkerService(QObject):
         # 既存の検索をキャンセル
         if self.current_search_worker_id:
             logger.info(f"既存の検索をキャンセル: {self.current_search_worker_id}")
-            self.worker_manager.cancel_worker(self.current_search_worker_id)
+            self.worker_manager.cancel_worker(
+                self.current_search_worker_id,
+                reason=CancelReason.SEARCH_REPLACED,
+            )
             self.current_search_worker_id = None
 
         worker = SearchWorker(self.db_manager, search_conditions)
@@ -273,9 +276,13 @@ class WorkerService(QObject):
         else:
             raise RuntimeError(f"ワーカー開始失敗: {worker_id}")
 
-    def cancel_search(self, worker_id: str) -> bool:
+    def cancel_search(
+        self,
+        worker_id: str,
+        reason: CancelReason = CancelReason.USER_REQUESTED,
+    ) -> bool:
         """検索キャンセル"""
-        return self.worker_manager.cancel_worker(worker_id)
+        return self._cancel_worker(worker_id, reason)
 
     # === Thumbnail ===
 
@@ -325,9 +332,13 @@ class WorkerService(QObject):
         else:
             raise RuntimeError(f"ワーカー開始失敗: {worker_id}")
 
-    def cancel_thumbnail_load(self, worker_id: str) -> bool:
+    def cancel_thumbnail_load(
+        self,
+        worker_id: str,
+        reason: CancelReason = CancelReason.USER_REQUESTED,
+    ) -> bool:
         """サムネイル読み込みキャンセル"""
-        return self.worker_manager.cancel_worker(worker_id)
+        return self._cancel_worker(worker_id, reason)
 
     def start_thumbnail_page_load(
         self,
@@ -364,7 +375,10 @@ class WorkerService(QObject):
 
         if cancel_previous and self.current_thumbnail_worker_id:
             logger.debug(f"既存のサムネイル読み込みをキャンセル: {self.current_thumbnail_worker_id}")
-            self.worker_manager.cancel_worker(self.current_thumbnail_worker_id)
+            self.worker_manager.cancel_worker(
+                self.current_thumbnail_worker_id,
+                reason=CancelReason.THUMBNAIL_REPLACED,
+            )
             self.current_thumbnail_worker_id = None
 
         worker = ThumbnailWorker(
@@ -451,7 +465,7 @@ class WorkerService(QObject):
 
     def cancel_all_workers(self) -> None:
         """全ワーカーキャンセル"""
-        self.worker_manager.cancel_all_workers()
+        self.worker_manager.cancel_all_workers(reason=CancelReason.SHUTDOWN)
 
     def get_active_worker_count(self) -> int:
         """アクティブワーカー数取得"""
@@ -476,7 +490,7 @@ class WorkerService(QObject):
         logger.info(f"プログレスダイアログからキャンセル要求: {worker_id}")
 
         # 該当ワーカーをキャンセル
-        success = self.worker_manager.cancel_worker(worker_id)
+        success = self.worker_manager.cancel_worker(worker_id, reason=CancelReason.PROGRESS_DIALOG)
         if success:
             logger.info(f"ワーカーキャンセル実行: {worker_id}")
         else:
@@ -568,7 +582,35 @@ class WorkerService(QObject):
 
     def _on_worker_canceled(self, worker_id: str) -> None:
         """ワーカーキャンセルハンドラ - エラー扱いせずプログレスを終了"""
-        logger.info(f"ワーカーキャンセル完了: {worker_id}")
+        self._on_worker_canceled_event(
+            WorkerTerminalEvent(
+                worker_id=worker_id,
+                worker_type=self._resolve_worker_type(worker_id),
+                outcome=WorkerOutcome.CANCELED,
+                cancel_reason=CancelReason.USER_REQUESTED,
+            )
+        )
+
+    def _on_worker_terminal(self, event: WorkerTerminalEvent) -> None:
+        """Unified worker terminal event dispatcher."""
+        self.worker_terminal.emit(event)
+
+        if event.outcome is WorkerOutcome.SUCCEEDED:
+            self._on_worker_finished(event.worker_id, event.result)
+        elif event.outcome is WorkerOutcome.FAILED:
+            self._on_worker_error(event.worker_id, event.error or "")
+        elif event.outcome is WorkerOutcome.CANCELED:
+            self._on_worker_canceled_event(event)
+        else:
+            self._on_worker_abnormal_terminal(event)
+
+    def _on_worker_canceled_event(self, event: WorkerTerminalEvent) -> None:
+        """ワーカーキャンセルハンドラ - エラー扱いせずプログレスを終了"""
+        worker_id = event.worker_id
+        logger.info(
+            f"ワーカーキャンセル完了: {worker_id}"
+            f" (reason={event.cancel_reason.value if event.cancel_reason else 'unknown'})"
+        )
 
         worker_type = self._resolve_worker_type(worker_id)
         if worker_type != "thumbnail":
@@ -583,6 +625,53 @@ class WorkerService(QObject):
         }
         if worker_type in canceled_dispatch:
             signal, attr = canceled_dispatch[worker_type]
-            signal.emit(worker_id)
+            if self._should_emit_compat_canceled(event):
+                signal.emit(worker_id)
             if attr and getattr(self, attr) == worker_id:
                 setattr(self, attr, None)
+
+    def _on_worker_abnormal_terminal(self, event: WorkerTerminalEvent) -> None:
+        """Handle timeout/terminate outcomes as abnormal terminals, not normal cancellation."""
+        message = event.error or f"ワーカー異常終了: {event.outcome.value}"
+        logger.warning(
+            f"ワーカー異常終了: {event.worker_id}, outcome={event.outcome.value}, "
+            f"reason={event.cancel_reason.value if event.cancel_reason else 'unknown'}, message={message}"
+        )
+        if self._is_replacement_terminal(event):
+            self._clear_current_worker_id(event.worker_id)
+            return
+
+        self._on_worker_error(event.worker_id, message)
+
+    def _should_emit_compat_canceled(self, event: WorkerTerminalEvent) -> bool:
+        """Suppress normal UI cancellation signals for replacement-only cancellation."""
+        return event.cancel_reason not in {
+            CancelReason.SEARCH_REPLACED,
+            CancelReason.THUMBNAIL_REPLACED,
+            CancelReason.PREFETCH_REPLACED,
+        }
+
+    def _is_replacement_terminal(self, event: WorkerTerminalEvent) -> bool:
+        return event.cancel_reason in {
+            CancelReason.SEARCH_REPLACED,
+            CancelReason.THUMBNAIL_REPLACED,
+            CancelReason.PREFETCH_REPLACED,
+        }
+
+    def _clear_current_worker_id(self, worker_id: str) -> None:
+        worker_type = self._resolve_worker_type(worker_id)
+        attr_by_type = {
+            "batch_reg": "current_registration_worker_id",
+            "batch_import": "current_batch_import_worker_id",
+            "annotation": "current_annotation_worker_id",
+            "search": "current_search_worker_id",
+            "thumbnail": "current_thumbnail_worker_id",
+        }
+        attr = attr_by_type.get(worker_type)
+        if attr and getattr(self, attr) == worker_id:
+            setattr(self, attr, None)
+
+    def _cancel_worker(self, worker_id: str, reason: CancelReason) -> bool:
+        if reason is CancelReason.USER_REQUESTED:
+            return self.worker_manager.cancel_worker(worker_id)
+        return self.worker_manager.cancel_worker(worker_id, reason=reason)

--- a/src/lorairo/gui/widgets/thumbnail.py
+++ b/src/lorairo/gui/widgets/thumbnail.py
@@ -26,6 +26,7 @@ from ...utils.log import logger
 from ..cache.thumbnail_page_cache import ThumbnailPageCache
 from ..state.dataset_state import DatasetStateManager
 from ..state.pagination_state import PaginationStateManager
+from ..workers.terminal import CancelReason
 from ..workers.thumbnail_worker import ThumbnailLoadResult
 from .pagination_nav_widget import PaginationNavWidget
 
@@ -516,7 +517,12 @@ class ThumbnailSelectorWidget(QWidget, Ui_ThumbnailSelectorWidget):
             if not worker_id:
                 continue
             try:
-                self._worker_service.cancel_thumbnail_load(worker_id)
+                reason = (
+                    CancelReason.PREFETCH_REPLACED
+                    if request_id in self._prefetch_request_ids
+                    else CancelReason.THUMBNAIL_REPLACED
+                )
+                self._worker_service.cancel_thumbnail_load(worker_id, reason=reason)
                 canceled_any = True
             except Exception:
                 logger.exception(f"Failed to cancel thumbnail worker: worker_id={worker_id}")
@@ -526,7 +532,10 @@ class ThumbnailSelectorWidget(QWidget, Ui_ThumbnailSelectorWidget):
             current_worker_id = getattr(self._worker_service, "current_thumbnail_worker_id", None)
             if current_worker_id:
                 try:
-                    self._worker_service.cancel_thumbnail_load(current_worker_id)
+                    self._worker_service.cancel_thumbnail_load(
+                        current_worker_id,
+                        reason=CancelReason.THUMBNAIL_REPLACED,
+                    )
                 except Exception:
                     logger.exception(
                         f"Failed to cancel current thumbnail worker: worker_id={current_worker_id}"

--- a/src/lorairo/gui/window/main_window.py
+++ b/src/lorairo/gui/window/main_window.py
@@ -664,6 +664,7 @@ class MainWindow(QMainWindow, Ui_MainWindow):
             "enhanced_annotation_canceled",
             "worker_progress_updated",
             "worker_batch_progress",
+            "worker_terminal",
         ]
 
         missing_signals = [
@@ -685,8 +686,7 @@ class MainWindow(QMainWindow, Ui_MainWindow):
         # Error handling connections
         self.worker_service.search_error.connect(self._on_pipeline_search_error)
         self.worker_service.thumbnail_error.connect(self._on_pipeline_thumbnail_error)
-        self.worker_service.search_canceled.connect(self._on_pipeline_search_canceled)
-        self.worker_service.thumbnail_canceled.connect(self._on_pipeline_thumbnail_canceled)
+        self.worker_service.worker_terminal.connect(self._on_worker_terminal)
 
         # Batch registration connections
         self.worker_service.batch_registration_started.connect(self._on_batch_registration_started)
@@ -708,7 +708,7 @@ class MainWindow(QMainWindow, Ui_MainWindow):
         self.worker_service.worker_progress_updated.connect(self._on_worker_progress_updated)
         self.worker_service.worker_batch_progress.connect(self._on_worker_batch_progress)
 
-        logger.info("WorkerService pipeline signals connected (18 connections)")
+        logger.info("WorkerService pipeline signals connected (17 connections)")
 
     def _delegate_to_pipeline_control(self, method_name: str, *args: Any) -> None:
         """PipelineControlServiceへのイベント委譲ヘルパー"""
@@ -746,6 +746,10 @@ class MainWindow(QMainWindow, Ui_MainWindow):
 
     def _on_pipeline_thumbnail_canceled(self, worker_id: str) -> None:
         self._delegate_to_pipeline_control("on_thumbnail_canceled", worker_id)
+
+    def _on_worker_terminal(self, event: Any) -> None:
+        """Route terminal events with outcome and reason details."""
+        self._delegate_to_pipeline_control("on_worker_terminal", event)
 
     def _delegate_to_progress_state(self, method_name: str, *args: Any) -> None:
         """ProgressStateServiceへのイベント委譲ヘルパー"""

--- a/src/lorairo/gui/workers/manager.py
+++ b/src/lorairo/gui/workers/manager.py
@@ -6,6 +6,7 @@ from PySide6.QtCore import QCoreApplication, QObject, QThread, Signal
 
 from ...utils.log import logger
 from .base import LoRAIroWorkerBase
+from .terminal import CancelReason, WorkerOutcome, WorkerTerminalEvent
 
 
 class WorkerManager(QObject):
@@ -19,6 +20,7 @@ class WorkerManager(QObject):
     worker_finished = Signal(str, object)  # worker_id, result
     worker_error = Signal(str, str)  # worker_id, error_message
     worker_canceled = Signal(str)  # worker_id
+    worker_terminal = Signal(object)  # WorkerTerminalEvent
 
     # === 全体管理シグナル ===
     all_workers_finished = Signal()
@@ -78,6 +80,9 @@ class WorkerManager(QObject):
             "worker": worker,
             "thread": thread,
             "auto_cleanup": auto_cleanup,
+            "cancel_reason": None,
+            "terminal_emitted": False,
+            "unresponsive": False,
         }
 
         thread.start()
@@ -87,7 +92,11 @@ class WorkerManager(QObject):
         logger.info(f"ワーカー開始: {worker_id} ({worker.__class__.__name__})")
         return True
 
-    def cancel_worker(self, worker_id: str) -> bool:
+    def cancel_worker(
+        self,
+        worker_id: str,
+        reason: CancelReason = CancelReason.USER_REQUESTED,
+    ) -> bool:
         """
         指定ワーカーをキャンセル
 
@@ -102,6 +111,7 @@ class WorkerManager(QObject):
             return False
 
         worker_info = self.active_workers[worker_id]
+        worker_info["cancel_reason"] = reason
         worker_info["worker"].cancel()
 
         # スレッドの適切な終了
@@ -114,18 +124,29 @@ class WorkerManager(QObject):
                 logger.warning(f"キャンセルされたワーカーの終了タイムアウト: {worker_id}")
                 thread.terminate()
                 if thread.wait(1000):  # 強制終了後も1秒待機
-                    self._finalize_canceled_if_no_terminal_signal(worker_id)
+                    self._finalize_canceled_if_no_terminal_signal(
+                        worker_id,
+                        fallback_outcome=WorkerOutcome.TERMINATED,
+                        fallback_error=f"ワーカーを強制終了しました: {worker_id}",
+                    )
                 else:
                     logger.error(f"キャンセルされたワーカーの強制終了失敗: {worker_id}")
+                    self._mark_worker_unresponsive(
+                        worker_id,
+                        error=f"ワーカー強制終了後も停止確認できませんでした: {worker_id}",
+                        cancel_reason=reason,
+                    )
+        else:
+            self._finalize_canceled_if_no_terminal_signal(worker_id)
 
         logger.info(f"ワーカーキャンセル: {worker_id}")
         return True
 
-    def cancel_all_workers(self) -> None:
+    def cancel_all_workers(self, reason: CancelReason = CancelReason.SHUTDOWN) -> None:
         """全ワーカーをキャンセル"""
         worker_ids = list(self.active_workers.keys())
         for worker_id in worker_ids:
-            self.cancel_worker(worker_id)
+            self.cancel_worker(worker_id, reason=reason)
 
         logger.info(f"全ワーカーキャンセル: {len(worker_ids)}個")
 
@@ -190,8 +211,7 @@ class WorkerManager(QObject):
 
     def _on_worker_finished(self, worker_id: str, result: Any) -> None:
         """ワーカー完了イベントハンドラー"""
-        if self._pop_active_worker(worker_id):
-            self.worker_finished.emit(worker_id, result)
+        if self._finalize_terminal(worker_id, WorkerOutcome.SUCCEEDED, result=result):
             logger.info(f"ワーカー完了: {worker_id}")
 
     def _cleanup_thread(self, worker_id: str, thread: QThread) -> None:
@@ -209,24 +229,134 @@ class WorkerManager(QObject):
 
     def _on_worker_error(self, worker_id: str, error: str) -> None:
         """ワーカーエラーイベントハンドラー"""
-        if self._pop_active_worker(worker_id):
-            self.worker_error.emit(worker_id, error)
+        if self._finalize_terminal(worker_id, WorkerOutcome.FAILED, error=error):
             logger.error(f"ワーカーエラー: {worker_id} - {error}")
 
     def _on_worker_canceled(self, worker_id: str) -> None:
         """ワーカーキャンセル完了イベントハンドラー"""
-        if self._pop_active_worker(worker_id):
-            self.worker_canceled.emit(worker_id)
+        cancel_reason = self._get_cancel_reason(worker_id)
+        if self._finalize_terminal(
+            worker_id,
+            WorkerOutcome.CANCELED,
+            cancel_reason=cancel_reason,
+        ):
             logger.info(f"ワーカーキャンセル完了: {worker_id}")
 
-    def _finalize_canceled_if_no_terminal_signal(self, worker_id: str) -> None:
+    def _finalize_canceled_if_no_terminal_signal(
+        self,
+        worker_id: str,
+        *,
+        fallback_outcome: WorkerOutcome = WorkerOutcome.CANCELED,
+        fallback_error: str | None = None,
+    ) -> None:
         """queued terminal signal を優先し、未確定なら cancel fallback で終端する。"""
         app = QCoreApplication.instance()
         if app is not None:
             app.processEvents()
 
         if worker_id in self.active_workers:
-            self._on_worker_canceled(worker_id)
+            self._finalize_terminal(
+                worker_id,
+                fallback_outcome,
+                error=fallback_error,
+                cancel_reason=self._get_cancel_reason(worker_id),
+            )
+
+    def _finalize_terminal(
+        self,
+        worker_id: str,
+        outcome: WorkerOutcome,
+        *,
+        result: Any | None = None,
+        error: str | None = None,
+        cancel_reason: CancelReason | None = None,
+    ) -> bool:
+        """Emit exactly one terminal event for a worker and compatibility signals."""
+        worker_info = self.active_workers.get(worker_id)
+        if worker_info is None:
+            return False
+
+        worker_type = self._resolve_worker_type(worker_id)
+        if cancel_reason is None:
+            cancel_reason = worker_info.get("cancel_reason")
+
+        if worker_info.get("terminal_emitted"):
+            self._pop_active_worker(worker_id)
+            return False
+
+        event = WorkerTerminalEvent(
+            worker_id=worker_id,
+            worker_type=worker_type,
+            outcome=outcome,
+            result=result,
+            error=error,
+            cancel_reason=cancel_reason,
+        )
+        if not self._emit_terminal_once(worker_id, event):
+            return False
+
+        if not self._pop_active_worker(worker_id):
+            return False
+
+        if outcome is WorkerOutcome.SUCCEEDED:
+            self.worker_finished.emit(worker_id, result)
+        elif outcome is WorkerOutcome.FAILED:
+            self.worker_error.emit(worker_id, error or "")
+        elif outcome is WorkerOutcome.CANCELED:
+            self.worker_canceled.emit(worker_id)
+        else:
+            self.worker_error.emit(worker_id, error or f"ワーカー異常終了: {outcome.value}")
+
+        return True
+
+    def _mark_worker_unresponsive(
+        self,
+        worker_id: str,
+        *,
+        error: str,
+        cancel_reason: CancelReason | None = None,
+    ) -> bool:
+        """Emit an abnormal observation but keep the still-running worker tracked."""
+        worker_info = self.active_workers.get(worker_id)
+        if worker_info is None:
+            return False
+
+        worker_info["unresponsive"] = True
+        worker_type = self._resolve_worker_type(worker_id)
+        if cancel_reason is None:
+            cancel_reason = worker_info.get("cancel_reason")
+
+        event = WorkerTerminalEvent(
+            worker_id=worker_id,
+            worker_type=worker_type,
+            outcome=WorkerOutcome.UNRESPONSIVE,
+            error=error,
+            cancel_reason=cancel_reason,
+        )
+        if not self._emit_terminal_once(worker_id, event):
+            return False
+
+        self.worker_error.emit(worker_id, error)
+        return True
+
+    def _emit_terminal_once(self, worker_id: str, event: WorkerTerminalEvent) -> bool:
+        worker_info = self.active_workers.get(worker_id)
+        if worker_info is None or worker_info.get("terminal_emitted"):
+            return False
+
+        worker_info["terminal_emitted"] = True
+        self.worker_terminal.emit(event)
+        return True
+
+    def _get_cancel_reason(self, worker_id: str) -> CancelReason | None:
+        worker_info = self.active_workers.get(worker_id)
+        return worker_info.get("cancel_reason") if worker_info else None
+
+    def _resolve_worker_type(self, worker_id: str) -> str:
+        for prefix in ("batch_reg_", "batch_import_", "annotation_", "search_", "thumbnail_"):
+            if worker_id.startswith(prefix):
+                return prefix.rstrip("_")
+        return "unknown"
 
     def _pop_active_worker(self, worker_id: str) -> bool:
         """ワーカー終端を一度だけ確定し、管理状態を更新する。"""
@@ -276,6 +406,7 @@ class WorkerManager(QObject):
                     "class_name": worker_info["worker"].__class__.__name__,
                     "status": worker_info["worker"].status.value,
                     "auto_cleanup": worker_info["auto_cleanup"],
+                    "unresponsive": worker_info.get("unresponsive", False),
                 }
                 for worker_id, worker_info in self.active_workers.items()
             },

--- a/src/lorairo/gui/workers/terminal.py
+++ b/src/lorairo/gui/workers/terminal.py
@@ -1,0 +1,41 @@
+"""Worker terminal event types."""
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any
+
+
+class WorkerOutcome(Enum):
+    """Authoritative terminal outcome for a worker."""
+
+    SUCCEEDED = "succeeded"
+    FAILED = "failed"
+    CANCELED = "canceled"
+    CANCEL_TIMEOUT = "cancel_timeout"
+    TERMINATED = "terminated"
+    UNRESPONSIVE = "unresponsive"
+
+
+class CancelReason(Enum):
+    """Reason a worker cancellation was requested."""
+
+    USER_REQUESTED = "user_requested"
+    PIPELINE_CANCEL = "pipeline_cancel"
+    SEARCH_REPLACED = "search_replaced"
+    THUMBNAIL_REPLACED = "thumbnail_replaced"
+    PREFETCH_REPLACED = "prefetch_replaced"
+    PROGRESS_DIALOG = "progress_dialog"
+    SHUTDOWN = "shutdown"
+    TIMEOUT_FALLBACK = "timeout_fallback"
+
+
+@dataclass(frozen=True)
+class WorkerTerminalEvent:
+    """Single terminal event emitted once per worker."""
+
+    worker_id: str
+    worker_type: str
+    outcome: WorkerOutcome
+    result: Any | None = None
+    error: str | None = None
+    cancel_reason: CancelReason | None = None

--- a/tests/integration/gui/test_worker_coordination.py
+++ b/tests/integration/gui/test_worker_coordination.py
@@ -10,6 +10,7 @@ from PySide6.QtCore import QEventLoop, QThread, QTimer
 
 from lorairo.gui.services.worker_service import WorkerService
 from lorairo.gui.workers.search_worker import SearchResult, SearchWorker
+from lorairo.gui.workers.terminal import CancelReason
 from lorairo.services.search_models import SearchConditions
 
 
@@ -91,7 +92,10 @@ class TestWorkerSystemCoordination:
             )
 
             # 1番目のワーカーがキャンセルされたことを確認
-            worker_service.worker_manager.cancel_worker.assert_called_with(worker_id1)
+            worker_service.worker_manager.cancel_worker.assert_called_with(
+                worker_id1,
+                reason=CancelReason.SEARCH_REPLACED,
+            )
 
             # 現在のワーカーIDが更新されたことを確認
             assert worker_service.current_search_worker_id == worker_id2
@@ -261,7 +265,10 @@ class TestWorkerSystemCoordination:
             )
 
             # 古いワーカーがキャンセルされ、新しいIDが設定される
-            worker_service.worker_manager.cancel_worker.assert_called_with(worker_id)
+            worker_service.worker_manager.cancel_worker.assert_called_with(
+                worker_id,
+                reason=CancelReason.SEARCH_REPLACED,
+            )
             assert worker_service.current_search_worker_id == new_worker_id
 
 

--- a/tests/unit/gui/services/test_pipeline_control_service.py
+++ b/tests/unit/gui/services/test_pipeline_control_service.py
@@ -9,6 +9,7 @@ import pytest
 
 from lorairo.gui.services.pipeline_control_service import PipelineControlService
 from lorairo.gui.workers.search_worker import SearchResult
+from lorairo.gui.workers.terminal import CancelReason, WorkerOutcome, WorkerTerminalEvent
 from lorairo.services.search_models import SearchConditions
 
 
@@ -85,8 +86,14 @@ class TestCancelCurrentPipeline:
         service.cancel_current_pipeline()
 
         # Assert
-        mock_worker_service.cancel_search.assert_called_once_with("search-123")
-        mock_worker_service.cancel_thumbnail_load.assert_called_once_with("thumb-456")
+        mock_worker_service.cancel_search.assert_called_once_with(
+            "search-123",
+            reason=CancelReason.PIPELINE_CANCEL,
+        )
+        mock_worker_service.cancel_thumbnail_load.assert_called_once_with(
+            "thumb-456",
+            reason=CancelReason.PIPELINE_CANCEL,
+        )
         mock_thumbnail_selector.clear_thumbnails.assert_called_once()
         mock_filter_panel.clear_pipeline_results.assert_called_once()
         mock_filter_panel.hide_progress_after_completion.assert_called_once()
@@ -196,6 +203,22 @@ class TestPipelineFlow:
 
         mock_thumbnail_selector.clear_thumbnails.assert_called_once()
         mock_filter_panel.clear_pipeline_results.assert_called_once()
+        mock_filter_panel.hide_progress_after_completion.assert_called_once()
+
+    def test_on_search_replaced_canceled_keeps_current_results(
+        self, service, mock_thumbnail_selector, mock_filter_panel
+    ):
+        event = WorkerTerminalEvent(
+            worker_id="search-123",
+            worker_type="search",
+            outcome=WorkerOutcome.CANCELED,
+            cancel_reason=CancelReason.SEARCH_REPLACED,
+        )
+
+        service.on_search_canceled(event)
+
+        mock_thumbnail_selector.clear_thumbnails.assert_not_called()
+        mock_filter_panel.clear_pipeline_results.assert_not_called()
         mock_filter_panel.hide_progress_after_completion.assert_called_once()
 
     def test_on_thumbnail_canceled_keeps_pipeline_results_without_error(
@@ -379,3 +402,37 @@ class TestPipelineFlow:
         )
         mock_thumbnail_selector.clear_thumbnails.assert_called_once()
         mock_filter_panel.hide_progress_after_completion.assert_called_once()
+
+    def test_on_worker_terminal_abnormal_thumbnail_clears_results(
+        self, service, mock_thumbnail_selector, mock_filter_panel
+    ):
+        event = WorkerTerminalEvent(
+            worker_id="thumbnail-123",
+            worker_type="thumbnail",
+            outcome=WorkerOutcome.TERMINATED,
+            error="terminated",
+            cancel_reason=CancelReason.USER_REQUESTED,
+        )
+
+        service.on_worker_terminal(event)
+
+        mock_thumbnail_selector.clear_thumbnails.assert_called_once()
+        mock_filter_panel.clear_pipeline_results.assert_not_called()
+        mock_filter_panel.hide_progress_after_completion.assert_called_once()
+
+    def test_on_worker_terminal_replacement_abnormal_keeps_results(
+        self, service, mock_thumbnail_selector, mock_filter_panel
+    ):
+        event = WorkerTerminalEvent(
+            worker_id="thumbnail-123",
+            worker_type="thumbnail",
+            outcome=WorkerOutcome.TERMINATED,
+            error="terminated",
+            cancel_reason=CancelReason.THUMBNAIL_REPLACED,
+        )
+
+        service.on_worker_terminal(event)
+
+        mock_thumbnail_selector.clear_thumbnails.assert_not_called()
+        mock_filter_panel.clear_pipeline_results.assert_not_called()
+        mock_filter_panel.hide_progress_after_completion.assert_not_called()

--- a/tests/unit/gui/services/test_pipeline_control_service.py
+++ b/tests/unit/gui/services/test_pipeline_control_service.py
@@ -403,7 +403,7 @@ class TestPipelineFlow:
         mock_thumbnail_selector.clear_thumbnails.assert_called_once()
         mock_filter_panel.hide_progress_after_completion.assert_called_once()
 
-    def test_on_worker_terminal_abnormal_thumbnail_clears_results(
+    def test_on_worker_terminal_abnormal_thumbnail_defers_cleanup_to_compat_error(
         self, service, mock_thumbnail_selector, mock_filter_panel
     ):
         event = WorkerTerminalEvent(
@@ -416,9 +416,9 @@ class TestPipelineFlow:
 
         service.on_worker_terminal(event)
 
-        mock_thumbnail_selector.clear_thumbnails.assert_called_once()
+        mock_thumbnail_selector.clear_thumbnails.assert_not_called()
         mock_filter_panel.clear_pipeline_results.assert_not_called()
-        mock_filter_panel.hide_progress_after_completion.assert_called_once()
+        mock_filter_panel.hide_progress_after_completion.assert_not_called()
 
     def test_on_worker_terminal_replacement_abnormal_keeps_results(
         self, service, mock_thumbnail_selector, mock_filter_panel

--- a/tests/unit/gui/services/test_worker_service.py
+++ b/tests/unit/gui/services/test_worker_service.py
@@ -514,6 +514,46 @@ class TestWorkerService:
         error_mock.assert_not_called()
         assert worker_service.current_thumbnail_worker_id is None
 
+    def test_worker_terminal_replacement_abnormal_finishes_search_progress(self, worker_service):
+        old_worker_id = "search_replaced"
+        worker_service.current_search_worker_id = old_worker_id
+        error_mock = Mock()
+        worker_service.search_error.connect(error_mock)
+        event = WorkerTerminalEvent(
+            worker_id=old_worker_id,
+            worker_type="search",
+            outcome=WorkerOutcome.CANCEL_TIMEOUT,
+            error="cancel timed out",
+            cancel_reason=CancelReason.SEARCH_REPLACED,
+        )
+
+        with patch.object(worker_service.progress_manager, "finish_worker_progress") as mock_finish:
+            worker_service._on_worker_terminal(event)
+
+        mock_finish.assert_called_once_with(old_worker_id, success=False)
+        error_mock.assert_not_called()
+        assert worker_service.current_search_worker_id is None
+
+    def test_worker_terminal_replacement_failed_suppresses_compat_error(self, worker_service):
+        old_worker_id = "search_replaced"
+        worker_service.current_search_worker_id = old_worker_id
+        error_mock = Mock()
+        worker_service.search_error.connect(error_mock)
+        event = WorkerTerminalEvent(
+            worker_id=old_worker_id,
+            worker_type="search",
+            outcome=WorkerOutcome.FAILED,
+            error="superseded worker failed",
+            cancel_reason=CancelReason.SEARCH_REPLACED,
+        )
+
+        with patch.object(worker_service.progress_manager, "finish_worker_progress") as mock_finish:
+            worker_service._on_worker_terminal(event)
+
+        mock_finish.assert_called_once_with(old_worker_id, success=False)
+        error_mock.assert_not_called()
+        assert worker_service.current_search_worker_id is None
+
     def test_worker_id_uniqueness(self, worker_service):
         """ワーカーID一意性テスト"""
         with patch("lorairo.gui.services.worker_service.SearchWorker"):

--- a/tests/unit/gui/services/test_worker_service.py
+++ b/tests/unit/gui/services/test_worker_service.py
@@ -11,6 +11,7 @@ from PySide6.QtCore import QSize
 
 from lorairo.gui.services.worker_service import WorkerService
 from lorairo.gui.workers.search_worker import SearchResult
+from lorairo.gui.workers.terminal import CancelReason, WorkerOutcome, WorkerTerminalEvent
 from lorairo.services.search_models import SearchConditions
 
 
@@ -80,6 +81,7 @@ class TestWorkerService:
         # 進捗・管理シグナル
         assert hasattr(worker_service, "worker_progress_updated")
         assert hasattr(worker_service, "worker_batch_progress")
+        assert hasattr(worker_service, "worker_terminal")
         assert hasattr(worker_service, "active_worker_count_changed")
         assert hasattr(worker_service, "all_workers_finished")
 
@@ -212,7 +214,10 @@ class TestWorkerService:
         new_worker_id = worker_service.start_search(filter_conditions)
 
         # 既存ワーカーのキャンセル確認
-        worker_service.worker_manager.cancel_worker.assert_called_once_with(existing_worker_id)
+        worker_service.worker_manager.cancel_worker.assert_called_once_with(
+            existing_worker_id,
+            reason=CancelReason.SEARCH_REPLACED,
+        )
 
         # 新しいワーカーID設定確認
         assert worker_service.current_search_worker_id == new_worker_id
@@ -366,7 +371,10 @@ class TestWorkerService:
             cancel_previous=True,
         )
 
-        worker_service.worker_manager.cancel_worker.assert_called_with("thumbnail_existing")
+        worker_service.worker_manager.cancel_worker.assert_called_with(
+            "thumbnail_existing",
+            reason=CancelReason.THUMBNAIL_REPLACED,
+        )
 
     @patch("lorairo.gui.services.worker_service.ThumbnailWorker")
     def test_start_thumbnail_page_load_failure_keeps_current_worker_id(
@@ -427,6 +435,84 @@ class TestWorkerService:
         assert worker_service.current_search_worker_id is None
         error_mock.assert_not_called()
         canceled_mock.assert_called_once_with(worker_id)
+
+    def test_worker_terminal_emits_rich_event_and_dispatches_compat_signal(self, worker_service):
+        worker_id = "search_cancelled"
+        worker_service.current_search_worker_id = worker_id
+        terminal_mock = Mock()
+        canceled_mock = Mock()
+        worker_service.worker_terminal.connect(terminal_mock)
+        worker_service.search_canceled.connect(canceled_mock)
+        event = WorkerTerminalEvent(
+            worker_id=worker_id,
+            worker_type="search",
+            outcome=WorkerOutcome.CANCELED,
+            cancel_reason=CancelReason.PIPELINE_CANCEL,
+        )
+
+        with patch.object(worker_service.progress_manager, "finish_worker_progress"):
+            worker_service._on_worker_terminal(event)
+
+        terminal_mock.assert_called_once_with(event)
+        canceled_mock.assert_called_once_with(worker_id)
+        assert worker_service.current_search_worker_id is None
+
+    def test_worker_terminal_suppresses_replacement_canceled_compat_signal(self, worker_service):
+        worker_id = "search_replaced"
+        worker_service.current_search_worker_id = worker_id
+        canceled_mock = Mock()
+        worker_service.search_canceled.connect(canceled_mock)
+        event = WorkerTerminalEvent(
+            worker_id=worker_id,
+            worker_type="search",
+            outcome=WorkerOutcome.CANCELED,
+            cancel_reason=CancelReason.SEARCH_REPLACED,
+        )
+
+        with patch.object(worker_service.progress_manager, "finish_worker_progress"):
+            worker_service._on_worker_terminal(event)
+
+        canceled_mock.assert_not_called()
+        assert worker_service.current_search_worker_id is None
+
+    def test_worker_terminal_abnormal_outcome_dispatches_error_not_canceled(self, worker_service):
+        worker_id = "thumbnail_timeout"
+        worker_service.current_thumbnail_worker_id = worker_id
+        error_mock = Mock()
+        canceled_mock = Mock()
+        worker_service.thumbnail_error.connect(error_mock)
+        worker_service.thumbnail_canceled.connect(canceled_mock)
+        event = WorkerTerminalEvent(
+            worker_id=worker_id,
+            worker_type="thumbnail",
+            outcome=WorkerOutcome.TERMINATED,
+            error="terminated",
+            cancel_reason=CancelReason.USER_REQUESTED,
+        )
+
+        worker_service._on_worker_terminal(event)
+
+        error_mock.assert_called_once_with("terminated")
+        canceled_mock.assert_not_called()
+        assert worker_service.current_thumbnail_worker_id is None
+
+    def test_worker_terminal_replacement_abnormal_suppresses_compat_error(self, worker_service):
+        old_worker_id = "thumbnail_replaced"
+        worker_service.current_thumbnail_worker_id = old_worker_id
+        error_mock = Mock()
+        worker_service.thumbnail_error.connect(error_mock)
+        event = WorkerTerminalEvent(
+            worker_id=old_worker_id,
+            worker_type="thumbnail",
+            outcome=WorkerOutcome.TERMINATED,
+            error="terminated",
+            cancel_reason=CancelReason.THUMBNAIL_REPLACED,
+        )
+
+        worker_service._on_worker_terminal(event)
+
+        error_mock.assert_not_called()
+        assert worker_service.current_thumbnail_worker_id is None
 
     def test_worker_id_uniqueness(self, worker_service):
         """ワーカーID一意性テスト"""
@@ -732,4 +818,7 @@ class TestWorkerService:
         worker_service._on_progress_cancellation_requested("test_worker_003")
 
         # WorkerManagerにキャンセルが要求されたことを確認
-        worker_service.worker_manager.cancel_worker.assert_called_with("test_worker_003")
+        worker_service.worker_manager.cancel_worker.assert_called_with(
+            "test_worker_003",
+            reason=CancelReason.PROGRESS_DIALOG,
+        )

--- a/tests/unit/gui/widgets/test_thumbnail_selector_widget.py
+++ b/tests/unit/gui/widgets/test_thumbnail_selector_widget.py
@@ -16,6 +16,7 @@ from PySide6.QtGui import QImage
 from lorairo.gui.state.dataset_state import DatasetStateManager
 from lorairo.gui.widgets.thumbnail import ThumbnailSelectorWidget
 from lorairo.gui.workers.search_worker import SearchResult
+from lorairo.gui.workers.terminal import CancelReason
 from lorairo.gui.workers.thumbnail_worker import ThumbnailLoadResult
 from lorairo.services.search_models import SearchConditions
 
@@ -809,7 +810,10 @@ class TestThumbnailSelectorWidgetPagination:
         widget.page_cache.set_page(1, [])
         widget._display_or_request_page(1, cancel_previous=True)
 
-        worker_service.cancel_thumbnail_load.assert_called_with("thumbnail_req_1")
+        worker_service.cancel_thumbnail_load.assert_called_with(
+            "thumbnail_req_1",
+            reason=CancelReason.THUMBNAIL_REPLACED,
+        )
         assert widget._display_request_id is None
         assert widget._request_id_to_page == {}
         assert widget._request_id_to_worker_id == {}

--- a/tests/unit/gui/window/test_main_window.py
+++ b/tests/unit/gui/window/test_main_window.py
@@ -335,6 +335,7 @@ class TestMainWindowAnnotationCompletion:
             "enhanced_annotation_canceled",
             "worker_progress_updated",
             "worker_batch_progress",
+            "worker_terminal",
         ]:
             setattr(mock_window.worker_service, signal_name, Mock())
 
@@ -345,11 +346,9 @@ class TestMainWindowAnnotationCompletion:
                 "search_finished",
                 "search_started",
                 "search_error",
-                "search_canceled",
                 "thumbnail_finished",
                 "thumbnail_started",
                 "thumbnail_error",
-                "thumbnail_canceled",
                 "batch_registration_started",
                 "batch_registration_finished",
                 "batch_registration_error",
@@ -362,6 +361,7 @@ class TestMainWindowAnnotationCompletion:
                 "enhanced_annotation_canceled",
                 "worker_progress_updated",
                 "worker_batch_progress",
+                "worker_terminal",
             ]:
                 getattr(mock_window.worker_service, signal_name).connect.assert_called_once()
 

--- a/tests/unit/gui/workers/test_manager.py
+++ b/tests/unit/gui/workers/test_manager.py
@@ -5,6 +5,7 @@ from unittest.mock import Mock
 import pytest
 
 from lorairo.gui.workers.manager import WorkerManager
+from lorairo.gui.workers.terminal import CancelReason, WorkerOutcome
 
 
 @pytest.fixture
@@ -59,15 +60,22 @@ class TestWorkerManagerCancellation:
         thread.wait.return_value = True
         manager.active_workers["worker-1"] = {"worker": worker, "thread": thread, "auto_cleanup": True}
         canceled_mock = Mock()
+        terminal_mock = Mock()
         manager.worker_canceled.connect(canceled_mock)
+        manager.worker_terminal.connect(terminal_mock)
 
-        result = manager.cancel_worker("worker-1")
+        result = manager.cancel_worker("worker-1", reason=CancelReason.PIPELINE_CANCEL)
 
         assert result is True
         worker.cancel.assert_called_once()
         thread.quit.assert_called_once()
         thread.wait.assert_called_once_with(2000)
         canceled_mock.assert_called_once_with("worker-1")
+        terminal_mock.assert_called_once()
+        event = terminal_mock.call_args.args[0]
+        assert event.worker_id == "worker-1"
+        assert event.outcome is WorkerOutcome.CANCELED
+        assert event.cancel_reason is CancelReason.PIPELINE_CANCEL
         assert "worker-1" not in manager.active_workers
 
     def test_cancel_worker_wait_success_prefers_queued_finished_signal(self, manager, monkeypatch):
@@ -80,6 +88,8 @@ class TestWorkerManagerCancellation:
         canceled_mock = Mock()
         manager.worker_finished.connect(finished_mock)
         manager.worker_canceled.connect(canceled_mock)
+        terminal_mock = Mock()
+        manager.worker_terminal.connect(terminal_mock)
         app = Mock()
         app.processEvents.side_effect = lambda: manager._on_worker_finished("worker-1", {"ok": True})
         monkeypatch.setattr("lorairo.gui.workers.manager.QCoreApplication.instance", Mock(return_value=app))
@@ -89,6 +99,7 @@ class TestWorkerManagerCancellation:
         assert result is True
         finished_mock.assert_called_once_with("worker-1", {"ok": True})
         canceled_mock.assert_not_called()
+        assert terminal_mock.call_args.args[0].outcome is WorkerOutcome.SUCCEEDED
         assert "worker-1" not in manager.active_workers
 
     def test_cancel_worker_wait_success_prefers_queued_error_signal(self, manager, monkeypatch):
@@ -101,6 +112,8 @@ class TestWorkerManagerCancellation:
         canceled_mock = Mock()
         manager.worker_error.connect(error_mock)
         manager.worker_canceled.connect(canceled_mock)
+        terminal_mock = Mock()
+        manager.worker_terminal.connect(terminal_mock)
         app = Mock()
         app.processEvents.side_effect = lambda: manager._on_worker_error("worker-1", "boom")
         monkeypatch.setattr("lorairo.gui.workers.manager.QCoreApplication.instance", Mock(return_value=app))
@@ -110,6 +123,7 @@ class TestWorkerManagerCancellation:
         assert result is True
         error_mock.assert_called_once_with("worker-1", "boom")
         canceled_mock.assert_not_called()
+        assert terminal_mock.call_args.args[0].outcome is WorkerOutcome.FAILED
         assert "worker-1" not in manager.active_workers
 
     def test_finished_after_cancel_request_wins_over_canceled(self, manager):
@@ -138,37 +152,80 @@ class TestWorkerManagerCancellation:
         error_mock.assert_called_once_with("worker-1", "boom")
         canceled_mock.assert_not_called()
 
-    def test_cancel_worker_timeout_forces_canceled_cleanup(self, manager):
+    def test_cancel_worker_timeout_terminate_success_emits_terminated(self, manager):
         worker = Mock()
         thread = Mock()
         thread.isRunning.return_value = True
         thread.wait.side_effect = [False, True]
         manager.active_workers["worker-1"] = {"worker": worker, "thread": thread, "auto_cleanup": True}
         canceled_mock = Mock()
+        error_mock = Mock()
+        terminal_mock = Mock()
         manager.worker_canceled.connect(canceled_mock)
-
-        result = manager.cancel_worker("worker-1")
-
-        assert result is True
-        thread.terminate.assert_called_once()
-        canceled_mock.assert_called_once_with("worker-1")
-        assert "worker-1" not in manager.active_workers
-
-    def test_cancel_worker_timeout_does_not_finalize_when_terminate_wait_fails(self, manager):
-        worker = Mock()
-        thread = Mock()
-        thread.isRunning.return_value = True
-        thread.wait.side_effect = [False, False]
-        manager.active_workers["worker-1"] = {"worker": worker, "thread": thread, "auto_cleanup": True}
-        canceled_mock = Mock()
-        manager.worker_canceled.connect(canceled_mock)
+        manager.worker_error.connect(error_mock)
+        manager.worker_terminal.connect(terminal_mock)
 
         result = manager.cancel_worker("worker-1")
 
         assert result is True
         thread.terminate.assert_called_once()
         canceled_mock.assert_not_called()
+        error_mock.assert_called_once()
+        event = terminal_mock.call_args.args[0]
+        assert event.outcome is WorkerOutcome.TERMINATED
+        assert event.cancel_reason is CancelReason.USER_REQUESTED
+        assert "worker-1" not in manager.active_workers
+
+    def test_cancel_worker_timeout_terminate_wait_failure_emits_unresponsive(self, manager):
+        worker = Mock()
+        thread = Mock()
+        thread.isRunning.return_value = True
+        thread.wait.side_effect = [False, False]
+        manager.active_workers["worker-1"] = {"worker": worker, "thread": thread, "auto_cleanup": True}
+        canceled_mock = Mock()
+        error_mock = Mock()
+        terminal_mock = Mock()
+        count_mock = Mock()
+        all_finished_mock = Mock()
+        manager.worker_canceled.connect(canceled_mock)
+        manager.worker_error.connect(error_mock)
+        manager.worker_terminal.connect(terminal_mock)
+        manager.active_worker_count_changed.connect(count_mock)
+        manager.all_workers_finished.connect(all_finished_mock)
+
+        result = manager.cancel_worker("worker-1")
+
+        assert result is True
+        thread.terminate.assert_called_once()
+        canceled_mock.assert_not_called()
+        error_mock.assert_called_once()
+        assert terminal_mock.call_args.args[0].outcome is WorkerOutcome.UNRESPONSIVE
         assert "worker-1" in manager.active_workers
+        assert manager.active_workers["worker-1"]["unresponsive"] is True
+        count_mock.assert_not_called()
+        all_finished_mock.assert_not_called()
+
+    def test_late_terminal_after_unresponsive_removes_active_worker_without_duplicate_event(self, manager):
+        manager.active_workers["worker-1"] = {
+            "worker": Mock(),
+            "thread": Mock(),
+            "auto_cleanup": True,
+            "terminal_emitted": True,
+            "unresponsive": True,
+        }
+        terminal_mock = Mock()
+        count_mock = Mock()
+        all_finished_mock = Mock()
+        manager.worker_terminal.connect(terminal_mock)
+        manager.active_worker_count_changed.connect(count_mock)
+        manager.all_workers_finished.connect(all_finished_mock)
+
+        manager._on_worker_finished("worker-1", {"ok": True})
+
+        terminal_mock.assert_not_called()
+        assert "worker-1" not in manager.active_workers
+        count_mock.assert_called_once_with(0)
+        all_finished_mock.assert_called_once()
 
     def test_on_worker_canceled_removes_active_worker_and_emits_terminal_signals(self, manager):
         manager.active_workers["worker-1"] = {"worker": Mock(), "thread": Mock(), "auto_cleanup": True}
@@ -176,6 +233,8 @@ class TestWorkerManagerCancellation:
         count_mock = Mock()
         all_finished_mock = Mock()
         manager.worker_canceled.connect(canceled_mock)
+        terminal_mock = Mock()
+        manager.worker_terminal.connect(terminal_mock)
         manager.active_worker_count_changed.connect(count_mock)
         manager.all_workers_finished.connect(all_finished_mock)
 
@@ -183,5 +242,6 @@ class TestWorkerManagerCancellation:
 
         assert manager.active_workers == {}
         canceled_mock.assert_called_once_with("worker-1")
+        assert terminal_mock.call_args.args[0].outcome is WorkerOutcome.CANCELED
         count_mock.assert_called_once_with(0)
         all_finished_mock.assert_called_once()


### PR DESCRIPTION
## Summary
- Add `WorkerTerminalEvent`, `WorkerOutcome`, and `CancelReason` for explicit worker terminal state.
- Route `WorkerManager` terminal handling through a single finalizer so each worker resolves once.
- Distinguish normal cancellation from terminate/unresponsive paths, and preserve cancel reasons through `WorkerService` and pipeline UI handling.
- Keep existing compatibility signals while suppressing replacement-only cancellation side effects for search/thumbnail flows.
- Add the missing generated `RatingScoreEditWidget_ui.py`, which was required by existing widget imports and MainWindow tests.

## Validation
- `uv run pytest tests/unit/gui/workers/test_manager.py tests/unit/gui/services/test_worker_service.py tests/unit/gui/services/test_pipeline_control_service.py tests/unit/gui/widgets/test_thumbnail_selector_widget.py::TestThumbnailSelectorWidgetPagination::test_display_or_request_page_cancels_pending_request tests/integration/gui/test_worker_coordination.py::TestWorkerSystemCoordination::test_multiple_search_worker_cancellation tests/integration/gui/test_worker_coordination.py::TestWorkerSystemCoordination::test_worker_lifecycle_management tests/integration/gui/test_worker_coordination.py::TestWorkerSystemCoordination::test_resource_cleanup_integration`
- `uv run ruff check ...` on touched files
- `uv run ruff format --check ...` on touched files
- `uv run mypy src/lorairo/gui/workers/terminal.py src/lorairo/gui/workers/manager.py src/lorairo/gui/services/worker_service.py src/lorairo/gui/services/pipeline_control_service.py src/lorairo/gui/widgets/thumbnail.py src/lorairo/gui/window/main_window.py`
- `uv run pytest tests/unit/gui/window/test_main_window.py::TestMainWindowPhase3Integration::test_setup_image_db_write_service -q`