### PR TITLE
feat: add provider batch job schema

### DIFF
--- a/src/lorairo/database/db_repository.py
+++ b/src/lorairo/database/db_repository.py
@@ -3,7 +3,7 @@
 import datetime
 from collections.abc import Callable
 from pathlib import Path
-from typing import Any, cast
+from typing import Any, ClassVar, cast
 
 from genai_tag_db_tools import search_tags
 from genai_tag_db_tools.db.repository import MergedTagReader, get_default_reader
@@ -31,6 +31,12 @@ from .schema import (
     ModelType,
     ProcessedImage,
     Project,
+    ProviderBatchArtifact,
+    ProviderBatchArtifactData,
+    ProviderBatchItem,
+    ProviderBatchItemData,
+    ProviderBatchJob,
+    ProviderBatchJobData,
     Rating,
     Score,
     ScoreLabel,
@@ -64,6 +70,37 @@ class ImageRepository:
     # SQLite バインド変数上限の安全マージン（32,766の約半分）
     # IN句以外にもクエリ内で変数を使うため余裕を持たせる
     BATCH_CHUNK_SIZE = 15000
+    PROVIDER_BATCH_JOB_UPDATE_FIELDS: ClassVar[set[str]] = {
+        "provider_job_id",
+        "status",
+        "provider_status",
+        "endpoint",
+        "model_id",
+        "request_count",
+        "succeeded_count",
+        "failed_count",
+        "canceled_count",
+        "expired_count",
+        "submitted_at",
+        "completed_at",
+        "canceled_at",
+        "imported_at",
+        "expires_at",
+        "input_artifact_path",
+        "output_artifact_path",
+        "error_artifact_path",
+        "raw_provider_payload",
+    }
+    PROVIDER_BATCH_ITEM_UPDATE_FIELDS: ClassVar[set[str]] = {
+        "image_id",
+        "model_id",
+        "task_type",
+        "status",
+        "error_type",
+        "error_message",
+        "raw_request",
+        "raw_response",
+    }
 
     def __init__(self, session_factory: Callable[[], Session] = DefaultSessionLocal):
         """ImageRepositoryのコンストラクタ。
@@ -3285,6 +3322,228 @@ class ImageRepository:
                 logger.error(
                     f"手動編集フラグの更新中にエラーが発生しました (Type: {annotation_type}, ID: {annotation_id}): {e}",
                     exc_info=True,
+                )
+                raise
+
+    # --- Provider Batch Job Management Methods ---
+
+    def create_provider_batch_job(self, data: ProviderBatchJobData) -> int:
+        """Provider Batch API job を作成する。"""
+        with self.session_factory() as session:
+            try:
+                job = ProviderBatchJob(**data)
+                session.add(job)
+                session.flush()
+                job_id = job.id
+                session.commit()
+                logger.debug(
+                    f"Provider batch job を作成しました: ID={job_id}, "
+                    f"provider={job.provider}, status={job.status}",
+                )
+                return job_id
+            except SQLAlchemyError as e:
+                session.rollback()
+                logger.error(f"Provider batch job 作成中にエラーが発生しました: {e}", exc_info=True)
+                raise
+
+    def get_provider_batch_job(self, job_id: int) -> ProviderBatchJob | None:
+        """Provider Batch API job を ID で取得する。"""
+        with self.session_factory() as session:
+            try:
+                stmt = (
+                    select(ProviderBatchJob)
+                    .options(
+                        selectinload(ProviderBatchJob.items),
+                        selectinload(ProviderBatchJob.artifacts),
+                    )
+                    .where(ProviderBatchJob.id == job_id)
+                )
+                return session.execute(stmt).scalar_one_or_none()
+            except SQLAlchemyError as e:
+                logger.error(f"Provider batch job 取得中にエラーが発生しました: {e}", exc_info=True)
+                raise
+
+    def get_provider_batch_job_by_provider_id(
+        self,
+        provider: str,
+        provider_job_id: str,
+    ) -> ProviderBatchJob | None:
+        """provider と provider_job_id で Provider Batch API job を取得する。"""
+        with self.session_factory() as session:
+            try:
+                stmt = select(ProviderBatchJob).where(
+                    ProviderBatchJob.provider == provider,
+                    ProviderBatchJob.provider_job_id == provider_job_id,
+                )
+                return session.execute(stmt).scalar_one_or_none()
+            except SQLAlchemyError as e:
+                logger.error(
+                    f"Provider batch job provider ID 取得中にエラーが発生しました: {e}", exc_info=True
+                )
+                raise
+
+    def list_provider_batch_jobs(
+        self,
+        provider: str | None = None,
+        status: str | None = None,
+        limit: int = 100,
+        offset: int = 0,
+    ) -> list[ProviderBatchJob]:
+        """Provider Batch API job 一覧を取得する。"""
+        with self.session_factory() as session:
+            try:
+                stmt = select(ProviderBatchJob).order_by(ProviderBatchJob.created_at.desc())
+                if provider is not None:
+                    stmt = stmt.where(ProviderBatchJob.provider == provider)
+                if status is not None:
+                    stmt = stmt.where(ProviderBatchJob.status == status)
+                stmt = stmt.limit(limit).offset(offset)
+                return list(session.execute(stmt).scalars().all())
+            except SQLAlchemyError as e:
+                logger.error(f"Provider batch job 一覧取得中にエラーが発生しました: {e}", exc_info=True)
+                raise
+
+    def update_provider_batch_job(self, job_id: int, updates: dict[str, Any]) -> bool:
+        """Provider Batch API job を更新する。許可フィールドのみ更新対象。"""
+        invalid_fields = set(updates) - self.PROVIDER_BATCH_JOB_UPDATE_FIELDS
+        if invalid_fields:
+            raise ValueError(f"更新できない provider batch job フィールド: {sorted(invalid_fields)}")
+        if not updates:
+            return False
+
+        with self.session_factory() as session:
+            try:
+                stmt = (
+                    update(ProviderBatchJob)
+                    .where(ProviderBatchJob.id == job_id)
+                    .values(**updates, updated_at=func.now())
+                )
+                result = cast(CursorResult[Any], session.execute(stmt))
+                session.commit()
+                return bool(result.rowcount)
+            except SQLAlchemyError as e:
+                session.rollback()
+                logger.error(f"Provider batch job 更新中にエラーが発生しました: {e}", exc_info=True)
+                raise
+
+    def delete_provider_batch_job(self, job_id: int) -> bool:
+        """Provider Batch API job を削除する。items / artifacts は cascade される。"""
+        with self.session_factory() as session:
+            try:
+                session.execute(delete(ProviderBatchArtifact).where(ProviderBatchArtifact.job_id == job_id))
+                session.execute(delete(ProviderBatchItem).where(ProviderBatchItem.job_id == job_id))
+                stmt = delete(ProviderBatchJob).where(ProviderBatchJob.id == job_id)
+                result = cast(CursorResult[Any], session.execute(stmt))
+                session.commit()
+                return bool(result.rowcount)
+            except SQLAlchemyError as e:
+                session.rollback()
+                logger.error(f"Provider batch job 削除中にエラーが発生しました: {e}", exc_info=True)
+                raise
+
+    def create_provider_batch_item(self, data: ProviderBatchItemData) -> int:
+        """Provider Batch API job item を作成する。"""
+        with self.session_factory() as session:
+            try:
+                item = ProviderBatchItem(**data)
+                session.add(item)
+                session.flush()
+                item_id = item.id
+                session.commit()
+                return item_id
+            except SQLAlchemyError as e:
+                session.rollback()
+                logger.error(f"Provider batch item 作成中にエラーが発生しました: {e}", exc_info=True)
+                raise
+
+    def list_provider_batch_items(
+        self,
+        job_id: int,
+        status: str | None = None,
+        limit: int = 1000,
+        offset: int = 0,
+    ) -> list[ProviderBatchItem]:
+        """Provider Batch API job item 一覧を取得する。"""
+        with self.session_factory() as session:
+            try:
+                stmt = (
+                    select(ProviderBatchItem)
+                    .where(ProviderBatchItem.job_id == job_id)
+                    .order_by(ProviderBatchItem.id)
+                )
+                if status is not None:
+                    stmt = stmt.where(ProviderBatchItem.status == status)
+                stmt = stmt.limit(limit).offset(offset)
+                return list(session.execute(stmt).scalars().all())
+            except SQLAlchemyError as e:
+                logger.error(f"Provider batch item 一覧取得中にエラーが発生しました: {e}", exc_info=True)
+                raise
+
+    def update_provider_batch_item_by_custom_id(
+        self,
+        job_id: int,
+        custom_id: str,
+        updates: dict[str, Any],
+    ) -> bool:
+        """job_id + custom_id で Provider Batch API job item を更新する。"""
+        invalid_fields = set(updates) - self.PROVIDER_BATCH_ITEM_UPDATE_FIELDS
+        if invalid_fields:
+            raise ValueError(f"更新できない provider batch item フィールド: {sorted(invalid_fields)}")
+        if not updates:
+            return False
+
+        with self.session_factory() as session:
+            try:
+                stmt = (
+                    update(ProviderBatchItem)
+                    .where(
+                        ProviderBatchItem.job_id == job_id,
+                        ProviderBatchItem.custom_id == custom_id,
+                    )
+                    .values(**updates, updated_at=func.now())
+                )
+                result = cast(CursorResult[Any], session.execute(stmt))
+                session.commit()
+                return bool(result.rowcount)
+            except SQLAlchemyError as e:
+                session.rollback()
+                logger.error(f"Provider batch item 更新中にエラーが発生しました: {e}", exc_info=True)
+                raise
+
+    def create_provider_batch_artifact(self, data: ProviderBatchArtifactData) -> int:
+        """Provider Batch API job artifact を作成する。"""
+        with self.session_factory() as session:
+            try:
+                artifact = ProviderBatchArtifact(**data)
+                session.add(artifact)
+                session.flush()
+                artifact_id = artifact.id
+                session.commit()
+                return artifact_id
+            except SQLAlchemyError as e:
+                session.rollback()
+                logger.error(f"Provider batch artifact 作成中にエラーが発生しました: {e}", exc_info=True)
+                raise
+
+    def list_provider_batch_artifacts(
+        self,
+        job_id: int,
+        artifact_type: str | None = None,
+    ) -> list[ProviderBatchArtifact]:
+        """Provider Batch API job artifact 一覧を取得する。"""
+        with self.session_factory() as session:
+            try:
+                stmt = (
+                    select(ProviderBatchArtifact)
+                    .where(ProviderBatchArtifact.job_id == job_id)
+                    .order_by(ProviderBatchArtifact.id)
+                )
+                if artifact_type is not None:
+                    stmt = stmt.where(ProviderBatchArtifact.artifact_type == artifact_type)
+                return list(session.execute(stmt).scalars().all())
+            except SQLAlchemyError as e:
+                logger.error(
+                    f"Provider batch artifact 一覧取得中にエラーが発生しました: {e}", exc_info=True
                 )
                 raise
 

--- a/src/lorairo/database/migrations/versions/c6d7e8f9a0b1_add_provider_batch_job_tables.py
+++ b/src/lorairo/database/migrations/versions/c6d7e8f9a0b1_add_provider_batch_job_tables.py
@@ -1,0 +1,135 @@
+"""Add provider batch job tables (ADR 0038).
+
+Revision ID: c6d7e8f9a0b1
+Revises: b4c5d6e7f8a9
+Create Date: 2026-05-25
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "c6d7e8f9a0b1"
+down_revision: str | None = "b4c5d6e7f8a9"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "provider_batch_jobs",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("provider", sa.String(), nullable=False),
+        sa.Column("provider_job_id", sa.String(), nullable=True),
+        sa.Column("status", sa.String(), nullable=False),
+        sa.Column("provider_status", sa.String(), nullable=True),
+        sa.Column("endpoint", sa.String(), nullable=True),
+        sa.Column("model_id", sa.Integer(), sa.ForeignKey("models.id", ondelete="SET NULL")),
+        sa.Column("request_count", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("succeeded_count", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("failed_count", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("canceled_count", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("expired_count", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("submitted_at", sa.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column("completed_at", sa.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column("canceled_at", sa.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column("imported_at", sa.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column("expires_at", sa.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column("input_artifact_path", sa.String(), nullable=True),
+        sa.Column("output_artifact_path", sa.String(), nullable=True),
+        sa.Column("error_artifact_path", sa.String(), nullable=True),
+        sa.Column("raw_provider_payload", sa.Text(), nullable=True),
+        sa.Column("created_at", sa.TIMESTAMP(timezone=True), server_default=sa.func.now()),
+        sa.Column(
+            "updated_at",
+            sa.TIMESTAMP(timezone=True),
+            server_default=sa.func.now(),
+            onupdate=sa.func.now(),
+        ),
+    )
+    op.create_index("ix_provider_batch_jobs_provider", "provider_batch_jobs", ["provider"])
+    op.create_index("ix_provider_batch_jobs_status", "provider_batch_jobs", ["status"])
+    op.create_index("ix_provider_batch_jobs_created_at", "provider_batch_jobs", ["created_at"])
+    op.create_index(
+        "uq_provider_batch_jobs_provider_job",
+        "provider_batch_jobs",
+        ["provider", "provider_job_id"],
+        unique=True,
+        sqlite_where=sa.text("provider_job_id IS NOT NULL"),
+    )
+
+    op.create_table(
+        "provider_batch_items",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column(
+            "job_id",
+            sa.Integer(),
+            sa.ForeignKey("provider_batch_jobs.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("custom_id", sa.String(), nullable=False),
+        sa.Column("image_id", sa.Integer(), sa.ForeignKey("images.id", ondelete="SET NULL")),
+        sa.Column("model_id", sa.Integer(), sa.ForeignKey("models.id", ondelete="SET NULL")),
+        sa.Column("task_type", sa.String(), nullable=False),
+        sa.Column("status", sa.String(), nullable=False),
+        sa.Column("error_type", sa.String(), nullable=True),
+        sa.Column("error_message", sa.String(), nullable=True),
+        sa.Column("raw_request", sa.Text(), nullable=True),
+        sa.Column("raw_response", sa.Text(), nullable=True),
+        sa.Column("created_at", sa.TIMESTAMP(timezone=True), server_default=sa.func.now()),
+        sa.Column(
+            "updated_at",
+            sa.TIMESTAMP(timezone=True),
+            server_default=sa.func.now(),
+            onupdate=sa.func.now(),
+        ),
+        sa.UniqueConstraint("job_id", "custom_id", name="uix_provider_batch_items_job_custom_id"),
+    )
+    op.create_index("ix_provider_batch_items_job_id", "provider_batch_items", ["job_id"])
+    op.create_index("ix_provider_batch_items_status", "provider_batch_items", ["status"])
+    op.create_index("ix_provider_batch_items_image_id", "provider_batch_items", ["image_id"])
+    op.create_index("ix_provider_batch_items_model_id", "provider_batch_items", ["model_id"])
+
+    op.create_table(
+        "provider_batch_artifacts",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column(
+            "job_id",
+            sa.Integer(),
+            sa.ForeignKey("provider_batch_jobs.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("artifact_type", sa.String(), nullable=False),
+        sa.Column("local_path", sa.String(), nullable=False),
+        sa.Column("provider_file_id", sa.String(), nullable=True),
+        sa.Column("sha256", sa.String(), nullable=True),
+        sa.Column("created_at", sa.TIMESTAMP(timezone=True), server_default=sa.func.now()),
+        sa.UniqueConstraint(
+            "job_id",
+            "artifact_type",
+            "local_path",
+            name="uix_provider_batch_artifacts_job_type_path",
+        ),
+    )
+    op.create_index("ix_provider_batch_artifacts_job_id", "provider_batch_artifacts", ["job_id"])
+    op.create_index("ix_provider_batch_artifacts_type", "provider_batch_artifacts", ["artifact_type"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_provider_batch_artifacts_type", table_name="provider_batch_artifacts")
+    op.drop_index("ix_provider_batch_artifacts_job_id", table_name="provider_batch_artifacts")
+    op.drop_table("provider_batch_artifacts")
+
+    op.drop_index("ix_provider_batch_items_model_id", table_name="provider_batch_items")
+    op.drop_index("ix_provider_batch_items_image_id", table_name="provider_batch_items")
+    op.drop_index("ix_provider_batch_items_status", table_name="provider_batch_items")
+    op.drop_index("ix_provider_batch_items_job_id", table_name="provider_batch_items")
+    op.drop_table("provider_batch_items")
+
+    op.drop_index("uq_provider_batch_jobs_provider_job", table_name="provider_batch_jobs")
+    op.drop_index("ix_provider_batch_jobs_created_at", table_name="provider_batch_jobs")
+    op.drop_index("ix_provider_batch_jobs_status", table_name="provider_batch_jobs")
+    op.drop_index("ix_provider_batch_jobs_provider", table_name="provider_batch_jobs")
+    op.drop_table("provider_batch_jobs")

--- a/src/lorairo/database/schema.py
+++ b/src/lorairo/database/schema.py
@@ -15,6 +15,7 @@ from sqlalchemy import (
     Integer,
     String,
     Table,  # 中間テーブル定義で使用
+    Text,
     UniqueConstraint,
     func,
 )
@@ -111,6 +112,12 @@ class Model(Base):
     scores: Mapped[list[Score]] = relationship("Score", back_populates="model")
     score_labels: Mapped[list[ScoreLabel]] = relationship("ScoreLabel", back_populates="model")
     ratings: Mapped[list[Rating]] = relationship("Rating", back_populates="model")
+    provider_batch_jobs: Mapped[list[ProviderBatchJob]] = relationship(
+        "ProviderBatchJob", back_populates="model"
+    )
+    provider_batch_items: Mapped[list[ProviderBatchItem]] = relationship(
+        "ProviderBatchItem", back_populates="model"
+    )
 
     def __repr__(self) -> str:
         return f"<Model(id={self.id}, name='{self.name}')>"
@@ -218,6 +225,9 @@ class Image(Base):
     )
     error_records: Mapped[list[ErrorRecord]] = relationship(
         "ErrorRecord", back_populates="image", cascade="all, delete-orphan"
+    )
+    provider_batch_items: Mapped[list[ProviderBatchItem]] = relationship(
+        "ProviderBatchItem", back_populates="image"
     )
 
     # uuid と phash の組み合わせはユニークであるべき
@@ -496,6 +506,137 @@ class ImageFilenameAlias(Base):
         return f"<ImageFilenameAlias(id={self.id}, stem='{self.stem}', image_id={self.image_id})>"
 
 
+class ProviderBatchJob(Base):
+    """プロバイダ Batch API の永続 job 状態。"""
+
+    __tablename__ = "provider_batch_jobs"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    provider: Mapped[str] = mapped_column(String, nullable=False)
+    provider_job_id: Mapped[str | None] = mapped_column(String)
+    status: Mapped[str] = mapped_column(String, nullable=False)
+    provider_status: Mapped[str | None] = mapped_column(String)
+    endpoint: Mapped[str | None] = mapped_column(String)
+    model_id: Mapped[int | None] = mapped_column(ForeignKey("models.id", ondelete="SET NULL"))
+    request_count: Mapped[int] = mapped_column(Integer, nullable=False, default=0, server_default="0")
+    succeeded_count: Mapped[int] = mapped_column(Integer, nullable=False, default=0, server_default="0")
+    failed_count: Mapped[int] = mapped_column(Integer, nullable=False, default=0, server_default="0")
+    canceled_count: Mapped[int] = mapped_column(Integer, nullable=False, default=0, server_default="0")
+    expired_count: Mapped[int] = mapped_column(Integer, nullable=False, default=0, server_default="0")
+    submitted_at: Mapped[datetime.datetime | None] = mapped_column(TIMESTAMP(timezone=True))
+    completed_at: Mapped[datetime.datetime | None] = mapped_column(TIMESTAMP(timezone=True))
+    canceled_at: Mapped[datetime.datetime | None] = mapped_column(TIMESTAMP(timezone=True))
+    imported_at: Mapped[datetime.datetime | None] = mapped_column(TIMESTAMP(timezone=True))
+    expires_at: Mapped[datetime.datetime | None] = mapped_column(TIMESTAMP(timezone=True))
+    input_artifact_path: Mapped[str | None] = mapped_column(String)
+    output_artifact_path: Mapped[str | None] = mapped_column(String)
+    error_artifact_path: Mapped[str | None] = mapped_column(String)
+    raw_provider_payload: Mapped[str | None] = mapped_column(Text)
+    created_at: Mapped[datetime.datetime] = mapped_column(
+        TIMESTAMP(timezone=True), server_default=func.now()
+    )
+    updated_at: Mapped[datetime.datetime] = mapped_column(
+        TIMESTAMP(timezone=True), server_default=func.now(), onupdate=func.now()
+    )
+
+    model: Mapped[Model | None] = relationship("Model", back_populates="provider_batch_jobs")
+    items: Mapped[list[ProviderBatchItem]] = relationship(
+        "ProviderBatchItem", back_populates="job", cascade="all, delete-orphan"
+    )
+    artifacts: Mapped[list[ProviderBatchArtifact]] = relationship(
+        "ProviderBatchArtifact", back_populates="job", cascade="all, delete-orphan"
+    )
+
+    __table_args__ = (
+        Index("ix_provider_batch_jobs_provider", "provider"),
+        Index("ix_provider_batch_jobs_status", "status"),
+        Index("ix_provider_batch_jobs_created_at", "created_at"),
+        Index(
+            "uq_provider_batch_jobs_provider_job",
+            "provider",
+            "provider_job_id",
+            unique=True,
+            sqlite_where=provider_job_id.is_not(None),
+        ),
+    )
+
+    def __repr__(self) -> str:
+        return f"<ProviderBatchJob(id={self.id}, provider='{self.provider}', status='{self.status}')>"
+
+
+class ProviderBatchItem(Base):
+    """Provider Batch API job 内の request/result item。"""
+
+    __tablename__ = "provider_batch_items"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    job_id: Mapped[int] = mapped_column(
+        ForeignKey("provider_batch_jobs.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    custom_id: Mapped[str] = mapped_column(String, nullable=False)
+    image_id: Mapped[int | None] = mapped_column(ForeignKey("images.id", ondelete="SET NULL"))
+    model_id: Mapped[int | None] = mapped_column(ForeignKey("models.id", ondelete="SET NULL"))
+    task_type: Mapped[str] = mapped_column(String, nullable=False)
+    status: Mapped[str] = mapped_column(String, nullable=False)
+    error_type: Mapped[str | None] = mapped_column(String)
+    error_message: Mapped[str | None] = mapped_column(String)
+    raw_request: Mapped[str | None] = mapped_column(Text)
+    raw_response: Mapped[str | None] = mapped_column(Text)
+    created_at: Mapped[datetime.datetime] = mapped_column(
+        TIMESTAMP(timezone=True), server_default=func.now()
+    )
+    updated_at: Mapped[datetime.datetime] = mapped_column(
+        TIMESTAMP(timezone=True), server_default=func.now(), onupdate=func.now()
+    )
+
+    job: Mapped[ProviderBatchJob] = relationship("ProviderBatchJob", back_populates="items")
+    image: Mapped[Image | None] = relationship("Image", back_populates="provider_batch_items")
+    model: Mapped[Model | None] = relationship("Model", back_populates="provider_batch_items")
+
+    __table_args__ = (
+        UniqueConstraint("job_id", "custom_id", name="uix_provider_batch_items_job_custom_id"),
+        Index("ix_provider_batch_items_status", "status"),
+        Index("ix_provider_batch_items_image_id", "image_id"),
+        Index("ix_provider_batch_items_model_id", "model_id"),
+    )
+
+    def __repr__(self) -> str:
+        return f"<ProviderBatchItem(id={self.id}, job_id={self.job_id}, custom_id='{self.custom_id}')>"
+
+
+class ProviderBatchArtifact(Base):
+    """Provider Batch API job に紐づく local/provider artifact。"""
+
+    __tablename__ = "provider_batch_artifacts"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    job_id: Mapped[int] = mapped_column(
+        ForeignKey("provider_batch_jobs.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    artifact_type: Mapped[str] = mapped_column(String, nullable=False)
+    local_path: Mapped[str] = mapped_column(String, nullable=False)
+    provider_file_id: Mapped[str | None] = mapped_column(String)
+    sha256: Mapped[str | None] = mapped_column(String)
+    created_at: Mapped[datetime.datetime] = mapped_column(
+        TIMESTAMP(timezone=True), server_default=func.now()
+    )
+
+    job: Mapped[ProviderBatchJob] = relationship("ProviderBatchJob", back_populates="artifacts")
+
+    __table_args__ = (
+        UniqueConstraint(
+            "job_id",
+            "artifact_type",
+            "local_path",
+            name="uix_provider_batch_artifacts_job_type_path",
+        ),
+        Index("ix_provider_batch_artifacts_type", "artifact_type"),
+    )
+
+    def __repr__(self) -> str:
+        return f"<ProviderBatchArtifact(id={self.id}, job_id={self.job_id}, type='{self.artifact_type}')>"
+
+
 # --- TypedDicts for data transfer ---
 
 
@@ -612,4 +753,56 @@ class ErrorRecordData(TypedDict):
     file_path: NotRequired[str | None]
     model_name: NotRequired[str | None]
     resolved_at: NotRequired[datetime.datetime | None]
+    created_at: NotRequired[datetime.datetime]
+
+
+class ProviderBatchJobData(TypedDict):
+    id: NotRequired[int]
+    provider: str
+    provider_job_id: NotRequired[str | None]
+    status: str
+    provider_status: NotRequired[str | None]
+    endpoint: NotRequired[str | None]
+    model_id: NotRequired[int | None]
+    request_count: NotRequired[int]
+    succeeded_count: NotRequired[int]
+    failed_count: NotRequired[int]
+    canceled_count: NotRequired[int]
+    expired_count: NotRequired[int]
+    submitted_at: NotRequired[datetime.datetime | None]
+    completed_at: NotRequired[datetime.datetime | None]
+    canceled_at: NotRequired[datetime.datetime | None]
+    imported_at: NotRequired[datetime.datetime | None]
+    expires_at: NotRequired[datetime.datetime | None]
+    input_artifact_path: NotRequired[str | None]
+    output_artifact_path: NotRequired[str | None]
+    error_artifact_path: NotRequired[str | None]
+    raw_provider_payload: NotRequired[str | None]
+    created_at: NotRequired[datetime.datetime]
+    updated_at: NotRequired[datetime.datetime]
+
+
+class ProviderBatchItemData(TypedDict):
+    id: NotRequired[int]
+    job_id: int
+    custom_id: str
+    image_id: NotRequired[int | None]
+    model_id: NotRequired[int | None]
+    task_type: str
+    status: str
+    error_type: NotRequired[str | None]
+    error_message: NotRequired[str | None]
+    raw_request: NotRequired[str | None]
+    raw_response: NotRequired[str | None]
+    created_at: NotRequired[datetime.datetime]
+    updated_at: NotRequired[datetime.datetime]
+
+
+class ProviderBatchArtifactData(TypedDict):
+    id: NotRequired[int]
+    job_id: int
+    artifact_type: str
+    local_path: str
+    provider_file_id: NotRequired[str | None]
+    sha256: NotRequired[str | None]
     created_at: NotRequired[datetime.datetime]

--- a/tests/unit/database/test_db_repository_provider_batch.py
+++ b/tests/unit/database/test_db_repository_provider_batch.py
@@ -1,0 +1,137 @@
+"""Provider Batch API job repository tests."""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy.exc import IntegrityError
+
+from lorairo.database.db_repository import ImageRepository
+
+
+@pytest.mark.unit
+class TestProviderBatchRepository:
+    def test_create_get_list_and_update_job(self, test_repository: ImageRepository) -> None:
+        job_id = test_repository.create_provider_batch_job(
+            {
+                "provider": "openai",
+                "provider_job_id": "batch_123",
+                "status": "submitted",
+                "provider_status": "validating",
+                "endpoint": "/v1/responses",
+                "request_count": 3,
+                "raw_provider_payload": '{"id":"batch_123"}',
+            }
+        )
+
+        job = test_repository.get_provider_batch_job(job_id)
+        assert job is not None
+        assert job.provider == "openai"
+        assert job.provider_job_id == "batch_123"
+        assert job.request_count == 3
+
+        by_provider = test_repository.get_provider_batch_job_by_provider_id("openai", "batch_123")
+        assert by_provider is not None
+        assert by_provider.id == job_id
+
+        assert [job.id for job in test_repository.list_provider_batch_jobs(provider="openai")] == [job_id]
+        assert test_repository.update_provider_batch_job(
+            job_id,
+            {
+                "status": "completed",
+                "provider_status": "completed",
+                "succeeded_count": 3,
+            },
+        )
+
+        updated = test_repository.get_provider_batch_job(job_id)
+        assert updated is not None
+        assert updated.status == "completed"
+        assert updated.succeeded_count == 3
+
+    def test_provider_job_id_unique_per_provider(self, test_repository: ImageRepository) -> None:
+        data = {
+            "provider": "openai",
+            "provider_job_id": "batch_dupe",
+            "status": "submitted",
+        }
+        test_repository.create_provider_batch_job(data)
+
+        with pytest.raises(IntegrityError):
+            test_repository.create_provider_batch_job(data)
+
+        other_provider_id = test_repository.create_provider_batch_job(
+            {
+                "provider": "anthropic",
+                "provider_job_id": "batch_dupe",
+                "status": "submitted",
+            }
+        )
+        assert other_provider_id > 0
+
+    def test_job_with_null_provider_job_id_can_be_created_multiple_times(
+        self,
+        test_repository: ImageRepository,
+    ) -> None:
+        first_id = test_repository.create_provider_batch_job({"provider": "openai", "status": "draft"})
+        second_id = test_repository.create_provider_batch_job({"provider": "openai", "status": "draft"})
+
+        assert first_id != second_id
+
+    def test_items_artifacts_and_delete_job(self, test_repository: ImageRepository) -> None:
+        job_id = test_repository.create_provider_batch_job(
+            {
+                "provider": "openai",
+                "provider_job_id": "batch_items",
+                "status": "submitted",
+            }
+        )
+        item_id = test_repository.create_provider_batch_item(
+            {
+                "job_id": job_id,
+                "custom_id": "img-1-model-1-task-tags-run-abcd",
+                "task_type": "tags",
+                "status": "submitted",
+                "raw_request": '{"custom_id":"img-1-model-1-task-tags-run-abcd"}',
+            }
+        )
+        artifact_id = test_repository.create_provider_batch_artifact(
+            {
+                "job_id": job_id,
+                "artifact_type": "input",
+                "local_path": "/tmp/batch.jsonl",
+                "provider_file_id": "file_123",
+                "sha256": "abc",
+            }
+        )
+
+        assert item_id > 0
+        assert artifact_id > 0
+        assert len(test_repository.list_provider_batch_items(job_id)) == 1
+        assert len(test_repository.list_provider_batch_artifacts(job_id)) == 1
+
+        assert test_repository.update_provider_batch_item_by_custom_id(
+            job_id,
+            "img-1-model-1-task-tags-run-abcd",
+            {
+                "status": "failed",
+                "error_type": "provider_error",
+                "error_message": "bad request",
+            },
+        )
+        failed_items = test_repository.list_provider_batch_items(job_id, status="failed")
+        assert len(failed_items) == 1
+        assert failed_items[0].error_message == "bad request"
+
+        assert test_repository.delete_provider_batch_job(job_id)
+        assert test_repository.get_provider_batch_job(job_id) is None
+        assert test_repository.list_provider_batch_items(job_id) == []
+        assert test_repository.list_provider_batch_artifacts(job_id) == []
+
+    def test_update_rejects_unknown_fields(self, test_repository: ImageRepository) -> None:
+        job_id = test_repository.create_provider_batch_job({"provider": "openai", "status": "draft"})
+
+        with pytest.raises(ValueError):
+            test_repository.update_provider_batch_job(job_id, {"provider": "anthropic"})
+
+        with pytest.raises(ValueError):
+            test_repository.update_provider_batch_item_by_custom_id(job_id, "missing", {"custom_id": "x"})

--- a/tests/unit/database/test_migration_c6d7e8f9a0b1_provider_batch.py
+++ b/tests/unit/database/test_migration_c6d7e8f9a0b1_provider_batch.py
@@ -1,0 +1,138 @@
+"""Alembic migration `c6d7e8f9a0b1` provider batch schema checks."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from alembic import command
+from alembic.config import Config
+from sqlalchemy import create_engine, inspect, text
+from sqlalchemy.exc import IntegrityError
+
+
+def _make_alembic_config(db_path: Path) -> Config:
+    project_root = Path(__file__).resolve().parents[3]
+    cfg = Config(str(project_root / "alembic.ini"))
+    cfg.set_main_option("script_location", str(project_root / "src/lorairo/database/migrations"))
+    cfg.set_main_option("sqlalchemy.url", f"sqlite:///{db_path}")
+    return cfg
+
+
+def _create_minimal_parent_schema(db_path: Path) -> None:
+    engine = create_engine(f"sqlite:///{db_path}")
+    with engine.begin() as conn:
+        conn.execute(
+            text(
+                """
+                CREATE TABLE models (
+                    id INTEGER NOT NULL PRIMARY KEY,
+                    name VARCHAR NOT NULL,
+                    provider VARCHAR,
+                    discontinued_at TIMESTAMP,
+                    litellm_model_id VARCHAR NOT NULL,
+                    estimated_size_gb FLOAT,
+                    requires_api_key BOOLEAN DEFAULT '0' NOT NULL,
+                    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
+                    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
+                    UNIQUE (litellm_model_id)
+                )
+                """
+            )
+        )
+        conn.execute(
+            text(
+                """
+                CREATE TABLE images (
+                    id INTEGER NOT NULL PRIMARY KEY,
+                    uuid VARCHAR NOT NULL,
+                    phash VARCHAR NOT NULL,
+                    original_image_path VARCHAR NOT NULL,
+                    stored_image_path VARCHAR NOT NULL,
+                    width INTEGER NOT NULL,
+                    height INTEGER NOT NULL,
+                    format VARCHAR NOT NULL,
+                    extension VARCHAR NOT NULL,
+                    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
+                    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
+                    UNIQUE (uuid, phash)
+                )
+                """
+            )
+        )
+        conn.execute(text("CREATE TABLE alembic_version (version_num VARCHAR(32) PRIMARY KEY)"))
+        conn.execute(text("INSERT INTO alembic_version (version_num) VALUES ('b4c5d6e7f8a9')"))
+    engine.dispose()
+
+
+@pytest.mark.unit
+def test_provider_batch_tables_upgrade_and_downgrade(tmp_path: Path) -> None:
+    db = tmp_path / "provider_batch.db"
+    _create_minimal_parent_schema(db)
+    cfg = _make_alembic_config(db)
+
+    command.upgrade(cfg, "c6d7e8f9a0b1")
+
+    engine = create_engine(f"sqlite:///{db}")
+    inspector = inspect(engine)
+    table_names = set(inspector.get_table_names())
+    assert "provider_batch_jobs" in table_names
+    assert "provider_batch_items" in table_names
+    assert "provider_batch_artifacts" in table_names
+
+    job_columns = {col["name"] for col in inspector.get_columns("provider_batch_jobs")}
+    assert {
+        "provider",
+        "provider_job_id",
+        "status",
+        "request_count",
+        "raw_provider_payload",
+        "created_at",
+        "updated_at",
+    }.issubset(job_columns)
+    assert "uq_provider_batch_jobs_provider_job" in {
+        index["name"] for index in inspector.get_indexes("provider_batch_jobs")
+    }
+
+    with engine.begin() as conn:
+        conn.execute(
+            text(
+                """
+                INSERT INTO provider_batch_jobs
+                    (provider, provider_job_id, status)
+                VALUES
+                    ('openai', 'batch_1', 'submitted')
+                """
+            )
+        )
+        with pytest.raises(IntegrityError):
+            conn.execute(
+                text(
+                    """
+                    INSERT INTO provider_batch_jobs
+                        (provider, provider_job_id, status)
+                    VALUES
+                        ('openai', 'batch_1', 'submitted')
+                    """
+                )
+            )
+        conn.execute(
+            text(
+                """
+                INSERT INTO provider_batch_jobs
+                    (provider, provider_job_id, status)
+                VALUES
+                    ('anthropic', 'batch_1', 'submitted')
+                """
+            )
+        )
+    engine.dispose()
+
+    command.downgrade(cfg, "b4c5d6e7f8a9")
+
+    engine = create_engine(f"sqlite:///{db}")
+    table_names = set(inspect(engine).get_table_names())
+    assert "provider_batch_jobs" not in table_names
+    assert "provider_batch_items" not in table_names
+    assert "provider_batch_artifacts" not in table_names
+    engine.dispose()


### PR DESCRIPTION
## Summary
- add ADR 0038 provider batch job ORM models for jobs, items, and artifacts
- add Alembic migration for provider_batch_jobs / provider_batch_items / provider_batch_artifacts
- add repository CRUD for job lifecycle state, item status updates, artifacts, and explicit delete cleanup
- add focused repository and migration tests

Closes #459
Refs #395
Refs #458

## Tests
- uv run pytest tests/unit/database/test_db_repository_provider_batch.py tests/unit/database/test_migration_c6d7e8f9a0b1_provider_batch.py
- uv run ruff check src/lorairo/database/schema.py src/lorairo/database/db_repository.py src/lorairo/database/migrations/versions/c6d7e8f9a0b1_add_provider_batch_job_tables.py tests/unit/database/test_db_repository_provider_batch.py tests/unit/database/test_migration_c6d7e8f9a0b1_provider_batch.py
- uv run ruff format --check src/lorairo/database/schema.py src/lorairo/database/db_repository.py src/lorairo/database/migrations/versions/c6d7e8f9a0b1_add_provider_batch_job_tables.py tests/unit/database/test_db_repository_provider_batch.py tests/unit/database/test_migration_c6d7e8f9a0b1_provider_batch.py
- uv run mypy src/lorairo/database/schema.py src/lorairo/database/db_repository.py
- uv run alembic -c alembic.ini heads