### PR TITLE
refactor: extract ModelRepository (#423 段階 1, ADR 0035)

### DIFF
--- a/src/lorairo/database/db_manager.py
+++ b/src/lorairo/database/db_manager.py
@@ -22,6 +22,7 @@ from .db_repository import (
     TagAnnotationData,
 )
 from .filter_criteria import ImageFilterCriteria
+from .repository.model import ModelRepository
 
 if TYPE_CHECKING:
     from ..services.configuration_service import ConfigurationService
@@ -38,6 +39,7 @@ class ImageDatabaseManager:
         repository: ImageRepository,
         config_service: "ConfigurationService",
         fsm: FileSystemManager | None = None,
+        model_repo: ModelRepository | None = None,
     ):
         """ImageDatabaseManagerのコンストラクタ。
 
@@ -45,11 +47,27 @@ class ImageDatabaseManager:
             repository (ImageRepository): 使用するImageRepositoryインスタンス。
             config_service (ConfigurationService): 設定サービスインスタンス。
             fsm (FileSystemManager): ファイルシステムマネージャー（オプション）。
+            model_repo (ModelRepository): Model 関連の Repository (ADR 0035 段階 1)。
+                None の場合は `repository` の `session_factory` を流用して生成する。
+                テスト時にモック化可能。
 
         """
         self.repository = repository
         self.config_service = config_service
         self.fsm = fsm
+        # ADR 0035 段階 1 (#423): Model 関連を ModelRepository に集約。
+        # 通常 manager は repository の session_factory を共有して ModelRepository を生成する。
+        # `Mock(spec=ImageRepository)` で生成された mock には session_factory が無いため、
+        # その場合は DefaultSessionLocal にフォールバックする (各テストは model_repo を明示
+        # Mock 注入することで本フォールバック経路を経由してもテスト独立性を保てる)。
+        if model_repo is None:
+            session_factory = getattr(repository, "session_factory", None)
+            if session_factory is None:
+                from .db_core import DefaultSessionLocal
+
+                session_factory = DefaultSessionLocal
+            model_repo = ModelRepository(session_factory=session_factory)
+        self.model_repo: ModelRepository = model_repo
         self._cached_project_id: int | None = None
         logger.info("ImageDatabaseManager initialized.")
 
@@ -60,6 +78,7 @@ class ImageDatabaseManager:
 
         repository = ImageRepository()
         config_service = ConfigurationService()
+        # ModelRepository は __init__ で自動生成 (repository.session_factory を共有)。
         return cls(repository, config_service)
 
     # __enter__ と __exit__ はリポジトリがセッション管理するため、ここでは不要になることが多い
@@ -692,7 +711,7 @@ class ImageDatabaseManager:
 
         """
         try:
-            return self.repository.get_models()
+            return self.model_repo.get_models()
         except SQLAlchemyError as e:
             logger.error(f"全モデル情報の取得中にエラー: {e}", exc_info=True)
             raise
@@ -705,7 +724,7 @@ class ImageDatabaseManager:
 
         """
         try:
-            return self.repository.get_models_by_type("tags")
+            return self.model_repo.get_models_by_type("tags")
         except SQLAlchemyError as e:
             logger.error(f"Taggerモデル情報の取得中にエラー: {e}", exc_info=True)
             raise
@@ -718,7 +737,7 @@ class ImageDatabaseManager:
 
         """
         try:
-            return self.repository.get_models_by_type("scores")
+            return self.model_repo.get_models_by_type("scores")
         except SQLAlchemyError as e:
             logger.error(f"Scoreモデル情報の取得中にエラー: {e}", exc_info=True)
             raise
@@ -731,7 +750,7 @@ class ImageDatabaseManager:
 
         """
         try:
-            return self.repository.get_models_by_type("caption")
+            return self.model_repo.get_models_by_type("caption")
         except SQLAlchemyError as e:
             logger.error(f"Captionerモデル情報の取得中にエラー: {e}", exc_info=True)
             raise
@@ -744,7 +763,7 @@ class ImageDatabaseManager:
 
         """
         try:
-            return self.repository.get_models_by_type("upscaler")
+            return self.model_repo.get_models_by_type("upscaler")
         except SQLAlchemyError as e:
             logger.error(f"Upscalerモデル情報の取得中にエラー: {e}", exc_info=True)
             raise
@@ -757,7 +776,7 @@ class ImageDatabaseManager:
 
         """
         try:
-            return self.repository.get_models_by_type("multimodal")
+            return self.model_repo.get_models_by_type("multimodal")
         except SQLAlchemyError as e:
             logger.error(f"LLMモデル情報の取得中にエラー: {e}", exc_info=True)
             raise
@@ -776,8 +795,8 @@ class ImageDatabaseManager:
 
         """
         if not hasattr(self, "_manual_edit_model_id"):
-            with self.repository.session_factory() as session:
-                self._manual_edit_model_id = self.repository._get_or_create_manual_edit_model(session)
+            with self.model_repo.session_factory() as session:
+                self._manual_edit_model_id = ModelRepository._get_or_create_manual_edit_model(session)
                 session.commit()
             logger.debug(f"MANUAL_EDITモデルIDをキャッシュ: {self._manual_edit_model_id}")
         return self._manual_edit_model_id

--- a/src/lorairo/database/db_manager.py
+++ b/src/lorairo/database/db_manager.py
@@ -796,7 +796,9 @@ class ImageDatabaseManager:
         """
         if not hasattr(self, "_manual_edit_model_id"):
             with self.model_repo.session_factory() as session:
-                self._manual_edit_model_id = ModelRepository._get_or_create_manual_edit_model(session)
+                # injected model_repo 経由で呼び出し DI contract を維持
+                # (test double / subclass override / tenant-aware wrapper を尊重)
+                self._manual_edit_model_id = self.model_repo._get_or_create_manual_edit_model(session)
                 session.commit()
             logger.debug(f"MANUAL_EDITモデルIDをキャッシュ: {self._manual_edit_model_id}")
         return self._manual_edit_model_id

--- a/src/lorairo/database/db_repository.py
+++ b/src/lorairo/database/db_repository.py
@@ -19,16 +19,15 @@ from ..domain.quality_tier import compute_quality_summary
 from ..utils.log import logger
 from .db_core import DefaultSessionLocal
 from .filter_criteria import ImageFilterCriteria
+from .repository.model import ModelRepository
 from .schema import (
     MANUAL_EDIT_LITELLM_ID,
     MANUAL_EDIT_NAME,
-    MANUAL_EDIT_PROVIDER,
     Caption,
     ErrorRecord,
     Image,
     ImageFilenameAlias,
     Model,
-    ModelType,
     ProcessedImage,
     Project,
     ProviderBatchArtifact,
@@ -112,6 +111,12 @@ class ImageRepository:
 
         """
         self.session_factory = session_factory
+        # ADR 0035 段階 1 (#423): Model 関連は ModelRepository に移設。
+        # 既存呼び出し (`image_repository.get_models_by_litellm_ids()` 等) との互換性のため、
+        # ImageRepository は内部で ModelRepository への delegating facade を保持する。
+        # 段階 2 以降で各 Service / Worker が直接 ModelRepository を参照するようになれば、
+        # 本 facade と _model_repo は削除可能。
+        self._model_repo = ModelRepository(session_factory=session_factory)
         logger.info("ImageRepository initialized.")
 
         # 外部tag_db統合（公開API経由、グレースフルデグラデーション対応）
@@ -165,127 +170,27 @@ class ImageRepository:
             logger.warning(f"Failed to initialize TagRegisterService: {e}", exc_info=True)
             return None  # エラー時はNoneで継続
 
+    # --- Model methods (delegating facade, ADR 0035 段階 1) ---
+    # 実装は src/lorairo/database/repository/model.py の ModelRepository に移設済み。
+    # 既存呼び出し (`image_repository.X()`) との互換性のため delegating wrapper を残す。
+    # 段階 2 以降で各 Service / Worker が `manager.model_repo` 経由で直接 ModelRepository
+    # を参照するようになれば、本 facade は削除可能。
+
     def _get_model_id(self, litellm_model_id: str) -> int | None:
-        """`litellm_model_id` (registry key SSoT) から Model.id を取得する。
-
-        ADR 0023 Phase 1.11 (Issue #238) 以降、モデルの一意キーは
-        `Model.litellm_model_id` (UNIQUE NOT NULL)。`Model.name` は表示名 (非 UNIQUE)
-        になったため lookup には使えない。
-
-        Args:
-            litellm_model_id: 検索する registry key (例: `openai/gpt-4o`,
-                `wd-vit-tagger-v3`, `__manual_edit__`)。
-
-        Returns:
-            int | None: 見つかったモデルのID。見つからない場合はNone。
-        """
-        with self.session_factory() as session:
-            try:
-                stmt = select(Model.id).where(Model.litellm_model_id == litellm_model_id)
-                result = session.execute(stmt).scalar_one_or_none()
-                if result is None:
-                    logger.warning(
-                        f"litellm_model_id '{litellm_model_id}' がデータベースに見つかりません。"
-                    )
-                return result
-            except SQLAlchemyError as e:
-                logger.error(f"モデルIDの取得中にエラーが発生しました: {e}", exc_info=True)
-                raise
+        """ModelRepository._get_model_id への delegate (ADR 0035)。"""
+        return self._model_repo._get_model_id(litellm_model_id)
 
     def get_model_by_litellm_id(self, litellm_model_id: str) -> Model | None:
-        """`litellm_model_id` (registry key SSoT) から Model オブジェクトを取得する。
-
-        ADR 0023 Phase 1.11 (Issue #238): 旧 `get_model_by_name` を本 API に置換。
-        registry key は WebAPI モデルで LiteLLM 完全 ID (`anthropic/claude-3-5-sonnet-...`)、
-        ローカル ML モデルで bare name (`wd-vit-tagger-v3`)、特殊行で sentinel
-        (`__manual_edit__`, `__legacy_<id>__`) を取る。
-
-        Args:
-            litellm_model_id: registry key (UNIQUE)。
-
-        Returns:
-            Model | None: 見つかった場合は Model (model_types eager load 済み)、
-                なければ None。
-
-        Raises:
-            SQLAlchemyError: DB 操作エラー。
-        """
-        with self.session_factory() as session:
-            try:
-                stmt = (
-                    select(Model)
-                    .options(selectinload(Model.model_types))
-                    .where(Model.litellm_model_id == litellm_model_id)
-                )
-                result = session.execute(stmt).scalar_one_or_none()
-                if result is None:
-                    logger.debug(f"モデル '{litellm_model_id}' は登録されていません")
-                return result
-            except SQLAlchemyError as e:
-                logger.error(
-                    f"モデル取得エラー (litellm_model_id={litellm_model_id}): {e}",
-                    exc_info=True,
-                )
-                raise
+        """ModelRepository.get_model_by_litellm_id への delegate (ADR 0035)。"""
+        return self._model_repo.get_model_by_litellm_id(litellm_model_id)
 
     def get_models_by_name(self, name: str) -> list[Model]:
-        """`Model.name` に完全一致する全行を返す (Issue #245)。
-
-        ADR 0023 Phase 1.11 以降、`Model.name` は非 UNIQUE となり、同一表示名で
-        provider/route の異なる行が共存しうる (例: migration 経由 OpenRouter 行と
-        新規 sync 経路の直接版が両方 `name='openai/gpt-4o'`)。CLI `--model` 入力で
-        ユーザーが name を打ったときの曖昧マッチ検出に使う。
-
-        Args:
-            name: `Model.name` 値 (表示名)。
-
-        Returns:
-            list[Model]: 一致した行のリスト。0 件なら空リスト。
-
-        Raises:
-            SQLAlchemyError: DB 操作エラー。
-        """
-        with self.session_factory() as session:
-            try:
-                stmt = select(Model).options(selectinload(Model.model_types)).where(Model.name == name)
-                results = session.execute(stmt).scalars().all()
-                logger.debug(f"name='{name}' に一致するモデル: {len(results)}件")
-                return list(results)
-            except SQLAlchemyError as e:
-                logger.error(f"モデル取得エラー (name={name}): {e}", exc_info=True)
-                raise
+        """ModelRepository.get_models_by_name への delegate (ADR 0035)。"""
+        return self._model_repo.get_models_by_name(name)
 
     def get_models_by_litellm_ids(self, litellm_model_ids: set[str]) -> dict[str, Model]:
-        """複数の `litellm_model_id` から Model オブジェクトを一括取得する。
-
-        ADR 0023 Phase 1.11 (Issue #238): 旧 `get_models_by_names` を本 API に置換。
-
-        Args:
-            litellm_model_ids: 取得する registry key のセット。
-
-        Returns:
-            litellm_model_id → Model のマッピング。見つからなかった key は含まれない。
-
-        Raises:
-            SQLAlchemyError: データベース操作でエラーが発生した場合。
-        """
-        if not litellm_model_ids:
-            return {}
-
-        with self.session_factory() as session:
-            try:
-                stmt = (
-                    select(Model)
-                    .options(selectinload(Model.model_types))
-                    .where(Model.litellm_model_id.in_(litellm_model_ids))
-                )
-                results = session.execute(stmt).scalars().all()
-                models_map = {model.litellm_model_id: model for model in results}
-                logger.debug(f"モデル一括取得: {len(models_map)}/{len(litellm_model_ids)}件見つかりました")
-                return models_map
-            except SQLAlchemyError as e:
-                logger.error(f"モデル一括取得エラー: {e}", exc_info=True)
-                raise
+        """ModelRepository.get_models_by_litellm_ids への delegate (ADR 0035)。"""
+        return self._model_repo.get_models_by_litellm_ids(litellm_model_ids)
 
     def get_all_image_filename_index(self) -> dict[str, int]:
         """全画像のfilename stem → image_id インデックスを構築する。
@@ -345,43 +250,13 @@ class ImageRepository:
                 raise
 
     def _get_or_create_manual_edit_model(self, session: Session) -> int:
-        """手動編集用のモデルIDを取得または作成します。
+        """ModelRepository._get_or_create_manual_edit_model への delegate (ADR 0035)。
 
-        ADR 0023 Phase 1.11 (Issue #238): `litellm_model_id` UNIQUE NOT NULL 化に伴い、
-        MANUAL_EDIT 行は sentinel `__manual_edit__` で lookup・作成する。
-        model_types テーブルへの関連付けは行わない (手動編集は AI カテゴリに属さない)。
-
-        Args:
-            session: データベースセッション。
-
-        Returns:
-            int: MANUAL_EDIT モデルの ID。
-
-        Raises:
-            SQLAlchemyError: データベース操作中にエラーが発生した場合。
-
+        本メソッドは既存セッションを受け取って動作する (`session_factory` を使わない)。
+        Image filter / annotation 更新など、呼び出し元が独自にセッションを管理する
+        コンテキストから利用される。
         """
-        try:
-            stmt = select(Model).where(Model.litellm_model_id == MANUAL_EDIT_LITELLM_ID)
-            existing_model = session.execute(stmt).scalar_one_or_none()
-
-            if existing_model:
-                logger.debug(f"既存のMANUAL_EDITモデルを使用: ID={existing_model.id}")
-                return existing_model.id
-
-            manual_edit_model = Model(
-                name=MANUAL_EDIT_NAME,
-                provider=MANUAL_EDIT_PROVIDER,
-                litellm_model_id=MANUAL_EDIT_LITELLM_ID,
-            )
-            session.add(manual_edit_model)
-            session.flush()
-            logger.info(f"MANUAL_EDITモデルを新規作成: ID={manual_edit_model.id}")
-            return manual_edit_model.id
-
-        except SQLAlchemyError as e:
-            logger.error(f"MANUAL_EDITモデルの取得/作成中にエラーが発生しました: {e}", exc_info=True)
-            raise
+        return ModelRepository._get_or_create_manual_edit_model(session)
 
     def insert_model(
         self,
@@ -393,70 +268,16 @@ class ImageRepository:
         requires_api_key: bool = False,
         discontinued_at: datetime.datetime | None = None,
     ) -> int:
-        """新規モデルをDBに登録する。
-
-        ADR 0023 Phase 1.11 (Issue #238): `litellm_model_id` は registry key SSoT
-        として必須 (UNIQUE NOT NULL)。`name` は表示名 (非 UNIQUE) になった。
-
-        Args:
-            name: 表示名 (例: `gpt-4.1`)。
-            provider: ルーティング元プロバイダー (例: `openai`, `anthropic`,
-                `openrouter`)。ローカル ML モデルは None。
-            model_types: LoRAIro の model_type リスト (`["caption"]`,
-                `["multimodal"]`, `["scores"]`, `["tags"]`, `["upscaler"]`, `["ratings"]` など)。
-            litellm_model_id: registry key (UNIQUE)。WebAPI では LiteLLM 完全 ID
-                (`openai/gpt-4o`)、ローカル ML では bare name (`wd-vit-tagger-v3`)。
-            estimated_size_gb: ローカルモデルの推定サイズ (GB)。
-            requires_api_key: API キー要否。
-            discontinued_at: 廃止日時 (該当する場合)。
-
-        Returns:
-            登録されたモデルのID。
-
-        Raises:
-            IntegrityError: `litellm_model_id` が既存モデルと重複する場合。
-            ValueError: model_types が無効な場合 (存在しない model_type 名)。
-        """
-        with self.session_factory() as session:
-            try:
-                # ModelTypeオブジェクトを取得
-                model_type_objects = []
-                for type_name in model_types:
-                    stmt = select(ModelType).where(ModelType.name == type_name)
-                    model_type = session.execute(stmt).scalar_one_or_none()
-                    if not model_type:
-                        valid_types = session.execute(select(ModelType.name)).scalars().all()
-                        raise ValueError(
-                            f"Invalid model_type: '{type_name}'. Valid types: {', '.join(valid_types)}",
-                        )
-                    model_type_objects.append(model_type)
-
-                # Model作成
-                new_model = Model(
-                    name=name,
-                    provider=provider,
-                    litellm_model_id=litellm_model_id,
-                    estimated_size_gb=estimated_size_gb,
-                    requires_api_key=requires_api_key,
-                    discontinued_at=discontinued_at,
-                )
-                new_model.model_types = model_type_objects
-
-                session.add(new_model)
-                session.commit()
-                session.refresh(new_model)  # IDを取得するためリフレッシュ
-
-                logger.info(f"モデル登録完了: {name} (ID={new_model.id}, types={model_types})")
-                return new_model.id
-
-            except IntegrityError:
-                session.rollback()
-                logger.warning(f"モデル登録失敗（既存モデルの可能性）: {name}")
-                raise
-            except SQLAlchemyError as e:
-                session.rollback()
-                logger.error(f"モデル登録エラー: {e}", exc_info=True)
-                raise
+        """ModelRepository.insert_model への delegate (ADR 0035)。"""
+        return self._model_repo.insert_model(
+            name=name,
+            provider=provider,
+            model_types=model_types,
+            litellm_model_id=litellm_model_id,
+            estimated_size_gb=estimated_size_gb,
+            requires_api_key=requires_api_key,
+            discontinued_at=discontinued_at,
+        )
 
     @staticmethod
     def _apply_simple_field_updates(
@@ -467,73 +288,20 @@ class ImageRepository:
         requires_api_key: bool | None,
         discontinued_at: datetime.datetime | None,
     ) -> bool:
-        """モデルの単純フィールドを差分更新する。
-
-        Args:
-            model: ModelのORMオブジェクト。
-            provider: プロバイダー名。
-            litellm_model_id: APIモデルID。
-            estimated_size_gb: 推定サイズ。
-            requires_api_key: APIキー要否。
-            discontinued_at: 廃止日時。
-
-        Returns:
-            変更があった場合True。
-
-        """
-        has_changes = False
-        simple_fields = {
-            "provider": provider,
-            "litellm_model_id": litellm_model_id,
-            "estimated_size_gb": estimated_size_gb,
-            "requires_api_key": requires_api_key,
-            "discontinued_at": discontinued_at,
-        }
-        for field_name, new_value in simple_fields.items():
-            if new_value is not None:
-                current_value = getattr(model, field_name)
-                if current_value != new_value:
-                    setattr(model, field_name, new_value)
-                    has_changes = True
-                    logger.debug(f"フィールド更新: {field_name} = {new_value}")
-        return has_changes
+        """ModelRepository._apply_simple_field_updates への delegate (ADR 0035)。"""
+        return ModelRepository._apply_simple_field_updates(
+            model,
+            provider,
+            litellm_model_id,
+            estimated_size_gb,
+            requires_api_key,
+            discontinued_at,
+        )
 
     @staticmethod
     def _update_model_types(session: Session, model: Any, model_types: list[str]) -> bool:
-        """モデルタイプの関連を差分更新する。
-
-        Args:
-            session: SQLAlchemyセッション。
-            model: ModelのORMオブジェクト。
-            model_types: 新しいモデルタイプ名リスト。
-
-        Returns:
-            変更があった場合True。
-
-        Raises:
-            ValueError: 無効なモデルタイプが指定された場合。
-
-        """
-        current_types = {mt.name for mt in model.model_types}
-        new_types = set(model_types)
-
-        if current_types == new_types:
-            return False
-
-        model_type_objects = []
-        for type_name in model_types:
-            stmt = select(ModelType).where(ModelType.name == type_name)
-            model_type = session.execute(stmt).scalar_one_or_none()
-            if not model_type:
-                valid_types = session.execute(select(ModelType.name)).scalars().all()
-                raise ValueError(
-                    f"Invalid model_type: '{type_name}'. Valid types: {', '.join(valid_types)}",
-                )
-            model_type_objects.append(model_type)
-
-        model.model_types = model_type_objects
-        logger.debug(f"model_types更新: {current_types} -> {new_types}")
-        return True
+        """ModelRepository._update_model_types への delegate (ADR 0035)。"""
+        return ModelRepository._update_model_types(session, model, model_types)
 
     def update_model(
         self,
@@ -545,58 +313,16 @@ class ImageRepository:
         requires_api_key: bool | None = None,
         discontinued_at: datetime.datetime | None = None,
     ) -> bool:
-        """既存モデルのメタデータを更新(差分検出あり)
-
-        NOTE: 引数がNoneの場合は更新しない
-
-        Args:
-            model_id: 更新対象モデルのID
-            provider: プロバイダー名
-            model_types: モデルタイプリスト
-            litellm_model_id: API呼び出し時のモデルID
-            estimated_size_gb: 推定サイズ
-            requires_api_key: APIキー要否
-            discontinued_at: 廃止日時
-
-        Returns:
-            実際に更新が発生したかどうか
-
-        Raises:
-            ValueError: model_idが存在しない、またはmodel_typesが無効な場合
-
-        """
-        with self.session_factory() as session:
-            try:
-                stmt = select(Model).options(selectinload(Model.model_types)).where(Model.id == model_id)
-                model = session.execute(stmt).scalar_one_or_none()
-
-                if not model:
-                    raise ValueError(f"Model not found: id={model_id}")
-
-                has_changes = self._apply_simple_field_updates(
-                    model,
-                    provider,
-                    litellm_model_id,
-                    estimated_size_gb,
-                    requires_api_key,
-                    discontinued_at,
-                )
-
-                if model_types is not None:
-                    if self._update_model_types(session, model, model_types):
-                        has_changes = True
-
-                if has_changes:
-                    session.commit()
-                    logger.info(f"モデル更新完了: {model.name} (ID={model_id})")
-                    return True
-                logger.debug(f"モデル更新なし: {model.name} (ID={model_id})")
-                return False
-
-            except SQLAlchemyError as e:
-                session.rollback()
-                logger.error(f"モデル更新エラー: {e}", exc_info=True)
-                raise
+        """ModelRepository.update_model への delegate (ADR 0035)。"""
+        return self._model_repo.update_model(
+            model_id=model_id,
+            provider=provider,
+            model_types=model_types,
+            litellm_model_id=litellm_model_id,
+            estimated_size_gb=estimated_size_gb,
+            requires_api_key=requires_api_key,
+            discontinued_at=discontinued_at,
+        )
 
     def _image_exists(self, image_id: int) -> bool:
         """指定された画像IDが images テーブルに存在するかを確認します。
@@ -3086,120 +2812,19 @@ class ImageRepository:
                 logger.error(f"画像件数取得中にエラーが発生しました: {e}", exc_info=True)
                 raise
 
-    # --- Model Information Retrieval ---
+    # --- Model Information Retrieval (delegating facade, ADR 0035 段階 1) ---
 
     def get_models(self) -> list[dict[str, Any]]:
-        """データベースに登録されている全てのモデルの情報を取得します。
-        各モデルに関連付けられたタイプ名も含まれます。
-
-        Returns:
-            list[dict[str, Any]]: モデル情報の辞書のリスト。
-                各辞書には 'id', 'name', 'provider', 'discontinued_at',
-                'created_at', 'updated_at', 'model_types' (タイプ名のリスト) が含まれます。
-
-        Raises:
-            SQLAlchemyError: データベース操作中にエラーが発生した場合。
-
-        """
-        with self.session_factory() as session:
-            try:
-                stmt = select(Model).options(selectinload(Model.model_types)).order_by(Model.name)
-
-                models_result: list[Model] = list(session.execute(stmt).scalars().unique().all())
-
-                model_list = [
-                    {
-                        "id": model.id,
-                        "name": model.name,
-                        "provider": model.provider,
-                        "discontinued_at": model.discontinued_at,
-                        "created_at": model.created_at,
-                        "updated_at": model.updated_at,
-                        "model_types": sorted([mt.name for mt in model.model_types]),  # タイプ名のリスト
-                    }
-                    for model in models_result
-                ]
-
-                logger.info(f"全モデル情報を取得しました。 件数: {len(model_list)}")
-                return model_list
-
-            except SQLAlchemyError as e:
-                logger.error(f"全モデル情報の取得中にエラーが発生しました: {e}", exc_info=True)
-                raise
+        """ModelRepository.get_models への delegate (ADR 0035)。"""
+        return self._model_repo.get_models()
 
     def get_model_objects(self) -> list[Model]:
-        """データベースから実際のModelオブジェクトを直接取得します（DB中心アーキテクチャ用）
-
-        Returns:
-            list[Model]: Modelオブジェクトのリスト（関連するmodel_types含む）
-
-        """
-        try:
-            with self.session_factory() as session:
-                stmt = select(Model).options(selectinload(Model.model_types)).order_by(Model.name)
-                models_result = session.execute(stmt).scalars().unique().all()
-
-                model_list = list(models_result)
-                logger.info(f"DB Modelオブジェクトを取得しました。 件数: {len(model_list)}")
-                return model_list
-
-        except SQLAlchemyError as e:
-            logger.error(f"DB Modelオブジェクトの取得中にエラーが発生しました: {e}", exc_info=True)
-            raise
+        """ModelRepository.get_model_objects への delegate (ADR 0035)。"""
+        return self._model_repo.get_model_objects()
 
     def get_models_by_type(self, model_type_name: str) -> list[dict[str, Any]]:
-        """指定されたタイプ名を持つモデルの情報を取得します。
-
-        Args:
-            model_type_name (str): フィルタリングするモデルのタイプ名 (例: 'tagger')。
-
-        Returns:
-            list[dict[str, Any]]: 条件に一致したモデル情報の辞書のリスト。
-                形式は get_models と同じです。
-
-        Raises:
-            SQLAlchemyError: データベース操作中にエラーが発生した場合。
-
-        """
-        from sqlalchemy.orm import selectinload
-
-        with self.session_factory() as session:
-            try:
-                stmt = (
-                    select(Model)
-                    .join(Model.model_types)
-                    .where(ModelType.name == model_type_name)
-                    .options(selectinload(Model.model_types))
-                    .order_by(Model.name)
-                    .distinct()
-                )
-
-                models_result: list[Model] = list(session.execute(stmt).scalars().all())
-
-                model_list = [
-                    {
-                        "id": model.id,
-                        "name": model.name,
-                        "provider": model.provider,
-                        "discontinued_at": model.discontinued_at,
-                        "created_at": model.created_at,
-                        "updated_at": model.updated_at,
-                        "model_types": sorted([mt.name for mt in model.model_types]),
-                    }
-                    for model in models_result
-                ]
-
-                logger.info(
-                    f"タイプ '{model_type_name}' のモデル情報を取得しました。 件数: {len(model_list)}",
-                )
-                return model_list
-
-            except SQLAlchemyError as e:
-                logger.error(
-                    f"タイプ '{model_type_name}' のモデル情報取得中にエラーが発生しました: {e}",
-                    exc_info=True,
-                )
-                raise
+        """ModelRepository.get_models_by_type への delegate (ADR 0035)。"""
+        return self._model_repo.get_models_by_type(model_type_name)
 
     # --- Count Methods ---
 

--- a/src/lorairo/database/repository/__init__.py
+++ b/src/lorairo/database/repository/__init__.py
@@ -1,0 +1,16 @@
+"""Aggregate 単位 Repository (ADR 0035)。
+
+`db_repository.py` god class を Aggregate 境界で分割した Repository 群。
+段階的に entity ごとに移行する (移行戦略は ADR 0035 §6 参照)。
+
+段階 1 (#423): `ModelRepository`
+段階 2 以降: `ProjectRepository`, `ErrorRecordRepository`, `ImageRepository`, `AnnotationRepository`
+"""
+
+from .base import BaseRepository
+from .model import ModelRepository
+
+__all__ = [
+    "BaseRepository",
+    "ModelRepository",
+]

--- a/src/lorairo/database/repository/base.py
+++ b/src/lorairo/database/repository/base.py
@@ -1,0 +1,41 @@
+"""Repository 層の共通基盤 (ADR 0035 §2)。
+
+`ImageRepository` を Aggregate 単位で分割した後、全 Repository クラスが本基盤を継承する。
+共通プロパティ (`session_factory`) と全体定数 (`BATCH_CHUNK_SIZE`) を保持する。
+"""
+
+from collections.abc import Callable
+from typing import ClassVar
+
+from sqlalchemy.orm import Session
+
+from ..db_core import DefaultSessionLocal
+
+
+class BaseRepository:
+    """Repository の共通基盤。
+
+    各 Aggregate Repository (`ModelRepository` / `ImageRepository` / `AnnotationRepository` /
+    `ProjectRepository` / `ErrorRecordRepository`) が本クラスを継承する。
+
+    Attributes:
+        session_factory: SQLAlchemy セッションを生成する callable。
+        BATCH_CHUNK_SIZE: SQLite バインド変数上限の安全マージン (32,766 の約半分)。
+            IN 句以外にもクエリ内で変数を使うため余裕を持たせる。
+
+    """
+
+    # SQLite バインド変数上限の安全マージン（32,766の約半分）
+    # IN句以外にもクエリ内で変数を使うため余裕を持たせる
+    BATCH_CHUNK_SIZE: ClassVar[int] = 15000
+
+    def __init__(self, session_factory: Callable[[], Session] = DefaultSessionLocal) -> None:
+        """BaseRepository のコンストラクタ。
+
+        Args:
+            session_factory: SQLAlchemy セッションを生成するファクトリ関数。
+                デフォルトは `db_core.DefaultSessionLocal` を使用。
+                テスト時にモック化可能。
+
+        """
+        self.session_factory = session_factory

--- a/src/lorairo/database/repository/model.py
+++ b/src/lorairo/database/repository/model.py
@@ -1,0 +1,538 @@
+"""Model / ModelType 永続化担当 Repository (ADR 0035 §1)。
+
+`ImageRepository` god class 分割の段階 1 として、Model / ModelType 関連の
+CRUD・検索を本 Repository に集約する。
+
+ADR 0023 Phase 1.11 (Issue #238) の registry key SSoT 設計に基づき、
+`Model.litellm_model_id` (UNIQUE NOT NULL) を一意キーとして扱う。
+"""
+
+from __future__ import annotations
+
+import datetime
+from typing import Any, ClassVar
+
+from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError, SQLAlchemyError
+from sqlalchemy.orm import Session, selectinload
+
+from ...utils.log import logger
+from ..schema import (
+    MANUAL_EDIT_LITELLM_ID,
+    MANUAL_EDIT_NAME,
+    MANUAL_EDIT_PROVIDER,
+    Model,
+    ModelType,
+)
+from .base import BaseRepository
+
+
+class ModelRepository(BaseRepository):
+    """Model / ModelType の永続化を担当する Repository (ADR 0035)。
+
+    管轄 entity:
+      - `Model`
+      - `ModelType`
+      - モデル関連アソシエーション (`model_model_types`)
+    """
+
+    # 単純フィールド差分更新の対象集合 (update_model で使用)
+    _MODEL_SIMPLE_UPDATE_FIELDS: ClassVar[tuple[str, ...]] = (
+        "provider",
+        "litellm_model_id",
+        "estimated_size_gb",
+        "requires_api_key",
+        "discontinued_at",
+    )
+
+    def _get_model_id(self, litellm_model_id: str) -> int | None:
+        """`litellm_model_id` (registry key SSoT) から Model.id を取得する。
+
+        ADR 0023 Phase 1.11 (Issue #238) 以降、モデルの一意キーは
+        `Model.litellm_model_id` (UNIQUE NOT NULL)。`Model.name` は表示名 (非 UNIQUE)
+        になったため lookup には使えない。
+
+        Args:
+            litellm_model_id: 検索する registry key (例: `openai/gpt-4o`,
+                `wd-vit-tagger-v3`, `__manual_edit__`)。
+
+        Returns:
+            int | None: 見つかったモデルのID。見つからない場合はNone。
+        """
+        with self.session_factory() as session:
+            try:
+                stmt = select(Model.id).where(Model.litellm_model_id == litellm_model_id)
+                result = session.execute(stmt).scalar_one_or_none()
+                if result is None:
+                    logger.warning(
+                        f"litellm_model_id '{litellm_model_id}' がデータベースに見つかりません。"
+                    )
+                return result
+            except SQLAlchemyError as e:
+                logger.error(f"モデルIDの取得中にエラーが発生しました: {e}", exc_info=True)
+                raise
+
+    def get_model_by_litellm_id(self, litellm_model_id: str) -> Model | None:
+        """`litellm_model_id` (registry key SSoT) から Model オブジェクトを取得する。
+
+        ADR 0023 Phase 1.11 (Issue #238): 旧 `get_model_by_name` を本 API に置換。
+        registry key は WebAPI モデルで LiteLLM 完全 ID (`anthropic/claude-3-5-sonnet-...`)、
+        ローカル ML モデルで bare name (`wd-vit-tagger-v3`)、特殊行で sentinel
+        (`__manual_edit__`, `__legacy_<id>__`) を取る。
+
+        Args:
+            litellm_model_id: registry key (UNIQUE)。
+
+        Returns:
+            Model | None: 見つかった場合は Model (model_types eager load 済み)、
+                なければ None。
+
+        Raises:
+            SQLAlchemyError: DB 操作エラー。
+        """
+        with self.session_factory() as session:
+            try:
+                stmt = (
+                    select(Model)
+                    .options(selectinload(Model.model_types))
+                    .where(Model.litellm_model_id == litellm_model_id)
+                )
+                result = session.execute(stmt).scalar_one_or_none()
+                if result is None:
+                    logger.debug(f"モデル '{litellm_model_id}' は登録されていません")
+                return result
+            except SQLAlchemyError as e:
+                logger.error(
+                    f"モデル取得エラー (litellm_model_id={litellm_model_id}): {e}",
+                    exc_info=True,
+                )
+                raise
+
+    def get_models_by_name(self, name: str) -> list[Model]:
+        """`Model.name` に完全一致する全行を返す (Issue #245)。
+
+        ADR 0023 Phase 1.11 以降、`Model.name` は非 UNIQUE となり、同一表示名で
+        provider/route の異なる行が共存しうる (例: migration 経由 OpenRouter 行と
+        新規 sync 経路の直接版が両方 `name='openai/gpt-4o'`)。CLI `--model` 入力で
+        ユーザーが name を打ったときの曖昧マッチ検出に使う。
+
+        Args:
+            name: `Model.name` 値 (表示名)。
+
+        Returns:
+            list[Model]: 一致した行のリスト。0 件なら空リスト。
+
+        Raises:
+            SQLAlchemyError: DB 操作エラー。
+        """
+        with self.session_factory() as session:
+            try:
+                stmt = select(Model).options(selectinload(Model.model_types)).where(Model.name == name)
+                results = session.execute(stmt).scalars().all()
+                logger.debug(f"name='{name}' に一致するモデル: {len(results)}件")
+                return list(results)
+            except SQLAlchemyError as e:
+                logger.error(f"モデル取得エラー (name={name}): {e}", exc_info=True)
+                raise
+
+    def get_models_by_litellm_ids(self, litellm_model_ids: set[str]) -> dict[str, Model]:
+        """複数の `litellm_model_id` から Model オブジェクトを一括取得する。
+
+        ADR 0023 Phase 1.11 (Issue #238): 旧 `get_models_by_names` を本 API に置換。
+
+        Args:
+            litellm_model_ids: 取得する registry key のセット。
+
+        Returns:
+            litellm_model_id → Model のマッピング。見つからなかった key は含まれない。
+
+        Raises:
+            SQLAlchemyError: データベース操作でエラーが発生した場合。
+        """
+        if not litellm_model_ids:
+            return {}
+
+        with self.session_factory() as session:
+            try:
+                stmt = (
+                    select(Model)
+                    .options(selectinload(Model.model_types))
+                    .where(Model.litellm_model_id.in_(litellm_model_ids))
+                )
+                results = session.execute(stmt).scalars().all()
+                models_map = {model.litellm_model_id: model for model in results}
+                logger.debug(f"モデル一括取得: {len(models_map)}/{len(litellm_model_ids)}件見つかりました")
+                return models_map
+            except SQLAlchemyError as e:
+                logger.error(f"モデル一括取得エラー: {e}", exc_info=True)
+                raise
+
+    @staticmethod
+    def _get_or_create_manual_edit_model(session: Session) -> int:
+        """手動編集用のモデルIDを取得または作成します。
+
+        ADR 0023 Phase 1.11 (Issue #238): `litellm_model_id` UNIQUE NOT NULL 化に伴い、
+        MANUAL_EDIT 行は sentinel `__manual_edit__` で lookup・作成する。
+        model_types テーブルへの関連付けは行わない (手動編集は AI カテゴリに属さない)。
+
+        本メソッドは既存セッションを受け取って動作する (`session_factory` を使わない)。
+        Image filter / annotation 更新など、呼び出し元が独自にセッションを管理する
+        コンテキストから利用される。
+
+        Args:
+            session: データベースセッション。
+
+        Returns:
+            int: MANUAL_EDIT モデルの ID。
+
+        Raises:
+            SQLAlchemyError: データベース操作中にエラーが発生した場合。
+
+        """
+        try:
+            stmt = select(Model).where(Model.litellm_model_id == MANUAL_EDIT_LITELLM_ID)
+            existing_model = session.execute(stmt).scalar_one_or_none()
+
+            if existing_model:
+                logger.debug(f"既存のMANUAL_EDITモデルを使用: ID={existing_model.id}")
+                return existing_model.id
+
+            manual_edit_model = Model(
+                name=MANUAL_EDIT_NAME,
+                provider=MANUAL_EDIT_PROVIDER,
+                litellm_model_id=MANUAL_EDIT_LITELLM_ID,
+            )
+            session.add(manual_edit_model)
+            session.flush()
+            logger.info(f"MANUAL_EDITモデルを新規作成: ID={manual_edit_model.id}")
+            return manual_edit_model.id
+
+        except SQLAlchemyError as e:
+            logger.error(f"MANUAL_EDITモデルの取得/作成中にエラーが発生しました: {e}", exc_info=True)
+            raise
+
+    def insert_model(
+        self,
+        name: str,
+        provider: str | None,
+        model_types: list[str],
+        litellm_model_id: str,
+        estimated_size_gb: float | None = None,
+        requires_api_key: bool = False,
+        discontinued_at: datetime.datetime | None = None,
+    ) -> int:
+        """新規モデルをDBに登録する。
+
+        ADR 0023 Phase 1.11 (Issue #238): `litellm_model_id` は registry key SSoT
+        として必須 (UNIQUE NOT NULL)。`name` は表示名 (非 UNIQUE) になった。
+
+        Args:
+            name: 表示名 (例: `gpt-4.1`)。
+            provider: ルーティング元プロバイダー (例: `openai`, `anthropic`,
+                `openrouter`)。ローカル ML モデルは None。
+            model_types: LoRAIro の model_type リスト (`["caption"]`,
+                `["multimodal"]`, `["scores"]`, `["tags"]`, `["upscaler"]`, `["ratings"]` など)。
+            litellm_model_id: registry key (UNIQUE)。WebAPI では LiteLLM 完全 ID
+                (`openai/gpt-4o`)、ローカル ML では bare name (`wd-vit-tagger-v3`)。
+            estimated_size_gb: ローカルモデルの推定サイズ (GB)。
+            requires_api_key: API キー要否。
+            discontinued_at: 廃止日時 (該当する場合)。
+
+        Returns:
+            登録されたモデルのID。
+
+        Raises:
+            IntegrityError: `litellm_model_id` が既存モデルと重複する場合。
+            ValueError: model_types が無効な場合 (存在しない model_type 名)。
+        """
+        with self.session_factory() as session:
+            try:
+                # ModelTypeオブジェクトを取得
+                model_type_objects = []
+                for type_name in model_types:
+                    stmt = select(ModelType).where(ModelType.name == type_name)
+                    model_type = session.execute(stmt).scalar_one_or_none()
+                    if not model_type:
+                        valid_types = session.execute(select(ModelType.name)).scalars().all()
+                        raise ValueError(
+                            f"Invalid model_type: '{type_name}'. Valid types: {', '.join(valid_types)}",
+                        )
+                    model_type_objects.append(model_type)
+
+                # Model作成
+                new_model = Model(
+                    name=name,
+                    provider=provider,
+                    litellm_model_id=litellm_model_id,
+                    estimated_size_gb=estimated_size_gb,
+                    requires_api_key=requires_api_key,
+                    discontinued_at=discontinued_at,
+                )
+                new_model.model_types = model_type_objects
+
+                session.add(new_model)
+                session.commit()
+                session.refresh(new_model)  # IDを取得するためリフレッシュ
+
+                logger.info(f"モデル登録完了: {name} (ID={new_model.id}, types={model_types})")
+                return new_model.id
+
+            except IntegrityError:
+                session.rollback()
+                logger.warning(f"モデル登録失敗（既存モデルの可能性）: {name}")
+                raise
+            except SQLAlchemyError as e:
+                session.rollback()
+                logger.error(f"モデル登録エラー: {e}", exc_info=True)
+                raise
+
+    @staticmethod
+    def _apply_simple_field_updates(
+        model: Any,
+        provider: str | None,
+        litellm_model_id: str | None,
+        estimated_size_gb: float | None,
+        requires_api_key: bool | None,
+        discontinued_at: datetime.datetime | None,
+    ) -> bool:
+        """モデルの単純フィールドを差分更新する。
+
+        Args:
+            model: ModelのORMオブジェクト。
+            provider: プロバイダー名。
+            litellm_model_id: APIモデルID。
+            estimated_size_gb: 推定サイズ。
+            requires_api_key: APIキー要否。
+            discontinued_at: 廃止日時。
+
+        Returns:
+            変更があった場合True。
+
+        """
+        has_changes = False
+        simple_fields = {
+            "provider": provider,
+            "litellm_model_id": litellm_model_id,
+            "estimated_size_gb": estimated_size_gb,
+            "requires_api_key": requires_api_key,
+            "discontinued_at": discontinued_at,
+        }
+        for field_name, new_value in simple_fields.items():
+            if new_value is not None:
+                current_value = getattr(model, field_name)
+                if current_value != new_value:
+                    setattr(model, field_name, new_value)
+                    has_changes = True
+                    logger.debug(f"フィールド更新: {field_name} = {new_value}")
+        return has_changes
+
+    @staticmethod
+    def _update_model_types(session: Session, model: Any, model_types: list[str]) -> bool:
+        """モデルタイプの関連を差分更新する。
+
+        Args:
+            session: SQLAlchemyセッション。
+            model: ModelのORMオブジェクト。
+            model_types: 新しいモデルタイプ名リスト。
+
+        Returns:
+            変更があった場合True。
+
+        Raises:
+            ValueError: 無効なモデルタイプが指定された場合。
+
+        """
+        current_types = {mt.name for mt in model.model_types}
+        new_types = set(model_types)
+
+        if current_types == new_types:
+            return False
+
+        model_type_objects = []
+        for type_name in model_types:
+            stmt = select(ModelType).where(ModelType.name == type_name)
+            model_type = session.execute(stmt).scalar_one_or_none()
+            if not model_type:
+                valid_types = session.execute(select(ModelType.name)).scalars().all()
+                raise ValueError(
+                    f"Invalid model_type: '{type_name}'. Valid types: {', '.join(valid_types)}",
+                )
+            model_type_objects.append(model_type)
+
+        model.model_types = model_type_objects
+        logger.debug(f"model_types更新: {current_types} -> {new_types}")
+        return True
+
+    def update_model(
+        self,
+        model_id: int,
+        provider: str | None = None,
+        model_types: list[str] | None = None,
+        litellm_model_id: str | None = None,
+        estimated_size_gb: float | None = None,
+        requires_api_key: bool | None = None,
+        discontinued_at: datetime.datetime | None = None,
+    ) -> bool:
+        """既存モデルのメタデータを更新(差分検出あり)
+
+        NOTE: 引数がNoneの場合は更新しない
+
+        Args:
+            model_id: 更新対象モデルのID
+            provider: プロバイダー名
+            model_types: モデルタイプリスト
+            litellm_model_id: API呼び出し時のモデルID
+            estimated_size_gb: 推定サイズ
+            requires_api_key: APIキー要否
+            discontinued_at: 廃止日時
+
+        Returns:
+            実際に更新が発生したかどうか
+
+        Raises:
+            ValueError: model_idが存在しない、またはmodel_typesが無効な場合
+
+        """
+        with self.session_factory() as session:
+            try:
+                stmt = select(Model).options(selectinload(Model.model_types)).where(Model.id == model_id)
+                model = session.execute(stmt).scalar_one_or_none()
+
+                if not model:
+                    raise ValueError(f"Model not found: id={model_id}")
+
+                has_changes = self._apply_simple_field_updates(
+                    model,
+                    provider,
+                    litellm_model_id,
+                    estimated_size_gb,
+                    requires_api_key,
+                    discontinued_at,
+                )
+
+                if model_types is not None:
+                    if self._update_model_types(session, model, model_types):
+                        has_changes = True
+
+                if has_changes:
+                    session.commit()
+                    logger.info(f"モデル更新完了: {model.name} (ID={model_id})")
+                    return True
+                logger.debug(f"モデル更新なし: {model.name} (ID={model_id})")
+                return False
+
+            except SQLAlchemyError as e:
+                session.rollback()
+                logger.error(f"モデル更新エラー: {e}", exc_info=True)
+                raise
+
+    def get_models(self) -> list[dict[str, Any]]:
+        """データベースに登録されている全てのモデルの情報を取得します。
+        各モデルに関連付けられたタイプ名も含まれます。
+
+        Returns:
+            list[dict[str, Any]]: モデル情報の辞書のリスト。
+                各辞書には 'id', 'name', 'provider', 'discontinued_at',
+                'created_at', 'updated_at', 'model_types' (タイプ名のリスト) が含まれます。
+
+        Raises:
+            SQLAlchemyError: データベース操作中にエラーが発生した場合。
+
+        """
+        with self.session_factory() as session:
+            try:
+                stmt = select(Model).options(selectinload(Model.model_types)).order_by(Model.name)
+
+                models_result: list[Model] = list(session.execute(stmt).scalars().unique().all())
+
+                model_list = [
+                    {
+                        "id": model.id,
+                        "name": model.name,
+                        "provider": model.provider,
+                        "discontinued_at": model.discontinued_at,
+                        "created_at": model.created_at,
+                        "updated_at": model.updated_at,
+                        "model_types": sorted([mt.name for mt in model.model_types]),  # タイプ名のリスト
+                    }
+                    for model in models_result
+                ]
+
+                logger.info(f"全モデル情報を取得しました。 件数: {len(model_list)}")
+                return model_list
+
+            except SQLAlchemyError as e:
+                logger.error(f"全モデル情報の取得中にエラーが発生しました: {e}", exc_info=True)
+                raise
+
+    def get_model_objects(self) -> list[Model]:
+        """データベースから実際のModelオブジェクトを直接取得します（DB中心アーキテクチャ用）
+
+        Returns:
+            list[Model]: Modelオブジェクトのリスト（関連するmodel_types含む）
+
+        """
+        try:
+            with self.session_factory() as session:
+                stmt = select(Model).options(selectinload(Model.model_types)).order_by(Model.name)
+                models_result = session.execute(stmt).scalars().unique().all()
+
+                model_list = list(models_result)
+                logger.info(f"DB Modelオブジェクトを取得しました。 件数: {len(model_list)}")
+                return model_list
+
+        except SQLAlchemyError as e:
+            logger.error(f"DB Modelオブジェクトの取得中にエラーが発生しました: {e}", exc_info=True)
+            raise
+
+    def get_models_by_type(self, model_type_name: str) -> list[dict[str, Any]]:
+        """指定されたタイプ名を持つモデルの情報を取得します。
+
+        Args:
+            model_type_name (str): フィルタリングするモデルのタイプ名 (例: 'tagger')。
+
+        Returns:
+            list[dict[str, Any]]: 条件に一致したモデル情報の辞書のリスト。
+                形式は get_models と同じです。
+
+        Raises:
+            SQLAlchemyError: データベース操作中にエラーが発生した場合。
+
+        """
+        with self.session_factory() as session:
+            try:
+                stmt = (
+                    select(Model)
+                    .join(Model.model_types)
+                    .where(ModelType.name == model_type_name)
+                    .options(selectinload(Model.model_types))
+                    .order_by(Model.name)
+                    .distinct()
+                )
+
+                models_result: list[Model] = list(session.execute(stmt).scalars().all())
+
+                model_list = [
+                    {
+                        "id": model.id,
+                        "name": model.name,
+                        "provider": model.provider,
+                        "discontinued_at": model.discontinued_at,
+                        "created_at": model.created_at,
+                        "updated_at": model.updated_at,
+                        "model_types": sorted([mt.name for mt in model.model_types]),
+                    }
+                    for model in models_result
+                ]
+
+                logger.info(
+                    f"タイプ '{model_type_name}' のモデル情報を取得しました。 件数: {len(model_list)}",
+                )
+                return model_list
+
+            except SQLAlchemyError as e:
+                logger.error(
+                    f"タイプ '{model_type_name}' のモデル情報取得中にエラーが発生しました: {e}",
+                    exc_info=True,
+                )
+                raise

--- a/tests/unit/database/repository/test_model_repository.py
+++ b/tests/unit/database/repository/test_model_repository.py
@@ -1,0 +1,224 @@
+"""ModelRepository 直接の単体テスト (ADR 0035 段階 1, Issue #423)。
+
+`db_repository.py` から抽出した `ModelRepository` の責務境界を独立して検証する。
+既存の `tests/unit/database/test_db_repository_litellm_lookup.py` 等は
+`ImageRepository` の delegating facade 経由で同じ実装をカバーしているため、本ファイルでは
+ModelRepository を直接 instantiate して以下を最小限カバーする:
+
+- BaseRepository 継承 / session_factory 共有
+- `_get_model_id` の基本動作 (found / not found)
+- `insert_model` / `update_model` / `_get_or_create_manual_edit_model` の正常系
+- `get_models_by_litellm_ids` の空入力ガード
+- 削除されていないことを保証する smoke (ファサード経由でも同一クラス)
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from lorairo.database.db_repository import ImageRepository, ModelRepository
+from lorairo.database.repository.base import BaseRepository
+from lorairo.database.repository.model import ModelRepository as ModelRepositoryDirect
+from lorairo.database.schema import (
+    MANUAL_EDIT_LITELLM_ID,
+    MANUAL_EDIT_NAME,
+    MANUAL_EDIT_PROVIDER,
+)
+
+
+@pytest.fixture
+def model_repository(db_session_factory) -> ModelRepository:
+    """In-memory SQLite に対する ModelRepository インスタンス。"""
+    return ModelRepository(session_factory=db_session_factory)
+
+
+@pytest.mark.unit
+class TestModelRepositoryStructure:
+    """ADR 0035 段階 1 で確立した抽出構造の sanity check。"""
+
+    def test_inherits_base_repository(self) -> None:
+        """ModelRepository は BaseRepository を継承する。"""
+        assert issubclass(ModelRepository, BaseRepository)
+
+    def test_db_repository_reexport_is_canonical_class(self) -> None:
+        """`db_repository.ModelRepository` は repository.model.ModelRepository を re-export する。"""
+        assert ModelRepository is ModelRepositoryDirect
+
+    def test_holds_session_factory(self, db_session_factory) -> None:
+        """`session_factory` を BaseRepository 経由で保持する。"""
+        repo = ModelRepository(session_factory=db_session_factory)
+        assert repo.session_factory is db_session_factory
+
+
+@pytest.mark.unit
+class TestGetModelId:
+    """`_get_model_id` の基本動作。"""
+
+    def test_returns_id_when_model_exists(self, model_repository: ModelRepository) -> None:
+        """登録済み litellm_model_id で int の id が返る。"""
+        new_id = model_repository.insert_model(
+            name="gpt-test",
+            provider="openai",
+            model_types=["multimodal"],
+            litellm_model_id="openai/test-get-id",
+            requires_api_key=True,
+        )
+
+        result = model_repository._get_model_id("openai/test-get-id")
+
+        assert result == new_id
+
+    def test_returns_none_when_not_found(self, model_repository: ModelRepository) -> None:
+        """未登録 litellm_model_id で None が返る (silent return せず警告ログのみ)。"""
+        result = model_repository._get_model_id("openai/never-registered")
+        assert result is None
+
+
+@pytest.mark.unit
+class TestInsertModel:
+    """`insert_model` の正常系と model_types バリデーション。"""
+
+    def test_inserts_with_all_fields(self, model_repository: ModelRepository) -> None:
+        """全フィールド指定で登録できる。"""
+        new_id = model_repository.insert_model(
+            name="local-tagger",
+            provider=None,
+            model_types=["tags"],
+            litellm_model_id="local-tagger-v1",
+            estimated_size_gb=2.5,
+            requires_api_key=False,
+        )
+
+        assert isinstance(new_id, int)
+        model = model_repository.get_model_by_litellm_id("local-tagger-v1")
+        assert model is not None
+        assert model.name == "local-tagger"
+        assert model.provider is None
+        assert model.estimated_size_gb == pytest.approx(2.5)
+        assert model.requires_api_key is False
+        assert {mt.name for mt in model.model_types} == {"tags"}
+
+    def test_invalid_model_type_raises_value_error(self, model_repository: ModelRepository) -> None:
+        """存在しない model_type 名で ValueError が発生する。"""
+        with pytest.raises(ValueError, match="Invalid model_type"):
+            model_repository.insert_model(
+                name="bad",
+                provider="openai",
+                model_types=["nonexistent_type"],
+                litellm_model_id="openai/bad-type",
+            )
+
+
+@pytest.mark.unit
+class TestUpdateModel:
+    """`update_model` の差分検出。"""
+
+    def test_updates_only_changed_fields(self, model_repository: ModelRepository) -> None:
+        """変更されたフィールドのみ更新し True を返す。"""
+        new_id = model_repository.insert_model(
+            name="update-target",
+            provider="openai",
+            model_types=["multimodal"],
+            litellm_model_id="openai/update-target",
+        )
+
+        changed = model_repository.update_model(model_id=new_id, provider="openrouter")
+
+        assert changed is True
+        model = model_repository.get_model_by_litellm_id("openai/update-target")
+        assert model is not None
+        assert model.provider == "openrouter"
+
+    def test_no_changes_returns_false(self, model_repository: ModelRepository) -> None:
+        """全引数 None の場合は差分なしで False を返す。"""
+        new_id = model_repository.insert_model(
+            name="no-change",
+            provider="openai",
+            model_types=["multimodal"],
+            litellm_model_id="openai/no-change",
+        )
+
+        changed = model_repository.update_model(model_id=new_id)
+        assert changed is False
+
+    def test_raises_when_not_found(self, model_repository: ModelRepository) -> None:
+        """存在しない model_id で ValueError が発生する。"""
+        with pytest.raises(ValueError, match="Model not found"):
+            model_repository.update_model(model_id=999999, provider="openai")
+
+
+@pytest.mark.unit
+class TestGetModelsByLitellmIds:
+    """`get_models_by_litellm_ids` のバルクルックアップ。"""
+
+    def test_empty_input_short_circuits(self, model_repository: ModelRepository) -> None:
+        """空集合では DB アクセスせず空 dict を返す。"""
+        result = model_repository.get_models_by_litellm_ids(set())
+        assert result == {}
+
+    def test_returns_only_found_keys(self, model_repository: ModelRepository) -> None:
+        """見つかった key のみ dict に含まれる。"""
+        model_repository.insert_model(
+            name="bulk-1",
+            provider="openai",
+            model_types=["multimodal"],
+            litellm_model_id="openai/bulk-1",
+        )
+        result = model_repository.get_models_by_litellm_ids({"openai/bulk-1", "openai/missing"})
+        assert "openai/bulk-1" in result
+        assert "openai/missing" not in result
+
+
+@pytest.mark.unit
+class TestGetOrCreateManualEditModel:
+    """`_get_or_create_manual_edit_model` の MANUAL_EDIT sentinel 動作 (static method)。"""
+
+    def test_creates_manual_edit_on_first_call(self, model_repository: ModelRepository) -> None:
+        """初回呼び出しで MANUAL_EDIT モデルを作成する。"""
+        with model_repository.session_factory() as session:
+            model_id = ModelRepository._get_or_create_manual_edit_model(session)
+            session.commit()
+
+        manual_edit = model_repository.get_model_by_litellm_id(MANUAL_EDIT_LITELLM_ID)
+        assert manual_edit is not None
+        assert manual_edit.id == model_id
+        assert manual_edit.name == MANUAL_EDIT_NAME
+        assert manual_edit.provider == MANUAL_EDIT_PROVIDER
+
+    def test_returns_existing_on_second_call(self, model_repository: ModelRepository) -> None:
+        """2 回目以降は既存 MANUAL_EDIT を再利用する。"""
+        with model_repository.session_factory() as session:
+            first_id = ModelRepository._get_or_create_manual_edit_model(session)
+            second_id = ModelRepository._get_or_create_manual_edit_model(session)
+            session.commit()
+
+        assert first_id == second_id
+
+
+@pytest.mark.unit
+class TestFacadeDelegation:
+    """`ImageRepository` の delegating facade が `ModelRepository` を正しく呼ぶ。"""
+
+    def test_image_repository_delegates_get_model_by_litellm_id(
+        self, temp_db_repository: ImageRepository
+    ) -> None:
+        """ImageRepository.get_model_by_litellm_id は内部で ModelRepository を経由する。"""
+        # delegating facade 経由でも同じ結果を得る
+        temp_db_repository.insert_model(
+            name="facade-test",
+            provider="openai",
+            model_types=["multimodal"],
+            litellm_model_id="openai/facade-test",
+        )
+        via_facade = temp_db_repository.get_model_by_litellm_id("openai/facade-test")
+        via_direct = temp_db_repository._model_repo.get_model_by_litellm_id("openai/facade-test")
+        assert via_facade is not None
+        assert via_direct is not None
+        assert via_facade.id == via_direct.id
+
+    def test_image_repository_exposes_model_repo_attribute(
+        self, temp_db_repository: ImageRepository
+    ) -> None:
+        """ImageRepository は内部 `_model_repo` を保持する (段階移行中の hook)。"""
+        assert isinstance(temp_db_repository._model_repo, ModelRepository)
+        assert temp_db_repository._model_repo.session_factory is temp_db_repository.session_factory

--- a/tests/unit/database/test_db_manager_core.py
+++ b/tests/unit/database/test_db_manager_core.py
@@ -24,6 +24,7 @@ from sqlalchemy.exc import SQLAlchemyError
 
 from lorairo.database.db_manager import ImageDatabaseManager
 from lorairo.database.db_repository import ImageRepository
+from lorairo.database.repository.model import ModelRepository
 from lorairo.services.configuration_service import ConfigurationService
 
 # ---------------------------------------------------------------------------
@@ -38,6 +39,12 @@ def mock_repository() -> Mock:
 
 
 @pytest.fixture
+def mock_model_repo() -> Mock:
+    """モック化された ModelRepository を返す (ADR 0035 段階 1)。"""
+    return Mock(spec=ModelRepository)
+
+
+@pytest.fixture
 def mock_config_service() -> Mock:
     """モック化された ConfigurationService を返す。"""
     svc = Mock(spec=ConfigurationService)
@@ -46,12 +53,15 @@ def mock_config_service() -> Mock:
 
 
 @pytest.fixture
-def manager(mock_repository: Mock, mock_config_service: Mock) -> ImageDatabaseManager:
+def manager(
+    mock_repository: Mock, mock_config_service: Mock, mock_model_repo: Mock
+) -> ImageDatabaseManager:
     """ImageDatabaseManager のインスタンスを返す（依存はすべてモック）。"""
     return ImageDatabaseManager(
         repository=mock_repository,
         config_service=mock_config_service,
         fsm=None,
+        model_repo=mock_model_repo,
     )
 
 
@@ -228,79 +238,79 @@ class TestGetImageAnnotations:
 
 @pytest.mark.unit
 class TestGetModels:
-    """モデル取得メソッドのテスト"""
+    """モデル取得メソッドのテスト (ADR 0035 段階 1: ModelRepository 経由)"""
 
     def test_get_models_raises_on_sqlalchemy_error(
-        self, manager: ImageDatabaseManager, mock_repository: Mock
+        self, manager: ImageDatabaseManager, mock_model_repo: Mock
     ) -> None:
         """get_models: SQLAlchemyError は呼び出し元に伝播 (silent return しない)。"""
-        mock_repository.get_models.side_effect = SQLAlchemyError("db error")
+        mock_model_repo.get_models.side_effect = SQLAlchemyError("db error")
         with pytest.raises(SQLAlchemyError):
             manager.get_models()
 
     def test_get_tagger_models_raises_on_sqlalchemy_error(
-        self, manager: ImageDatabaseManager, mock_repository: Mock
+        self, manager: ImageDatabaseManager, mock_model_repo: Mock
     ) -> None:
         """get_tagger_models: SQLAlchemyError は呼び出し元に伝播。"""
-        mock_repository.get_models_by_type.side_effect = SQLAlchemyError("db error")
+        mock_model_repo.get_models_by_type.side_effect = SQLAlchemyError("db error")
         with pytest.raises(SQLAlchemyError):
             manager.get_tagger_models()
 
     def test_get_score_models_raises_on_sqlalchemy_error(
-        self, manager: ImageDatabaseManager, mock_repository: Mock
+        self, manager: ImageDatabaseManager, mock_model_repo: Mock
     ) -> None:
         """get_score_models: SQLAlchemyError は呼び出し元に伝播。"""
-        mock_repository.get_models_by_type.side_effect = SQLAlchemyError("db error")
+        mock_model_repo.get_models_by_type.side_effect = SQLAlchemyError("db error")
         with pytest.raises(SQLAlchemyError):
             manager.get_score_models()
 
     def test_get_captioner_models_raises_on_sqlalchemy_error(
-        self, manager: ImageDatabaseManager, mock_repository: Mock
+        self, manager: ImageDatabaseManager, mock_model_repo: Mock
     ) -> None:
         """get_captioner_models: SQLAlchemyError は呼び出し元に伝播。"""
-        mock_repository.get_models_by_type.side_effect = SQLAlchemyError("db error")
+        mock_model_repo.get_models_by_type.side_effect = SQLAlchemyError("db error")
         with pytest.raises(SQLAlchemyError):
             manager.get_captioner_models()
 
     def test_get_upscaler_models_raises_on_sqlalchemy_error(
-        self, manager: ImageDatabaseManager, mock_repository: Mock
+        self, manager: ImageDatabaseManager, mock_model_repo: Mock
     ) -> None:
         """get_upscaler_models: SQLAlchemyError は呼び出し元に伝播。"""
-        mock_repository.get_models_by_type.side_effect = SQLAlchemyError("db error")
+        mock_model_repo.get_models_by_type.side_effect = SQLAlchemyError("db error")
         with pytest.raises(SQLAlchemyError):
             manager.get_upscaler_models()
 
     def test_get_llm_models_raises_on_sqlalchemy_error(
-        self, manager: ImageDatabaseManager, mock_repository: Mock
+        self, manager: ImageDatabaseManager, mock_model_repo: Mock
     ) -> None:
         """get_llm_models: SQLAlchemyError は呼び出し元に伝播。"""
-        mock_repository.get_models_by_type.side_effect = SQLAlchemyError("db error")
+        mock_model_repo.get_models_by_type.side_effect = SQLAlchemyError("db error")
         with pytest.raises(SQLAlchemyError):
             manager.get_llm_models()
 
     def test_get_models_returns_list_on_success(
-        self, manager: ImageDatabaseManager, mock_repository: Mock
+        self, manager: ImageDatabaseManager, mock_model_repo: Mock
     ) -> None:
-        """get_models: 正常系ではリポジトリの返値をそのまま返す。"""
+        """get_models: 正常系では ModelRepository の返値をそのまま返す。"""
         expected = [{"id": 1, "name": "model_a"}]
-        mock_repository.get_models.return_value = expected
+        mock_model_repo.get_models.return_value = expected
         assert manager.get_models() == expected
 
     def test_get_tagger_models_passes_correct_type(
-        self, manager: ImageDatabaseManager, mock_repository: Mock
+        self, manager: ImageDatabaseManager, mock_model_repo: Mock
     ) -> None:
-        """get_tagger_models は 'tags' タイプでリポジトリを呼び出す。"""
-        mock_repository.get_models_by_type.return_value = []
+        """get_tagger_models は 'tags' タイプで ModelRepository を呼び出す。"""
+        mock_model_repo.get_models_by_type.return_value = []
         manager.get_tagger_models()
-        mock_repository.get_models_by_type.assert_called_once_with("tags")
+        mock_model_repo.get_models_by_type.assert_called_once_with("tags")
 
     def test_get_llm_models_passes_multimodal_type(
-        self, manager: ImageDatabaseManager, mock_repository: Mock
+        self, manager: ImageDatabaseManager, mock_model_repo: Mock
     ) -> None:
-        """get_llm_models は 'multimodal' タイプでリポジトリを呼び出す。"""
-        mock_repository.get_models_by_type.return_value = []
+        """get_llm_models は 'multimodal' タイプで ModelRepository を呼び出す。"""
+        mock_model_repo.get_models_by_type.return_value = []
         manager.get_llm_models()
-        mock_repository.get_models_by_type.assert_called_once_with("multimodal")
+        mock_model_repo.get_models_by_type.assert_called_once_with("multimodal")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/database/test_db_manager_extended.py
+++ b/tests/unit/database/test_db_manager_extended.py
@@ -520,10 +520,14 @@ class TestGetProcessedMetadata:
 class TestGetManualEditModelId:
     """get_manual_edit_model_id メソッドのテスト"""
 
-    def test_returns_model_id_from_session(self, mock_repository: Mock, mock_config_service: Mock) -> None:
-        """セッションを使って model_id を返す (ADR 0035 段階 1: model_repo 経由)。"""
-        # ADR 0035 段階 1: manual edit model は ModelRepository._get_or_create_manual_edit_model
-        # (static) で取得する。manager は self.model_repo.session_factory でセッションを開く。
+    def test_returns_model_id_via_injected_model_repo(
+        self, mock_repository: Mock, mock_config_service: Mock
+    ) -> None:
+        """injected model_repo の _get_or_create_manual_edit_model 経由で model_id を返す (DI contract)。
+
+        PR #477 review (P2): クラス経由 static 呼び出しではなく、injected instance 経由で
+        dispatch することを固定。test double / subclass override / tenant-aware wrapper を尊重する。
+        """
         mock_session = MagicMock()
         mock_session_ctx = MagicMock()
         mock_session_ctx.__enter__ = Mock(return_value=mock_session)
@@ -531,19 +535,19 @@ class TestGetManualEditModelId:
         mock_session_factory = Mock(return_value=mock_session_ctx)
         mock_model_repo = Mock()
         mock_model_repo.session_factory = mock_session_factory
+        # injected model_repo のメソッドが呼ばれることを直接固定
+        mock_model_repo._get_or_create_manual_edit_model = Mock(return_value=99)
 
         mgr = ImageDatabaseManager(
             repository=mock_repository,
             config_service=mock_config_service,
             model_repo=mock_model_repo,
         )
-        with patch(
-            "lorairo.database.db_manager.ModelRepository._get_or_create_manual_edit_model",
-            return_value=99,
-        ):
-            result = mgr.get_manual_edit_model_id()
+        result = mgr.get_manual_edit_model_id()
 
         assert result == 99
+        # injected method が session 引数で呼ばれた
+        mock_model_repo._get_or_create_manual_edit_model.assert_called_once_with(mock_session)
 
     def test_caches_model_id_on_second_call(self, mock_repository: Mock, mock_config_service: Mock) -> None:
         """2回目以降の呼び出しはキャッシュから返す (ADR 0035 段階 1)。"""
@@ -554,25 +558,24 @@ class TestGetManualEditModelId:
         mock_session_factory = Mock(return_value=mock_session_ctx)
         mock_model_repo = Mock()
         mock_model_repo.session_factory = mock_session_factory
+        mock_model_repo._get_or_create_manual_edit_model = Mock(return_value=55)
 
         mgr = ImageDatabaseManager(
             repository=mock_repository,
             config_service=mock_config_service,
             model_repo=mock_model_repo,
         )
-        with patch(
-            "lorairo.database.db_manager.ModelRepository._get_or_create_manual_edit_model",
-            return_value=55,
-        ):
-            # 1回目
-            result1 = mgr.get_manual_edit_model_id()
-            # 2回目
-            result2 = mgr.get_manual_edit_model_id()
+        # 1回目
+        result1 = mgr.get_manual_edit_model_id()
+        # 2回目
+        result2 = mgr.get_manual_edit_model_id()
 
         assert result1 == 55
         assert result2 == 55
-        # session_factory は1回だけ呼ばれる
+        # session_factory は1回だけ呼ばれる (キャッシュ機能)
         mock_session_factory.assert_called_once()
+        # injected method も1回だけ呼ばれる
+        mock_model_repo._get_or_create_manual_edit_model.assert_called_once()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/database/test_db_manager_extended.py
+++ b/tests/unit/database/test_db_manager_extended.py
@@ -521,44 +521,53 @@ class TestGetManualEditModelId:
     """get_manual_edit_model_id メソッドのテスト"""
 
     def test_returns_model_id_from_session(self, mock_repository: Mock, mock_config_service: Mock) -> None:
-        """セッションを使って model_id を返す。"""
-        # session_factory は ImageRepository の __init__ で設定されるインスタンス属性。
-        # spec=ImageRepository の Mock では含まれないため、直接設定する。
+        """セッションを使って model_id を返す (ADR 0035 段階 1: model_repo 経由)。"""
+        # ADR 0035 段階 1: manual edit model は ModelRepository._get_or_create_manual_edit_model
+        # (static) で取得する。manager は self.model_repo.session_factory でセッションを開く。
         mock_session = MagicMock()
         mock_session_ctx = MagicMock()
         mock_session_ctx.__enter__ = Mock(return_value=mock_session)
         mock_session_ctx.__exit__ = Mock(return_value=False)
         mock_session_factory = Mock(return_value=mock_session_ctx)
-        mock_repository.session_factory = mock_session_factory
-        mock_repository._get_or_create_manual_edit_model.return_value = 99
+        mock_model_repo = Mock()
+        mock_model_repo.session_factory = mock_session_factory
 
         mgr = ImageDatabaseManager(
             repository=mock_repository,
             config_service=mock_config_service,
+            model_repo=mock_model_repo,
         )
-        result = mgr.get_manual_edit_model_id()
+        with patch(
+            "lorairo.database.db_manager.ModelRepository._get_or_create_manual_edit_model",
+            return_value=99,
+        ):
+            result = mgr.get_manual_edit_model_id()
 
         assert result == 99
 
     def test_caches_model_id_on_second_call(self, mock_repository: Mock, mock_config_service: Mock) -> None:
-        """2回目以降の呼び出しはキャッシュから返す。"""
+        """2回目以降の呼び出しはキャッシュから返す (ADR 0035 段階 1)。"""
         mock_session = MagicMock()
         mock_session_ctx = MagicMock()
         mock_session_ctx.__enter__ = Mock(return_value=mock_session)
         mock_session_ctx.__exit__ = Mock(return_value=False)
         mock_session_factory = Mock(return_value=mock_session_ctx)
-        mock_repository.session_factory = mock_session_factory
-        mock_repository._get_or_create_manual_edit_model.return_value = 55
+        mock_model_repo = Mock()
+        mock_model_repo.session_factory = mock_session_factory
 
         mgr = ImageDatabaseManager(
             repository=mock_repository,
             config_service=mock_config_service,
+            model_repo=mock_model_repo,
         )
-
-        # 1回目
-        result1 = mgr.get_manual_edit_model_id()
-        # 2回目
-        result2 = mgr.get_manual_edit_model_id()
+        with patch(
+            "lorairo.database.db_manager.ModelRepository._get_or_create_manual_edit_model",
+            return_value=55,
+        ):
+            # 1回目
+            result1 = mgr.get_manual_edit_model_id()
+            # 2回目
+            result2 = mgr.get_manual_edit_model_id()
 
         assert result1 == 55
         assert result2 == 55


### PR DESCRIPTION
## Summary

ADR 0035 §6 移行戦略の **段階 1**: `db_repository.py` の god class から **Model / ModelType 関連 11 メソッド** を `ModelRepository` として独立 Repository に抽出。

### 新規ファイル (`src/lorairo/database/repository/`)

- `base.py` (41 行): `BaseRepository` (`session_factory` + `BATCH_CHUNK_SIZE`)
- `model.py` (538 行): `ModelRepository(BaseRepository)`
- `__init__.py` (16 行): re-export

### 変更ファイル

| ファイル | 変化 |
|---|---|
| `db_repository.py` | **4,201 → 3,826 行** (-375)。Model 実装 (439 行) を削除し ADR 0035 §5 ファサード方針として 64 行の delegating wrapper (`ImageRepository.X()` → `self._model_repo.X()`) に置換 |
| `db_manager.py` | `__init__` で `self.model_repo = ModelRepository(...)` を composition で保持。Model 系 method 6 箇所 (`get_models`, `get_models_by_type` × 5) を `self.repository.X()` → `self.model_repo.X()` に置換。`get_manual_edit_model_id` を `ModelRepository._get_or_create_manual_edit_model(session)` static 呼び出しに変更 |

### 移設した 11 メソッド (439 行)

`_get_model_id` / `get_model_by_litellm_id` / `get_models_by_name` / `get_models_by_litellm_ids` / `_get_or_create_manual_edit_model` (static) / `insert_model` / `_apply_simple_field_updates` (static) / `_update_model_types` (static) / `update_model` / `get_models` / `get_model_objects` / `get_models_by_type`

## Test plan

- [x] 新規 unit test **16 件** (`tests/unit/database/repository/test_model_repository.py`)
- [x] 既存 test 修正 **11 件** (`test_db_manager_core.py` 9 件 + `test_db_manager_extended.py` 2 件)
- [x] CI-equivalent filter: **3234 passed, 2 skipped, 0 failures** (5 分 17 秒)
- [x] Coverage: db_manager **98%** / db_repository **75%** / model.py **73%** / base.py **100%** / database package 全体 **82%** (75% gate クリア)
- [x] `ruff format` / `ruff check` / `mypy -p lorairo.database`: 全 pass

## ADR 0035 準拠

- **§3 Manager composition**: `self.model_repo` を `__init__` で保持
- **§5 段階移行ファサード**: `ImageRepository` の delegating wrapper で既存 production 10+ 呼び出しサイトの一括書換リスクを回避しつつ import 互換維持
- **§6 移行戦略**: Model entity から開始 (依存少)。Image / Annotation / Project / ErrorRecord は段階 2-5 で未着手

## 段階 2 以降への引き継ぎ

各 Service / Worker での `manager.repository.<Model 系>` 呼び出しを `manager.model_repo` 直接参照に切替後、delegating wrapper と `_model_repo` 属性を削除可能。本 PR では互換維持を優先し未着手。

## Commit 一覧

| Hash | Subject |
|---|---|
| `1f264954` | refactor: extract ModelRepository (#423 段階 1, ADR 0035) |
| `bedb10d8` | refactor: remove Model methods from ImageRepository, re-export ModelRepository (#423 段階 1) |
| `00937da7` | refactor: inject ModelRepository into ImageDatabaseManager (#423 段階 1) |
| `770e9a88` | test: cover ModelRepository extraction (#423 段階 1) |

Refs: #423 (段階 1 のみ、残 4 段階は別 PR で順次)
Refs: #418, ADR 0035