### PR TITLE
fix: remove fake search batch progress

### DIFF
--- a/src/lorairo/gui/workers/search_worker.py
+++ b/src/lorairo/gui/workers/search_worker.py
@@ -55,19 +55,6 @@ class SearchWorker(LoRAIroWorkerBase[SearchResult]):
             )
             self._check_cancellation()
 
-            # バッチ進捗報告（検索結果処理）
-            if total_count > 0:
-                # 検索結果を一件ずつ処理するバッチ進捗として報告
-                batch_size = min(100, total_count)  # 100件ずつバッチ処理をシミュレート
-                for i in range(0, total_count, batch_size):
-                    self._check_cancellation()  # キャンセルチェック
-
-                    current_batch = min(i + batch_size, total_count)
-                    # ファイル名の代わりに件数情報を使用
-                    self._report_batch_progress(
-                        current_batch, total_count, f"search_batch_{i // batch_size + 1}"
-                    )
-
             search_time = time.time() - start_time
 
             # 完了

--- a/tests/unit/workers/test_database_related_workers.py
+++ b/tests/unit/workers/test_database_related_workers.py
@@ -328,6 +328,23 @@ class TestSearchWorker:
             assert result.total_count == 0
             assert len(result.image_metadata) == 0
 
+    def test_successful_search_does_not_emit_fake_batch_progress(self, real_db_manager, search_conditions):
+        """検索成功時に fake search_batch_* の batch_progress を emit しない"""
+        image_metadata = [{"id": i, "stored_image_path": f"/test/image{i}.jpg"} for i in range(1, 126)]
+
+        with patch.object(real_db_manager, "get_images_by_filter") as mock_search:
+            mock_search.return_value = (image_metadata, len(image_metadata))
+
+            worker = SearchWorker(real_db_manager, search_conditions)
+            worker._report_batch_progress = Mock()
+
+            result = worker.execute()
+
+            assert result.total_count == len(image_metadata)
+            assert result.image_metadata == image_metadata
+            assert result.filter_conditions == search_conditions
+            worker._report_batch_progress.assert_not_called()
+
 
 class TestRegisterSingleImage:
     """_register_single_image() の単体テスト"""


### PR DESCRIPTION
## Summary
- Remove simulated SearchWorker batch_progress events after database search
- Keep coarse search start/filter/completion progress updates
- Add regression coverage that successful search does not emit fake search_batch_N progress

Closes #389

## Tests
- uv run pytest tests/unit/workers/test_database_related_workers.py::TestSearchWorker
- uv run ruff check src/lorairo/gui/workers/search_worker.py tests/unit/workers/test_database_related_workers.py
- uv run ruff format --check src/lorairo/gui/workers/search_worker.py tests/unit/workers/test_database_related_workers.py
- uv run mypy src/lorairo/gui/workers/search_worker.py