### PR TITLE
feat: add provider batch job service

### DIFF
--- a/src/lorairo/services/__init__.py
+++ b/src/lorairo/services/__init__.py
@@ -7,12 +7,34 @@ from .configuration_service import ConfigurationService
 from .date_formatter import format_datetime_for_display
 from .image_processing_service import ImageProcessingService
 from .model_sync_service import ModelSyncService
+from .provider_batch_service import (
+    BatchSubmitMetadata,
+    InvalidProviderBatchStatusTransition,
+    ProviderBatchAdapter,
+    ProviderBatchAdapterNotFoundError,
+    ProviderBatchArtifactRef,
+    ProviderBatchArtifacts,
+    ProviderBatchError,
+    ProviderBatchJobService,
+    ProviderBatchStatus,
+    ProviderBatchSubmission,
+)
 from .service_container import ServiceContainer, get_service_container
 
 __all__ = [
+    "BatchSubmitMetadata",
     "ConfigurationService",
     "ImageProcessingService",
+    "InvalidProviderBatchStatusTransition",
     "ModelSyncService",
+    "ProviderBatchAdapter",
+    "ProviderBatchAdapterNotFoundError",
+    "ProviderBatchArtifactRef",
+    "ProviderBatchArtifacts",
+    "ProviderBatchError",
+    "ProviderBatchJobService",
+    "ProviderBatchStatus",
+    "ProviderBatchSubmission",
     "ServiceContainer",
     "format_datetime_for_display",
     "get_service_container",

--- a/src/lorairo/services/provider_batch_service.py
+++ b/src/lorairo/services/provider_batch_service.py
@@ -157,6 +157,7 @@ _PROVIDER_STATUS_MAP: dict[str, dict[str, str]] = {
         "JOB_STATE_QUEUED": "validating",
         "JOB_STATE_RUNNING": "running",
         "JOB_STATE_SUCCEEDED": "completed",
+        "JOB_STATE_PARTIALLY_SUCCEEDED": "completed",
         "JOB_STATE_FAILED": "failed",
         "JOB_STATE_CANCELLING": "canceling",
         "JOB_STATE_CANCELLED": "canceled",
@@ -164,6 +165,7 @@ _PROVIDER_STATUS_MAP: dict[str, dict[str, str]] = {
         "pending": "validating",
         "running": "running",
         "succeeded": "completed",
+        "partially_succeeded": "completed",
         "failed": "failed",
         "cancelled": "canceled",
         "canceled": "canceled",
@@ -184,7 +186,7 @@ _ALLOWED_TRANSITIONS: dict[str, set[str]] = {
     "submitted": {"validating", "running", "completed", "failed", "canceling", "canceled", "expired"},
     "validating": {"running", "completed", "failed", "canceling", "canceled", "expired"},
     "running": {"completed", "failed", "canceling", "canceled", "expired"},
-    "canceling": {"canceled", "failed"},
+    "canceling": {"completed", "canceled", "failed"},
     "completed": {"imported"},
     "failed": set(),
     "canceled": set(),
@@ -202,24 +204,27 @@ class ProviderBatchJobService:
         adapters: Mapping[str, ProviderBatchAdapter] | None = None,
     ) -> None:
         self._repository = repository
-        self._adapters = {name.lower(): adapter for name, adapter in (adapters or {}).items()}
+        self._adapters = {
+            self._normalize_provider_name(name): adapter for name, adapter in (adapters or {}).items()
+        }
 
     def register_adapter(self, adapter: ProviderBatchAdapter) -> None:
         """Provider adapter を追加登録する。"""
-        self._adapters[adapter.provider.lower()] = adapter
+        self._adapters[self._normalize_provider_name(adapter.provider)] = adapter
 
     def submit(self, request_file: Path, metadata: BatchSubmitMetadata) -> int:
         """Provider batch job を投入し、DB job を作成する。"""
-        adapter = self._get_adapter(metadata.provider)
+        provider = self._normalize_provider_name(metadata.provider)
+        adapter = self._get_adapter(provider)
         submission = adapter.submit(request_file, metadata)
         status = self.normalize_status(
-            metadata.provider,
+            provider,
             submission.status or submission.provider_status,
         )
 
         job_id = self._repository.create_provider_batch_job(
             {
-                "provider": metadata.provider,
+                "provider": provider,
                 "provider_job_id": submission.provider_job_id,
                 "status": status,
                 "provider_status": submission.provider_status,
@@ -232,12 +237,14 @@ class ProviderBatchJobService:
                 "expires_at": submission.expires_at,
                 "input_artifact_path": metadata.input_artifact_path or str(request_file),
                 "raw_provider_payload": self._serialize_payload(
-                    submission.raw_provider_payload or metadata.raw_provider_payload
+                    submission.raw_provider_payload
+                    if submission.raw_provider_payload is not None
+                    else metadata.raw_provider_payload
                 ),
             }
         )
         logger.info(
-            f"Provider batch job submitted: provider={metadata.provider}, "
+            f"Provider batch job submitted: provider={provider}, "
             f"provider_job_id={submission.provider_job_id}, job_id={job_id}, status={status}"
         )
         return job_id
@@ -271,24 +278,33 @@ class ProviderBatchJobService:
 
         adapter = self._get_adapter(job.provider)
         artifacts = adapter.download_results(job.provider_job_id, destination_dir)
+        self._validate_provider_job_id(job, artifacts.provider_job_id)
 
         updates: dict[str, Any] = {}
+        existing_artifact_keys = {
+            (registered.artifact_type, registered.local_path)
+            for registered in self._repository.list_provider_batch_artifacts(job_id)
+        }
         for artifact in artifacts.artifacts:
-            self._repository.create_provider_batch_artifact(
-                {
-                    "job_id": job_id,
-                    "artifact_type": artifact.artifact_type,
-                    "local_path": str(artifact.local_path),
-                    "provider_file_id": artifact.provider_file_id,
-                    "sha256": artifact.sha256,
-                }
-            )
+            local_path = str(artifact.local_path)
+            artifact_key = (artifact.artifact_type, local_path)
+            if artifact_key not in existing_artifact_keys:
+                self._repository.create_provider_batch_artifact(
+                    {
+                        "job_id": job_id,
+                        "artifact_type": artifact.artifact_type,
+                        "local_path": local_path,
+                        "provider_file_id": artifact.provider_file_id,
+                        "sha256": artifact.sha256,
+                    }
+                )
+                existing_artifact_keys.add(artifact_key)
             if artifact.artifact_type == "input":
-                updates["input_artifact_path"] = str(artifact.local_path)
+                updates["input_artifact_path"] = local_path
             elif artifact.artifact_type == "output":
-                updates["output_artifact_path"] = str(artifact.local_path)
+                updates["output_artifact_path"] = local_path
             elif artifact.artifact_type == "error":
-                updates["error_artifact_path"] = str(artifact.local_path)
+                updates["error_artifact_path"] = local_path
 
         if artifacts.raw_provider_payload is not None:
             updates["raw_provider_payload"] = self._serialize_payload(artifacts.raw_provider_payload)
@@ -304,7 +320,7 @@ class ProviderBatchJobService:
         if status in _COMMON_STATUSES:
             return status
 
-        provider_map = _PROVIDER_STATUS_MAP.get(provider.lower(), {})
+        provider_map = _PROVIDER_STATUS_MAP.get(cls._normalize_provider_name(provider), {})
         normalized = provider_map.get(status) or provider_map.get(status.lower())
         if normalized is None:
             raise ProviderBatchError(
@@ -328,6 +344,7 @@ class ProviderBatchJobService:
     def _apply_status(
         self, job: ProviderBatchJob, provider_status: ProviderBatchStatus
     ) -> ProviderBatchJob:
+        self._validate_provider_job_id(job, provider_status.provider_job_id)
         next_status = self.normalize_status(
             job.provider, provider_status.status or provider_status.provider_status
         )
@@ -336,8 +353,9 @@ class ProviderBatchJobService:
         updates: dict[str, Any] = {
             "status": next_status,
             "provider_status": provider_status.provider_status,
-            "raw_provider_payload": self._serialize_payload(provider_status.raw_provider_payload),
         }
+        if provider_status.raw_provider_payload is not None:
+            updates["raw_provider_payload"] = self._serialize_payload(provider_status.raw_provider_payload)
         optional_fields = {
             "request_count": provider_status.request_count,
             "succeeded_count": provider_status.succeeded_count,
@@ -364,10 +382,22 @@ class ProviderBatchJobService:
         return job
 
     def _get_adapter(self, provider: str) -> ProviderBatchAdapter:
-        adapter = self._adapters.get(provider.lower())
+        adapter = self._adapters.get(self._normalize_provider_name(provider))
         if adapter is None:
             raise ProviderBatchAdapterNotFoundError(f"Provider batch adapter 未登録: {provider}")
         return adapter
+
+    @staticmethod
+    def _validate_provider_job_id(job: ProviderBatchJob, provider_job_id: str) -> None:
+        if job.provider_job_id != provider_job_id:
+            raise ProviderBatchError(
+                "Provider batch adapter response job ID mismatch: "
+                f"job_id={job.id}, expected={job.provider_job_id}, actual={provider_job_id}"
+            )
+
+    @staticmethod
+    def _normalize_provider_name(provider: str) -> str:
+        return provider.strip().lower()
 
     @staticmethod
     def _serialize_payload(payload: ProviderBatchRawPayload) -> str | None:

--- a/src/lorairo/services/provider_batch_service.py
+++ b/src/lorairo/services/provider_batch_service.py
@@ -1,0 +1,378 @@
+"""Provider Batch API job service boundary.
+
+ADR 0038 の共通 job lifecycle 層。ここでは provider 実 API は実装せず、
+OpenAI / Anthropic / Google adapter を差し替え可能な Protocol と永続 job 更新を扱う。
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Protocol
+
+from lorairo.database.db_repository import ImageRepository
+from lorairo.database.schema import ProviderBatchJob
+from lorairo.utils.log import logger
+
+ProviderBatchRawPayload = Mapping[str, Any] | str | None
+
+
+class ProviderBatchError(RuntimeError):
+    """Provider Batch service の基底例外。"""
+
+
+class ProviderBatchAdapterNotFoundError(ProviderBatchError):
+    """指定 provider の adapter が登録されていない。"""
+
+
+class InvalidProviderBatchStatusTransition(ProviderBatchError):
+    """Provider Batch job status transition が許可されていない。"""
+
+
+@dataclass(frozen=True)
+class BatchSubmitMetadata:
+    """Provider batch submit 時に LoRAIro 側から渡す metadata。"""
+
+    provider: str
+    endpoint: str | None = None
+    model_id: int | None = None
+    request_count: int = 0
+    input_artifact_path: str | None = None
+    raw_provider_payload: ProviderBatchRawPayload = None
+
+
+@dataclass(frozen=True)
+class ProviderBatchSubmission:
+    """Provider adapter の submit 結果。"""
+
+    provider_job_id: str
+    provider_status: str
+    status: str | None = None
+    request_count: int | None = None
+    submitted_at: datetime | None = None
+    expires_at: datetime | None = None
+    raw_provider_payload: ProviderBatchRawPayload = None
+
+
+@dataclass(frozen=True)
+class ProviderBatchStatus:
+    """Provider adapter の retrieve / cancel 結果。"""
+
+    provider_job_id: str
+    provider_status: str
+    status: str | None = None
+    request_count: int | None = None
+    succeeded_count: int | None = None
+    failed_count: int | None = None
+    canceled_count: int | None = None
+    expired_count: int | None = None
+    submitted_at: datetime | None = None
+    completed_at: datetime | None = None
+    canceled_at: datetime | None = None
+    expires_at: datetime | None = None
+    raw_provider_payload: ProviderBatchRawPayload = None
+
+
+@dataclass(frozen=True)
+class ProviderBatchArtifactRef:
+    """Downloaded provider batch artifact metadata."""
+
+    artifact_type: str
+    local_path: Path
+    provider_file_id: str | None = None
+    sha256: str | None = None
+
+
+@dataclass(frozen=True)
+class ProviderBatchArtifacts:
+    """Provider adapter の download_results 結果。"""
+
+    provider_job_id: str
+    artifacts: tuple[ProviderBatchArtifactRef, ...] = field(default_factory=tuple)
+    raw_provider_payload: ProviderBatchRawPayload = None
+
+
+class ProviderBatchAdapter(Protocol):
+    """Provider Batch API adapter interface."""
+
+    provider: str
+
+    def submit(self, request_file: Path, metadata: BatchSubmitMetadata) -> ProviderBatchSubmission:
+        """Provider batch job を投入する。"""
+        ...
+
+    def retrieve(self, provider_job_id: str) -> ProviderBatchStatus:
+        """Provider batch job の最新状態を取得する。"""
+        ...
+
+    def cancel(self, provider_job_id: str) -> ProviderBatchStatus:
+        """Provider batch job を cancel する。"""
+        ...
+
+    def download_results(self, provider_job_id: str, destination_dir: Path) -> ProviderBatchArtifacts:
+        """Provider batch job の output/error artifacts を download する。"""
+        ...
+
+
+_COMMON_STATUSES = {
+    "draft",
+    "submitted",
+    "validating",
+    "running",
+    "completed",
+    "failed",
+    "canceling",
+    "canceled",
+    "expired",
+    "imported",
+}
+
+_PROVIDER_STATUS_MAP: dict[str, dict[str, str]] = {
+    "openai": {
+        "validating": "validating",
+        "in_progress": "running",
+        "finalizing": "running",
+        "completed": "completed",
+        "failed": "failed",
+        "expired": "expired",
+        "cancelling": "canceling",
+        "canceling": "canceling",
+        "cancelled": "canceled",
+        "canceled": "canceled",
+    },
+    "anthropic": {
+        "in_progress": "running",
+        "canceling": "canceling",
+        "canceled": "canceled",
+        "ended": "completed",
+        "completed": "completed",
+        "failed": "failed",
+        "expired": "expired",
+    },
+    "google": {
+        "JOB_STATE_PENDING": "validating",
+        "JOB_STATE_QUEUED": "validating",
+        "JOB_STATE_RUNNING": "running",
+        "JOB_STATE_SUCCEEDED": "completed",
+        "JOB_STATE_FAILED": "failed",
+        "JOB_STATE_CANCELLING": "canceling",
+        "JOB_STATE_CANCELLED": "canceled",
+        "JOB_STATE_EXPIRED": "expired",
+        "pending": "validating",
+        "running": "running",
+        "succeeded": "completed",
+        "failed": "failed",
+        "cancelled": "canceled",
+        "canceled": "canceled",
+    },
+}
+
+_ALLOWED_TRANSITIONS: dict[str, set[str]] = {
+    "draft": {
+        "submitted",
+        "validating",
+        "running",
+        "completed",
+        "failed",
+        "canceling",
+        "canceled",
+        "expired",
+    },
+    "submitted": {"validating", "running", "completed", "failed", "canceling", "canceled", "expired"},
+    "validating": {"running", "completed", "failed", "canceling", "canceled", "expired"},
+    "running": {"completed", "failed", "canceling", "canceled", "expired"},
+    "canceling": {"canceled", "failed"},
+    "completed": {"imported"},
+    "failed": set(),
+    "canceled": set(),
+    "expired": set(),
+    "imported": set(),
+}
+
+
+class ProviderBatchJobService:
+    """Provider Batch API job lifecycle service."""
+
+    def __init__(
+        self,
+        repository: ImageRepository,
+        adapters: Mapping[str, ProviderBatchAdapter] | None = None,
+    ) -> None:
+        self._repository = repository
+        self._adapters = {name.lower(): adapter for name, adapter in (adapters or {}).items()}
+
+    def register_adapter(self, adapter: ProviderBatchAdapter) -> None:
+        """Provider adapter を追加登録する。"""
+        self._adapters[adapter.provider.lower()] = adapter
+
+    def submit(self, request_file: Path, metadata: BatchSubmitMetadata) -> int:
+        """Provider batch job を投入し、DB job を作成する。"""
+        adapter = self._get_adapter(metadata.provider)
+        submission = adapter.submit(request_file, metadata)
+        status = self.normalize_status(
+            metadata.provider,
+            submission.status or submission.provider_status,
+        )
+
+        job_id = self._repository.create_provider_batch_job(
+            {
+                "provider": metadata.provider,
+                "provider_job_id": submission.provider_job_id,
+                "status": status,
+                "provider_status": submission.provider_status,
+                "endpoint": metadata.endpoint,
+                "model_id": metadata.model_id,
+                "request_count": submission.request_count
+                if submission.request_count is not None
+                else metadata.request_count,
+                "submitted_at": submission.submitted_at,
+                "expires_at": submission.expires_at,
+                "input_artifact_path": metadata.input_artifact_path or str(request_file),
+                "raw_provider_payload": self._serialize_payload(
+                    submission.raw_provider_payload or metadata.raw_provider_payload
+                ),
+            }
+        )
+        logger.info(
+            f"Provider batch job submitted: provider={metadata.provider}, "
+            f"provider_job_id={submission.provider_job_id}, job_id={job_id}, status={status}"
+        )
+        return job_id
+
+    def refresh(self, job_id: int) -> ProviderBatchJob:
+        """Provider から最新 status を取得し、DB job を更新する。"""
+        job = self._require_job(job_id)
+        if job.provider_job_id is None:
+            raise ProviderBatchError(f"provider_job_id が未設定です: job_id={job_id}")
+
+        adapter = self._get_adapter(job.provider)
+        provider_status = adapter.retrieve(job.provider_job_id)
+        return self._apply_status(job, provider_status)
+
+    def cancel(self, job_id: int) -> ProviderBatchJob:
+        """Provider batch job を cancel し、DB job を更新する。"""
+        job = self._require_job(job_id)
+        if job.provider_job_id is None:
+            raise ProviderBatchError(f"provider_job_id が未設定です: job_id={job_id}")
+        self.validate_transition(job.status, "canceling")
+
+        adapter = self._get_adapter(job.provider)
+        provider_status = adapter.cancel(job.provider_job_id)
+        return self._apply_status(job, provider_status)
+
+    def download_results(self, job_id: int, destination_dir: Path) -> ProviderBatchArtifacts:
+        """Provider result artifacts を download し、artifact records を保存する。"""
+        job = self._require_job(job_id)
+        if job.provider_job_id is None:
+            raise ProviderBatchError(f"provider_job_id が未設定です: job_id={job_id}")
+
+        adapter = self._get_adapter(job.provider)
+        artifacts = adapter.download_results(job.provider_job_id, destination_dir)
+
+        updates: dict[str, Any] = {}
+        for artifact in artifacts.artifacts:
+            self._repository.create_provider_batch_artifact(
+                {
+                    "job_id": job_id,
+                    "artifact_type": artifact.artifact_type,
+                    "local_path": str(artifact.local_path),
+                    "provider_file_id": artifact.provider_file_id,
+                    "sha256": artifact.sha256,
+                }
+            )
+            if artifact.artifact_type == "input":
+                updates["input_artifact_path"] = str(artifact.local_path)
+            elif artifact.artifact_type == "output":
+                updates["output_artifact_path"] = str(artifact.local_path)
+            elif artifact.artifact_type == "error":
+                updates["error_artifact_path"] = str(artifact.local_path)
+
+        if artifacts.raw_provider_payload is not None:
+            updates["raw_provider_payload"] = self._serialize_payload(artifacts.raw_provider_payload)
+        if updates:
+            self._repository.update_provider_batch_job(job_id, updates)
+
+        return artifacts
+
+    @classmethod
+    def normalize_status(cls, provider: str, provider_status: str) -> str:
+        """provider 固有 status を ADR 0038 共通 status に変換する。"""
+        status = provider_status.strip()
+        if status in _COMMON_STATUSES:
+            return status
+
+        provider_map = _PROVIDER_STATUS_MAP.get(provider.lower(), {})
+        normalized = provider_map.get(status) or provider_map.get(status.lower())
+        if normalized is None:
+            raise ProviderBatchError(
+                f"未対応の provider status: provider={provider}, status={provider_status}"
+            )
+        return normalized
+
+    @classmethod
+    def validate_transition(cls, current_status: str, next_status: str) -> None:
+        """ADR 0038 共通 status transition を検証する。"""
+        if current_status == next_status:
+            return
+        allowed = _ALLOWED_TRANSITIONS.get(current_status)
+        if allowed is None:
+            raise ProviderBatchError(f"未対応の現在 status: {current_status}")
+        if next_status not in allowed:
+            raise InvalidProviderBatchStatusTransition(
+                f"Provider batch status transition は許可されていません: {current_status} -> {next_status}"
+            )
+
+    def _apply_status(
+        self, job: ProviderBatchJob, provider_status: ProviderBatchStatus
+    ) -> ProviderBatchJob:
+        next_status = self.normalize_status(
+            job.provider, provider_status.status or provider_status.provider_status
+        )
+        self.validate_transition(job.status, next_status)
+
+        updates: dict[str, Any] = {
+            "status": next_status,
+            "provider_status": provider_status.provider_status,
+            "raw_provider_payload": self._serialize_payload(provider_status.raw_provider_payload),
+        }
+        optional_fields = {
+            "request_count": provider_status.request_count,
+            "succeeded_count": provider_status.succeeded_count,
+            "failed_count": provider_status.failed_count,
+            "canceled_count": provider_status.canceled_count,
+            "expired_count": provider_status.expired_count,
+            "submitted_at": provider_status.submitted_at,
+            "completed_at": provider_status.completed_at,
+            "canceled_at": provider_status.canceled_at,
+            "expires_at": provider_status.expires_at,
+        }
+        updates.update({key: value for key, value in optional_fields.items() if value is not None})
+
+        self._repository.update_provider_batch_job(job.id, updates)
+        refreshed = self._repository.get_provider_batch_job(job.id)
+        if refreshed is None:
+            raise ProviderBatchError(f"更新後の provider batch job が見つかりません: job_id={job.id}")
+        return refreshed
+
+    def _require_job(self, job_id: int) -> ProviderBatchJob:
+        job = self._repository.get_provider_batch_job(job_id)
+        if job is None:
+            raise ProviderBatchError(f"Provider batch job が見つかりません: job_id={job_id}")
+        return job
+
+    def _get_adapter(self, provider: str) -> ProviderBatchAdapter:
+        adapter = self._adapters.get(provider.lower())
+        if adapter is None:
+            raise ProviderBatchAdapterNotFoundError(f"Provider batch adapter 未登録: {provider}")
+        return adapter
+
+    @staticmethod
+    def _serialize_payload(payload: ProviderBatchRawPayload) -> str | None:
+        if payload is None:
+            return None
+        if isinstance(payload, str):
+            return payload
+        return json.dumps(payload, ensure_ascii=False, sort_keys=True)

--- a/tests/unit/database/test_migration_a7b8c9d0e1f2_score_labels.py
+++ b/tests/unit/database/test_migration_a7b8c9d0e1f2_score_labels.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import pytest
 from alembic import command
 from alembic.config import Config
+from alembic.script import ScriptDirectory
 from sqlalchemy import create_engine, inspect, text
 
 
@@ -17,6 +18,12 @@ def _make_alembic_config(db_path: Path) -> Config:
     cfg.set_main_option("script_location", str(project_root / "src/lorairo/database/migrations"))
     cfg.set_main_option("sqlalchemy.url", f"sqlite:///{db_path}")
     return cfg
+
+
+def _get_current_head(cfg: Config) -> str:
+    heads = ScriptDirectory.from_config(cfg).get_heads()
+    assert len(heads) == 1
+    return heads[0]
 
 
 def _create_d8_schema_with_precreated_score_labels(db_path: Path) -> None:
@@ -111,8 +118,9 @@ def test_score_labels_migration_converges_when_table_was_precreated(tmp_path: Pa
     """Upgrade succeeds even if create_all already added score_labels."""
     db_path = tmp_path / "stale.db"
     _create_d8_schema_with_precreated_score_labels(db_path)
+    cfg = _make_alembic_config(db_path)
 
-    command.upgrade(_make_alembic_config(db_path), "head")
+    command.upgrade(cfg, "head")
 
     engine = create_engine(f"sqlite:///{db_path}")
     inspector = inspect(engine)
@@ -121,7 +129,7 @@ def test_score_labels_migration_converges_when_table_was_precreated(tmp_path: Pa
         version = conn.execute(text("SELECT version_num FROM alembic_version")).scalar_one()
     engine.dispose()
 
-    assert version == "b4c5d6e7f8a9"
+    assert version == _get_current_head(cfg)
     assert "ix_score_labels_image_id" in indexes
 
 
@@ -132,6 +140,7 @@ def test_project_database_prepare_upgrades_alembic_managed_db(tmp_path: Path) ->
 
     db_path = tmp_path / "project.db"
     _create_d8_schema_with_precreated_score_labels(db_path)
+    cfg = _make_alembic_config(db_path)
 
     engine = _prepare_project_database(db_path)
     engine.dispose()
@@ -142,7 +151,7 @@ def test_project_database_prepare_upgrades_alembic_managed_db(tmp_path: Path) ->
         score_label_count = conn.execute(text("SELECT count(*) FROM score_labels")).scalar_one()
     engine.dispose()
 
-    assert version == "b4c5d6e7f8a9"
+    assert version == _get_current_head(cfg)
     assert score_label_count == 0
 
 

--- a/tests/unit/database/test_migration_f1b2c3d4e5f6_ratings_backfill.py
+++ b/tests/unit/database/test_migration_f1b2c3d4e5f6_ratings_backfill.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import pytest
 from alembic import command
 from alembic.config import Config
+from alembic.script import ScriptDirectory
 from sqlalchemy import create_engine, text
 
 
@@ -17,6 +18,12 @@ def _make_alembic_config(db_path: Path) -> Config:
     cfg.set_main_option("script_location", str(project_root / "src/lorairo/database/migrations"))
     cfg.set_main_option("sqlalchemy.url", f"sqlite:///{db_path}")
     return cfg
+
+
+def _get_current_head(cfg: Config) -> str:
+    heads = ScriptDirectory.from_config(cfg).get_heads()
+    assert len(heads) == 1
+    return heads[0]
 
 
 def _create_schema_at_f0(db_path: Path) -> None:
@@ -93,8 +100,9 @@ def _create_schema_at_f0(db_path: Path) -> None:
 def test_ratings_backfill_adds_associations_for_known_rating_models(tmp_path: Path) -> None:
     db_path = tmp_path / "ratings-backfill.db"
     _create_schema_at_f0(db_path)
+    cfg = _make_alembic_config(db_path)
 
-    command.upgrade(_make_alembic_config(db_path), "head")
+    command.upgrade(cfg, "head")
 
     engine = create_engine(f"sqlite:///{db_path}")
     with engine.connect() as conn:
@@ -113,7 +121,7 @@ def test_ratings_backfill_adds_associations_for_known_rating_models(tmp_path: Pa
         version = conn.execute(text("SELECT version_num FROM alembic_version")).scalar_one()
     engine.dispose()
 
-    assert version == "b4c5d6e7f8a9"
+    assert version == _get_current_head(cfg)
     assert rows == [
         ("wd-vit-tagger-v3", "tags,ratings"),
         ("Z3D-E621-Convnext", "tags,ratings"),

--- a/tests/unit/services/test_provider_batch_service.py
+++ b/tests/unit/services/test_provider_batch_service.py
@@ -1,0 +1,192 @@
+"""ProviderBatchJobService tests."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+
+from lorairo.database.db_repository import ImageRepository
+from lorairo.services.provider_batch_service import (
+    BatchSubmitMetadata,
+    InvalidProviderBatchStatusTransition,
+    ProviderBatchAdapterNotFoundError,
+    ProviderBatchArtifactRef,
+    ProviderBatchArtifacts,
+    ProviderBatchError,
+    ProviderBatchJobService,
+    ProviderBatchStatus,
+    ProviderBatchSubmission,
+)
+
+
+class FakeProviderBatchAdapter:
+    provider = "openai"
+
+    def __init__(self) -> None:
+        self.submission = ProviderBatchSubmission(
+            provider_job_id="batch_123",
+            provider_status="validating",
+            request_count=2,
+            submitted_at=datetime(2026, 5, 25, tzinfo=UTC),
+            raw_provider_payload={"id": "batch_123", "status": "validating"},
+        )
+        self.retrieve_status = ProviderBatchStatus(
+            provider_job_id="batch_123",
+            provider_status="completed",
+            request_count=2,
+            succeeded_count=2,
+            failed_count=0,
+            completed_at=datetime(2026, 5, 25, 1, tzinfo=UTC),
+            raw_provider_payload={"id": "batch_123", "status": "completed"},
+        )
+        self.cancel_status = ProviderBatchStatus(
+            provider_job_id="batch_123",
+            provider_status="cancelled",
+            canceled_count=2,
+            canceled_at=datetime(2026, 5, 25, 1, tzinfo=UTC),
+            raw_provider_payload={"id": "batch_123", "status": "cancelled"},
+        )
+        self.artifacts = ProviderBatchArtifacts(
+            provider_job_id="batch_123",
+            artifacts=(
+                ProviderBatchArtifactRef("output", Path("/tmp/output.jsonl"), "file_out", "abc"),
+                ProviderBatchArtifactRef("error", Path("/tmp/error.jsonl"), "file_err", "def"),
+            ),
+            raw_provider_payload={"output_file_id": "file_out"},
+        )
+
+    def submit(self, request_file: Path, metadata: BatchSubmitMetadata) -> ProviderBatchSubmission:
+        return self.submission
+
+    def retrieve(self, provider_job_id: str) -> ProviderBatchStatus:
+        return self.retrieve_status
+
+    def cancel(self, provider_job_id: str) -> ProviderBatchStatus:
+        return self.cancel_status
+
+    def download_results(self, provider_job_id: str, destination_dir: Path) -> ProviderBatchArtifacts:
+        return self.artifacts
+
+
+@pytest.mark.unit
+class TestProviderBatchStatusMapping:
+    def test_openai_status_mapping(self) -> None:
+        assert ProviderBatchJobService.normalize_status("openai", "validating") == "validating"
+        assert ProviderBatchJobService.normalize_status("openai", "in_progress") == "running"
+        assert ProviderBatchJobService.normalize_status("openai", "finalizing") == "running"
+        assert ProviderBatchJobService.normalize_status("openai", "completed") == "completed"
+        assert ProviderBatchJobService.normalize_status("openai", "cancelled") == "canceled"
+
+    def test_anthropic_status_mapping(self) -> None:
+        assert ProviderBatchJobService.normalize_status("anthropic", "in_progress") == "running"
+        assert ProviderBatchJobService.normalize_status("anthropic", "ended") == "completed"
+
+    def test_google_status_mapping(self) -> None:
+        assert ProviderBatchJobService.normalize_status("google", "JOB_STATE_PENDING") == "validating"
+        assert ProviderBatchJobService.normalize_status("google", "JOB_STATE_RUNNING") == "running"
+        assert ProviderBatchJobService.normalize_status("google", "JOB_STATE_SUCCEEDED") == "completed"
+
+    def test_unknown_status_raises(self) -> None:
+        with pytest.raises(ProviderBatchError):
+            ProviderBatchJobService.normalize_status("openai", "mystery")
+
+    def test_invalid_transition_raises(self) -> None:
+        ProviderBatchJobService.validate_transition("running", "completed")
+        ProviderBatchJobService.validate_transition("completed", "completed")
+
+        with pytest.raises(InvalidProviderBatchStatusTransition):
+            ProviderBatchJobService.validate_transition("completed", "running")
+
+
+@pytest.mark.unit
+class TestProviderBatchJobService:
+    def test_submit_creates_job_with_normalized_status_and_raw_payload(
+        self,
+        test_repository: ImageRepository,
+    ) -> None:
+        adapter = FakeProviderBatchAdapter()
+        service = ProviderBatchJobService(test_repository, {"openai": adapter})
+
+        job_id = service.submit(
+            Path("/tmp/input.jsonl"),
+            BatchSubmitMetadata(provider="openai", endpoint="/v1/responses", request_count=1),
+        )
+
+        job = test_repository.get_provider_batch_job(job_id)
+        assert job is not None
+        assert job.provider == "openai"
+        assert job.provider_job_id == "batch_123"
+        assert job.status == "validating"
+        assert job.provider_status == "validating"
+        assert job.endpoint == "/v1/responses"
+        assert job.request_count == 2
+        assert job.input_artifact_path == "/tmp/input.jsonl"
+        assert job.raw_provider_payload == '{"id": "batch_123", "status": "validating"}'
+
+    def test_refresh_updates_job_status_counts_and_raw_payload(
+        self,
+        test_repository: ImageRepository,
+    ) -> None:
+        adapter = FakeProviderBatchAdapter()
+        service = ProviderBatchJobService(test_repository, {"openai": adapter})
+        job_id = service.submit(Path("/tmp/input.jsonl"), BatchSubmitMetadata(provider="openai"))
+
+        refreshed = service.refresh(job_id)
+
+        assert refreshed.status == "completed"
+        assert refreshed.provider_status == "completed"
+        assert refreshed.succeeded_count == 2
+        assert refreshed.failed_count == 0
+        assert refreshed.raw_provider_payload == '{"id": "batch_123", "status": "completed"}'
+
+    def test_cancel_validates_transition_and_updates_job(
+        self,
+        test_repository: ImageRepository,
+    ) -> None:
+        adapter = FakeProviderBatchAdapter()
+        adapter.submission = replace(adapter.submission, provider_status="in_progress")
+        service = ProviderBatchJobService(test_repository, {"openai": adapter})
+        job_id = service.submit(Path("/tmp/input.jsonl"), BatchSubmitMetadata(provider="openai"))
+
+        canceled = service.cancel(job_id)
+
+        assert canceled.status == "canceled"
+        assert canceled.provider_status == "cancelled"
+        assert canceled.canceled_count == 2
+
+    def test_cancel_rejects_completed_job(self, test_repository: ImageRepository) -> None:
+        adapter = FakeProviderBatchAdapter()
+        service = ProviderBatchJobService(test_repository, {"openai": adapter})
+        job_id = service.submit(Path("/tmp/input.jsonl"), BatchSubmitMetadata(provider="openai"))
+        service.refresh(job_id)
+
+        with pytest.raises(InvalidProviderBatchStatusTransition):
+            service.cancel(job_id)
+
+    def test_download_results_registers_artifacts_and_updates_paths(
+        self,
+        test_repository: ImageRepository,
+    ) -> None:
+        adapter = FakeProviderBatchAdapter()
+        service = ProviderBatchJobService(test_repository, {"openai": adapter})
+        job_id = service.submit(Path("/tmp/input.jsonl"), BatchSubmitMetadata(provider="openai"))
+
+        artifacts = service.download_results(job_id, Path("/tmp"))
+
+        assert len(artifacts.artifacts) == 2
+        registered = test_repository.list_provider_batch_artifacts(job_id)
+        assert [artifact.artifact_type for artifact in registered] == ["output", "error"]
+        job = test_repository.get_provider_batch_job(job_id)
+        assert job is not None
+        assert job.output_artifact_path == "/tmp/output.jsonl"
+        assert job.error_artifact_path == "/tmp/error.jsonl"
+        assert job.raw_provider_payload == '{"output_file_id": "file_out"}'
+
+    def test_missing_adapter_raises(self, test_repository: ImageRepository) -> None:
+        service = ProviderBatchJobService(test_repository)
+
+        with pytest.raises(ProviderBatchAdapterNotFoundError):
+            service.submit(Path("/tmp/input.jsonl"), BatchSubmitMetadata(provider="openai"))

--- a/tests/unit/services/test_provider_batch_service.py
+++ b/tests/unit/services/test_provider_batch_service.py
@@ -88,6 +88,9 @@ class TestProviderBatchStatusMapping:
         assert ProviderBatchJobService.normalize_status("google", "JOB_STATE_PENDING") == "validating"
         assert ProviderBatchJobService.normalize_status("google", "JOB_STATE_RUNNING") == "running"
         assert ProviderBatchJobService.normalize_status("google", "JOB_STATE_SUCCEEDED") == "completed"
+        assert ProviderBatchJobService.normalize_status("google", "JOB_STATE_PARTIALLY_SUCCEEDED") == (
+            "completed"
+        )
 
     def test_unknown_status_raises(self) -> None:
         with pytest.raises(ProviderBatchError):
@@ -95,6 +98,7 @@ class TestProviderBatchStatusMapping:
 
     def test_invalid_transition_raises(self) -> None:
         ProviderBatchJobService.validate_transition("running", "completed")
+        ProviderBatchJobService.validate_transition("canceling", "completed")
         ProviderBatchJobService.validate_transition("completed", "completed")
 
         with pytest.raises(InvalidProviderBatchStatusTransition):
@@ -126,6 +130,43 @@ class TestProviderBatchJobService:
         assert job.input_artifact_path == "/tmp/input.jsonl"
         assert job.raw_provider_payload == '{"id": "batch_123", "status": "validating"}'
 
+    def test_submit_preserves_empty_submission_payload(
+        self,
+        test_repository: ImageRepository,
+    ) -> None:
+        adapter = FakeProviderBatchAdapter()
+        adapter.submission = replace(adapter.submission, raw_provider_payload={})
+        service = ProviderBatchJobService(test_repository, {"openai": adapter})
+
+        job_id = service.submit(
+            Path("/tmp/input.jsonl"),
+            BatchSubmitMetadata(provider="openai", raw_provider_payload={"request": "metadata"}),
+        )
+
+        job = test_repository.get_provider_batch_job(job_id)
+        assert job is not None
+        assert job.raw_provider_payload == "{}"
+
+    def test_submit_normalizes_provider_before_persisting(
+        self,
+        test_repository: ImageRepository,
+    ) -> None:
+        adapter = FakeProviderBatchAdapter()
+        service = ProviderBatchJobService(test_repository, {"openai": adapter})
+
+        job_id = service.submit(
+            Path("/tmp/input.jsonl"),
+            BatchSubmitMetadata(provider=" OpenAI ", endpoint="/v1/responses"),
+        )
+
+        job = test_repository.get_provider_batch_job(job_id)
+        assert job is not None
+        assert job.provider == "openai"
+        assert test_repository.get_provider_batch_job_by_provider_id("openai", "batch_123") is not None
+        assert [listed.id for listed in test_repository.list_provider_batch_jobs(provider="openai")] == [
+            job_id
+        ]
+
     def test_refresh_updates_job_status_counts_and_raw_payload(
         self,
         test_repository: ImageRepository,
@@ -141,6 +182,87 @@ class TestProviderBatchJobService:
         assert refreshed.succeeded_count == 2
         assert refreshed.failed_count == 0
         assert refreshed.raw_provider_payload == '{"id": "batch_123", "status": "completed"}'
+
+    def test_refresh_preserves_anthropic_terminal_counts_when_ended(
+        self,
+        test_repository: ImageRepository,
+    ) -> None:
+        adapter = FakeProviderBatchAdapter()
+        adapter.provider = "anthropic"
+        adapter.submission = replace(adapter.submission, provider_status="in_progress")
+        adapter.retrieve_status = replace(
+            adapter.retrieve_status,
+            provider_status="ended",
+            succeeded_count=1,
+            failed_count=1,
+            canceled_count=0,
+            expired_count=0,
+        )
+        service = ProviderBatchJobService(test_repository, {"anthropic": adapter})
+        job_id = service.submit(Path("/tmp/input.jsonl"), BatchSubmitMetadata(provider="anthropic"))
+
+        refreshed = service.refresh(job_id)
+
+        assert refreshed.status == "completed"
+        assert refreshed.provider_status == "ended"
+        assert refreshed.succeeded_count == 1
+        assert refreshed.failed_count == 1
+
+    def test_refresh_allows_anthropic_canceling_to_end_as_completed(
+        self,
+        test_repository: ImageRepository,
+    ) -> None:
+        adapter = FakeProviderBatchAdapter()
+        adapter.provider = "anthropic"
+        adapter.submission = replace(adapter.submission, provider_status="in_progress")
+        adapter.cancel_status = replace(adapter.cancel_status, provider_status="canceling")
+        adapter.retrieve_status = replace(
+            adapter.retrieve_status,
+            provider_status="ended",
+            succeeded_count=0,
+            failed_count=0,
+            canceled_count=2,
+        )
+        service = ProviderBatchJobService(test_repository, {"anthropic": adapter})
+        job_id = service.submit(Path("/tmp/input.jsonl"), BatchSubmitMetadata(provider="anthropic"))
+
+        canceling = service.cancel(job_id)
+        refreshed = service.refresh(job_id)
+
+        assert canceling.status == "canceling"
+        assert refreshed.status == "completed"
+        assert refreshed.provider_status == "ended"
+        assert refreshed.canceled_count == 2
+
+    def test_refresh_preserves_raw_payload_when_provider_omits_payload(
+        self,
+        test_repository: ImageRepository,
+    ) -> None:
+        adapter = FakeProviderBatchAdapter()
+        adapter.retrieve_status = replace(adapter.retrieve_status, raw_provider_payload=None)
+        service = ProviderBatchJobService(test_repository, {"openai": adapter})
+        job_id = service.submit(Path("/tmp/input.jsonl"), BatchSubmitMetadata(provider="openai"))
+
+        refreshed = service.refresh(job_id)
+
+        assert refreshed.status == "completed"
+        assert refreshed.raw_provider_payload == '{"id": "batch_123", "status": "validating"}'
+
+    def test_refresh_rejects_mismatched_provider_job_id(
+        self,
+        test_repository: ImageRepository,
+    ) -> None:
+        adapter = FakeProviderBatchAdapter()
+        adapter.retrieve_status = replace(adapter.retrieve_status, provider_job_id="batch_other")
+        service = ProviderBatchJobService(test_repository, {"openai": adapter})
+        job_id = service.submit(Path("/tmp/input.jsonl"), BatchSubmitMetadata(provider="openai"))
+
+        with pytest.raises(ProviderBatchError, match="job ID mismatch"):
+            service.refresh(job_id)
+
+        job = test_repository.get_provider_batch_job(job_id)
+        assert job is not None
+        assert job.status == "validating"
 
     def test_cancel_validates_transition_and_updates_job(
         self,
@@ -184,6 +306,35 @@ class TestProviderBatchJobService:
         assert job.output_artifact_path == "/tmp/output.jsonl"
         assert job.error_artifact_path == "/tmp/error.jsonl"
         assert job.raw_provider_payload == '{"output_file_id": "file_out"}'
+
+    def test_download_results_is_idempotent_for_existing_artifacts(
+        self,
+        test_repository: ImageRepository,
+    ) -> None:
+        adapter = FakeProviderBatchAdapter()
+        service = ProviderBatchJobService(test_repository, {"openai": adapter})
+        job_id = service.submit(Path("/tmp/input.jsonl"), BatchSubmitMetadata(provider="openai"))
+
+        service.download_results(job_id, Path("/tmp"))
+        service.download_results(job_id, Path("/tmp"))
+
+        registered = test_repository.list_provider_batch_artifacts(job_id)
+        assert len(registered) == 2
+        assert [artifact.artifact_type for artifact in registered] == ["output", "error"]
+
+    def test_download_results_rejects_mismatched_provider_job_id(
+        self,
+        test_repository: ImageRepository,
+    ) -> None:
+        adapter = FakeProviderBatchAdapter()
+        adapter.artifacts = replace(adapter.artifacts, provider_job_id="batch_other")
+        service = ProviderBatchJobService(test_repository, {"openai": adapter})
+        job_id = service.submit(Path("/tmp/input.jsonl"), BatchSubmitMetadata(provider="openai"))
+
+        with pytest.raises(ProviderBatchError, match="job ID mismatch"):
+            service.download_results(job_id, Path("/tmp"))
+
+        assert test_repository.list_provider_batch_artifacts(job_id) == []
 
     def test_missing_adapter_raises(self, test_repository: ImageRepository) -> None:
         service = ProviderBatchJobService(test_repository)


### PR DESCRIPTION
## Summary
- add ProviderBatchAdapter Protocol and shared DTOs for submit/retrieve/cancel/download results
- add ProviderBatchJobService to submit jobs, refresh status, cancel jobs, download artifacts, and persist raw provider payloads
- add OpenAI / Anthropic / Google provider status normalization to ADR 0038 common statuses
- add status transition validation with InvalidProviderBatchStatusTransition
- export the service boundary from lorairo.services

Closes #460
Refs #395
Refs #458
Depends on #459

## Tests
- uv run pytest tests/unit/services/test_provider_batch_service.py
- uv run ruff check src/lorairo/services/provider_batch_service.py src/lorairo/services/__init__.py tests/unit/services/test_provider_batch_service.py
- uv run ruff format --check src/lorairo/services/provider_batch_service.py src/lorairo/services/__init__.py tests/unit/services/test_provider_batch_service.py
- uv run mypy src/lorairo/services/provider_batch_service.py