### PR TITLE
fix: close progress from worker terminal events

### DIFF
--- a/src/lorairo/gui/services/worker_service.py
+++ b/src/lorairo/gui/services/worker_service.py
@@ -544,8 +544,8 @@ class WorkerService(QObject):
             operation_name = "サムネイル読み込み"
             self.thumbnail_started.emit(worker_id)
 
-        # サムネイル先読みはバックグラウンド処理のためプログレスダイアログ不要
-        if not worker_id.startswith("thumbnail_"):
+        # Thumbnail/page/prefetch workers never start modal progress; terminal close mirrors this policy.
+        if self._worker_uses_modal_progress(worker_id):
             self.progress_manager.start_worker_progress(
                 worker_id,
                 operation_name,
@@ -564,11 +564,8 @@ class WorkerService(QObject):
         return "unknown"
 
     def _on_worker_finished(self, worker_id: str, result: Any) -> None:
-        """ワーカー完了ハンドラ - プログレスダイアログ終了処理"""
+        """ワーカー完了ハンドラ - 互換シグナルとcurrent idの更新のみ行う"""
         worker_type = self._resolve_worker_type(worker_id)
-        if worker_type != "thumbnail":
-            self.progress_manager.finish_worker_progress(worker_id, success=True)
-
         finished_dispatch: dict[str, tuple[Any, str | None]] = {
             "batch_reg": (self.batch_registration_finished, "current_registration_worker_id"),
             "batch_import": (self.batch_import_finished, "current_batch_import_worker_id"),
@@ -585,13 +582,10 @@ class WorkerService(QObject):
         logger.info(f"ワーカー完了: {worker_id}")
 
     def _on_worker_error(self, worker_id: str, error: str) -> None:
-        """ワーカーエラーハンドラ - プログレスダイアログエラー処理"""
+        """ワーカーエラーハンドラ - 互換エラーシグナルとcurrent idの更新のみ行う"""
         logger.error(f"ワーカーエラー {worker_id}: {error}")
 
         worker_type = self._resolve_worker_type(worker_id)
-        if worker_type != "thumbnail":
-            self.progress_manager.finish_worker_progress(worker_id, success=False)
-
         error_dispatch: dict[str, tuple[Any, str | None]] = {
             "batch_reg": (self.batch_registration_error, "current_registration_worker_id"),
             "batch_import": (self.batch_import_error, "current_batch_import_worker_id"),
@@ -605,7 +599,7 @@ class WorkerService(QObject):
             if attr and getattr(self, attr) == worker_id:
                 setattr(self, attr, None)
 
-        logger.info(f"ワーカーエラーとプログレス終了: {worker_id}")
+        logger.info(f"ワーカーエラー処理完了: {worker_id}")
 
     def _on_worker_canceled(self, worker_id: str) -> None:
         """ワーカーキャンセルハンドラ - エラー扱いせずプログレスを終了"""
@@ -621,13 +615,13 @@ class WorkerService(QObject):
     def _on_worker_terminal(self, event: WorkerTerminalEvent) -> None:
         """Unified worker terminal event dispatcher."""
         self.worker_terminal.emit(event)
+        self._finish_worker_terminal_progress(event)
         self._emit_operation_terminal(event)
 
         if event.outcome is WorkerOutcome.SUCCEEDED:
             self._on_worker_finished(event.worker_id, event.result)
         elif event.outcome is WorkerOutcome.FAILED:
             if self._is_replacement_terminal(event):
-                self._finish_worker_terminal_progress(event, success=False)
                 self._clear_current_worker_id(event.worker_id)
                 return
             self._on_worker_error(event.worker_id, event.error or "")
@@ -645,9 +639,6 @@ class WorkerService(QObject):
         )
 
         worker_type = self._resolve_worker_type(worker_id)
-        if worker_type != "thumbnail":
-            self.progress_manager.finish_worker_progress(worker_id, success=False)
-
         canceled_dispatch: dict[str, tuple[Any, str | None]] = {
             "batch_reg": (self.batch_registration_canceled, "current_registration_worker_id"),
             "batch_import": (self.batch_import_canceled, "current_batch_import_worker_id"),
@@ -670,17 +661,22 @@ class WorkerService(QObject):
             f"reason={event.cancel_reason.value if event.cancel_reason else 'unknown'}, message={message}"
         )
         if self._is_replacement_terminal(event):
-            self._finish_worker_terminal_progress(event, success=False)
             self._clear_current_worker_id(event.worker_id)
             return
 
         self._on_worker_error(event.worker_id, message)
 
-    def _finish_worker_terminal_progress(self, event: WorkerTerminalEvent, *, success: bool) -> None:
-        """Close modal progress for terminal events that intentionally skip compat dispatch."""
-        worker_type = self._resolve_worker_type(event.worker_id)
-        if worker_type != "thumbnail":
-            self.progress_manager.finish_worker_progress(event.worker_id, success=success)
+    def _finish_worker_terminal_progress(self, event: WorkerTerminalEvent) -> None:
+        """Close modal progress exactly once from the canonical terminal fact."""
+        if self._worker_uses_modal_progress(event.worker_id):
+            self.progress_manager.finish_worker_progress(
+                event.worker_id,
+                success=event.outcome is WorkerOutcome.SUCCEEDED,
+            )
+
+    def _worker_uses_modal_progress(self, worker_id: str) -> bool:
+        """Return whether WorkerService starts modal progress for this worker."""
+        return self._resolve_worker_type(worker_id) != "thumbnail"
 
     def _should_emit_compat_canceled(self, event: WorkerTerminalEvent) -> bool:
         """Suppress normal UI cancellation signals for replacement-only cancellation."""

--- a/tests/unit/gui/services/test_worker_service.py
+++ b/tests/unit/gui/services/test_worker_service.py
@@ -631,6 +631,102 @@ class TestWorkerService:
         error_mock.assert_not_called()
         assert worker_service.current_search_worker_id is None
 
+    def test_stale_search_replacement_failure_preserves_current_search_operation(self, worker_service):
+        """古い search replacement failure は current search id を壊さず superseded operation になる"""
+        old_worker_id = "search_old"
+        current_worker_id = "search_current"
+        worker_service.current_search_worker_id = current_worker_id
+        worker_service._register_operation(old_worker_id, OperationType.SEARCH, generation=1)
+        worker_service._register_operation(current_worker_id, OperationType.SEARCH, generation=2)
+        worker_service._search_generation = 2
+        operation_mock = Mock()
+        error_mock = Mock()
+        worker_service.operation_event.connect(operation_mock)
+        worker_service.search_error.connect(error_mock)
+        event = WorkerTerminalEvent(
+            worker_id=old_worker_id,
+            worker_type="search",
+            outcome=WorkerOutcome.FAILED,
+            error="old search failed after replacement",
+            cancel_reason=CancelReason.SEARCH_REPLACED,
+        )
+
+        with patch.object(worker_service.progress_manager, "finish_worker_progress") as mock_finish:
+            worker_service._on_worker_terminal(event)
+
+        operation_event = operation_mock.call_args.args[0]
+        assert operation_event.worker_id == old_worker_id
+        assert operation_event.outcome is OperationOutcome.SUPERSEDED
+        assert operation_event.is_current is False
+        error_mock.assert_not_called()
+        mock_finish.assert_called_once_with(old_worker_id, success=False)
+        assert worker_service.current_search_worker_id == current_worker_id
+
+    def test_stale_prefetch_replacement_failure_preserves_current_thumbnail_operation(self, worker_service):
+        """prefetch replacement failure は current thumbnail id と表示要求を壊さない"""
+        old_worker_id = "thumbnail_prefetch_old"
+        current_worker_id = "thumbnail_current"
+        worker_service.current_thumbnail_worker_id = current_worker_id
+        worker_service._register_operation(
+            old_worker_id,
+            OperationType.THUMBNAIL,
+            request_id="prefetch-old",
+            generation=1,
+        )
+        worker_service._register_operation(
+            current_worker_id,
+            OperationType.THUMBNAIL,
+            request_id="visible-current",
+            generation=2,
+        )
+        worker_service._thumbnail_generation = 2
+        operation_mock = Mock()
+        error_mock = Mock()
+        worker_service.operation_event.connect(operation_mock)
+        worker_service.thumbnail_error.connect(error_mock)
+        event = WorkerTerminalEvent(
+            worker_id=old_worker_id,
+            worker_type="thumbnail",
+            outcome=WorkerOutcome.TERMINATED,
+            error="old prefetch terminated",
+            cancel_reason=CancelReason.PREFETCH_REPLACED,
+        )
+
+        with patch.object(worker_service.progress_manager, "finish_worker_progress") as mock_finish:
+            worker_service._on_worker_terminal(event)
+
+        operation_event = operation_mock.call_args.args[0]
+        assert operation_event.worker_id == old_worker_id
+        assert operation_event.request_id == "prefetch-old"
+        assert operation_event.outcome is OperationOutcome.SUPERSEDED
+        assert operation_event.is_current is False
+        error_mock.assert_not_called()
+        mock_finish.assert_not_called()
+        assert worker_service.current_thumbnail_worker_id == current_worker_id
+
+    def test_non_replacement_search_failure_closes_progress_and_dispatches_error_once(self, worker_service):
+        """通常 failure は terminal でprogress closeし、compat errorを一度だけdispatchする"""
+        worker_id = "search_failed"
+        worker_service.current_search_worker_id = worker_id
+        error_mock = Mock()
+        canceled_mock = Mock()
+        worker_service.search_error.connect(error_mock)
+        worker_service.search_canceled.connect(canceled_mock)
+        event = WorkerTerminalEvent(
+            worker_id=worker_id,
+            worker_type="search",
+            outcome=WorkerOutcome.FAILED,
+            error="search failed",
+        )
+
+        with patch.object(worker_service.progress_manager, "finish_worker_progress") as mock_finish:
+            worker_service._on_worker_terminal(event)
+
+        mock_finish.assert_called_once_with(worker_id, success=False)
+        error_mock.assert_called_once_with("search failed")
+        canceled_mock.assert_not_called()
+        assert worker_service.current_search_worker_id is None
+
     @pytest.mark.parametrize(
         ("outcome", "cancel_reason", "expected_success"),
         [

--- a/tests/unit/gui/services/test_worker_service.py
+++ b/tests/unit/gui/services/test_worker_service.py
@@ -421,17 +421,23 @@ class TestWorkerService:
         assert hasattr(worker_service, "_on_worker_error")
         assert hasattr(worker_service, "_on_worker_canceled")
 
-    def test_on_worker_canceled_clears_current_id_and_finishes_progress(self, worker_service):
-        """キャンセル完了時はエラーシグナルなしで進捗とcurrent idを片付ける"""
+    def test_worker_terminal_canceled_clears_current_id_and_finishes_progress(self, worker_service):
+        """キャンセル終端時はエラーシグナルなしで進捗とcurrent idを片付ける"""
         worker_id = "search_cancelled"
         worker_service.current_search_worker_id = worker_id
         error_mock = Mock()
         canceled_mock = Mock()
         worker_service.search_error.connect(error_mock)
         worker_service.search_canceled.connect(canceled_mock)
+        event = WorkerTerminalEvent(
+            worker_id=worker_id,
+            worker_type="search",
+            outcome=WorkerOutcome.CANCELED,
+            cancel_reason=CancelReason.USER_REQUESTED,
+        )
 
         with patch.object(worker_service.progress_manager, "finish_worker_progress") as mock_finish:
-            worker_service._on_worker_canceled(worker_id)
+            worker_service._on_worker_terminal(event)
 
         mock_finish.assert_called_once_with(worker_id, success=False)
         assert worker_service.current_search_worker_id is None
@@ -624,6 +630,66 @@ class TestWorkerService:
         mock_finish.assert_called_once_with(old_worker_id, success=False)
         error_mock.assert_not_called()
         assert worker_service.current_search_worker_id is None
+
+    @pytest.mark.parametrize(
+        ("outcome", "cancel_reason", "expected_success"),
+        [
+            (WorkerOutcome.SUCCEEDED, None, True),
+            (WorkerOutcome.FAILED, None, False),
+            (WorkerOutcome.CANCELED, CancelReason.USER_REQUESTED, False),
+            (WorkerOutcome.TERMINATED, None, False),
+            (WorkerOutcome.UNRESPONSIVE, None, False),
+            (WorkerOutcome.CANCELED, CancelReason.SEARCH_REPLACED, False),
+            (WorkerOutcome.FAILED, CancelReason.SEARCH_REPLACED, False),
+        ],
+    )
+    def test_worker_terminal_progress_closes_once_for_terminal_outcomes(
+        self, worker_service, outcome, cancel_reason, expected_success
+    ):
+        """terminal outcome がcompat分岐に入ってもprogress closeはWorkerService terminalで1回だけ行う"""
+        worker_id = "search_terminal"
+        worker_service.current_search_worker_id = worker_id
+        event = WorkerTerminalEvent(
+            worker_id=worker_id,
+            worker_type="search",
+            outcome=outcome,
+            result={"ok": True} if outcome is WorkerOutcome.SUCCEEDED else None,
+            error="boom" if outcome is not WorkerOutcome.SUCCEEDED else None,
+            cancel_reason=cancel_reason,
+        )
+
+        with patch.object(worker_service.progress_manager, "finish_worker_progress") as mock_finish:
+            worker_service._on_worker_terminal(event)
+
+        mock_finish.assert_called_once_with(worker_id, success=expected_success)
+
+    @pytest.mark.parametrize(
+        "outcome",
+        [
+            WorkerOutcome.SUCCEEDED,
+            WorkerOutcome.FAILED,
+            WorkerOutcome.CANCELED,
+            WorkerOutcome.TERMINATED,
+            WorkerOutcome.UNRESPONSIVE,
+        ],
+    )
+    def test_thumbnail_terminal_never_closes_modal_progress(self, worker_service, outcome):
+        """thumbnail/page/prefetch workers never start modal progress, so terminal close skips them."""
+        worker_id = "thumbnail_terminal"
+        worker_service.current_thumbnail_worker_id = worker_id
+        event = WorkerTerminalEvent(
+            worker_id=worker_id,
+            worker_type="thumbnail",
+            outcome=outcome,
+            result={"ok": True} if outcome is WorkerOutcome.SUCCEEDED else None,
+            error="boom" if outcome is not WorkerOutcome.SUCCEEDED else None,
+            cancel_reason=CancelReason.PREFETCH_REPLACED if outcome is WorkerOutcome.CANCELED else None,
+        )
+
+        with patch.object(worker_service.progress_manager, "finish_worker_progress") as mock_finish:
+            worker_service._on_worker_terminal(event)
+
+        mock_finish.assert_not_called()
 
     def test_worker_id_uniqueness(self, worker_service):
         """ワーカーID一意性テスト"""
@@ -871,7 +937,7 @@ class TestWorkerService:
     def test_worker_terminal_dispatch_table(
         self, worker_service, worker_id, terminal, signal_name, current_attr, payload
     ):
-        """全worker種別の終端signalとcurrent id cleanupを表で検証する"""
+        """全worker種別の互換終端signalとcurrent id cleanupを表で検証する"""
         setattr(worker_service, current_attr, worker_id)
         terminal_mock = Mock()
         getattr(worker_service, signal_name).connect(terminal_mock)
@@ -888,10 +954,7 @@ class TestWorkerService:
                 terminal_mock.assert_called_once_with(worker_id)
 
         assert getattr(worker_service, current_attr) is None
-        if not worker_id.startswith("thumbnail_"):
-            mock_finish.assert_called_once()
-        else:
-            mock_finish.assert_not_called()
+        mock_finish.assert_not_called()
 
     def test_modern_progress_manager_integration(self, worker_service):
         """ModernProgressManager統合検証


### PR DESCRIPTION
## Summary
- Make WorkerService close modal progress once from worker terminal outcomes
- Keep thumbnail/page/prefetch workers excluded from modal progress closing
- Remove duplicated progress closing from legacy compat dispatch paths

Closes #439

## Tests
- uv run pytest tests/unit/gui/services/test_worker_service.py
- uv run ruff format --check src/lorairo/gui/services/worker_service.py tests/unit/gui/services/test_worker_service.py
- uv run ruff check src/lorairo/gui/services/worker_service.py tests/unit/gui/services/test_worker_service.py
- uv run mypy src/lorairo/gui/services/worker_service.py