### PR TITLE
refactor: derive manager compat signals from terminal events

### DIFF
--- a/src/lorairo/gui/workers/manager.py
+++ b/src/lorairo/gui/workers/manager.py
@@ -17,6 +17,8 @@ class WorkerManager(QObject):
 
     # === ワーカー管理シグナル ===
     worker_started = Signal(str)  # worker_id
+    # Compatibility signals derived from worker_terminal. New code should consume
+    # worker_terminal so it can inspect outcome and cancel_reason.
     worker_finished = Signal(str, object)  # worker_id, result
     worker_error = Signal(str, str)  # worker_id, error_message
     worker_canceled = Signal(str)  # worker_id
@@ -271,7 +273,7 @@ class WorkerManager(QObject):
         error: str | None = None,
         cancel_reason: CancelReason | None = None,
     ) -> bool:
-        """Emit exactly one terminal event for a worker and compatibility signals."""
+        """Emit exactly one worker fact terminal event and derived compatibility signals."""
         worker_info = self.active_workers.get(worker_id)
         if worker_info is None:
             return False
@@ -298,14 +300,7 @@ class WorkerManager(QObject):
         if not self._pop_active_worker(worker_id):
             return False
 
-        if outcome is WorkerOutcome.SUCCEEDED:
-            self.worker_finished.emit(worker_id, result)
-        elif outcome is WorkerOutcome.FAILED:
-            self.worker_error.emit(worker_id, error or "")
-        elif outcome is WorkerOutcome.CANCELED:
-            self.worker_canceled.emit(worker_id)
-        else:
-            self.worker_error.emit(worker_id, error or f"ワーカー異常終了: {outcome.value}")
+        self._emit_compat_terminal_signal(event)
 
         return True
 
@@ -336,7 +331,7 @@ class WorkerManager(QObject):
         if not self._emit_terminal_once(worker_id, event):
             return False
 
-        self.worker_error.emit(worker_id, error)
+        self._emit_compat_terminal_signal(event)
         return True
 
     def _emit_terminal_once(self, worker_id: str, event: WorkerTerminalEvent) -> bool:
@@ -347,6 +342,18 @@ class WorkerManager(QObject):
         worker_info["terminal_emitted"] = True
         self.worker_terminal.emit(event)
         return True
+
+    def _emit_compat_terminal_signal(self, event: WorkerTerminalEvent) -> None:
+        """Emit legacy manager signals from the canonical worker terminal fact."""
+        if event.outcome is WorkerOutcome.SUCCEEDED:
+            self.worker_finished.emit(event.worker_id, event.result)
+        elif event.outcome is WorkerOutcome.CANCELED:
+            self.worker_canceled.emit(event.worker_id)
+        else:
+            self.worker_error.emit(
+                event.worker_id,
+                event.error or f"ワーカー異常終了: {event.outcome.value}",
+            )
 
     def _get_cancel_reason(self, worker_id: str) -> CancelReason | None:
         worker_info = self.active_workers.get(worker_id)

--- a/src/lorairo/gui/workers/terminal.py
+++ b/src/lorairo/gui/workers/terminal.py
@@ -6,7 +6,7 @@ from typing import Any
 
 
 class WorkerOutcome(Enum):
-    """Authoritative terminal outcome for a worker."""
+    """Authoritative worker lifecycle outcome observed by WorkerManager."""
 
     SUCCEEDED = "succeeded"
     FAILED = "failed"
@@ -31,7 +31,7 @@ class CancelReason(Enum):
 
 @dataclass(frozen=True)
 class WorkerTerminalEvent:
-    """Single terminal event emitted once per worker."""
+    """Single worker fact event emitted once per worker observation."""
 
     worker_id: str
     worker_type: str

--- a/tests/unit/gui/workers/test_manager.py
+++ b/tests/unit/gui/workers/test_manager.py
@@ -176,6 +176,21 @@ class TestWorkerManagerCancellation:
         assert event.cancel_reason is CancelReason.USER_REQUESTED
         assert "worker-1" not in manager.active_workers
 
+    def test_worker_terminal_precedes_derived_compat_signal(self, manager):
+        manager.active_workers["worker-1"] = {"worker": Mock(), "thread": Mock(), "auto_cleanup": True}
+        calls = []
+        manager.worker_terminal.connect(lambda event: calls.append(("terminal", event.outcome)))
+        manager.worker_error.connect(
+            lambda worker_id, error: calls.append(("compat_error", worker_id, error))
+        )
+
+        manager._on_worker_error("worker-1", "boom")
+
+        assert calls == [
+            ("terminal", WorkerOutcome.FAILED),
+            ("compat_error", "worker-1", "boom"),
+        ]
+
     def test_cancel_worker_timeout_terminate_wait_failure_emits_unresponsive(self, manager):
         worker = Mock()
         thread = Mock()


### PR DESCRIPTION
## Summary
- Clarify WorkerManager worker_terminal as the canonical worker fact event
- Derive legacy manager worker_finished/error/canceled signals from WorkerTerminalEvent
- Add coverage that worker_terminal is emitted before derived compat error signals

## Tests
- uv run pytest tests/unit/gui/workers/test_manager.py
- uv run ruff check src/lorairo/gui/workers/manager.py src/lorairo/gui/workers/terminal.py tests/unit/gui/workers/test_manager.py
- uv run ruff format --check src/lorairo/gui/workers/manager.py src/lorairo/gui/workers/terminal.py tests/unit/gui/workers/test_manager.py
- uv run mypy src/lorairo/gui/workers/manager.py src/lorairo/gui/workers/terminal.py

Closes #436
Part of #434
Stacked on #443