### PR TITLE
refactor: extract ProjectRepository (#423 段階 2, ADR 0035)

### DIFF
--- a/src/lorairo/database/db_manager.py
+++ b/src/lorairo/database/db_manager.py
@@ -23,6 +23,7 @@ from .db_repository import (
 )
 from .filter_criteria import ImageFilterCriteria
 from .repository.model import ModelRepository
+from .repository.project import ProjectRepository
 
 if TYPE_CHECKING:
     from ..services.configuration_service import ConfigurationService
@@ -40,6 +41,7 @@ class ImageDatabaseManager:
         config_service: "ConfigurationService",
         fsm: FileSystemManager | None = None,
         model_repo: ModelRepository | None = None,
+        project_repo: ProjectRepository | None = None,
     ):
         """ImageDatabaseManagerのコンストラクタ。
 
@@ -48,6 +50,9 @@ class ImageDatabaseManager:
             config_service (ConfigurationService): 設定サービスインスタンス。
             fsm (FileSystemManager): ファイルシステムマネージャー（オプション）。
             model_repo (ModelRepository): Model 関連の Repository (ADR 0035 段階 1)。
+                None の場合は `repository` の `session_factory` を流用して生成する。
+                テスト時にモック化可能。
+            project_repo (ProjectRepository): Project 関連の Repository (ADR 0035 段階 2)。
                 None の場合は `repository` の `session_factory` を流用して生成する。
                 テスト時にモック化可能。
 
@@ -60,14 +65,19 @@ class ImageDatabaseManager:
         # `Mock(spec=ImageRepository)` で生成された mock には session_factory が無いため、
         # その場合は DefaultSessionLocal にフォールバックする (各テストは model_repo を明示
         # Mock 注入することで本フォールバック経路を経由してもテスト独立性を保てる)。
-        if model_repo is None:
-            session_factory = getattr(repository, "session_factory", None)
-            if session_factory is None:
-                from .db_core import DefaultSessionLocal
+        session_factory = getattr(repository, "session_factory", None)
+        if session_factory is None:
+            from .db_core import DefaultSessionLocal
 
-                session_factory = DefaultSessionLocal
+            session_factory = DefaultSessionLocal
+        if model_repo is None:
             model_repo = ModelRepository(session_factory=session_factory)
         self.model_repo: ModelRepository = model_repo
+        # ADR 0035 段階 2 (#423): Project 関連を ProjectRepository に集約。
+        # session_factory は ModelRepository と同様に repository から取得する。
+        if project_repo is None:
+            project_repo = ProjectRepository(session_factory=session_factory)
+        self.project_repo: ProjectRepository = project_repo
         self._cached_project_id: int | None = None
         logger.info("ImageDatabaseManager initialized.")
 
@@ -118,7 +128,8 @@ class ImageDatabaseManager:
             project_name = project_root.name
 
         try:
-            self._cached_project_id = self.repository.ensure_project(project_name, project_root)
+            # ADR 0035 段階 2 (#423): injected project_repo 経由で呼び出し DI contract を維持。
+            self._cached_project_id = self.project_repo.ensure_project(project_name, project_root)
         except SQLAlchemyError:
             logger.error(
                 f"ensure_project 失敗 (project_name={project_name}) — project_id 未設定で続行",

--- a/src/lorairo/database/db_repository.py
+++ b/src/lorairo/database/db_repository.py
@@ -20,6 +20,7 @@ from ..utils.log import logger
 from .db_core import DefaultSessionLocal
 from .filter_criteria import ImageFilterCriteria
 from .repository.model import ModelRepository
+from .repository.project import ProjectRepository
 from .schema import (
     MANUAL_EDIT_LITELLM_ID,
     MANUAL_EDIT_NAME,
@@ -117,6 +118,10 @@ class ImageRepository:
         # 段階 2 以降で各 Service / Worker が直接 ModelRepository を参照するようになれば、
         # 本 facade と _model_repo は削除可能。
         self._model_repo = ModelRepository(session_factory=session_factory)
+        # ADR 0035 段階 2 (#423): Project 関連は ProjectRepository に移設。
+        # 既存呼び出し (`image_repository.ensure_project()` 等) との互換性のため、
+        # ImageRepository は内部で ProjectRepository への delegating facade を保持する。
+        self._project_repo = ProjectRepository(session_factory=session_factory)
         logger.info("ImageRepository initialized.")
 
         # 外部tag_db統合（公開API経由、グレースフルデグラデーション対応）
@@ -2477,126 +2482,27 @@ class ImageRepository:
             logger.debug(f"Project filter applied: project_name='{project_name}'")
         return query
 
+    # --- Project methods (delegating facade, ADR 0035 段階 2) ---
+    # 実装は src/lorairo/database/repository/project.py の ProjectRepository に移設済み。
+    # 既存呼び出し (`image_repository.ensure_project()` 等) との互換性のため delegating
+    # wrapper を残す。段階 3 以降で各 Service / Worker が `manager.project_repo` 経由で
+    # 直接 ProjectRepository を参照するようになれば、本 facade は削除可能。
+
     def ensure_project(self, name: str, path: Path, description: str = "") -> int:
-        """プロジェクトを upsert して ID を返す（name UNIQUE）。
-
-        Args:
-            name: プロジェクト名（UNIQUE制約あり）。
-            path: プロジェクトの絶対パス。
-            description: プロジェクト説明（省略可）。
-
-        Returns:
-            int: プロジェクトID。
-
-        Raises:
-            SQLAlchemyError: DB操作エラー。
-        """
-        with self.session_factory() as session:
-            try:
-                existing = session.execute(select(Project).where(Project.name == name)).scalar_one_or_none()
-
-                if existing is not None:
-                    if str(existing.path) != str(path):
-                        existing.path = str(path)
-                        session.commit()
-                    return existing.id
-
-                project = Project(name=name, path=str(path), description=description or None)
-                session.add(project)
-                session.flush()
-                project_id = project.id
-                session.commit()
-                logger.info(f"Project created: name='{name}', id={project_id}")
-                return project_id
-            except IntegrityError:
-                session.rollback()
-                return session.execute(select(Project.id).where(Project.name == name)).scalar_one()
-            except SQLAlchemyError as e:
-                session.rollback()
-                logger.error(f"ensure_project エラー (name={name}): {e}", exc_info=True)
-                raise
+        """ProjectRepository.ensure_project への delegate (ADR 0035 段階 2)。"""
+        return self._project_repo.ensure_project(name, path, description)
 
     def get_image_ids_by_project(self, project_name: str) -> list[int]:
-        """プロジェクト名で画像ID一覧を取得する。
-
-        Args:
-            project_name: フィルタ対象プロジェクト名。
-
-        Returns:
-            list[int]: 画像IDのリスト。プロジェクトが存在しない場合は空リスト。
-
-        Raises:
-            SQLAlchemyError: DB操作エラー。
-        """
-        with self.session_factory() as session:
-            try:
-                stmt = (
-                    select(Image.id)
-                    .join(Project, Image.project_id == Project.id)
-                    .where(Project.name == project_name)
-                )
-                result = list(session.execute(stmt).scalars().all())
-                logger.debug(f"get_image_ids_by_project: name='{project_name}', count={len(result)}")
-                return result
-            except SQLAlchemyError as e:
-                logger.error(f"get_image_ids_by_project エラー: {e}", exc_info=True)
-                raise
+        """ProjectRepository.get_image_ids_by_project への delegate (ADR 0035 段階 2)。"""
+        return self._project_repo.get_image_ids_by_project(project_name)
 
     def get_image_ids_by_project_id(self, project_id: int) -> list[int]:
-        """プロジェクトIDで画像ID一覧を取得する。
-
-        Args:
-            project_id: フィルタ対象プロジェクトID。
-
-        Returns:
-            list[int]: 画像IDのリスト。
-
-        Raises:
-            SQLAlchemyError: DB操作エラー。
-        """
-        with self.session_factory() as session:
-            try:
-                stmt = select(Image.id).where(Image.project_id == project_id)
-                result = list(session.execute(stmt).scalars().all())
-                logger.debug(f"get_image_ids_by_project_id: id={project_id}, count={len(result)}")
-                return result
-            except SQLAlchemyError as e:
-                logger.error(f"get_image_ids_by_project_id エラー: {e}", exc_info=True)
-                raise
+        """ProjectRepository.get_image_ids_by_project_id への delegate (ADR 0035 段階 2)。"""
+        return self._project_repo.get_image_ids_by_project_id(project_id)
 
     def assign_images_to_project(self, image_ids: list[int], project_id: int) -> int:
-        """画像IDリストをプロジェクトに割り当てる。
-
-        Args:
-            image_ids: 割り当てる画像IDリスト。
-            project_id: 割り当て先プロジェクトID。
-
-        Returns:
-            int: 実際に更新された件数。
-
-        Raises:
-            SQLAlchemyError: DB操作エラー。
-        """
-        if not image_ids:
-            return 0
-
-        with self.session_factory() as session:
-            try:
-                total_updated = 0
-                for i in range(0, len(image_ids), self.BATCH_CHUNK_SIZE):
-                    chunk = image_ids[i : i + self.BATCH_CHUNK_SIZE]
-                    stmt = update(Image).where(Image.id.in_(chunk)).values(project_id=project_id)
-                    total_updated += cast("CursorResult[Any]", session.execute(stmt)).rowcount
-                session.commit()
-                logger.info(
-                    f"assign_images_to_project: {total_updated}/{len(image_ids)} images"
-                    f" → project_id={project_id}"
-                )
-                return total_updated
-            except SQLAlchemyError as e:
-                session.rollback()
-                logger.error(f"assign_images_to_project エラー: {e}", exc_info=True)
-                raise
+        """ProjectRepository.assign_images_to_project への delegate (ADR 0035 段階 2)。"""
+        return self._project_repo.assign_images_to_project(image_ids, project_id)
 
     # --- Main Filter Method ---
 

--- a/src/lorairo/database/repository/__init__.py
+++ b/src/lorairo/database/repository/__init__.py
@@ -4,13 +4,16 @@
 段階的に entity ごとに移行する (移行戦略は ADR 0035 §6 参照)。
 
 段階 1 (#423): `ModelRepository`
-段階 2 以降: `ProjectRepository`, `ErrorRecordRepository`, `ImageRepository`, `AnnotationRepository`
+段階 2 (#423): `ProjectRepository`
+段階 3 以降: `ErrorRecordRepository`, `ImageRepository`, `AnnotationRepository`
 """
 
 from .base import BaseRepository
 from .model import ModelRepository
+from .project import ProjectRepository
 
 __all__ = [
     "BaseRepository",
     "ModelRepository",
+    "ProjectRepository",
 ]

--- a/src/lorairo/database/repository/project.py
+++ b/src/lorairo/database/repository/project.py
@@ -1,0 +1,155 @@
+"""Project 永続化担当 Repository (ADR 0035 §1)。
+
+`ImageRepository` god class 分割の段階 2 として、Project エンティティおよび
+`Image.project_id` (FK) 関連の CRUD・割り当てを本 Repository に集約する。
+
+管轄 entity:
+  - `Project` (`name` UNIQUE, `path`, `description`)
+  - `Image.project_id` FK 経由のプロジェクトアサイン
+
+段階 1 で確立した `BaseRepository` (`session_factory` + `BATCH_CHUNK_SIZE`) を継承する。
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, cast
+
+from sqlalchemy import update
+from sqlalchemy.engine import CursorResult
+from sqlalchemy.exc import IntegrityError, SQLAlchemyError
+from sqlalchemy.future import select
+
+from ...utils.log import logger
+from ..schema import Image, Project
+from .base import BaseRepository
+
+
+class ProjectRepository(BaseRepository):
+    """Project / Image.project_id (FK) の永続化を担当する Repository (ADR 0035)。
+
+    管轄 entity:
+      - `Project`
+      - `Image.project_id` (FK) を介したプロジェクトアサイン
+    """
+
+    def ensure_project(self, name: str, path: Path, description: str = "") -> int:
+        """プロジェクトを upsert して ID を返す（name UNIQUE）。
+
+        Args:
+            name: プロジェクト名（UNIQUE制約あり）。
+            path: プロジェクトの絶対パス。
+            description: プロジェクト説明（省略可）。
+
+        Returns:
+            int: プロジェクトID。
+
+        Raises:
+            SQLAlchemyError: DB操作エラー。
+        """
+        with self.session_factory() as session:
+            try:
+                existing = session.execute(select(Project).where(Project.name == name)).scalar_one_or_none()
+
+                if existing is not None:
+                    if str(existing.path) != str(path):
+                        existing.path = str(path)
+                        session.commit()
+                    return existing.id
+
+                project = Project(name=name, path=str(path), description=description or None)
+                session.add(project)
+                session.flush()
+                project_id = project.id
+                session.commit()
+                logger.info(f"Project created: name='{name}', id={project_id}")
+                return project_id
+            except IntegrityError:
+                session.rollback()
+                return session.execute(select(Project.id).where(Project.name == name)).scalar_one()
+            except SQLAlchemyError as e:
+                session.rollback()
+                logger.error(f"ensure_project エラー (name={name}): {e}", exc_info=True)
+                raise
+
+    def get_image_ids_by_project(self, project_name: str) -> list[int]:
+        """プロジェクト名で画像ID一覧を取得する。
+
+        Args:
+            project_name: フィルタ対象プロジェクト名。
+
+        Returns:
+            list[int]: 画像IDのリスト。プロジェクトが存在しない場合は空リスト。
+
+        Raises:
+            SQLAlchemyError: DB操作エラー。
+        """
+        with self.session_factory() as session:
+            try:
+                stmt = (
+                    select(Image.id)
+                    .join(Project, Image.project_id == Project.id)
+                    .where(Project.name == project_name)
+                )
+                result = list(session.execute(stmt).scalars().all())
+                logger.debug(f"get_image_ids_by_project: name='{project_name}', count={len(result)}")
+                return result
+            except SQLAlchemyError as e:
+                logger.error(f"get_image_ids_by_project エラー: {e}", exc_info=True)
+                raise
+
+    def get_image_ids_by_project_id(self, project_id: int) -> list[int]:
+        """プロジェクトIDで画像ID一覧を取得する。
+
+        Args:
+            project_id: フィルタ対象プロジェクトID。
+
+        Returns:
+            list[int]: 画像IDのリスト。
+
+        Raises:
+            SQLAlchemyError: DB操作エラー。
+        """
+        with self.session_factory() as session:
+            try:
+                stmt = select(Image.id).where(Image.project_id == project_id)
+                result = list(session.execute(stmt).scalars().all())
+                logger.debug(f"get_image_ids_by_project_id: id={project_id}, count={len(result)}")
+                return result
+            except SQLAlchemyError as e:
+                logger.error(f"get_image_ids_by_project_id エラー: {e}", exc_info=True)
+                raise
+
+    def assign_images_to_project(self, image_ids: list[int], project_id: int) -> int:
+        """画像IDリストをプロジェクトに割り当てる。
+
+        Args:
+            image_ids: 割り当てる画像IDリスト。
+            project_id: 割り当て先プロジェクトID。
+
+        Returns:
+            int: 実際に更新された件数。
+
+        Raises:
+            SQLAlchemyError: DB操作エラー。
+        """
+        if not image_ids:
+            return 0
+
+        with self.session_factory() as session:
+            try:
+                total_updated = 0
+                for i in range(0, len(image_ids), self.BATCH_CHUNK_SIZE):
+                    chunk = image_ids[i : i + self.BATCH_CHUNK_SIZE]
+                    stmt = update(Image).where(Image.id.in_(chunk)).values(project_id=project_id)
+                    total_updated += cast("CursorResult[Any]", session.execute(stmt)).rowcount
+                session.commit()
+                logger.info(
+                    f"assign_images_to_project: {total_updated}/{len(image_ids)} images"
+                    f" → project_id={project_id}"
+                )
+                return total_updated
+            except SQLAlchemyError as e:
+                session.rollback()
+                logger.error(f"assign_images_to_project エラー: {e}", exc_info=True)
+                raise

--- a/tests/unit/database/repository/test_project_repository.py
+++ b/tests/unit/database/repository/test_project_repository.py
@@ -1,0 +1,302 @@
+"""ProjectRepository 直接の単体テスト (ADR 0035 段階 2, Issue #423)。
+
+`db_repository.py` から抽出した `ProjectRepository` の責務境界を独立して検証する。
+既存の `tests/unit/database/test_db_repository_project_filter.py` は
+`ImageRepository` の delegating facade 経由で同じ実装をカバーしているため、本ファイルでは
+ProjectRepository を直接 instantiate して以下を最小限カバーする:
+
+- BaseRepository 継承 / session_factory 共有
+- `ensure_project` の upsert / path 更新 / SQLAlchemyError 伝播
+- `get_image_ids_by_project` / `get_image_ids_by_project_id` の動作
+- `assign_images_to_project` の正常系 + 空入力ガード
+- ImageRepository facade 経由でも同じ ProjectRepository クラスが見えること
+- DI contract: ImageDatabaseManager は injected project_repo 経由で呼ぶ
+"""
+
+from __future__ import annotations
+
+import uuid
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+import pytest
+from sqlalchemy import create_engine, select
+from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.orm import sessionmaker
+
+from lorairo.database.db_manager import ImageDatabaseManager
+from lorairo.database.db_repository import ImageRepository
+from lorairo.database.repository.base import BaseRepository
+from lorairo.database.repository.project import ProjectRepository
+from lorairo.database.schema import Image, Project
+from lorairo.services.configuration_service import ConfigurationService
+
+
+@pytest.fixture
+def memory_session_factory():
+    """in-memory SQLite セッションファクトリ（schema 全テーブル）。"""
+    from lorairo.database.schema import Base
+
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    return sessionmaker(engine)
+
+
+@pytest.fixture
+def project_repository(memory_session_factory) -> ProjectRepository:
+    """In-memory SQLite に対する ProjectRepository インスタンス。"""
+    return ProjectRepository(session_factory=memory_session_factory)
+
+
+def _make_image(session_factory, project_id: int | None = None) -> int:
+    """テスト用 Image を 1 件作成して id を返す。"""
+    with session_factory() as session:
+        img = Image(
+            uuid=str(uuid.uuid4()),
+            phash=f"aa{uuid.uuid4().hex[:10]}",
+            original_image_path=f"/tmp/{uuid.uuid4().hex}.png",
+            stored_image_path=f"/tmp/{uuid.uuid4().hex}.png",
+            width=100,
+            height=100,
+            format="PNG",
+            extension="png",
+            project_id=project_id,
+        )
+        session.add(img)
+        session.commit()
+        return img.id
+
+
+@pytest.mark.unit
+class TestProjectRepositoryStructure:
+    """ADR 0035 段階 2 で確立した抽出構造の sanity check。"""
+
+    def test_inherits_base_repository(self) -> None:
+        """ProjectRepository は BaseRepository を継承する。"""
+        assert issubclass(ProjectRepository, BaseRepository)
+
+    def test_holds_session_factory(self, memory_session_factory) -> None:
+        """`session_factory` を BaseRepository 経由で保持する。"""
+        repo = ProjectRepository(session_factory=memory_session_factory)
+        assert repo.session_factory is memory_session_factory
+
+
+@pytest.mark.unit
+class TestEnsureProject:
+    """`ensure_project` の upsert 動作。"""
+
+    def test_creates_new_project(self, project_repository: ProjectRepository) -> None:
+        """新規プロジェクトを作成し正の ID を返す。"""
+        project_id = project_repository.ensure_project("alpha", Path("/tmp/alpha"))
+        assert isinstance(project_id, int)
+        assert project_id > 0
+
+    def test_returns_same_id_on_duplicate(self, project_repository: ProjectRepository) -> None:
+        """同名で 2 回呼んでも同じ ID が返る (upsert)。"""
+        id1 = project_repository.ensure_project("beta", Path("/tmp/beta"))
+        id2 = project_repository.ensure_project("beta", Path("/tmp/beta"))
+        assert id1 == id2
+
+    def test_updates_path_when_different(
+        self, project_repository: ProjectRepository, memory_session_factory
+    ) -> None:
+        """同名でパスが変わった場合、path カラムが更新される。"""
+        project_id = project_repository.ensure_project("gamma", Path("/tmp/old"))
+        project_repository.ensure_project("gamma", Path("/tmp/new"))
+
+        with memory_session_factory() as session:
+            project = session.execute(select(Project).where(Project.id == project_id)).scalar_one()
+            assert project.path == str(Path("/tmp/new"))
+
+    def test_persists_description(
+        self, project_repository: ProjectRepository, memory_session_factory
+    ) -> None:
+        """description 引数が DB に保存される。"""
+        project_id = project_repository.ensure_project(
+            "delta", Path("/tmp/delta"), description="some description"
+        )
+        with memory_session_factory() as session:
+            project = session.execute(select(Project).where(Project.id == project_id)).scalar_one()
+            assert project.description == "some description"
+
+    def test_empty_description_stored_as_none(
+        self, project_repository: ProjectRepository, memory_session_factory
+    ) -> None:
+        """空文字 description は None として保存される (`description or None`)。"""
+        project_id = project_repository.ensure_project("epsilon", Path("/tmp/epsilon"))
+        with memory_session_factory() as session:
+            project = session.execute(select(Project).where(Project.id == project_id)).scalar_one()
+            assert project.description is None
+
+    def test_raises_sqlalchemy_error(self, project_repository: ProjectRepository) -> None:
+        """予期しない SQLAlchemyError は呼び出し元に伝播する (silent return しない)。"""
+        # session.execute で SQLAlchemyError を発生させる
+        mock_session = Mock()
+        mock_session.__enter__ = Mock(return_value=mock_session)
+        mock_session.__exit__ = Mock(return_value=False)
+        mock_session.execute.side_effect = SQLAlchemyError("simulated DB failure")
+        mock_session.rollback = Mock()
+
+        with patch.object(project_repository, "session_factory", return_value=mock_session):
+            with pytest.raises(SQLAlchemyError, match="simulated DB failure"):
+                project_repository.ensure_project("zeta", Path("/tmp/zeta"))
+        mock_session.rollback.assert_called()
+
+
+@pytest.mark.unit
+class TestGetImageIdsByProject:
+    """`get_image_ids_by_project` / `get_image_ids_by_project_id` の動作。"""
+
+    @pytest.fixture
+    def populated_repo(self, project_repository: ProjectRepository, memory_session_factory):
+        """proj_a に 3 枚 / proj_b に 2 枚を保持する fixture。"""
+        pid_a = project_repository.ensure_project("proj_a", Path("/tmp/a"))
+        pid_b = project_repository.ensure_project("proj_b", Path("/tmp/b"))
+        ids_a = [_make_image(memory_session_factory, project_id=pid_a) for _ in range(3)]
+        ids_b = [_make_image(memory_session_factory, project_id=pid_b) for _ in range(2)]
+        return project_repository, pid_a, pid_b, ids_a, ids_b
+
+    def test_get_by_name_returns_correct_ids(self, populated_repo) -> None:
+        """get_image_ids_by_project は名前から正しい id セットを返す。"""
+        repo, _, _, ids_a, _ = populated_repo
+        result = repo.get_image_ids_by_project("proj_a")
+        assert set(result) == set(ids_a)
+
+    def test_get_by_id_returns_correct_ids(self, populated_repo) -> None:
+        """get_image_ids_by_project_id は id から正しい id セットを返す。"""
+        repo, pid_a, _, ids_a, _ = populated_repo
+        result = repo.get_image_ids_by_project_id(pid_a)
+        assert set(result) == set(ids_a)
+
+    def test_get_by_unknown_name_returns_empty(self, populated_repo) -> None:
+        """存在しないプロジェクト名では空リストを返す (silent return ではなく正常系)。"""
+        repo, _, _, _, _ = populated_repo
+        assert repo.get_image_ids_by_project("nonexistent") == []
+
+    def test_get_by_unknown_id_returns_empty(self, populated_repo) -> None:
+        """存在しないプロジェクト ID では空リストを返す。"""
+        repo, _, _, _, _ = populated_repo
+        assert repo.get_image_ids_by_project_id(99999) == []
+
+    def test_does_not_mix_projects(self, populated_repo) -> None:
+        """proj_a の取得結果に proj_b の画像が含まれない。"""
+        repo, _, _, _, _ = populated_repo
+        result_a = set(repo.get_image_ids_by_project("proj_a"))
+        result_b = set(repo.get_image_ids_by_project("proj_b"))
+        assert result_a.isdisjoint(result_b)
+
+
+@pytest.mark.unit
+class TestAssignImagesToProject:
+    """`assign_images_to_project` の動作。"""
+
+    def test_returns_zero_for_empty_input(self, project_repository: ProjectRepository) -> None:
+        """空リスト入力では DB アクセスせず 0 を返す。"""
+        pid = project_repository.ensure_project("only", Path("/tmp/only"))
+        assert project_repository.assign_images_to_project([], pid) == 0
+
+    def test_assigns_images_and_returns_count(
+        self, project_repository: ProjectRepository, memory_session_factory
+    ) -> None:
+        """画像を割り当てた件数を返し、DB に反映される。"""
+        pid = project_repository.ensure_project("target", Path("/tmp/target"))
+        unassigned_ids = [_make_image(memory_session_factory, project_id=None) for _ in range(3)]
+
+        updated = project_repository.assign_images_to_project(unassigned_ids, pid)
+
+        assert updated == 3
+        result = project_repository.get_image_ids_by_project_id(pid)
+        assert set(result) == set(unassigned_ids)
+
+    def test_reassigns_to_different_project(
+        self, project_repository: ProjectRepository, memory_session_factory
+    ) -> None:
+        """既に割り当てられた画像を別プロジェクトに再割り当てできる。"""
+        pid_a = project_repository.ensure_project("from", Path("/tmp/from"))
+        pid_b = project_repository.ensure_project("to", Path("/tmp/to"))
+        image_ids = [_make_image(memory_session_factory, project_id=pid_a) for _ in range(2)]
+
+        updated = project_repository.assign_images_to_project(image_ids, pid_b)
+
+        assert updated == 2
+        assert project_repository.get_image_ids_by_project_id(pid_a) == []
+        assert set(project_repository.get_image_ids_by_project_id(pid_b)) == set(image_ids)
+
+
+@pytest.mark.unit
+class TestFacadeDelegation:
+    """`ImageRepository` の delegating facade が `ProjectRepository` を正しく呼ぶ。"""
+
+    def test_image_repository_holds_project_repo(self, memory_session_factory) -> None:
+        """ImageRepository は内部 `_project_repo` を保持する (段階移行中の hook)。"""
+        repo = ImageRepository(session_factory=memory_session_factory)
+        assert isinstance(repo._project_repo, ProjectRepository)
+        assert repo._project_repo.session_factory is repo.session_factory
+
+    def test_ensure_project_via_facade_matches_direct(self, memory_session_factory) -> None:
+        """facade 経由でも直接呼び出しでも同じ動作。"""
+        repo = ImageRepository(session_factory=memory_session_factory)
+
+        id1 = repo.ensure_project("via_facade", Path("/tmp/x"))
+        id2 = repo._project_repo.ensure_project("via_facade", Path("/tmp/x"))
+
+        assert id1 == id2
+
+    def test_get_image_ids_via_facade_matches_direct(self, memory_session_factory) -> None:
+        """get_image_ids_by_project も facade 経由で同一結果を返す。"""
+        repo = ImageRepository(session_factory=memory_session_factory)
+        pid = repo.ensure_project("facade_test", Path("/tmp/facade"))
+        image_ids = [_make_image(memory_session_factory, project_id=pid) for _ in range(2)]
+
+        via_facade = set(repo.get_image_ids_by_project("facade_test"))
+        via_direct = set(repo._project_repo.get_image_ids_by_project("facade_test"))
+
+        assert via_facade == via_direct == set(image_ids)
+
+
+@pytest.mark.unit
+class TestImageDatabaseManagerDIContract:
+    """ImageDatabaseManager が injected `project_repo` 経由で ensure_project を呼ぶ (DI contract)。
+
+    PR #477 review 教訓: クラス経由 static 呼び出しではなく、インスタンス経由で呼ぶことで
+    テストが mock 注入で動作を制御できる。
+    """
+
+    def test_get_current_project_id_uses_injected_project_repo(self) -> None:
+        """`_get_current_project_id` は self.project_repo.ensure_project を呼ぶ。"""
+        mock_repository = Mock(spec=ImageRepository)
+        mock_config_service = Mock(spec=ConfigurationService)
+        mock_project_repo = Mock(spec=ProjectRepository)
+        mock_project_repo.ensure_project.return_value = 123
+
+        manager = ImageDatabaseManager(
+            repository=mock_repository,
+            config_service=mock_config_service,
+            project_repo=mock_project_repo,
+        )
+
+        fake_root = Path("/tmp/some_project")
+        with patch("lorairo.database.db_core.get_current_project_root", return_value=fake_root):
+            result = manager._get_current_project_id()
+
+        assert result == 123
+        # injected mock 経由で呼ばれることを assert (DI contract)
+        mock_project_repo.ensure_project.assert_called_once_with("some_project", fake_root)
+        # repository (ImageRepository) の ensure_project は呼ばれない
+        mock_repository.ensure_project.assert_not_called()
+
+    def test_auto_constructs_project_repo_when_omitted(self) -> None:
+        """`project_repo` 省略時は repository の session_factory を共有して自動生成される。"""
+        from lorairo.database.repository.project import ProjectRepository as PR
+
+        mock_repository = Mock(spec=ImageRepository)
+        mock_repository.session_factory = lambda: None  # 任意の callable
+        mock_config_service = Mock(spec=ConfigurationService)
+
+        manager = ImageDatabaseManager(
+            repository=mock_repository,
+            config_service=mock_config_service,
+        )
+
+        assert isinstance(manager.project_repo, PR)
+        assert manager.project_repo.session_factory is mock_repository.session_factory

--- a/tests/unit/database/test_db_manager_core.py
+++ b/tests/unit/database/test_db_manager_core.py
@@ -25,6 +25,7 @@ from sqlalchemy.exc import SQLAlchemyError
 from lorairo.database.db_manager import ImageDatabaseManager
 from lorairo.database.db_repository import ImageRepository
 from lorairo.database.repository.model import ModelRepository
+from lorairo.database.repository.project import ProjectRepository
 from lorairo.services.configuration_service import ConfigurationService
 
 # ---------------------------------------------------------------------------
@@ -45,6 +46,12 @@ def mock_model_repo() -> Mock:
 
 
 @pytest.fixture
+def mock_project_repo() -> Mock:
+    """モック化された ProjectRepository を返す (ADR 0035 段階 2)。"""
+    return Mock(spec=ProjectRepository)
+
+
+@pytest.fixture
 def mock_config_service() -> Mock:
     """モック化された ConfigurationService を返す。"""
     svc = Mock(spec=ConfigurationService)
@@ -54,7 +61,10 @@ def mock_config_service() -> Mock:
 
 @pytest.fixture
 def manager(
-    mock_repository: Mock, mock_config_service: Mock, mock_model_repo: Mock
+    mock_repository: Mock,
+    mock_config_service: Mock,
+    mock_model_repo: Mock,
+    mock_project_repo: Mock,
 ) -> ImageDatabaseManager:
     """ImageDatabaseManager のインスタンスを返す（依存はすべてモック）。"""
     return ImageDatabaseManager(
@@ -62,6 +72,7 @@ def manager(
         config_service=mock_config_service,
         fsm=None,
         model_repo=mock_model_repo,
+        project_repo=mock_project_repo,
     )
 
 
@@ -75,13 +86,14 @@ class TestGetCurrentProjectId:
     """_get_current_project_id メソッドのテスト"""
 
     def test_returns_cached_value_without_db_access(
-        self, manager: ImageDatabaseManager, mock_repository: Mock
+        self, manager: ImageDatabaseManager, mock_project_repo: Mock
     ) -> None:
         """キャッシュ済みの場合はリポジトリを呼ばずにキャッシュ値を返す。"""
         manager._cached_project_id = 42
         result = manager._get_current_project_id()
         assert result == 42
-        mock_repository.ensure_project.assert_not_called()
+        # ADR 0035 段階 2: ensure_project は project_repo 経由で呼ばれる (DI contract)
+        mock_project_repo.ensure_project.assert_not_called()
 
     def test_returns_none_when_project_root_unavailable(self, manager: ImageDatabaseManager) -> None:
         """project root 取得に失敗 (RuntimeError) したとき None を返す。"""
@@ -95,20 +107,20 @@ class TestGetCurrentProjectId:
         assert result is None
 
     def test_returns_none_when_ensure_project_fails(
-        self, manager: ImageDatabaseManager, mock_repository: Mock
+        self, manager: ImageDatabaseManager, mock_project_repo: Mock
     ) -> None:
         """ensure_project が SQLAlchemyError を投げたとき None を返す (project_id 未設定で続行)。"""
-        mock_repository.ensure_project.side_effect = SQLAlchemyError("DB error")
+        mock_project_repo.ensure_project.side_effect = SQLAlchemyError("DB error")
         fake_root = Path("/fake/project")
         with patch("lorairo.database.db_core.get_current_project_root", return_value=fake_root):
             result = manager._get_current_project_id()
         assert result is None
 
     def test_caches_project_id_on_success(
-        self, manager: ImageDatabaseManager, mock_repository: Mock
+        self, manager: ImageDatabaseManager, mock_project_repo: Mock
     ) -> None:
         """正常取得後は _cached_project_id にキャッシュされる。"""
-        mock_repository.ensure_project.return_value = 7
+        mock_project_repo.ensure_project.return_value = 7
 
         fake_root = Path("/fake/project")
         with patch("lorairo.database.db_core.get_current_project_root", return_value=fake_root):
@@ -119,7 +131,7 @@ class TestGetCurrentProjectId:
         assert manager._cached_project_id == 7
 
     def test_falls_back_to_project_root_name_on_non_dict_metadata(
-        self, manager: ImageDatabaseManager, mock_repository: Mock, tmp_path: Path
+        self, manager: ImageDatabaseManager, mock_project_repo: Mock, tmp_path: Path
     ) -> None:
         """`.lorairo-project` が JSON object でない (list/string 等) なら project_root.name で fallback。
 
@@ -130,14 +142,15 @@ class TestGetCurrentProjectId:
         project_root.mkdir()
         # 有効な JSON だが dict でない (list)
         (project_root / ".lorairo-project").write_text("[]", encoding="utf-8")
-        mock_repository.ensure_project.return_value = 42
+        mock_project_repo.ensure_project.return_value = 42
 
         with patch("lorairo.database.db_core.get_current_project_root", return_value=project_root):
             result = manager._get_current_project_id()
 
         assert result == 42
         # project_root.name でフォールバック呼び出し
-        args, _ = mock_repository.ensure_project.call_args
+        # ADR 0035 段階 2: DI contract — project_repo 経由で呼ばれる
+        args, _ = mock_project_repo.ensure_project.call_args
         assert args[0] == "fake-project"
 
 

--- a/tests/unit/database/test_db_manager_extended.py
+++ b/tests/unit/database/test_db_manager_extended.py
@@ -31,6 +31,7 @@ from sqlalchemy.exc import SQLAlchemyError
 
 from lorairo.database.db_manager import ImageDatabaseManager
 from lorairo.database.db_repository import ImageRepository
+from lorairo.database.repository.project import ProjectRepository
 from lorairo.services.configuration_service import ConfigurationService
 
 # ---------------------------------------------------------------------------
@@ -53,12 +54,21 @@ def mock_config_service() -> Mock:
 
 
 @pytest.fixture
-def manager(mock_repository: Mock, mock_config_service: Mock) -> ImageDatabaseManager:
+def mock_project_repo() -> Mock:
+    """モック化された ProjectRepository を返す (ADR 0035 段階 2)。"""
+    return Mock(spec=ProjectRepository)
+
+
+@pytest.fixture
+def manager(
+    mock_repository: Mock, mock_config_service: Mock, mock_project_repo: Mock
+) -> ImageDatabaseManager:
     """ImageDatabaseManager のインスタンスを返す（依存はすべてモック）。"""
     return ImageDatabaseManager(
         repository=mock_repository,
         config_service=mock_config_service,
         fsm=None,
+        project_repo=mock_project_repo,
     )
 
 
@@ -94,10 +104,11 @@ class TestGetCurrentProjectIdMetadata:
     """_get_current_project_id のメタデータ読み込みパスのテスト"""
 
     def test_uses_name_from_metadata_file(
-        self, manager: ImageDatabaseManager, mock_repository: Mock
+        self, manager: ImageDatabaseManager, mock_project_repo: Mock
     ) -> None:
         """メタデータファイルが存在するとき、そのname フィールドを使用する。"""
-        mock_repository.ensure_project.return_value = 10
+        # ADR 0035 段階 2: ensure_project は project_repo 経由で呼ばれる (DI contract)
+        mock_project_repo.ensure_project.return_value = 10
         fake_root = Path("/tmp/fake_project")
 
         # .lorairo-project ファイルが読めるようにパッチ
@@ -107,13 +118,13 @@ class TestGetCurrentProjectIdMetadata:
                 result = manager._get_current_project_id()
 
         assert result == 10
-        mock_repository.ensure_project.assert_called_once_with("my_project", fake_root)
+        mock_project_repo.ensure_project.assert_called_once_with("my_project", fake_root)
 
     def test_falls_back_to_dir_name_on_json_error(
-        self, manager: ImageDatabaseManager, mock_repository: Mock
+        self, manager: ImageDatabaseManager, mock_project_repo: Mock
     ) -> None:
         """JSONDecodeError が発生したとき、ディレクトリ名にフォールバックする。"""
-        mock_repository.ensure_project.return_value = 20
+        mock_project_repo.ensure_project.return_value = 20
         fake_root = Path("/tmp/my_dir")
 
         with patch("lorairo.database.db_core.get_current_project_root", return_value=fake_root):
@@ -121,7 +132,7 @@ class TestGetCurrentProjectIdMetadata:
                 result = manager._get_current_project_id()
 
         assert result == 20
-        mock_repository.ensure_project.assert_called_once_with("my_dir", fake_root)
+        mock_project_repo.ensure_project.assert_called_once_with("my_dir", fake_root)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

ADR 0035 §6 移行戦略の **段階 2**: `db_repository.py` から **Project / ImageProject (FK) 関連 4 メソッド** を `ProjectRepository` として独立 Repository に抽出。段階 1 (#477 ModelRepository) と同パターン。

### 新規ファイル

- `src/lorairo/database/repository/project.py` (155 行): `ProjectRepository(BaseRepository)`
- `src/lorairo/database/repository/__init__.py` 更新: `ProjectRepository` re-export 追加

### 変更ファイル

| ファイル | 変化 |
|---|---|
| `db_repository.py` | **3826 → 3732 行** (-94)。Project 4 メソッド (~115 行) を削除し ADR 0035 §5 ファサード方針として ~21 行の delegating wrapper (`ImageRepository.X()` → `self._project_repo.X()`) に置換 |
| `db_manager.py` | `__init__` で `self.project_repo = ProjectRepository(...)` を composition で保持。`_get_current_project_id` 内の `ensure_project` 呼び出しを `self.repository.ensure_project(...)` → `self.project_repo.ensure_project(...)` に置換 (1 箇所、PR #476 で確立した SQLAlchemyError catch 動作は維持) |

### 移設した 4 メソッド (~115 行)

`ensure_project` / `get_image_ids_by_project` / `get_image_ids_by_project_id` / `assign_images_to_project`

## Test plan

- [x] 新規 unit test **21 件** (`tests/unit/database/repository/test_project_repository.py`)
  - 5 クラス: `Structure` / `EnsureProject` / `GetImageIdsByProject` / `AssignImagesToProject` / `FacadeDelegation` / `DIContract`
- [x] 既存 test 修正 **7 件** (`test_db_manager_core.py` 5 件 + `test_db_manager_extended.py` 2 件、`mock_project_repo` fixture 追加)
- [x] CI-equivalent filter: **3239 passed**, 16 failed (baseline `e2f12bd7` でも fail する `AnnotatorLibraryAdapter` / `MockAnnotatorLibrary` 関連、本 refactor と無関係。git stash 検証済), 2 skipped
- [x] Database 関連 test: 457 全 pass
- [x] Coverage: db_manager **98%** / db_repository **81%** / project.py **83%** / base.py 100% / model.py 78% (変更なし)
- [x] `ruff format` / `ruff check` / `mypy -p lorairo.database`: 全 pass

## ADR 0035 準拠

- **§3 Manager composition**: `self.project_repo` を `__init__` で保持、`session_factory` を共有
- **§5 段階移行ファサード**: `ImageRepository` の delegating wrapper で既存 import / callsite 互換維持
- **§6 移行戦略**: 推奨順 2 (Project entity) を本 PR で実装

## PR #477 review 教訓の継承 (DI contract)

- `_get_current_project_id` の `ensure_project` 呼び出しは `self.project_repo.ensure_project(...)` (instance 経由) で実装
- test `TestImageDatabaseManagerDIContract::test_get_current_project_id_uses_injected_project_repo` で `assert_called_once_with(...)` により injected method が確実に呼ばれることを固定
- クラス経由 static 呼び出しは新規追加なし (全 4 メソッドは instance method)
- silent return は新規追加なし (PR #476 で確立した SQLAlchemyError catch → None 動作は維持)

## Commit 一覧

| Hash | Subject |
|---|---|
| `cb7f09c6` | refactor: extract ProjectRepository (#423 段階 2, ADR 0035) |
| `534d3a6d` | refactor: convert Project methods to delegating wrappers (#423 段階 2) |
| `49304d26` | refactor: inject ProjectRepository into ImageDatabaseManager (#423 段階 2) |
| `981cef02` | test: cover ProjectRepository extraction (#423 段階 2) |

Refs: #423 (段階 2 のみ、残 3 段階 ErrorRecord / Image / Annotation は別 PR で順次)
Refs: #418, ADR 0035