### PR TITLE
refactor: implement ADR 0033 worker contract

### DIFF
--- a/src/lorairo/database/db_repository.py
+++ b/src/lorairo/database/db_repository.py
@@ -3646,7 +3646,9 @@ class ImageRepository:
             filenames.add(resolved.name)
         return path_resolved, filenames
 
-    def _build_candidates_by_filename(self, candidates: list[Image]) -> dict[str, list[tuple[Path, int]]]:
+    def _build_candidates_by_filename(
+        self, candidates: list[Image]
+    ) -> dict[str, list[tuple[Path, int, str]]]:
         """candidates を filename をキーとする dict に集約する helper。
 
         ADR 0023 Phase 1.5 (Codex P2 r3209511028): row-level resolve guard 経由で
@@ -3656,17 +3658,17 @@ class ImageRepository:
             candidates: filename IN 句で取得した Image ORM 行のリスト。
 
         Returns:
-            filename -> [(resolved_abs Path, image_id), ...] の dict。
+            filename -> [(resolved_abs Path, image_id, phash), ...] の dict。
             同じ filename で複数 image (別ディレクトリ) があり得るため list 値。
         """
-        by_filename: dict[str, list[tuple[Path, int]]] = {}
+        by_filename: dict[str, list[tuple[Path, int, str]]] = {}
         for img in candidates:
             if img.filename is None:
                 continue
             resolved_abs = self._safe_resolve_stored_path(img.id, img.stored_image_path)
             if resolved_abs is None:
                 continue
-            by_filename.setdefault(img.filename, []).append((resolved_abs, img.id))
+            by_filename.setdefault(img.filename, []).append((resolved_abs, img.id, img.phash))
         return by_filename
 
     @staticmethod
@@ -3731,7 +3733,7 @@ class ImageRepository:
                 # input path ごとに対応する image_id を resolve 比較で確定
                 for raw, resolved_input in path_resolved.items():
                     matches = by_filename.get(resolved_input.name, [])
-                    for stored_resolved, image_id in matches:
+                    for stored_resolved, image_id, _phash in matches:
                         if stored_resolved == resolved_input:
                             result[raw] = image_id
                             break
@@ -3743,6 +3745,44 @@ class ImageRepository:
                 return result
             except Exception as e:
                 logger.error(f"バッチ画像 ID 解決エラー: {e}", exc_info=True)
+                return result
+
+    def get_phashes_by_filepaths(self, filepaths: list[str]) -> dict[str, str | None]:
+        """複数のファイルパスから pHash をバッチ解決する。
+
+        `get_image_ids_by_filepaths()` と同じ path resolve 規則で、登録済み画像の
+        pHash を input path 順に引けるようにする。未登録または resolve 不能な path
+        は None を返す。
+        """
+        if not filepaths:
+            return {}
+
+        path_resolved, filenames = self._normalize_input_paths(filepaths)
+        result: dict[str, str | None] = dict.fromkeys(filepaths)
+
+        if not filenames:
+            return result
+
+        with self.session_factory() as session:
+            try:
+                stmt = select(Image).where(Image.filename.in_(filenames))
+                candidates = list(session.execute(stmt).scalars().all())
+                by_filename = self._build_candidates_by_filename(candidates)
+
+                for raw, resolved_input in path_resolved.items():
+                    matches = by_filename.get(resolved_input.name, [])
+                    for stored_resolved, _image_id, phash in matches:
+                        if stored_resolved == resolved_input:
+                            result[raw] = phash
+                            break
+
+                logger.debug(
+                    f"バッチ pHash 解決: 入力 {len(filepaths)}件 → "
+                    f"解決 {sum(1 for v in result.values() if v is not None)}件"
+                )
+                return result
+            except Exception as e:
+                logger.error(f"バッチ pHash 解決エラー: {e}", exc_info=True)
                 return result
 
     def update_rating_batch(

--- a/src/lorairo/gui/widgets/annotation_summary_dialog.py
+++ b/src/lorairo/gui/widgets/annotation_summary_dialog.py
@@ -24,10 +24,11 @@ from PySide6.QtWidgets import (
     QWidget,
 )
 
-from lorairo.gui.workers.annotation_worker import AnnotationExecutionResult
+from lorairo.gui.workers.annotation_worker import AnnotationExecutionResult, ModelErrorDetail
 
 # テーブルの最大表示行数
 _MAX_TABLE_ROWS = 50
+_ERROR_TYPE_INTEGRITY = "integrity_violation"
 
 
 class AnnotationSummaryDialog(QDialog):
@@ -105,7 +106,10 @@ class AnnotationSummaryDialog(QDialog):
         if self._result.image_summaries:
             layout.addWidget(self._create_results_group())
 
-        if self._result.model_errors:
+        if self._integrity_violations:
+            layout.addWidget(self._create_integrity_violation_group())
+
+        if self._regular_model_errors:
             layout.addWidget(self._create_error_group())
 
         layout.addStretch()
@@ -155,12 +159,35 @@ class AnnotationSummaryDialog(QDialog):
             form.addRow("DB保存失敗:", fail_label)
 
         if self._result.model_errors:
-            unique_model_errors = len({e.model_name for e in self._result.model_errors})
-            error_label = QLabel(f"{unique_model_errors}モデルでエラー発生")
-            error_label.setStyleSheet("color: #FF9800;")
-            form.addRow("モデルエラー:", error_label)
+            if self._regular_model_errors:
+                unique_model_errors = len({e.model_name for e in self._regular_model_errors})
+                error_label = QLabel(f"{unique_model_errors}モデルでエラー発生")
+                error_label.setStyleSheet("color: #FF9800;")
+                form.addRow("モデルエラー:", error_label)
+            if self._integrity_violations:
+                integrity_label = QLabel(f"{len(self._integrity_violations)}件")
+                integrity_label.setStyleSheet("color: #F44336; font-weight: bold;")
+                form.addRow("整合性違反:", integrity_label)
 
         return group
+
+    @property
+    def _regular_model_errors(self) -> list[ModelErrorDetail]:
+        """integrity_violation 以外の通常モデルエラー。"""
+        return [
+            error
+            for error in self._result.model_errors
+            if getattr(error, "error_type", "model_error") != _ERROR_TYPE_INTEGRITY
+        ]
+
+    @property
+    def _integrity_violations(self) -> list[ModelErrorDetail]:
+        """内部整合性違反として分類されたエラー。"""
+        return [
+            error
+            for error in self._result.model_errors
+            if getattr(error, "error_type", "model_error") == _ERROR_TYPE_INTEGRITY
+        ]
 
     def _create_models_used_view(self) -> QTextBrowser:
         """使用モデル一覧を横に伸びないスクロール表示で作成する。"""
@@ -238,7 +265,7 @@ class AnnotationSummaryDialog(QDialog):
         Returns:
             エラー一覧テーブルを含むグループボックス。
         """
-        errors = self._result.model_errors
+        errors = self._regular_model_errors
         total_errors = len(errors)
         display_count = min(total_errors, _MAX_TABLE_ROWS)
 
@@ -266,6 +293,40 @@ class AnnotationSummaryDialog(QDialog):
 
         if total_errors > _MAX_TABLE_ROWS:
             overflow_label = QLabel(f"他 {total_errors - _MAX_TABLE_ROWS}件のエラー")
+            overflow_label.setStyleSheet("color: #999; font-style: italic;")
+            layout.addWidget(overflow_label)
+
+        return group
+
+    def _create_integrity_violation_group(self) -> QGroupBox:
+        """内部整合性違反セクションを作成する。"""
+        errors = self._integrity_violations
+        total_errors = len(errors)
+        display_count = min(total_errors, _MAX_TABLE_ROWS)
+
+        group = QGroupBox(f"整合性違反 ({total_errors}件)")
+        layout = QVBoxLayout(group)
+
+        table = QTableWidget(display_count, 3)
+        table.setObjectName("integrityViolationTable")
+        table.setHorizontalHeaderLabels(["画像", "モデル", "内容"])
+        table.horizontalHeader().setSectionResizeMode(0, QHeaderView.ResizeMode.ResizeToContents)
+        table.horizontalHeader().setSectionResizeMode(1, QHeaderView.ResizeMode.ResizeToContents)
+        table.horizontalHeader().setSectionResizeMode(2, QHeaderView.ResizeMode.Stretch)
+        table.verticalHeader().setVisible(False)
+        table.setEditTriggers(QTableWidget.EditTrigger.NoEditTriggers)
+        table.setSelectionBehavior(QTableWidget.SelectionBehavior.SelectRows)
+        table.setMaximumHeight(200)
+
+        for row, error in enumerate(errors[:_MAX_TABLE_ROWS]):
+            table.setItem(row, 0, QTableWidgetItem(error.image_path))
+            table.setItem(row, 1, QTableWidgetItem(error.model_name))
+            table.setItem(row, 2, QTableWidgetItem(error.error_message))
+
+        layout.addWidget(table)
+
+        if total_errors > _MAX_TABLE_ROWS:
+            overflow_label = QLabel(f"他 {total_errors - _MAX_TABLE_ROWS}件")
             overflow_label.setStyleSheet("color: #999; font-style: italic;")
             layout.addWidget(overflow_label)
 

--- a/src/lorairo/gui/workers/annotation_worker.py
+++ b/src/lorairo/gui/workers/annotation_worker.py
@@ -33,6 +33,7 @@ class ModelErrorDetail:
     model_name: str
     image_path: str
     error_message: str
+    error_type: str = "model_error"
 
 
 @dataclass
@@ -95,20 +96,9 @@ class AnnotationWorker(LoRAIroWorkerBase["AnnotationExecutionResult"]):
     """
 
     _OPERATION_TYPE = "annotation"
-    _LEGACY_SENTINEL_PREFIX = "__legacy_"
-    _LEGACY_SENTINEL_SUFFIX = "__"
-
-    @staticmethod
-    def _is_legacy_sentinel_model_id(model_name: str) -> bool:
-        if not (
-            model_name.startswith(AnnotationWorker._LEGACY_SENTINEL_PREFIX)
-            and model_name.endswith(AnnotationWorker._LEGACY_SENTINEL_SUFFIX)
-        ):
-            return False
-        body = model_name[
-            len(AnnotationWorker._LEGACY_SENTINEL_PREFIX) : -len(AnnotationWorker._LEGACY_SENTINEL_SUFFIX)
-        ]
-        return body.isdecimal()
+    _ERROR_TYPE_L2 = "lib_call_exception"
+    _ERROR_TYPE_L3 = "fatal"
+    _ERROR_TYPE_INTEGRITY = "integrity_violation"
 
     def __init__(
         self,
@@ -136,14 +126,12 @@ class AnnotationWorker(LoRAIroWorkerBase["AnnotationExecutionResult"]):
 
         self.annotation_logic = annotation_logic
         self.image_paths = image_paths
-        self.litellm_model_ids = [
-            model_id for model_id in litellm_model_ids if not self._is_legacy_sentinel_model_id(model_id)
-        ]
-        dropped = len(litellm_model_ids) - len(self.litellm_model_ids)
-        if dropped:
-            logger.info(f"AnnotationWorker初期化: legacy sentinel を除外しました: {dropped}件")
+        self.litellm_model_ids = list(litellm_model_ids)
         self.db_manager = db_manager
         self.model_registry = model_registry
+        self._path_to_phash: dict[str, str | None] = {}
+        self._phash_to_input_path: dict[str, str] = {}
+        self._phash_to_input_filename: dict[str, str] = {}
 
         logger.info(
             f"AnnotationWorker初期化 - Images: {len(self.image_paths)}, "
@@ -153,7 +141,11 @@ class AnnotationWorker(LoRAIroWorkerBase["AnnotationExecutionResult"]):
         logger.debug(f"  対象画像パス: {self.image_paths[:5]}{'...' if len(self.image_paths) > 5 else ''}")
 
     def _save_error_records(
-        self, error: Exception, image_paths: list[str], model_name: str | None = None
+        self,
+        error: Exception,
+        image_paths: list[str],
+        model_name: str | None = None,
+        error_type: str | None = None,
     ) -> None:
         """エラーレコードを各画像パスに対して保存する。
 
@@ -164,6 +156,7 @@ class AnnotationWorker(LoRAIroWorkerBase["AnnotationExecutionResult"]):
             error: 発生した例外。
             image_paths: エラー対象の画像パスリスト。
             model_name: エラー発生モデル名(全体エラーの場合はNone)。
+            error_type: ADR 0033 予約分類。省略時は例外型名を使う。
         """
         # 例外オブジェクトから直接トレースバックを取得(except外でも確実に動作)
         stack_trace = "".join(traceback.format_exception(error))
@@ -175,7 +168,7 @@ class AnnotationWorker(LoRAIroWorkerBase["AnnotationExecutionResult"]):
                     logger.warning(f"image_id取得失敗(file_pathで記録): {image_path}")
                 self.db_manager.save_error_record(
                     operation_type="annotation",
-                    error_type=type(error).__name__,
+                    error_type=error_type or type(error).__name__,
                     error_message=str(error),
                     image_id=image_id,
                     stack_trace=stack_trace,
@@ -184,6 +177,115 @@ class AnnotationWorker(LoRAIroWorkerBase["AnnotationExecutionResult"]):
                 )
             except Exception as save_error:
                 logger.error(f"エラーレコード保存失敗: {image_path}, {save_error}")
+
+    def _refresh_input_phash_cache(self) -> None:
+        """現在の `image_paths` に対応する DB 登録済み pHash を一括取得する。"""
+        try:
+            path_to_phash = self.db_manager.repository.get_phashes_by_filepaths(self.image_paths)
+        except Exception as exc:
+            logger.warning(
+                f"pHash 一括取得に失敗しました。lib 側自動計算に委任します: {exc}", exc_info=True
+            )
+            path_to_phash = {}
+        self._path_to_phash = path_to_phash if isinstance(path_to_phash, dict) else {}
+
+        self._phash_to_input_path = {
+            phash: image_path for image_path, phash in self._path_to_phash.items() if phash is not None
+        }
+        self._phash_to_input_filename = {
+            phash: Path(image_path).name for phash, image_path in self._phash_to_input_path.items()
+        }
+
+    def _build_phash_list_for_current_paths(self) -> list[str] | None:
+        """lib に渡す pHash list を input path 順に構築する。
+
+        未登録画像が混ざる場合は alignment を壊さないため None を返し、lib 側計算へ
+        フォールバックする。
+        """
+        if not self.image_paths:
+            return []
+        if not self._path_to_phash:
+            return None
+        phash_list = [self._path_to_phash.get(image_path) for image_path in self.image_paths]
+        if any(phash is None for phash in phash_list):
+            return None
+        return [str(phash) for phash in phash_list]
+
+    def _collect_valid_model_results(
+        self,
+        model_results: PHashAnnotationResults,
+        expected_model_ids: set[str],
+        model_errors: list[ModelErrorDetail],
+    ) -> PHashAnnotationResults:
+        """選択外 model_id を integrity violation として除外した結果を返す。"""
+        valid_results: PHashAnnotationResults = PHashAnnotationResults()
+        for phash, annotations in model_results.items():
+            valid_annotations: dict[str, Any] = {}
+            for model_name, unified_result in annotations.items():
+                if model_name not in expected_model_ids:
+                    self._record_integrity_violation(phash, model_name, unified_result, model_errors)
+                    continue
+                valid_annotations[model_name] = unified_result
+            if valid_annotations:
+                valid_results[phash] = valid_annotations
+        return valid_results
+
+    def _record_integrity_violation(
+        self,
+        phash: str,
+        model_name: str,
+        unified_result: Any,
+        model_errors: list[ModelErrorDetail],
+    ) -> None:
+        """選択外 model_id が結果に混入したことを error_records と summary に記録する。"""
+        message = f"Annotation result contains unexpected model_id: {model_name}"
+        image_path = self._phash_to_input_path.get(phash)
+        image_label = Path(image_path).name if image_path else phash[:12] + "..."
+        model_errors.append(
+            ModelErrorDetail(
+                model_name=model_name,
+                image_path=image_label,
+                error_message=message,
+                error_type=self._ERROR_TYPE_INTEGRITY,
+            )
+        )
+
+        try:
+            image_id = None
+            if image_path is not None:
+                image_id = self.db_manager.get_image_id_by_filepath(image_path)
+            self.db_manager.save_error_record(
+                operation_type="annotation",
+                error_type=self._ERROR_TYPE_INTEGRITY,
+                error_message=message,
+                image_id=image_id,
+                stack_trace=f"phash={phash}, result={unified_result!r}",
+                file_path=image_path or image_label,
+                model_name=model_name,
+            )
+        except Exception as save_error:
+            logger.error(f"integrity_violation 保存失敗: phash={phash}, model={model_name}, {save_error}")
+
+    def _collect_l1_model_errors(
+        self,
+        model_results: PHashAnnotationResults,
+        model_errors: list[ModelErrorDetail],
+    ) -> None:
+        """lib `result.error` を DB 保存せず summary 用 model_errors に集約する。"""
+        for phash, annotations in model_results.items():
+            image_label = self._phash_to_input_filename.get(phash, phash[:12] + "...")
+            for model_name, unified_result in annotations.items():
+                error = self._extract_field(unified_result, "error")
+                if not error:
+                    continue
+                model_errors.append(
+                    ModelErrorDetail(
+                        model_name=model_name,
+                        image_path=image_label,
+                        error_message=str(error),
+                        error_type="result_error",
+                    )
+                )
 
     def _run_annotation(self) -> tuple[PHashAnnotationResults, list[ModelErrorDetail]]:
         """モデル単位でアノテーションを実行し、結果をマージする。
@@ -194,18 +296,21 @@ class AnnotationWorker(LoRAIroWorkerBase["AnnotationExecutionResult"]):
         merged_results: PHashAnnotationResults = PHashAnnotationResults()
         model_errors: list[ModelErrorDetail] = []
         total_models = len(self.litellm_model_ids)
+        phash_list = self._build_phash_list_for_current_paths()
 
         logger.debug(f"モデル順次実行開始: {total_models}モデル = {self.litellm_model_ids}")
 
         for model_idx, litellm_model_id in enumerate(self.litellm_model_ids):
             self._check_cancellation()
 
-            progress = 10 + int((model_idx / total_models) * 70)
+            processed_steps = model_idx * len(self.image_paths)
+            total_steps = max(total_models * len(self.image_paths), 1)
+            progress = 5 + int((processed_steps / total_steps) * 85)
             self._report_progress(
                 progress,
                 f"AIモデル実行中: {litellm_model_id} ({model_idx + 1}/{total_models})",
-                processed_count=model_idx,
-                total_count=total_models,
+                processed_count=min(processed_steps, len(self.image_paths)),
+                total_count=len(self.image_paths),
             )
 
             try:
@@ -217,10 +322,17 @@ class AnnotationWorker(LoRAIroWorkerBase["AnnotationExecutionResult"]):
                 model_results = self.annotation_logic.execute_annotation(
                     image_paths=self.image_paths,
                     litellm_model_ids=[litellm_model_id],
-                    phash_list=None,
+                    phash_list=phash_list,
                 )
 
-                for phash, annotations in model_results.items():
+                valid_model_results = self._collect_valid_model_results(
+                    model_results,
+                    {litellm_model_id},
+                    model_errors,
+                )
+                self._collect_l1_model_errors(valid_model_results, model_errors)
+
+                for phash, annotations in valid_model_results.items():
                     if phash not in merged_results:
                         merged_results[phash] = {}
                     merged_results[phash].update(annotations)
@@ -236,7 +348,12 @@ class AnnotationWorker(LoRAIroWorkerBase["AnnotationExecutionResult"]):
 
             except Exception as e:
                 logger.error(f"モデル {litellm_model_id} でエラー: {e}", exc_info=True)
-                self._save_error_records(e, self.image_paths, model_name=litellm_model_id)
+                self._save_error_records(
+                    e,
+                    self.image_paths,
+                    model_name=litellm_model_id,
+                    error_type=self._ERROR_TYPE_L2,
+                )
                 # エラー詳細を収集（全画像に対するモデルレベルエラー）
                 # NOTE: ModelErrorDetail.model_name はサマリー表示用ラベルとして
                 # litellm_model_id 値をそのまま入れる (登録 ID と一致するため
@@ -247,9 +364,18 @@ class AnnotationWorker(LoRAIroWorkerBase["AnnotationExecutionResult"]):
                             model_name=litellm_model_id,
                             image_path=Path(image_path).name,
                             error_message=str(e),
+                            error_type=self._ERROR_TYPE_L2,
                         )
                     )
                 # エラーでも次のモデルに進む(部分的成功を許容)
+
+            completed_steps = (model_idx + 1) * len(self.image_paths)
+            self._report_progress(
+                5 + int((completed_steps / max(total_models * len(self.image_paths), 1)) * 85),
+                f"AIモデル実行完了: {litellm_model_id} ({model_idx + 1}/{total_models})",
+                processed_count=len(self.image_paths),
+                total_count=len(self.image_paths),
+            )
 
         logger.debug(f"モデル順次実行完了: 最終結果={len(merged_results)}件")
         return merged_results, model_errors
@@ -284,15 +410,17 @@ class AnnotationWorker(LoRAIroWorkerBase["AnnotationExecutionResult"]):
             self._check_cancellation()
             self._apply_refusal_prefilter()
 
-            # Phase 1: アノテーション実行(10-80%)
-            self._report_progress(10, "アノテーション処理を開始...", total_count=len(self.image_paths))
+            self._refresh_input_phash_cache()
+
+            # Phase 1: アノテーション実行(5-90%)
+            self._report_progress(5, "アノテーション処理を開始...", total_count=len(self.image_paths))
             self._check_cancellation()
 
             merged_results, model_errors = self._run_annotation()
 
-            # Phase 2: DB保存(85%)
+            # Phase 2: DB保存(90-95%)
             self._report_progress(
-                85,
+                90,
                 "結果をDBに保存中...",
                 processed_count=len(self.image_paths),
                 total_count=len(self.image_paths),
@@ -303,7 +431,13 @@ class AnnotationWorker(LoRAIroWorkerBase["AnnotationExecutionResult"]):
                 self._save_results_to_database(merged_results)
             )
 
-            # モデル統計を構築
+            # Phase 3: 統計集計(95-100%)
+            self._report_progress(
+                95,
+                "統計を集計中...",
+                processed_count=len(self.image_paths),
+                total_count=len(self.image_paths),
+            )
             model_statistics = self._build_model_statistics(merged_results)
 
             self._report_progress(
@@ -333,7 +467,7 @@ class AnnotationWorker(LoRAIroWorkerBase["AnnotationExecutionResult"]):
 
         except Exception as e:
             logger.error(f"アノテーション処理エラー: {e}", exc_info=True)
-            self._save_error_records(e, self.image_paths, model_name=None)
+            self._save_error_records(e, self.image_paths, model_name=None, error_type=self._ERROR_TYPE_L3)
             self._error_already_recorded = True
             raise
 
@@ -422,6 +556,8 @@ class AnnotationWorker(LoRAIroWorkerBase["AnnotationExecutionResult"]):
         """
         # image_id → file_path マッピングを構築
         path_to_image_id = self.db_manager.repository.get_image_ids_by_filepaths(self.image_paths)
+        if not isinstance(path_to_image_id, dict):
+            path_to_image_id = {}
         image_id_to_path: dict[int, str] = {
             image_id: image_path
             for image_path, image_id in path_to_image_id.items()
@@ -614,8 +750,6 @@ class AnnotationWorker(LoRAIroWorkerBase["AnnotationExecutionResult"]):
 
         for annotations in results.values():
             for model_name, unified_result in annotations.items():
-                if self._is_legacy_sentinel_model_id(model_name):
-                    continue
                 if model_name not in model_stats:
                     info = info_map.get(model_name)
                     provider_name = info.provider if info else None

--- a/tests/bdd/steps/test_annotation_worker_failure_propagation.py
+++ b/tests/bdd/steps/test_annotation_worker_failure_propagation.py
@@ -1,52 +1,118 @@
-"""AnnotationWorker 部分失敗階層伝播 BDD step skeleton (ADR 0033 #406).
-
-Worker 側の修正 (#399-#403) が未完了の段階では各 step が `pytest.skip` で保留される。
-Worker 側 PR が main に merge されたら、対応する step を実装に置き換える。
-"""
+"""AnnotationWorker 部分失敗階層伝播 BDD steps (ADR 0033 #406)."""
 
 from pathlib import Path
+from typing import Any, cast
+from unittest.mock import Mock
 
-import pytest
+from PySide6.QtWidgets import QTableWidget
 from pytest_bdd import given, parsers, scenarios, then, when
+from pytestqt.qtbot import QtBot
+
+from lorairo.gui.widgets.annotation_summary_dialog import AnnotationSummaryDialog
+from lorairo.gui.workers.annotation_worker import AnnotationExecutionResult, AnnotationWorker
 
 _FEATURE_FILE = Path(__file__).parent.parent / "features" / "annotation_worker_failure_propagation.feature"
 scenarios(str(_FEATURE_FILE))
 
-_PENDING_MESSAGE = (
-    "pending: AnnotationWorker 部分失敗階層伝播の実装 (ADR 0033 #400/#401/#402/#403) 完了待ち"
-)
+
+def _success_result(model: str) -> dict[str, dict[str, dict[str, Any]]]:
+    return {
+        f"phash{i}": {model: {"tags": [f"tag-{i}"], "formatted_output": {}, "error": None}}
+        for i in range(1, 4)
+    }
+
+
+def _error_result(model: str, message: str) -> dict[str, dict[str, dict[str, Any]]]:
+    return {
+        f"phash{i}": {model: {"tags": [], "formatted_output": {}, "error": message}} for i in range(1, 4)
+    }
+
+
+def _exception_from_name(exc_type: str, message: str) -> Exception:
+    exc_cls = (
+        RuntimeError
+        if exc_type == "RuntimeError"
+        else ValueError
+        if exc_type == "ValueError"
+        else Exception
+    )
+    return exc_cls(message)
 
 
 @given("AnnotationWorker が 2 モデル × 3 画像のタスクで初期化されている", target_fixture="worker_ctx")
 def given_worker_initialized() -> dict[str, object]:
-    pytest.skip(_PENDING_MESSAGE)
+    image_paths = [f"/images/image_{i}.jpg" for i in range(1, 4)]
+    db_manager = Mock()
+    db_manager.repository.get_phashes_by_filepaths.return_value = {
+        image_path: f"phash{i}" for i, image_path in enumerate(image_paths, start=1)
+    }
+    db_manager.repository.find_image_ids_by_phashes.return_value = {f"phash{i}": i for i in range(1, 4)}
+    db_manager.repository.get_models_by_litellm_ids.return_value = {
+        "model-a": Mock(id=1),
+        "model-b": Mock(id=2),
+    }
+    db_manager.repository.save_annotations = Mock()
+    db_manager.repository.get_image_ids_by_filepaths.return_value = {
+        image_path: i for i, image_path in enumerate(image_paths, start=1)
+    }
+    db_manager.get_image_id_by_filepath.side_effect = lambda path: {
+        image_path: i for i, image_path in enumerate(image_paths, start=1)
+    }.get(path)
+
+    model_registry = Mock()
+    model_registry.get_available_models.return_value = []
+    annotation_logic = Mock()
+
+    worker = AnnotationWorker(
+        annotation_logic=annotation_logic,
+        image_paths=image_paths,
+        litellm_model_ids=["model-a", "model-b"],
+        db_manager=db_manager,
+        model_registry=model_registry,
+    )
+    return {
+        "worker": worker,
+        "annotation_logic": annotation_logic,
+        "db_manager": db_manager,
+        "behaviors": {},
+        "result": None,
+        "exception": None,
+    }
 
 
 @given("db_manager および model_registry が利用可能である")
-def given_db_and_registry() -> None:
-    pytest.skip(_PENDING_MESSAGE)
+def given_db_and_registry(worker_ctx: dict[str, object]) -> None:
+    assert worker_ctx["db_manager"] is not None
 
 
 @given(
     parsers.parse('image-annotator-lib がモデル "{model}" で全画像に対し result.error="{message}" を返す')
 )
-def given_lib_returns_result_error(model: str, message: str) -> None:
-    pytest.skip(_PENDING_MESSAGE)
+def given_lib_returns_result_error(worker_ctx: dict[str, object], model: str, message: str) -> None:
+    behaviors = worker_ctx["behaviors"]
+    assert isinstance(behaviors, dict)
+    behaviors[model] = _error_result(model, message)
 
 
 @given(parsers.parse('モデル "{model}" は全画像で成功する'))
-def given_model_succeeds(model: str) -> None:
-    pytest.skip(_PENDING_MESSAGE)
+def given_model_succeeds(worker_ctx: dict[str, object], model: str) -> None:
+    behaviors = worker_ctx["behaviors"]
+    assert isinstance(behaviors, dict)
+    behaviors[model] = _success_result(model)
 
 
 @given(parsers.parse('image-annotator-lib がモデル "{model}" の呼び出しで {exc_type} を raise する'))
-def given_lib_raises_exception(model: str, exc_type: str) -> None:
-    pytest.skip(_PENDING_MESSAGE)
+def given_lib_raises_exception(worker_ctx: dict[str, object], model: str, exc_type: str) -> None:
+    behaviors = worker_ctx["behaviors"]
+    assert isinstance(behaviors, dict)
+    behaviors[model] = _exception_from_name(exc_type, f"{model} failed")
 
 
 @given(parsers.parse("refusal filter が {exc_type} を raise する"))
-def given_refusal_filter_raises(exc_type: str) -> None:
-    pytest.skip(_PENDING_MESSAGE)
+def given_refusal_filter_raises(worker_ctx: dict[str, object], exc_type: str) -> None:
+    worker = worker_ctx["worker"]
+    assert isinstance(worker, AnnotationWorker)
+    worker._apply_refusal_prefilter = Mock(side_effect=_exception_from_name(exc_type, "filter failed"))  # type: ignore[method-assign]
 
 
 @given(
@@ -54,65 +120,122 @@ def given_refusal_filter_raises(exc_type: str) -> None:
         'image-annotator-lib が litellm_model_ids に含まれない model_id "{model_id}" を結果に混入させる'
     )
 )
-def given_lib_inserts_unknown_model_id(model_id: str) -> None:
-    pytest.skip(_PENDING_MESSAGE)
+def given_lib_inserts_unknown_model_id(worker_ctx: dict[str, object], model_id: str) -> None:
+    behaviors = worker_ctx["behaviors"]
+    assert isinstance(behaviors, dict)
+    behaviors["model-a"] = {f"phash{i}": {model_id: {"tags": ["cat"], "error": None}} for i in range(1, 4)}
 
 
 @when("AnnotationWorker を実行する")
-def when_run_worker() -> None:
-    pytest.skip(_PENDING_MESSAGE)
+def when_run_worker(worker_ctx: dict[str, object]) -> None:
+    worker = worker_ctx["worker"]
+    annotation_logic = worker_ctx["annotation_logic"]
+    behaviors = worker_ctx["behaviors"]
+    assert isinstance(worker, AnnotationWorker)
+    assert isinstance(annotation_logic, Mock)
+    assert isinstance(behaviors, dict)
+
+    def execute_annotation(*_args: object, **kwargs: object) -> object:
+        model = cast("list[str]", kwargs["litellm_model_ids"])[0]
+        behavior = behaviors.get(model, _success_result(model))
+        if isinstance(behavior, Exception):
+            raise behavior
+        return behavior
+
+    annotation_logic.execute_annotation.side_effect = execute_annotation
+    try:
+        worker_ctx["result"] = worker.execute()
+    except Exception as exc:
+        worker_ctx["exception"] = exc
 
 
 @then("error_records テーブルに該当 row は追加されない")
-def then_no_error_records_added() -> None:
-    pytest.skip(_PENDING_MESSAGE)
+def then_no_error_records_added(worker_ctx: dict[str, object]) -> None:
+    db_manager = worker_ctx["db_manager"]
+    assert isinstance(db_manager, Mock)
+    db_manager.save_error_record.assert_not_called()
 
 
 @then(parsers.parse('model_statistics の "{model}" の error_count は {count:d} である'))
-def then_error_count_equals(model: str, count: int) -> None:
-    pytest.skip(_PENDING_MESSAGE)
+def then_error_count_equals(worker_ctx: dict[str, object], model: str, count: int) -> None:
+    result = worker_ctx["result"]
+    assert isinstance(result, AnnotationExecutionResult)
+    assert result.model_statistics[model].error_count == count
 
 
 @then(parsers.parse('model_statistics の "{model}" の success_count は {count:d} である'))
-def then_success_count_equals(model: str, count: int) -> None:
-    pytest.skip(_PENDING_MESSAGE)
+def then_success_count_equals(worker_ctx: dict[str, object], model: str, count: int) -> None:
+    result = worker_ctx["result"]
+    assert isinstance(result, AnnotationExecutionResult)
+    assert result.model_statistics[model].success_count == count
 
 
 @then(parsers.parse('サマリーダイアログの model_errors に "{model}" のエラーが含まれる'))
-def then_summary_includes_model_error(model: str) -> None:
-    pytest.skip(_PENDING_MESSAGE)
+def then_summary_includes_model_error(worker_ctx: dict[str, object], model: str) -> None:
+    result = worker_ctx["result"]
+    assert isinstance(result, AnnotationExecutionResult)
+    assert any(error.model_name == model for error in result.model_errors)
 
 
 @then(parsers.parse('error_records テーブルに {count:d} 行追加される (対象モデル="{model}")'))
-def then_error_records_added_for_model(count: int, model: str) -> None:
-    pytest.skip(_PENDING_MESSAGE)
+def then_error_records_added_for_model(worker_ctx: dict[str, object], count: int, model: str) -> None:
+    db_manager = worker_ctx["db_manager"]
+    assert isinstance(db_manager, Mock)
+    calls = [
+        call for call in db_manager.save_error_record.call_args_list if call.kwargs["model_name"] == model
+    ]
+    assert len(calls) == count
 
 
 @then(parsers.parse('各 row の error_type は "{expected}" または例外型名である'))
-def then_error_type_matches(expected: str) -> None:
-    pytest.skip(_PENDING_MESSAGE)
+def then_error_type_matches(worker_ctx: dict[str, object], expected: str) -> None:
+    db_manager = worker_ctx["db_manager"]
+    assert isinstance(db_manager, Mock)
+    error_types = {call.kwargs["error_type"] for call in db_manager.save_error_record.call_args_list}
+    assert error_types <= {expected, "RuntimeError", "ValueError", "Exception"}
 
 
 @then(parsers.parse('モデル "{model}" の処理は完了する'))
-def then_model_completes(model: str) -> None:
-    pytest.skip(_PENDING_MESSAGE)
+def then_model_completes(worker_ctx: dict[str, object], model: str) -> None:
+    result = worker_ctx["result"]
+    assert isinstance(result, AnnotationExecutionResult)
+    assert any(model in annotations for annotations in result.results.values())
 
 
 @then(parsers.parse("error_records テーブルに {count:d} 行追加される (model_name は NULL)"))
-def then_error_records_added_no_model(count: int) -> None:
-    pytest.skip(_PENDING_MESSAGE)
+def then_error_records_added_no_model(worker_ctx: dict[str, object], count: int) -> None:
+    db_manager = worker_ctx["db_manager"]
+    assert isinstance(db_manager, Mock)
+    calls = [
+        call for call in db_manager.save_error_record.call_args_list if call.kwargs["model_name"] is None
+    ]
+    assert len(calls) == count
 
 
 @then("Worker は失敗 Signal を emit する")
-def then_worker_emits_failure_signal() -> None:
-    pytest.skip(_PENDING_MESSAGE)
+def then_worker_emits_failure_signal(worker_ctx: dict[str, object]) -> None:
+    assert worker_ctx["exception"] is not None
 
 
 @then(parsers.parse('error_records テーブルに該当 row が追加され error_type は "{expected}" である'))
-def then_integrity_violation_recorded(expected: str) -> None:
-    pytest.skip(_PENDING_MESSAGE)
+def then_integrity_violation_recorded(worker_ctx: dict[str, object], expected: str) -> None:
+    db_manager = worker_ctx["db_manager"]
+    assert isinstance(db_manager, Mock)
+    assert any(
+        call.kwargs["error_type"] == expected for call in db_manager.save_error_record.call_args_list
+    )
 
 
 @then("サマリーダイアログの integrity_violation 専用セクションに該当エントリが表示される")
-def then_integrity_violation_displayed() -> None:
-    pytest.skip(_PENDING_MESSAGE)
+def then_integrity_violation_displayed(worker_ctx: dict[str, object], qtbot: QtBot) -> None:
+    result = worker_ctx["result"]
+    assert isinstance(result, AnnotationExecutionResult)
+    dialog = AnnotationSummaryDialog(result)
+    qtbot.addWidget(dialog)
+
+    table = dialog.findChild(QTableWidget, "integrityViolationTable")
+    assert table is not None
+    assert table.rowCount() >= 1
+    model_item = table.item(0, 1)
+    assert model_item is not None
+    assert model_item.text() == "unknown-model"

--- a/tests/integration/gui/workers/test_worker_error_recording.py
+++ b/tests/integration/gui/workers/test_worker_error_recording.py
@@ -155,7 +155,7 @@ class TestAnnotationWorkerErrorRecording:
         # エラーレコードの詳細を確認
         error_records = db_manager.repository.get_error_records(operation_type="annotation")
         assert len(error_records) > 0
-        assert error_records[0].error_type == "Exception"
+        assert error_records[0].error_type == "lib_call_exception"
         assert "API Error" in error_records[0].error_message
         assert error_records[0].model_name == "test-model"
 

--- a/tests/unit/gui/widgets/test_annotation_summary_dialog.py
+++ b/tests/unit/gui/widgets/test_annotation_summary_dialog.py
@@ -94,6 +94,32 @@ def partial_error_result() -> AnnotationExecutionResult:
 
 
 @pytest.fixture
+def integrity_violation_result() -> AnnotationExecutionResult:
+    """内部整合性違反を含むアノテーション結果"""
+    return AnnotationExecutionResult(
+        results={"phash1": {"gpt-4o-mini": {"tags": ["cat"]}}},
+        total_images=2,
+        models_used=["gpt-4o-mini"],
+        db_save_success=1,
+        db_save_skip=0,
+        model_errors=[
+            ModelErrorDetail(
+                model_name="unknown-model",
+                image_path="image_001.png",
+                error_message="Annotation result contains unexpected model_id: unknown-model",
+                error_type="integrity_violation",
+            ),
+            ModelErrorDetail(
+                model_name="gpt-4o-mini",
+                image_path="image_002.png",
+                error_message="Rate limit exceeded",
+                error_type="result_error",
+            ),
+        ],
+    )
+
+
+@pytest.fixture
 def all_error_result() -> AnnotationExecutionResult:
     """全失敗のアノテーション結果"""
     return AnnotationExecutionResult(
@@ -166,6 +192,45 @@ class TestAnnotationSummaryDialogLayout:
         assert table.item(0, 0).text() == "image_001.png"
         assert table.item(0, 1).text() == "claude-3-haiku"
         assert table.item(0, 2).text() == "Rate limit exceeded"
+
+    def test_integrity_violation_uses_dedicated_table(
+        self, qtbot, integrity_violation_result, find_child_widget
+    ):
+        """integrity_violation は通常エラーとは別テーブルに表示される"""
+        dialog = AnnotationSummaryDialog(integrity_violation_result)
+        qtbot.addWidget(dialog)
+
+        integrity_table = find_child_widget(dialog, QTableWidget, "integrityViolationTable")
+        assert integrity_table.rowCount() == 1
+        assert integrity_table.item(0, 0).text() == "image_001.png"
+        assert integrity_table.item(0, 1).text() == "unknown-model"
+        assert "unexpected model_id" in integrity_table.item(0, 2).text()
+
+        regular_table = find_child_widget(dialog, QTableWidget, "errorTable")
+        assert regular_table.rowCount() == 1
+        assert regular_table.item(0, 0).text() == "image_002.png"
+        assert regular_table.item(0, 1).text() == "gpt-4o-mini"
+
+    def test_only_integrity_violation_hides_regular_error_table(self, qtbot):
+        """通常エラーが無い場合は errorTable を作らず専用セクションだけ表示する"""
+        result = AnnotationExecutionResult(
+            results={},
+            total_images=1,
+            models_used=["gpt-4o-mini"],
+            model_errors=[
+                ModelErrorDetail(
+                    model_name="unknown-model",
+                    image_path="image_001.png",
+                    error_message="unexpected model",
+                    error_type="integrity_violation",
+                )
+            ],
+        )
+        dialog = AnnotationSummaryDialog(result)
+        qtbot.addWidget(dialog)
+
+        assert dialog.findChild(QTableWidget, "integrityViolationTable") is not None
+        assert dialog.findChild(QTableWidget, "errorTable") is None
 
     def test_summary_shows_image_count(self, qtbot, success_result):
         """概要セクションに画像件数が表示される"""

--- a/tests/unit/gui/workers/test_annotation_worker.py
+++ b/tests/unit/gui/workers/test_annotation_worker.py
@@ -66,10 +66,10 @@ class TestAnnotationWorkerInitialization:
         assert worker.db_manager is mock_db_manager
         assert worker.model_registry is mock_model_registry
 
-    def test_initialization_filters_legacy_sentinel_models(
+    def test_initialization_keeps_model_ids_without_legacy_filter(
         self, mock_annotation_logic, mock_model_registry
     ):
-        """legacy sentinel を受け取ると初期化時に除外して保持する。"""
+        """ADR 0033: Worker は legacy sentinel 互換フィルタを持たず入力IDを保持する。"""
         image_paths = ["/path/to/image1.jpg"]
         models = ["__legacy_17__", "gpt-4o-mini"]
         mock_db_manager = Mock()
@@ -82,7 +82,7 @@ class TestAnnotationWorkerInitialization:
             model_registry=mock_model_registry,
         )
 
-        assert worker.litellm_model_ids == ["gpt-4o-mini"]
+        assert worker.litellm_model_ids == models
 
 
 class TestAnnotationWorkerExecute:
@@ -180,8 +180,10 @@ class TestAnnotationWorkerExecute:
         assert result.total_images == 1
         assert result.models_used == ["gpt-4o-mini", "claude-3-haiku-20240307"]
 
-    def test_execute_skips_legacy_sentinel_models(self, mock_annotation_logic, mock_model_registry):
-        """legacy sentinel は execute 時の対象モデルから除外される。"""
+    def test_execute_does_not_filter_legacy_sentinel_models(
+        self, mock_annotation_logic, mock_model_registry
+    ):
+        """ADR 0033: Worker 実行時も legacy sentinel 互換フィルタを持たない。"""
         image_paths = ["/path/to/image.jpg"]
         models = ["__legacy_17__", "gpt-4o-mini"]
 
@@ -200,10 +202,10 @@ class TestAnnotationWorkerExecute:
         )
         result = worker.execute()
 
-        mock_annotation_logic.execute_annotation.assert_called_once()
-        assert result.models_used == ["gpt-4o-mini"]
-        called_kwargs = mock_annotation_logic.execute_annotation.call_args.kwargs
-        assert called_kwargs["litellm_model_ids"] == ["gpt-4o-mini"]
+        assert mock_annotation_logic.execute_annotation.call_count == 2
+        assert result.models_used == models
+        first_call_kwargs = mock_annotation_logic.execute_annotation.call_args_list[0].kwargs
+        assert first_call_kwargs["litellm_model_ids"] == ["__legacy_17__"]
 
     def test_execute_model_error_partial_success(self, mock_annotation_logic, mock_model_registry):
         """モデルエラー時の部分的成功"""
@@ -251,6 +253,108 @@ class TestAnnotationWorkerExecute:
         assert len(result.model_errors) == 1
         assert result.model_errors[0].model_name == "claude-3-haiku-20240307"
         assert "API Error" in result.model_errors[0].error_message
+        assert result.model_errors[0].error_type == "lib_call_exception"
+
+    def test_execute_collects_l1_result_error_without_error_record(
+        self, mock_annotation_logic, mock_model_registry
+    ):
+        """ADR 0033 L1: lib result.error は error_records に保存せず summary/statistics に載せる。"""
+        image_paths = ["/path/to/image.jpg"]
+        models = ["model-a", "model-b"]
+
+        mock_db_manager = Mock()
+        mock_db_manager.repository.find_image_ids_by_phashes.return_value = {"phash1": 1}
+        mock_db_manager.repository.get_models_by_litellm_ids.return_value = {"model-b": Mock(id=2)}
+        mock_db_manager.repository.save_annotations = Mock()
+        mock_db_manager.repository.get_phashes_by_filepaths.return_value = {}
+
+        mock_annotation_logic.execute_annotation.side_effect = [
+            {"phash1": {"model-a": {"tags": [], "error": "rate_limited"}}},
+            {"phash1": {"model-b": {"tags": ["cat"], "formatted_output": {}, "error": None}}},
+        ]
+
+        worker = AnnotationWorker(
+            annotation_logic=mock_annotation_logic,
+            image_paths=image_paths,
+            litellm_model_ids=models,
+            db_manager=mock_db_manager,
+            model_registry=mock_model_registry,
+        )
+
+        result = worker.execute()
+
+        mock_db_manager.save_error_record.assert_not_called()
+        assert result.model_statistics["model-a"].error_count == 1
+        assert result.model_statistics["model-b"].success_count == 1
+        assert len(result.model_errors) == 1
+        assert result.model_errors[0].model_name == "model-a"
+        assert result.model_errors[0].error_type == "result_error"
+
+    def test_execute_records_integrity_violation_for_unexpected_model(
+        self, mock_annotation_logic, mock_model_registry
+    ):
+        """ADR 0033 integrity: 選択外 model_id が混入した結果は保存対象外で記録する。"""
+        image_paths = ["/path/to/image.jpg"]
+        models = ["model-a"]
+
+        mock_db_manager = Mock()
+        mock_db_manager.repository.find_image_ids_by_phashes.return_value = {}
+        mock_db_manager.repository.get_models_by_litellm_ids.return_value = {}
+        mock_db_manager.repository.save_annotations = Mock()
+        mock_db_manager.repository.get_phashes_by_filepaths.return_value = {"/path/to/image.jpg": "phash1"}
+        mock_db_manager.get_image_id_by_filepath.return_value = 1
+
+        mock_annotation_logic.execute_annotation.return_value = {
+            "phash1": {"unknown-model": {"tags": ["cat"], "error": None}}
+        }
+
+        worker = AnnotationWorker(
+            annotation_logic=mock_annotation_logic,
+            image_paths=image_paths,
+            litellm_model_ids=models,
+            db_manager=mock_db_manager,
+            model_registry=mock_model_registry,
+        )
+
+        result = worker.execute()
+
+        assert result.results == {}
+        assert len(result.model_errors) == 1
+        assert result.model_errors[0].model_name == "unknown-model"
+        assert result.model_errors[0].error_type == "integrity_violation"
+        call_kwargs = mock_db_manager.save_error_record.call_args.kwargs
+        assert call_kwargs["error_type"] == "integrity_violation"
+        assert call_kwargs["model_name"] == "unknown-model"
+
+    def test_execute_passes_registered_phash_list(self, mock_annotation_logic, mock_model_registry):
+        """登録済み画像は DB pHash を input order で AnnotationLogic に渡す。"""
+        image_paths = ["/path/to/a.jpg", "/path/to/b.jpg"]
+        models = ["model-a"]
+
+        mock_db_manager = Mock()
+        mock_db_manager.repository.find_image_ids_by_phashes.return_value = {"phash-a": 1}
+        mock_db_manager.repository.get_models_by_litellm_ids.return_value = {"model-a": Mock(id=1)}
+        mock_db_manager.repository.save_annotations = Mock()
+        mock_db_manager.repository.get_phashes_by_filepaths.return_value = {
+            "/path/to/a.jpg": "phash-a",
+            "/path/to/b.jpg": "phash-b",
+        }
+        mock_annotation_logic.execute_annotation.return_value = {
+            "phash-a": {"model-a": {"tags": ["cat"], "error": None}}
+        }
+
+        worker = AnnotationWorker(
+            annotation_logic=mock_annotation_logic,
+            image_paths=image_paths,
+            litellm_model_ids=models,
+            db_manager=mock_db_manager,
+            model_registry=mock_model_registry,
+        )
+
+        worker.execute()
+
+        called_kwargs = mock_annotation_logic.execute_annotation.call_args.kwargs
+        assert called_kwargs["phash_list"] == ["phash-a", "phash-b"]
 
     def test_execute_all_models_fail(self, mock_annotation_logic, mock_model_registry):
         """全モデルエラー時（空結果）"""


### PR DESCRIPTION
## Summary
- implement ADR 0033 worker contract for the annotation worker
- remove legacy sentinel filtering and let compatibility be handled outside the worker contract
- classify error records as lib_call_exception, fatal, or integrity_violation while keeping L1 result.error out of error_records
- pass registered pHash values to AnnotationLogic and add a repository batch pHash lookup
- update worker progress phases and focused worker tests

Closes #399
Closes #400
Closes #401
Closes #402
Closes #403
Refs #384

## Tests
- uv run pytest tests/unit/gui/workers/test_annotation_worker.py
- uv run pytest tests/integration/gui/workers/test_worker_error_recording.py
- uv run pytest tests/unit/gui/workers/test_annotation_worker.py tests/integration/gui/workers/test_worker_error_recording.py
- uv run ruff check src/lorairo/gui/workers/annotation_worker.py src/lorairo/database/db_repository.py tests/unit/gui/workers/test_annotation_worker.py tests/integration/gui/workers/test_worker_error_recording.py
- uv run ruff format --check src/lorairo/gui/workers/annotation_worker.py src/lorairo/database/db_repository.py tests/unit/gui/workers/test_annotation_worker.py tests/integration/gui/workers/test_worker_error_recording.py
- uv run mypy src/lorairo/gui/workers/annotation_worker.py src/lorairo/database/db_repository.py