### PR TITLE
[codex] fix annotation cancellation checkpoints after bulk pass

### DIFF
--- a/src/lorairo/gui/workers/annotation_worker.py
+++ b/src/lorairo/gui/workers/annotation_worker.py
@@ -5,6 +5,7 @@ GUI Layer: 非同期処理とQt進捗管理のみ担当
 """
 
 import traceback
+from collections.abc import Callable, Iterator
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -80,6 +81,19 @@ class AnnotationExecutionResult:
     model_statistics: dict[str, ModelStatistics] = field(default_factory=dict)
     phash_to_filename: dict[str, str] = field(default_factory=dict)
     total_processing_time_sec: float = 0.0
+
+
+class _CancellationCheckingModelList(list[str]):
+    """モデル iteration の各要素直前に Worker cancellation を確認する list。"""
+
+    def __init__(self, models: list[str], check_cancellation: Callable[[], None]) -> None:
+        super().__init__(models)
+        self._check_cancellation = check_cancellation
+
+    def __iter__(self) -> Iterator[str]:
+        for model in super().__iter__():
+            self._check_cancellation()
+            yield model
 
 
 class AnnotationWorker(LoRAIroWorkerBase["AnnotationExecutionResult"]):
@@ -326,7 +340,10 @@ class AnnotationWorker(LoRAIroWorkerBase["AnnotationExecutionResult"]):
             self._check_cancellation()
             bulk_results = self.annotation_logic.execute_annotation(
                 image_paths=self.image_paths,
-                litellm_model_ids=list(self.litellm_model_ids),
+                litellm_model_ids=_CancellationCheckingModelList(
+                    self.litellm_model_ids,
+                    self._check_cancellation,
+                ),
                 phash_list=phash_list,
             )
             valid_results = self._collect_valid_model_results(

--- a/tests/unit/gui/workers/test_annotation_worker.py
+++ b/tests/unit/gui/workers/test_annotation_worker.py
@@ -17,6 +17,7 @@ from lorairo.gui.workers.annotation_worker import (
     AnnotationExecutionResult,
     AnnotationWorker,
 )
+from lorairo.gui.workers.base import CancellationError
 
 
 @pytest.fixture
@@ -177,6 +178,41 @@ class TestAnnotationWorkerExecute:
         assert "claude-3-haiku-20240307" in result.results["phash1"]
         assert result.total_images == 1
         assert result.models_used == ["gpt-4o-mini", "claude-3-haiku-20240307"]
+
+    def test_execute_bulk_model_iteration_checks_cancellation_between_models(
+        self, mock_annotation_logic, mock_model_registry
+    ):
+        """一括実行でも lib 内部のモデル間 iteration でキャンセルを検知する。"""
+        image_paths = ["/path/to/image.jpg"]
+        models = ["model-a", "model-b"]
+
+        mock_db_manager = Mock()
+        mock_db_manager.repository.get_phashes_by_filepaths.return_value = {}
+
+        worker = AnnotationWorker(
+            annotation_logic=mock_annotation_logic,
+            image_paths=image_paths,
+            litellm_model_ids=models,
+            db_manager=mock_db_manager,
+            model_registry=mock_model_registry,
+        )
+
+        processed_models: list[str] = []
+
+        def execute_annotation(*_args: object, **kwargs: object) -> object:
+            for model in kwargs["litellm_model_ids"]:
+                processed_models.append(model)
+                worker.cancel()
+            return {}
+
+        mock_annotation_logic.execute_annotation.side_effect = execute_annotation
+
+        with pytest.raises(CancellationError):
+            worker.execute()
+
+        assert processed_models == ["model-a"]
+        mock_annotation_logic.execute_annotation.assert_called_once()
+        mock_db_manager.save_error_record.assert_not_called()
 
     def test_execute_does_not_filter_legacy_sentinel_models(
         self, mock_annotation_logic, mock_model_registry


### PR DESCRIPTION
## Summary
- Address Codex review feedback from #478 after it was merged.
- Keep the bulk `model_name_list` call path, but pass a cancellation-checking list so image-annotator-lib's internal per-model iteration observes Worker cancellation between selected models.
- Add a regression test proving cancellation after the first model prevents the next model from being yielded and does not fall back into normal error recording.

## Review addressed
- https://github.com/NEXTAltair/LoRAIro/pull/478#discussion_r3299951506

## Validation
- `uv run pytest tests/unit/test_annotator_adapter_model_registry.py tests/unit/annotations/test_annotation_logic.py tests/unit/gui/workers/test_annotation_worker.py tests/bdd/steps/test_annotation_worker_failure_propagation.py` (66 passed)
- `uv run ruff check src/lorairo/gui/workers/annotation_worker.py tests/unit/gui/workers/test_annotation_worker.py`
- `uv run mypy src/lorairo/gui/workers/annotation_worker.py`
- `git diff --check`