### PR TITLE
refactor: throttle worker batch progress

### DIFF
--- a/src/lorairo/gui/workers/base.py
+++ b/src/lorairo/gui/workers/base.py
@@ -69,6 +69,7 @@ class ProgressReporter(QObject):
     def __init__(self) -> None:
         super().__init__()
         self._last_emit_time = 0
+        self._last_batch_emit_time = 0
         self._min_interval_ms = 50  # 50ms間隔でスロットリング
 
     def report(self, progress: WorkerProgress) -> None:
@@ -91,6 +92,16 @@ class ProgressReporter(QObject):
     def report_batch(self, current: int, total: int, filename: str) -> None:
         """バッチ進捗報告"""
         self.batch_progress.emit(current, total, filename)
+
+    def report_batch_throttled(
+        self, current: int, total: int, filename: str, force_emit: bool = False
+    ) -> None:
+        """スロットリング付きバッチ進捗報告"""
+        current_time = time.monotonic_ns() // 1_000_000
+
+        if force_emit or (current_time - self._last_batch_emit_time >= self._min_interval_ms):
+            self.batch_progress.emit(current, total, filename)
+            self._last_batch_emit_time = current_time
 
 
 class LoRAIroWorkerBase[T](QObject):
@@ -249,3 +260,9 @@ class LoRAIroWorkerBase[T](QObject):
     def _report_batch_progress(self, current: int, total: int, filename: str) -> None:
         """バッチ進捗報告ヘルパー"""
         self.progress.report_batch(current, total, filename)
+
+    def _report_batch_progress_throttled(
+        self, current: int, total: int, filename: str, force_emit: bool = False
+    ) -> None:
+        """スロットリング付きバッチ進捗報告ヘルパー"""
+        self.progress.report_batch_throttled(current, total, filename, force_emit)

--- a/src/lorairo/gui/workers/batch_import_worker.py
+++ b/src/lorairo/gui/workers/batch_import_worker.py
@@ -69,6 +69,7 @@ class BatchImportWorker(LoRAIroWorkerBase[BatchImportResult]):
         for i, jsonl_path in enumerate(self._jsonl_files):
             self._check_cancellation()
 
+            force_progress_emit = i == 0 or i + 1 == total_files
             percentage = 10 + int((i / total_files) * 85)
             self._report_progress_throttled(
                 percentage,
@@ -76,8 +77,11 @@ class BatchImportWorker(LoRAIroWorkerBase[BatchImportResult]):
                 current_item=str(jsonl_path),
                 processed_count=i,
                 total_count=total_files,
+                force_emit=force_progress_emit,
             )
-            self._report_batch_progress(i + 1, total_files, jsonl_path.name)
+            self._report_batch_progress_throttled(
+                i + 1, total_files, jsonl_path.name, force_emit=force_progress_emit
+            )
 
             result = service.import_from_jsonl(
                 jsonl_path,

--- a/src/lorairo/gui/workers/registration_worker.py
+++ b/src/lorairo/gui/workers/registration_worker.py
@@ -177,8 +177,12 @@ class DatabaseRegistrationWorker(LoRAIroWorkerBase[DatabaseRegistrationResult]):
                 - result_type: "registered"|"skipped"|"error"
                 - image_id: 登録されたID、失敗時は-1
         """
+        force_progress_emit = i == 0 or i + 1 == total_count
+
         # バッチ進捗報告
-        self._report_batch_progress(i + 1, total_count, image_path.name)
+        self._report_batch_progress_throttled(
+            i + 1, total_count, image_path.name, force_emit=force_progress_emit
+        )
 
         # 重複チェック
         duplicate_image_id = self.db_manager.detect_duplicate_image(image_path)
@@ -214,12 +218,13 @@ class DatabaseRegistrationWorker(LoRAIroWorkerBase[DatabaseRegistrationResult]):
 
         # 進捗報告（ProgressHelper使用）
         percentage = ProgressHelper.calculate_percentage(i + 1, total_count, 10, 85)  # 10-95%
-        self._report_progress(
+        self._report_progress_throttled(
             percentage,
             f"登録中: {image_path.name}",
             current_item=str(image_path),
             processed_count=i + 1,
             total_count=total_count,
+            force_emit=force_progress_emit,
         )
 
         return result_type, image_id

--- a/src/lorairo/gui/workers/thumbnail_worker.py
+++ b/src/lorairo/gui/workers/thumbnail_worker.py
@@ -122,6 +122,7 @@ class ThumbnailWorker(LoRAIroWorkerBase[ThumbnailLoadResult]):
             failed_count += batch_failed
 
             # バッチ境界での進捗報告（重要：シグナル発行はここのみ）
+            force_progress_emit = batch_idx == 0 or batch_idx + 1 == total_batches
             percentage = ProgressHelper.calculate_percentage(end_idx, total_count, 5, 90)  # 5-95%
             current_item = f"バッチ {batch_idx + 1}/{total_batches}"
 
@@ -131,10 +132,13 @@ class ThumbnailWorker(LoRAIroWorkerBase[ThumbnailLoadResult]):
                 current_item=current_item,
                 processed_count=end_idx,
                 total_count=total_count,
+                force_emit=force_progress_emit,
             )
 
             # バッチ進捗も報告
-            self._report_batch_progress(end_idx, total_count, current_item)
+            self._report_batch_progress_throttled(
+                end_idx, total_count, current_item, force_emit=force_progress_emit
+            )
 
             logger.debug(
                 f"バッチ {batch_idx + 1}/{total_batches} 完了: 成功={batch_loaded}, 失敗={batch_failed}"

--- a/tests/unit/gui/workers/test_base_worker.py
+++ b/tests/unit/gui/workers/test_base_worker.py
@@ -104,6 +104,41 @@ class TestProgressReporter:
         reporter.report_batch(1, 10, "file.jpg")
         batch_mock.assert_called_once_with(1, 10, "file.jpg")
 
+    def test_throttled_batch_signal_emission(self):
+        """バッチ進捗報告のスロットリングテスト"""
+        reporter = ProgressReporter()
+        batch_mock = Mock()
+        reporter.batch_progress.connect(batch_mock)
+
+        with patch("lorairo.gui.workers.base.time.monotonic_ns") as mock_monotonic:
+            mock_monotonic.return_value = 100_000_000
+            reporter.report_batch_throttled(1, 10, "first.jpg")
+
+            mock_monotonic.return_value = 120_000_000
+            reporter.report_batch_throttled(2, 10, "second.jpg")
+
+            mock_monotonic.return_value = 130_000_000
+            reporter.report_batch_throttled(3, 10, "forced.jpg", force_emit=True)
+
+        assert batch_mock.call_count == 2
+        batch_mock.assert_any_call(1, 10, "first.jpg")
+        batch_mock.assert_any_call(3, 10, "forced.jpg")
+
+    def test_progress_and_batch_throttle_windows_are_independent(self):
+        """通常進捗とバッチ進捗が別々にスロットリングされることを確認"""
+        reporter = ProgressReporter()
+        progress_mock = Mock()
+        batch_mock = Mock()
+        reporter.progress_updated.connect(progress_mock)
+        reporter.batch_progress.connect(batch_mock)
+
+        with patch("lorairo.gui.workers.base.time.monotonic_ns", return_value=100_000_000):
+            reporter.report_throttled(WorkerProgress(10, "progress"))
+            reporter.report_batch_throttled(1, 10, "file.jpg")
+
+        progress_mock.assert_called_once()
+        batch_mock.assert_called_once_with(1, 10, "file.jpg")
+
 
 class ConcreteWorker(LoRAIroWorkerBase[str]):
     """テスト用具象ワーカー"""
@@ -271,6 +306,15 @@ class TestLoRAIroWorkerBase:
         worker._report_batch_progress(5, 20, "test_file.jpg")
 
         # 呼び出し確認
+        batch_mock.assert_called_once_with(5, 20, "test_file.jpg")
+
+    def test_batch_progress_report_throttled_helper(self, worker):
+        """スロットリング付きバッチ進捗報告ヘルパーテスト"""
+        batch_mock = Mock()
+        worker.batch_progress.connect(batch_mock)
+
+        worker._report_batch_progress_throttled(5, 20, "test_file.jpg", force_emit=True)
+
         batch_mock.assert_called_once_with(5, 20, "test_file.jpg")
 
     def test_status_change_prevention(self, worker):

--- a/tests/unit/workers/test_database_related_workers.py
+++ b/tests/unit/workers/test_database_related_workers.py
@@ -346,9 +346,9 @@ class TestRegisterSingleImage:
 
         worker = DatabaseRegistrationWorker(temp_dir, mock_db_manager, mock_fsm)
 
-        # _report_batch_progress と _report_progress をモック
-        worker._report_batch_progress = Mock()
-        worker._report_progress = Mock()
+        # ループ内のスロットリング付き進捗報告をモック
+        worker._report_batch_progress_throttled = Mock()
+        worker._report_progress_throttled = Mock()
 
         return worker, mock_db_manager, mock_fsm
 
@@ -373,8 +373,8 @@ class TestRegisterSingleImage:
             assert image_id == 1
             mock_db_manager.detect_duplicate_image.assert_called_once_with(image_path)
             mock_db_manager.register_original_image.assert_called_once()
-            worker._report_batch_progress.assert_called_once()
-            worker._report_progress.assert_called_once()
+            worker._report_batch_progress_throttled.assert_called_once()
+            worker._report_progress_throttled.assert_called_once()
 
     def test_register_single_image_duplicate_detection(self, temp_dir, worker_setup):
         """pHash一致で重複検出 → スキップ"""
@@ -397,8 +397,8 @@ class TestRegisterSingleImage:
             assert image_id == 42
             mock_db_manager.detect_duplicate_image.assert_called_once_with(image_path)
             mock_db_manager.register_original_image.assert_not_called()
-            worker._report_batch_progress.assert_called_once()
-            worker._report_progress.assert_called_once()
+            worker._report_batch_progress_throttled.assert_called_once()
+            worker._report_progress_throttled.assert_called_once()
 
     def test_register_single_image_with_tags_only(self, temp_dir, worker_setup):
         """ ".txt 存在、.caption 不在"""
@@ -520,7 +520,7 @@ class TestRegisterSingleImage:
             mock_db_manager.save_captions.assert_not_called()
 
     def test_register_single_image_progress_reporting(self, temp_dir, worker_setup):
-        """_report_batch_progress() と _report_progress() が呼ばれる"""
+        """スロットリング付き進捗報告が呼ばれる"""
         worker, mock_db_manager, _mock_fsm = worker_setup
 
         image_path = temp_dir / "test.jpg"
@@ -536,12 +536,14 @@ class TestRegisterSingleImage:
 
             _result_type, _image_id = worker._register_single_image(image_path, 5, 100)
 
-            # _report_batch_progress の呼び出しを確認
-            worker._report_batch_progress.assert_called_once_with(6, 100, image_path.name)
+            # バッチ進捗報告の呼び出しを確認
+            worker._report_batch_progress_throttled.assert_called_once_with(
+                6, 100, image_path.name, force_emit=False
+            )
 
-            # _report_progress の呼び出しを確認
-            worker._report_progress.assert_called_once()
-            call_args = worker._report_progress.call_args
+            # 通常進捗報告の呼び出しを確認
+            worker._report_progress_throttled.assert_called_once()
+            call_args = worker._report_progress_throttled.call_args
             assert call_args[0][0] > 10  # percentage >= 10
 
     def test_register_single_image_associated_file_processing_error(self, temp_dir, worker_setup):
@@ -941,7 +943,8 @@ class TestRegistrationErrorHandling:
             patch.object(real_db_manager, "detect_duplicate_image") as mock_detect,
             patch.object(real_db_manager, "register_original_image") as mock_register,
             patch.object(worker, "_report_progress") as mock_progress,
-            patch.object(worker, "_report_batch_progress") as mock_batch,
+            patch.object(worker, "_report_progress_throttled") as mock_progress_throttled,
+            patch.object(worker, "_report_batch_progress_throttled") as mock_batch,
         ):
             mock_detect.return_value = None
             mock_register.return_value = (1, {})
@@ -950,6 +953,7 @@ class TestRegistrationErrorHandling:
 
             # 進捗報告が呼ばれたことを確認
             assert mock_progress.called
+            assert mock_progress_throttled.called
             # 最初の呼び出しで "画像ファイルを検索中..." を確認
             first_call = mock_progress.call_args_list[0]
             assert "画像ファイルを検索中" in first_call[0][1]
@@ -1089,7 +1093,8 @@ class TestRegistrationErrorHandling:
             patch.object(real_db_manager, "detect_duplicate_image") as mock_detect,
             patch.object(real_db_manager, "register_original_image") as mock_register,
             patch.object(worker, "_report_progress") as mock_progress,
-            patch.object(worker, "_report_batch_progress") as mock_batch,
+            patch.object(worker, "_report_progress_throttled") as mock_progress_throttled,
+            patch.object(worker, "_report_batch_progress_throttled") as mock_batch,
         ):
             mock_detect.return_value = None
             mock_register.return_value = (1, {})
@@ -1099,7 +1104,8 @@ class TestRegistrationErrorHandling:
             # _report_progress の呼び出し回数：開始 + ループ内 + 完了
             # 最低3回（開始、開始2、完了）以上
             assert mock_progress.call_count >= 3
-            # _report_batch_progress は画像ごとに1回呼ばれる（3回）
+            assert mock_progress_throttled.call_count == 3
+            # _report_batch_progress_throttled は画像ごとに1回呼ばれる（3回）
             assert mock_batch.call_count == 3
 
 
@@ -1120,9 +1126,9 @@ class TestRegisterSingleImageUnits:
 
         worker = DatabaseRegistrationWorker(temp_dir, mock_db_manager, mock_fsm)
 
-        # _report_batch_progress と _report_progress をモック
-        worker._report_batch_progress = Mock()
-        worker._report_progress = Mock()
+        # ループ内のスロットリング付き進捗報告をモック
+        worker._report_batch_progress_throttled = Mock()
+        worker._report_progress_throttled = Mock()
 
         return worker, mock_db_manager, mock_fsm
 
@@ -1270,7 +1276,7 @@ class TestRegisterSingleImageUnits:
             mock_calc.assert_called_once_with(6, 100, 10, 85)
 
     def test_batch_progress_reporting(self, temp_dir, worker_setup):
-        """8. _report_batch_progress() が (i+1, total_count, image_path.name) で呼ばれる"""
+        """8. _report_batch_progress_throttled() が (i+1, total_count, image_path.name) で呼ばれる"""
         worker, mock_db_manager, _ = worker_setup
         image_path = temp_dir / "batch_report.jpg"
         image_path.write_bytes(b"fake_image")
@@ -1283,7 +1289,9 @@ class TestRegisterSingleImageUnits:
 
             worker._register_single_image(image_path, 7, 50)
 
-            worker._report_batch_progress.assert_called_once_with(8, 50, "batch_report.jpg")
+            worker._report_batch_progress_throttled.assert_called_once_with(
+                8, 50, "batch_report.jpg", force_emit=False
+            )
 
     def test_associated_files_error_handling(self, temp_dir, worker_setup):
         """9. save_tags() で例外 → エラーログ出力、処理継続"""


### PR DESCRIPTION
## Summary
- Add throttled batch progress reporting alongside existing direct batch progress API
- Use throttled progress in registration, thumbnail, and batch import loops while forcing first/last loop updates
- Cover batch throttling and registration progress call changes in unit tests

Closes #391

## Tests
- uv run pytest tests/unit/gui/workers/test_base_worker.py
- uv run pytest tests/unit/workers/test_database_related_workers.py
- uv run pytest tests/unit/gui/workers/test_batch_import_worker.py tests/unit/gui/workers/test_thumbnail_worker.py
- uv run ruff check src/lorairo/gui/workers/base.py src/lorairo/gui/workers/registration_worker.py src/lorairo/gui/workers/thumbnail_worker.py src/lorairo/gui/workers/batch_import_worker.py tests/unit/gui/workers/test_base_worker.py tests/unit/workers/test_database_related_workers.py
- uv run ruff format --check src/lorairo/gui/workers/base.py src/lorairo/gui/workers/registration_worker.py src/lorairo/gui/workers/thumbnail_worker.py src/lorairo/gui/workers/batch_import_worker.py tests/unit/gui/workers/test_base_worker.py tests/unit/workers/test_database_related_workers.py
- uv run mypy src/lorairo/gui/workers/base.py src/lorairo/gui/workers/registration_worker.py src/lorairo/gui/workers/thumbnail_worker.py src/lorairo/gui/workers/batch_import_worker.py