### PR TITLE
[codex] refactor annotator model bulk pass

### DIFF
--- a/src/lorairo/gui/workers/annotation_worker.py
+++ b/src/lorairo/gui/workers/annotation_worker.py
@@ -287,8 +287,19 @@ class AnnotationWorker(LoRAIroWorkerBase["AnnotationExecutionResult"]):
                     )
                 )
 
+    def _merge_annotation_results(
+        self,
+        destination: PHashAnnotationResults,
+        source: PHashAnnotationResults,
+    ) -> None:
+        """pHash -> model result の辞書を destination にマージする。"""
+        for phash, annotations in source.items():
+            if phash not in destination:
+                destination[phash] = {}
+            destination[phash].update(annotations)
+
     def _run_annotation(self) -> tuple[PHashAnnotationResults, list[ModelErrorDetail]]:
-        """モデル単位でアノテーションを実行し、結果をマージする。
+        """選択モデルを一括渡ししてアノテーションを実行する。
 
         Returns:
             (マージされたアノテーション結果, モデルエラー詳細リスト) のタプル。
@@ -298,7 +309,63 @@ class AnnotationWorker(LoRAIroWorkerBase["AnnotationExecutionResult"]):
         total_models = len(self.litellm_model_ids)
         phash_list = self._build_phash_list_for_current_paths()
 
-        logger.debug(f"モデル順次実行開始: {total_models}モデル = {self.litellm_model_ids}")
+        if total_models == 0:
+            logger.debug("選択モデルなし: アノテーション実行をスキップ")
+            return merged_results, model_errors
+
+        logger.debug(f"モデル一括実行開始: {total_models}モデル = {self.litellm_model_ids}")
+
+        self._report_progress(
+            5,
+            f"AIモデル一括実行中: {total_models}モデル",
+            processed_count=0,
+            total_count=len(self.image_paths),
+        )
+
+        try:
+            self._check_cancellation()
+            bulk_results = self.annotation_logic.execute_annotation(
+                image_paths=self.image_paths,
+                litellm_model_ids=list(self.litellm_model_ids),
+                phash_list=phash_list,
+            )
+            valid_results = self._collect_valid_model_results(
+                bulk_results,
+                set(self.litellm_model_ids),
+                model_errors,
+            )
+            self._collect_l1_model_errors(valid_results, model_errors)
+            self._merge_annotation_results(merged_results, valid_results)
+
+            self._report_progress(
+                90,
+                f"AIモデル一括実行完了: {total_models}モデル",
+                processed_count=len(self.image_paths),
+                total_count=len(self.image_paths),
+            )
+            logger.debug(f"モデル一括実行完了: 結果={len(bulk_results)}件")
+            return merged_results, model_errors
+
+        except CancellationError:
+            logger.info("モデル一括アノテーション処理がキャンセルされました")
+            raise
+        except Exception as bulk_error:
+            logger.warning(
+                f"モデル一括実行に失敗したためモデル単位 fallback に切り替えます: {bulk_error}",
+                exc_info=True,
+            )
+            return self._run_annotation_per_model_fallback(phash_list)
+
+    def _run_annotation_per_model_fallback(
+        self,
+        phash_list: list[str] | None,
+    ) -> tuple[PHashAnnotationResults, list[ModelErrorDetail]]:
+        """一括呼び出し失敗時の互換 fallback としてモデル単位で実行する。"""
+        merged_results: PHashAnnotationResults = PHashAnnotationResults()
+        model_errors: list[ModelErrorDetail] = []
+        total_models = len(self.litellm_model_ids)
+
+        logger.debug(f"モデル単位 fallback 実行開始: {total_models}モデル = {self.litellm_model_ids}")
 
         for model_idx, litellm_model_id in enumerate(self.litellm_model_ids):
             self._check_cancellation()
@@ -332,10 +399,7 @@ class AnnotationWorker(LoRAIroWorkerBase["AnnotationExecutionResult"]):
                 )
                 self._collect_l1_model_errors(valid_model_results, model_errors)
 
-                for phash, annotations in valid_model_results.items():
-                    if phash not in merged_results:
-                        merged_results[phash] = {}
-                    merged_results[phash].update(annotations)
+                self._merge_annotation_results(merged_results, valid_model_results)
 
                 logger.debug(
                     f"モデル実行完了: {litellm_model_id}, 結果={len(model_results)}件, "
@@ -377,7 +441,7 @@ class AnnotationWorker(LoRAIroWorkerBase["AnnotationExecutionResult"]):
                 total_count=len(self.image_paths),
             )
 
-        logger.debug(f"モデル順次実行完了: 最終結果={len(merged_results)}件")
+        logger.debug(f"モデル単位 fallback 実行完了: 最終結果={len(merged_results)}件")
         return merged_results, model_errors
 
     def execute(self) -> AnnotationExecutionResult:

--- a/tests/bdd/steps/test_annotation_worker_failure_propagation.py
+++ b/tests/bdd/steps/test_annotation_worker_failure_propagation.py
@@ -136,7 +136,18 @@ def when_run_worker(worker_ctx: dict[str, object]) -> None:
     assert isinstance(behaviors, dict)
 
     def execute_annotation(*_args: object, **kwargs: object) -> object:
-        model = cast("list[str]", kwargs["litellm_model_ids"])[0]
+        models = cast("list[str]", kwargs["litellm_model_ids"])
+        if len(models) > 1:
+            merged: dict[str, dict[str, dict[str, Any]]] = {}
+            for model in models:
+                behavior = behaviors.get(model, _success_result(model))
+                if isinstance(behavior, Exception):
+                    raise behavior
+                for phash, annotations in behavior.items():
+                    merged.setdefault(phash, {}).update(annotations)
+            return merged
+
+        model = models[0]
         behavior = behaviors.get(model, _success_result(model))
         if isinstance(behavior, Exception):
             raise behavior

--- a/tests/unit/gui/workers/test_annotation_worker.py
+++ b/tests/unit/gui/workers/test_annotation_worker.py
@@ -140,26 +140,20 @@ class TestAnnotationWorkerExecute:
         }
         mock_db_manager.repository.save_annotations = Mock()
 
-        mock_annotation_logic.execute_annotation.side_effect = [
-            {
-                "phash1": {
-                    "gpt-4o-mini": {
-                        "tags": ["cat"],
-                        "formatted_output": {},
-                        "error": None,
-                    }
-                }
-            },
-            {
-                "phash1": {
-                    "claude-3-haiku-20240307": {
-                        "tags": ["feline"],
-                        "formatted_output": {},
-                        "error": None,
-                    }
-                }
-            },
-        ]
+        mock_annotation_logic.execute_annotation.return_value = {
+            "phash1": {
+                "gpt-4o-mini": {
+                    "tags": ["cat"],
+                    "formatted_output": {},
+                    "error": None,
+                },
+                "claude-3-haiku-20240307": {
+                    "tags": ["feline"],
+                    "formatted_output": {},
+                    "error": None,
+                },
+            }
+        }
 
         worker = AnnotationWorker(
             annotation_logic=mock_annotation_logic,
@@ -171,7 +165,11 @@ class TestAnnotationWorkerExecute:
 
         result = worker.execute()
 
-        assert mock_annotation_logic.execute_annotation.call_count == 2
+        mock_annotation_logic.execute_annotation.assert_called_once_with(
+            image_paths=image_paths,
+            litellm_model_ids=models,
+            phash_list=None,
+        )
 
         assert isinstance(result, AnnotationExecutionResult)
         assert "phash1" in result.results
@@ -202,10 +200,10 @@ class TestAnnotationWorkerExecute:
         )
         result = worker.execute()
 
-        assert mock_annotation_logic.execute_annotation.call_count == 2
+        mock_annotation_logic.execute_annotation.assert_called_once()
         assert result.models_used == models
-        first_call_kwargs = mock_annotation_logic.execute_annotation.call_args_list[0].kwargs
-        assert first_call_kwargs["litellm_model_ids"] == ["__legacy_17__"]
+        call_kwargs = mock_annotation_logic.execute_annotation.call_args.kwargs
+        assert call_kwargs["litellm_model_ids"] == models
 
     def test_execute_model_error_partial_success(self, mock_annotation_logic, mock_model_registry):
         """モデルエラー時の部分的成功"""
@@ -223,6 +221,7 @@ class TestAnnotationWorkerExecute:
         mock_db_manager.get_image_id_by_filepath.return_value = 1
 
         mock_annotation_logic.execute_annotation.side_effect = [
+            RuntimeError("bulk call failed"),
             {"phash1": {"gpt-4o-mini": {"tags": ["cat"], "formatted_output": {}, "error": None}}},
             RuntimeError("API Error"),
             {
@@ -242,7 +241,9 @@ class TestAnnotationWorkerExecute:
 
         result = worker.execute()
 
-        assert mock_annotation_logic.execute_annotation.call_count == 3
+        assert mock_annotation_logic.execute_annotation.call_count == 4
+        bulk_call_kwargs = mock_annotation_logic.execute_annotation.call_args_list[0].kwargs
+        assert bulk_call_kwargs["litellm_model_ids"] == models
 
         assert isinstance(result, AnnotationExecutionResult)
         assert "phash1" in result.results
@@ -268,10 +269,12 @@ class TestAnnotationWorkerExecute:
         mock_db_manager.repository.save_annotations = Mock()
         mock_db_manager.repository.get_phashes_by_filepaths.return_value = {}
 
-        mock_annotation_logic.execute_annotation.side_effect = [
-            {"phash1": {"model-a": {"tags": [], "error": "rate_limited"}}},
-            {"phash1": {"model-b": {"tags": ["cat"], "formatted_output": {}, "error": None}}},
-        ]
+        mock_annotation_logic.execute_annotation.return_value = {
+            "phash1": {
+                "model-a": {"tags": [], "error": "rate_limited"},
+                "model-b": {"tags": ["cat"], "formatted_output": {}, "error": None},
+            }
+        }
 
         worker = AnnotationWorker(
             annotation_logic=mock_annotation_logic,
@@ -369,6 +372,7 @@ class TestAnnotationWorkerExecute:
         mock_db_manager.get_image_id_by_filepath.return_value = 1
 
         mock_annotation_logic.execute_annotation.side_effect = [
+            RuntimeError("bulk call failed"),
             RuntimeError("API Error 1"),
             RuntimeError("API Error 2"),
         ]

--- a/tests/unit/test_annotator_adapter_model_registry.py
+++ b/tests/unit/test_annotator_adapter_model_registry.py
@@ -1,11 +1,11 @@
 """AnnotatorLibraryAdapter model registry tests."""
 
 from unittest.mock import MagicMock, patch
-from PIL import Image
 
 import pytest
 from image_annotator_lib import AnnotatorInfo
 from image_annotator_lib.core.types import TaskCapability
+from PIL import Image
 
 from lorairo.annotations.annotator_adapter import AnnotatorLibraryAdapter
 
@@ -378,7 +378,7 @@ def test_annotate_calls_library_annotate_with_correct_args() -> None:
     try:
         result = adapter.annotate(
             images=[fake_image],
-            litellm_model_ids=["openai/gpt-4o"],
+            litellm_model_ids=["openai/gpt-4o", "google/gemini-1.5-flash"],
             phash_list=["hash001"],
         )
     finally:
@@ -387,7 +387,7 @@ def test_annotate_calls_library_annotate_with_correct_args() -> None:
     assert result == expected_result
     mock_lib_annotate.assert_called_once_with(
         images_list=[fake_image],
-        model_name_list=["openai/gpt-4o"],
+        model_name_list=["openai/gpt-4o", "google/gemini-1.5-flash"],
         phash_list=["hash001"],
         api_keys={},
     )


### PR DESCRIPTION
## Summary
- Change AnnotationWorker to call AnnotationLogic once with the full selected `litellm_model_ids` list by default.
- Keep the previous per-model execution path as an automatic fallback when the bulk call raises.
- Update adapter, worker, and BDD tests to cover bulk model forwarding and fallback behavior.

## Validation
- `uv run pytest tests/unit/test_annotator_adapter_model_registry.py tests/unit/annotations/test_annotation_logic.py tests/unit/gui/workers/test_annotation_worker.py tests/bdd/steps/test_annotation_worker_failure_propagation.py` (65 passed)
- `uv run ruff check src/lorairo/annotations src/lorairo/gui/workers tests/unit/test_annotator_adapter_model_registry.py tests/unit/gui/workers/test_annotation_worker.py tests/bdd/steps/test_annotation_worker_failure_propagation.py`
- `uv run mypy src/lorairo/annotations src/lorairo/gui/workers/annotation_worker.py`
- `git diff --check`

Closes #396