### PR TITLE
chore: update worker comments

### DIFF
--- a/src/lorairo/gui/workers/__init__.py
+++ b/src/lorairo/gui/workers/__init__.py
@@ -3,7 +3,7 @@
 GUI統合型ワーカーシステム
 
 PySide6標準機能を活用したシンプルなワーカー実装。
-QRunnable + QThreadPool + QProgressDialog による効率的な非同期処理を提供。
+QObject + QThread + QProgressDialog による効率的な非同期処理を提供。
 """
 
 from .base import (

--- a/src/lorairo/gui/workers/annotation_worker.py
+++ b/src/lorairo/gui/workers/annotation_worker.py
@@ -88,7 +88,7 @@ class AnnotationWorker(LoRAIroWorkerBase["AnnotationExecutionResult"]):
     ビジネスロジックはAnnotationLogicに委譲
 
     主要機能:
-    - Qt QRunnableベースの非同期実行
+    - QObject + QThreadベースの非同期実行
     - 進捗レポート（Signal経由）
     - キャンセル対応
     - AnnotationLogic呼び出し

--- a/src/lorairo/gui/workers/modern_progress_manager.py
+++ b/src/lorairo/gui/workers/modern_progress_manager.py
@@ -185,7 +185,7 @@ class ModernProgressManager(QObject):
         dialog = self._progress_dialogs.get(worker_id)
         if dialog:
             dialog.setLabelText("キャンセル処理中...")
-            dialog.setCancelButton(None)  # キャンセルボタン無効化  # キャンセルボタン無効化
+            dialog.setCancelButton(None)  # キャンセルボタン無効化
 
     def _close_dialog(self, worker_id: str) -> None:
         """ダイアログクローズとリソース解放"""


### PR DESCRIPTION
## Summary
- Update stale worker comments from QRunnable/QThreadPool to current QObject/QThread design
- Remove duplicate ModernProgressManager cancel-button comment
- Keep create_worker_id export unchanged

Closes #393

## Tests
- uv run pytest tests/unit/gui/workers/test_modern_progress_manager.py
- uv run ruff check src/lorairo/gui/workers/__init__.py src/lorairo/gui/workers/annotation_worker.py src/lorairo/gui/workers/modern_progress_manager.py
- uv run ruff format --check src/lorairo/gui/workers/__init__.py src/lorairo/gui/workers/annotation_worker.py src/lorairo/gui/workers/modern_progress_manager.py