### PR TITLE
refactor: extract ErrorRecordRepository (#423 段階 3, ADR 0035)

### DIFF
--- a/src/lorairo/database/db_manager.py
+++ b/src/lorairo/database/db_manager.py
@@ -22,6 +22,7 @@ from .db_repository import (
     TagAnnotationData,
 )
 from .filter_criteria import ImageFilterCriteria
+from .repository.error_record import ErrorRecordRepository
 from .repository.model import ModelRepository
 from .repository.project import ProjectRepository
 
@@ -42,6 +43,7 @@ class ImageDatabaseManager:
         fsm: FileSystemManager | None = None,
         model_repo: ModelRepository | None = None,
         project_repo: ProjectRepository | None = None,
+        error_record_repo: ErrorRecordRepository | None = None,
     ):
         """ImageDatabaseManagerのコンストラクタ。
 
@@ -55,6 +57,9 @@ class ImageDatabaseManager:
             project_repo (ProjectRepository): Project 関連の Repository (ADR 0035 段階 2)。
                 None の場合は `repository` の `session_factory` を流用して生成する。
                 テスト時にモック化可能。
+            error_record_repo (ErrorRecordRepository): ErrorRecord 関連の Repository
+                (ADR 0035 段階 3)。None の場合は `repository` の `session_factory` を
+                流用して生成する。テスト時にモック化可能。
 
         """
         self.repository = repository
@@ -78,6 +83,11 @@ class ImageDatabaseManager:
         if project_repo is None:
             project_repo = ProjectRepository(session_factory=session_factory)
         self.project_repo: ProjectRepository = project_repo
+        # ADR 0035 段階 3 (#423): ErrorRecord 関連を ErrorRecordRepository に集約。
+        # session_factory は他 Repository と同様に repository から取得する。
+        if error_record_repo is None:
+            error_record_repo = ErrorRecordRepository(session_factory=session_factory)
+        self.error_record_repo: ErrorRecordRepository = error_record_repo
         self._cached_project_id: int | None = None
         logger.info("ImageDatabaseManager initialized.")
 
@@ -991,7 +1001,10 @@ class ImageDatabaseManager:
                 completed_images: int = result.scalar() or 0
 
                 # エラー画像数取得 (未解決のアノテーションエラーのみ)
-                error_images = self.repository.get_error_count_unresolved(operation_type="annotation")
+                # ADR 0035 段階 3 (#423): injected error_record_repo 経由で呼び出し DI contract を維持。
+                error_images = self.error_record_repo.get_error_count_unresolved(
+                    operation_type="annotation"
+                )
 
                 completion_rate = (completed_images / total_images) * 100.0 if total_images > 0 else 0.0
 
@@ -1038,7 +1051,8 @@ class ImageDatabaseManager:
                     """)
                 elif error:
                     # エラー画像（未解決のアノテーションエラーのみ）
-                    error_image_ids = self.repository.get_error_image_ids(
+                    # ADR 0035 段階 3 (#423): injected error_record_repo 経由で呼び出し DI contract を維持。
+                    error_image_ids = self.error_record_repo.get_error_image_ids(
                         operation_type="annotation",
                         resolved=False,
                     )
@@ -1359,7 +1373,8 @@ class ImageDatabaseManager:
 
         """
         try:
-            error_id = self.repository.save_error_record(
+            # ADR 0035 段階 3 (#423): injected error_record_repo 経由で呼び出し DI contract を維持。
+            error_id = self.error_record_repo.save_error_record(
                 operation_type=operation_type,
                 error_type=error_type,
                 error_message=error_message,
@@ -1395,7 +1410,8 @@ class ImageDatabaseManager:
 
         """
         try:
-            return self.repository.mark_errors_resolved_batch(error_ids)
+            # ADR 0035 段階 3 (#423): injected error_record_repo 経由で呼び出し DI contract を維持。
+            return self.error_record_repo.mark_errors_resolved_batch(error_ids)
         except SQLAlchemyError as e:
             logger.error(f"一括解決マーク失敗（Manager）: {e}", exc_info=True)
             raise

--- a/src/lorairo/database/db_repository.py
+++ b/src/lorairo/database/db_repository.py
@@ -19,6 +19,7 @@ from ..domain.quality_tier import compute_quality_summary
 from ..utils.log import logger
 from .db_core import DefaultSessionLocal
 from .filter_criteria import ImageFilterCriteria
+from .repository.error_record import ErrorRecordRepository
 from .repository.model import ModelRepository
 from .repository.project import ProjectRepository
 from .schema import (
@@ -122,6 +123,10 @@ class ImageRepository:
         # 既存呼び出し (`image_repository.ensure_project()` 等) との互換性のため、
         # ImageRepository は内部で ProjectRepository への delegating facade を保持する。
         self._project_repo = ProjectRepository(session_factory=session_factory)
+        # ADR 0035 段階 3 (#423): ErrorRecord 関連は ErrorRecordRepository に移設。
+        # 既存呼び出し (`image_repository.save_error_record()` 等) との互換性のため、
+        # ImageRepository は内部で ErrorRecordRepository への delegating facade を保持する。
+        self._error_record_repo = ErrorRecordRepository(session_factory=session_factory)
         logger.info("ImageRepository initialized.")
 
         # 外部tag_db統合（公開API経由、グレースフルデグラデーション対応）
@@ -3078,7 +3083,14 @@ class ImageRepository:
                 )
                 raise
 
-    # --- Error Record Management Methods ---
+    # --- ErrorRecord methods (delegating facade, ADR 0035 段階 3) ---
+    # 実装は src/lorairo/database/repository/error_record.py の ErrorRecordRepository に移設済み。
+    # 既存呼び出し (`image_repository.save_error_record()` 等) との互換性のため delegating
+    # wrapper を残す。段階 4 以降で各 Service / Worker が `manager.error_record_repo` 経由で
+    # 直接 ErrorRecordRepository を参照するようになれば、本 facade は削除可能。
+    #
+    # NOTE: Manager 層 (`ImageDatabaseManager.save_error_record`) の二次エラー防止
+    # (sentinel `-1` return) は本 facade ではなく Manager 側で維持する (PR #476)。
 
     def save_error_record(
         self,
@@ -3090,75 +3102,20 @@ class ImageRepository:
         file_path: str | None = None,
         model_name: str | None = None,
     ) -> int:
-        """エラーレコードを保存
-
-        Args:
-            operation_type: 操作種別 ("registration" | "annotation" | "processing")
-            error_type: エラー種別 ("pHash calculation" | "API error" | "DB constraint")
-            error_message: エラーメッセージ
-            image_id: 画像ID (Optional)
-            stack_trace: スタックトレース (Optional)
-            file_path: ファイルパス (Optional)
-            model_name: モデル名 (Optional)
-
-        Returns:
-            int: 作成された error_record_id
-
-        Raises:
-            SQLAlchemyError: データベース操作でエラーが発生した場合
-
-        """
-        with self.session_factory() as session:
-            try:
-                record = ErrorRecord(
-                    image_id=image_id,
-                    operation_type=operation_type,
-                    error_type=error_type,
-                    error_message=error_message,
-                    stack_trace=stack_trace,
-                    file_path=file_path,
-                    model_name=model_name,
-                )
-                session.add(record)
-                session.flush()
-                error_id = record.id
-                session.commit()
-                logger.debug(
-                    f"エラーレコードを保存しました: ID={error_id}, "
-                    f"operation={operation_type}, type={error_type}",
-                )
-                return error_id
-            except SQLAlchemyError as e:
-                session.rollback()
-                logger.error(f"エラーレコードの保存中にエラーが発生しました: {e}", exc_info=True)
-                raise
+        """ErrorRecordRepository.save_error_record への delegate (ADR 0035 段階 3)。"""
+        return self._error_record_repo.save_error_record(
+            operation_type=operation_type,
+            error_type=error_type,
+            error_message=error_message,
+            image_id=image_id,
+            stack_trace=stack_trace,
+            file_path=file_path,
+            model_name=model_name,
+        )
 
     def get_error_count_unresolved(self, operation_type: str | None = None) -> int:
-        """未解決エラー件数を取得（resolved_at IS NULL）
-
-        Args:
-            operation_type: 操作種別（None = 全操作）
-
-        Returns:
-            int: 未解決エラー件数
-
-        Raises:
-            SQLAlchemyError: データベース操作でエラーが発生した場合
-
-        """
-        with self.session_factory() as session:
-            try:
-                query = select(func.count(ErrorRecord.id)).where(ErrorRecord.resolved_at.is_(None))
-                if operation_type:
-                    query = query.where(ErrorRecord.operation_type == operation_type)
-                count = session.execute(query).scalar() or 0
-                logger.debug(
-                    f"未解決エラー件数を取得: {count}件 (operation_type={operation_type or 'all'})",
-                )
-                return count
-            except SQLAlchemyError as e:
-                logger.error(f"未解決エラー件数の取得中にエラーが発生しました: {e}", exc_info=True)
-                raise
+        """ErrorRecordRepository.get_error_count_unresolved への delegate (ADR 0035 段階 3)。"""
+        return self._error_record_repo.get_error_count_unresolved(operation_type)
 
     def get_error_image_ids(
         self,
@@ -3166,46 +3123,12 @@ class ImageRepository:
         resolved: bool = False,
         error_types: list[str] | None = None,
     ) -> list[int]:
-        """エラー画像のID一覧を取得
-
-        Args:
-            operation_type: 操作種別フィルタ
-            resolved: True = 解決済み（resolved_at IS NOT NULL）、
-                     False = 未解決（resolved_at IS NULL）
-            error_types: 特定 error_type のみに絞る (e.g.
-                ["SafetyRefusalError", "ContentPolicyRefusalError"])。
-                None = 全 type。ADR 0023 Phase 1.5 の送信前 filter で使用。
-
-        Returns:
-            list[int]: 画像IDリスト（重複除去済み、Noneを除外）
-
-        Raises:
-            SQLAlchemyError: データベース操作でエラーが発生した場合
-
-        """
-        with self.session_factory() as session:
-            try:
-                query = select(ErrorRecord.image_id).distinct().where(ErrorRecord.image_id.is_not(None))
-                if resolved:
-                    query = query.where(ErrorRecord.resolved_at.is_not(None))
-                else:
-                    query = query.where(ErrorRecord.resolved_at.is_(None))
-                if operation_type:
-                    query = query.where(ErrorRecord.operation_type == operation_type)
-                if error_types:
-                    query = query.where(ErrorRecord.error_type.in_(error_types))
-
-                results = session.execute(query).scalars().all()
-                image_ids = [id for id in results if id is not None]
-                logger.debug(
-                    f"エラー画像ID一覧を取得: {len(image_ids)}件 "
-                    f"(operation_type={operation_type or 'all'}, resolved={resolved}, "
-                    f"error_types={error_types or 'all'})",
-                )
-                return image_ids
-            except SQLAlchemyError as e:
-                logger.error(f"エラー画像ID一覧の取得中にエラーが発生しました: {e}", exc_info=True)
-                raise
+        """ErrorRecordRepository.get_error_image_ids への delegate (ADR 0035 段階 3)。"""
+        return self._error_record_repo.get_error_image_ids(
+            operation_type=operation_type,
+            resolved=resolved,
+            error_types=error_types,
+        )
 
     def get_images_by_ids(self, image_ids: list[int]) -> list[dict[str, Any]]:
         """画像IDリストから画像メタデータを取得
@@ -3261,112 +3184,21 @@ class ImageRepository:
         limit: int = 100,
         offset: int = 0,
     ) -> list[ErrorRecord]:
-        """エラーレコードを取得（ページネーション対応）
-
-        Args:
-            operation_type: 操作種別フィルタ
-            resolved: None = 全て、True = 解決済み、False = 未解決
-            limit: 取得件数上限
-            offset: オフセット
-
-        Returns:
-            list[ErrorRecord]: エラーレコードリスト
-
-        Raises:
-            SQLAlchemyError: データベース操作でエラーが発生した場合
-
-        """
-        with self.session_factory() as session:
-            try:
-                query = select(ErrorRecord).order_by(ErrorRecord.created_at.desc())
-                if operation_type:
-                    query = query.where(ErrorRecord.operation_type == operation_type)
-                if resolved is not None:
-                    if resolved:
-                        query = query.where(ErrorRecord.resolved_at.is_not(None))
-                    else:
-                        query = query.where(ErrorRecord.resolved_at.is_(None))
-                query = query.limit(limit).offset(offset)
-                records = list(session.execute(query).scalars().all())
-                logger.debug(
-                    f"エラーレコードを取得: {len(records)}件 "
-                    f"(operation_type={operation_type or 'all'}, "
-                    f"resolved={resolved}, limit={limit}, offset={offset})",
-                )
-                return records
-            except SQLAlchemyError as e:
-                logger.error(f"エラーレコードの取得中にエラーが発生しました: {e}", exc_info=True)
-                raise
+        """ErrorRecordRepository.get_error_records への delegate (ADR 0035 段階 3)。"""
+        return self._error_record_repo.get_error_records(
+            operation_type=operation_type,
+            resolved=resolved,
+            limit=limit,
+            offset=offset,
+        )
 
     def mark_error_resolved(self, error_id: int) -> None:
-        """エラーを解決済みにマーク（resolved_at = 現在時刻）
-
-        Args:
-            error_id: エラーレコードID
-
-        Raises:
-            SQLAlchemyError: データベース操作でエラーが発生した場合
-
-        """
-        from datetime import UTC
-
-        with self.session_factory() as session:
-            try:
-                record = session.get(ErrorRecord, error_id)
-                if record:
-                    record.resolved_at = datetime.datetime.now(UTC)
-                    session.commit()
-                    logger.info(f"エラーレコードを解決済みにマーク: ID={error_id}")
-                else:
-                    logger.warning(f"エラーレコードが見つかりません: ID={error_id}")
-            except SQLAlchemyError as e:
-                session.rollback()
-                logger.error(f"エラーレコードの解決マーク中にエラーが発生しました: {e}", exc_info=True)
-                raise
+        """ErrorRecordRepository.mark_error_resolved への delegate (ADR 0035 段階 3)。"""
+        self._error_record_repo.mark_error_resolved(error_id)
 
     def mark_errors_resolved_batch(self, error_ids: list[int]) -> tuple[bool, int]:
-        """複数のエラーレコードを原子的に解決済みにマーク
-
-        単一トランザクションで全エラーを処理する。全件成功 or 全件ロールバック。
-        ADR-0012 (Batch Tag Atomic Transaction) パターン準拠。
-
-        Args:
-            error_ids: 対象エラーレコードのIDリスト
-
-        Returns:
-            (成功フラグ, 解決済みマーク件数)
-
-        Raises:
-            SQLAlchemyError: データベースエラー時（ロールバック後に再送出）
-        """
-        from datetime import UTC
-
-        if not error_ids:
-            logger.warning("mark_errors_resolved_batch: 空のerror_idsリストが渡されました")
-            return (False, 0)
-
-        with self.session_factory() as session:
-            try:
-                existing = (
-                    session.execute(select(ErrorRecord).where(ErrorRecord.id.in_(error_ids)))
-                    .scalars()
-                    .all()
-                )
-
-                now = datetime.datetime.now(UTC)
-                updated_count = 0
-                for record in existing:
-                    record.resolved_at = now
-                    updated_count += 1
-
-                session.commit()
-                logger.info(f"エラーレコード一括解決完了: 要求={len(error_ids)}件, 更新={updated_count}件")
-                return (True, updated_count)
-
-            except SQLAlchemyError as e:
-                session.rollback()
-                logger.error(f"エラーレコード一括解決失敗: {e}", exc_info=True)
-                raise
+        """ErrorRecordRepository.mark_errors_resolved_batch への delegate (ADR 0035 段階 3)。"""
+        return self._error_record_repo.mark_errors_resolved_batch(error_ids)
 
     def get_session(self) -> Session:
         """セッションを取得（Manager層で生SQLを実行する際に使用）

--- a/src/lorairo/database/repository/__init__.py
+++ b/src/lorairo/database/repository/__init__.py
@@ -5,15 +5,18 @@
 
 段階 1 (#423): `ModelRepository`
 段階 2 (#423): `ProjectRepository`
-段階 3 以降: `ErrorRecordRepository`, `ImageRepository`, `AnnotationRepository`
+段階 3 (#423): `ErrorRecordRepository`
+段階 4 以降: `ImageRepository`, `AnnotationRepository`
 """
 
 from .base import BaseRepository
+from .error_record import ErrorRecordRepository
 from .model import ModelRepository
 from .project import ProjectRepository
 
 __all__ = [
     "BaseRepository",
+    "ErrorRecordRepository",
     "ModelRepository",
     "ProjectRepository",
 ]

--- a/src/lorairo/database/repository/error_record.py
+++ b/src/lorairo/database/repository/error_record.py
@@ -1,0 +1,269 @@
+"""ErrorRecord 永続化担当 Repository (ADR 0035 §1)。
+
+`ImageRepository` god class 分割の段階 3 として、`ErrorRecord` エンティティの
+CRUD・状態遷移 (resolved_at 更新) を本 Repository に集約する。
+
+管轄 entity:
+  - `ErrorRecord` (`operation_type`, `error_type`, `error_message`, `resolved_at` 他)
+
+段階 1 で確立した `BaseRepository` (`session_factory` + `BATCH_CHUNK_SIZE`) を継承する。
+
+Note:
+    Manager 層 (`ImageDatabaseManager.save_error_record`) では「二次エラー防止」のため
+    本 Repository が送出する例外を sentinel `-1` に畳む。本 Repository 側では
+    SQLAlchemyError を rollback 後に呼び出し元へ伝播させる責務に留める
+    (PR #476 で確立した方針)。
+"""
+
+from __future__ import annotations
+
+import datetime
+from datetime import UTC
+
+from sqlalchemy import func
+from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.future import select
+
+from ...utils.log import logger
+from ..schema import ErrorRecord
+from .base import BaseRepository
+
+
+class ErrorRecordRepository(BaseRepository):
+    """`ErrorRecord` の永続化を担当する Repository (ADR 0035)。
+
+    管轄 entity:
+      - `ErrorRecord` (CRUD + 解決マーク + 集計クエリ)
+    """
+
+    def save_error_record(
+        self,
+        operation_type: str,
+        error_type: str,
+        error_message: str,
+        image_id: int | None = None,
+        stack_trace: str | None = None,
+        file_path: str | None = None,
+        model_name: str | None = None,
+    ) -> int:
+        """エラーレコードを保存する。
+
+        Args:
+            operation_type: 操作種別 ("registration" | "annotation" | "processing")。
+            error_type: エラー種別 ("pHash calculation" | "API error" | "DB constraint")。
+            error_message: エラーメッセージ。
+            image_id: 画像ID (Optional)。
+            stack_trace: スタックトレース (Optional)。
+            file_path: ファイルパス (Optional)。
+            model_name: モデル名 (Optional)。
+
+        Returns:
+            int: 作成された error_record_id。
+
+        Raises:
+            SQLAlchemyError: データベース操作でエラーが発生した場合。
+        """
+        with self.session_factory() as session:
+            try:
+                record = ErrorRecord(
+                    image_id=image_id,
+                    operation_type=operation_type,
+                    error_type=error_type,
+                    error_message=error_message,
+                    stack_trace=stack_trace,
+                    file_path=file_path,
+                    model_name=model_name,
+                )
+                session.add(record)
+                session.flush()
+                error_id = record.id
+                session.commit()
+                logger.debug(
+                    f"エラーレコードを保存しました: ID={error_id}, "
+                    f"operation={operation_type}, type={error_type}",
+                )
+                return error_id
+            except SQLAlchemyError as e:
+                session.rollback()
+                logger.error(f"エラーレコードの保存中にエラーが発生しました: {e}", exc_info=True)
+                raise
+
+    def get_error_count_unresolved(self, operation_type: str | None = None) -> int:
+        """未解決エラー件数を取得する (resolved_at IS NULL)。
+
+        Args:
+            operation_type: 操作種別フィルタ (None = 全操作)。
+
+        Returns:
+            int: 未解決エラー件数。
+
+        Raises:
+            SQLAlchemyError: データベース操作でエラーが発生した場合。
+        """
+        with self.session_factory() as session:
+            try:
+                query = select(func.count(ErrorRecord.id)).where(ErrorRecord.resolved_at.is_(None))
+                if operation_type:
+                    query = query.where(ErrorRecord.operation_type == operation_type)
+                count = session.execute(query).scalar() or 0
+                logger.debug(
+                    f"未解決エラー件数を取得: {count}件 (operation_type={operation_type or 'all'})",
+                )
+                return count
+            except SQLAlchemyError as e:
+                logger.error(f"未解決エラー件数の取得中にエラーが発生しました: {e}", exc_info=True)
+                raise
+
+    def get_error_image_ids(
+        self,
+        operation_type: str | None = None,
+        resolved: bool = False,
+        error_types: list[str] | None = None,
+    ) -> list[int]:
+        """エラー画像のID一覧を取得する。
+
+        Args:
+            operation_type: 操作種別フィルタ (None = 全操作)。
+            resolved: True = 解決済み (resolved_at IS NOT NULL)、
+                False = 未解決 (resolved_at IS NULL)。
+            error_types: 特定 error_type のみに絞る (例:
+                ["SafetyRefusalError", "ContentPolicyRefusalError"])。
+                None = 全 type。ADR 0023 Phase 1.5 の送信前 filter で使用。
+
+        Returns:
+            list[int]: 画像IDリスト (重複除去済み、None を除外)。
+
+        Raises:
+            SQLAlchemyError: データベース操作でエラーが発生した場合。
+        """
+        with self.session_factory() as session:
+            try:
+                query = select(ErrorRecord.image_id).distinct().where(ErrorRecord.image_id.is_not(None))
+                if resolved:
+                    query = query.where(ErrorRecord.resolved_at.is_not(None))
+                else:
+                    query = query.where(ErrorRecord.resolved_at.is_(None))
+                if operation_type:
+                    query = query.where(ErrorRecord.operation_type == operation_type)
+                if error_types:
+                    query = query.where(ErrorRecord.error_type.in_(error_types))
+
+                results = session.execute(query).scalars().all()
+                image_ids = [id for id in results if id is not None]
+                logger.debug(
+                    f"エラー画像ID一覧を取得: {len(image_ids)}件 "
+                    f"(operation_type={operation_type or 'all'}, resolved={resolved}, "
+                    f"error_types={error_types or 'all'})",
+                )
+                return image_ids
+            except SQLAlchemyError as e:
+                logger.error(f"エラー画像ID一覧の取得中にエラーが発生しました: {e}", exc_info=True)
+                raise
+
+    def get_error_records(
+        self,
+        operation_type: str | None = None,
+        resolved: bool | None = None,
+        limit: int = 100,
+        offset: int = 0,
+    ) -> list[ErrorRecord]:
+        """エラーレコードを取得する (ページネーション対応)。
+
+        Args:
+            operation_type: 操作種別フィルタ (None = 全操作)。
+            resolved: None = 全て、True = 解決済み、False = 未解決。
+            limit: 取得件数上限。
+            offset: オフセット。
+
+        Returns:
+            list[ErrorRecord]: エラーレコードリスト。
+
+        Raises:
+            SQLAlchemyError: データベース操作でエラーが発生した場合。
+        """
+        with self.session_factory() as session:
+            try:
+                query = select(ErrorRecord).order_by(ErrorRecord.created_at.desc())
+                if operation_type:
+                    query = query.where(ErrorRecord.operation_type == operation_type)
+                if resolved is not None:
+                    if resolved:
+                        query = query.where(ErrorRecord.resolved_at.is_not(None))
+                    else:
+                        query = query.where(ErrorRecord.resolved_at.is_(None))
+                query = query.limit(limit).offset(offset)
+                records = list(session.execute(query).scalars().all())
+                logger.debug(
+                    f"エラーレコードを取得: {len(records)}件 "
+                    f"(operation_type={operation_type or 'all'}, "
+                    f"resolved={resolved}, limit={limit}, offset={offset})",
+                )
+                return records
+            except SQLAlchemyError as e:
+                logger.error(f"エラーレコードの取得中にエラーが発生しました: {e}", exc_info=True)
+                raise
+
+    def mark_error_resolved(self, error_id: int) -> None:
+        """エラーを解決済みにマークする (resolved_at = 現在時刻)。
+
+        Args:
+            error_id: エラーレコードID。
+
+        Raises:
+            SQLAlchemyError: データベース操作でエラーが発生した場合。
+        """
+        with self.session_factory() as session:
+            try:
+                record = session.get(ErrorRecord, error_id)
+                if record:
+                    record.resolved_at = datetime.datetime.now(UTC)
+                    session.commit()
+                    logger.info(f"エラーレコードを解決済みにマーク: ID={error_id}")
+                else:
+                    logger.warning(f"エラーレコードが見つかりません: ID={error_id}")
+            except SQLAlchemyError as e:
+                session.rollback()
+                logger.error(f"エラーレコードの解決マーク中にエラーが発生しました: {e}", exc_info=True)
+                raise
+
+    def mark_errors_resolved_batch(self, error_ids: list[int]) -> tuple[bool, int]:
+        """複数のエラーレコードを原子的に解決済みにマークする。
+
+        単一トランザクションで全エラーを処理する。全件成功 or 全件ロールバック。
+        ADR-0012 (Batch Tag Atomic Transaction) パターン準拠。
+
+        Args:
+            error_ids: 対象エラーレコードのIDリスト。
+
+        Returns:
+            tuple[bool, int]: (成功フラグ, 解決済みマーク件数)。
+
+        Raises:
+            SQLAlchemyError: データベースエラー時 (ロールバック後に再送出)。
+        """
+        if not error_ids:
+            logger.warning("mark_errors_resolved_batch: 空のerror_idsリストが渡されました")
+            return (False, 0)
+
+        with self.session_factory() as session:
+            try:
+                existing = (
+                    session.execute(select(ErrorRecord).where(ErrorRecord.id.in_(error_ids)))
+                    .scalars()
+                    .all()
+                )
+
+                now = datetime.datetime.now(UTC)
+                updated_count = 0
+                for record in existing:
+                    record.resolved_at = now
+                    updated_count += 1
+
+                session.commit()
+                logger.info(f"エラーレコード一括解決完了: 要求={len(error_ids)}件, 更新={updated_count}件")
+                return (True, updated_count)
+
+            except SQLAlchemyError as e:
+                session.rollback()
+                logger.error(f"エラーレコード一括解決失敗: {e}", exc_info=True)
+                raise

--- a/tests/unit/database/repository/test_error_record_repository.py
+++ b/tests/unit/database/repository/test_error_record_repository.py
@@ -1,0 +1,453 @@
+"""ErrorRecordRepository 直接の単体テスト (ADR 0035 段階 3, Issue #423)。
+
+`db_repository.py` から抽出した `ErrorRecordRepository` の責務境界を独立して検証する。
+既存の `tests/unit/database/test_db_repository_error_records.py` は
+`ImageRepository` の delegating facade 経由で同じ実装をカバーしているため、本ファイルでは
+ErrorRecordRepository を直接 instantiate して以下を最小限カバーする:
+
+- BaseRepository 継承 / session_factory 共有
+- `save_error_record` の正常系 + SQLAlchemyError 伝播 (PR #476: Repository 側で raise、
+  二次エラー防止 sentinel `-1` は Manager 層の責務)
+- `get_error_count_unresolved` / `get_error_image_ids` / `get_error_records` の動作
+- `mark_error_resolved` / `mark_errors_resolved_batch` の動作 + 空入力ガード
+- ImageRepository facade 経由でも同じ ErrorRecordRepository クラスが見えること
+- DI contract: ImageDatabaseManager は injected error_record_repo 経由で呼ぶ
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import Mock, patch
+
+import pytest
+from sqlalchemy import create_engine, select
+from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.orm import sessionmaker
+
+from lorairo.database.db_manager import ImageDatabaseManager
+from lorairo.database.db_repository import ImageRepository
+from lorairo.database.repository.base import BaseRepository
+from lorairo.database.repository.error_record import ErrorRecordRepository
+from lorairo.database.schema import ErrorRecord
+from lorairo.services.configuration_service import ConfigurationService
+
+
+@pytest.fixture
+def memory_session_factory():
+    """in-memory SQLite セッションファクトリ（schema 全テーブル）。"""
+    from lorairo.database.schema import Base
+
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    return sessionmaker(engine)
+
+
+@pytest.fixture
+def error_record_repository(memory_session_factory) -> ErrorRecordRepository:
+    """In-memory SQLite に対する ErrorRecordRepository インスタンス。"""
+    return ErrorRecordRepository(session_factory=memory_session_factory)
+
+
+def _insert_error(
+    repo: ErrorRecordRepository,
+    *,
+    operation_type: str = "annotation",
+    error_type: str = "APIError",
+    error_message: str = "test",
+    image_id: int | None = None,
+) -> int:
+    """テスト用エラーを 1 件作成して id を返す。"""
+    return repo.save_error_record(
+        operation_type=operation_type,
+        error_type=error_type,
+        error_message=error_message,
+        image_id=image_id,
+    )
+
+
+@pytest.mark.unit
+class TestErrorRecordRepositoryStructure:
+    """ADR 0035 段階 3 で確立した抽出構造の sanity check。"""
+
+    def test_inherits_base_repository(self) -> None:
+        """ErrorRecordRepository は BaseRepository を継承する。"""
+        assert issubclass(ErrorRecordRepository, BaseRepository)
+
+    def test_holds_session_factory(self, memory_session_factory) -> None:
+        """`session_factory` を BaseRepository 経由で保持する。"""
+        repo = ErrorRecordRepository(session_factory=memory_session_factory)
+        assert repo.session_factory is memory_session_factory
+
+
+@pytest.mark.unit
+class TestSaveErrorRecord:
+    """`save_error_record` の永続化動作。"""
+
+    def test_creates_record_and_returns_positive_id(
+        self, error_record_repository: ErrorRecordRepository, memory_session_factory
+    ) -> None:
+        """新規エラーレコードを保存して正の ID を返し、DB にも書き込まれる。"""
+        error_id = error_record_repository.save_error_record(
+            operation_type="annotation",
+            error_type="APIError",
+            error_message="timeout",
+            image_id=100,
+            stack_trace="trace lines",
+            file_path="/path/to/file.jpg",
+            model_name="gpt-4",
+        )
+        assert isinstance(error_id, int)
+        assert error_id > 0
+
+        with memory_session_factory() as session:
+            record = session.execute(select(ErrorRecord).where(ErrorRecord.id == error_id)).scalar_one()
+            assert record.operation_type == "annotation"
+            assert record.error_type == "APIError"
+            assert record.error_message == "timeout"
+            assert record.image_id == 100
+            assert record.stack_trace == "trace lines"
+            assert record.file_path == "/path/to/file.jpg"
+            assert record.model_name == "gpt-4"
+            assert record.resolved_at is None
+
+    def test_minimal_fields_persisted(
+        self, error_record_repository: ErrorRecordRepository, memory_session_factory
+    ) -> None:
+        """必須 3 フィールドのみでも保存できる (Optional 引数は None で永続化される)。"""
+        error_id = error_record_repository.save_error_record(
+            operation_type="registration",
+            error_type="FileNotFoundError",
+            error_message="missing file",
+        )
+        with memory_session_factory() as session:
+            record = session.execute(select(ErrorRecord).where(ErrorRecord.id == error_id)).scalar_one()
+            assert record.image_id is None
+            assert record.stack_trace is None
+            assert record.file_path is None
+            assert record.model_name is None
+
+    def test_raises_sqlalchemy_error(self, error_record_repository: ErrorRecordRepository) -> None:
+        """予期しない SQLAlchemyError は呼び出し元へ伝播し rollback される。
+
+        PR #476 教訓: Repository 層では `except Exception` で握り潰さない。
+        二次エラー防止 (sentinel `-1` return) は Manager 層 (`ImageDatabaseManager`)
+        の責務として維持する。
+        """
+        mock_session = Mock()
+        mock_session.__enter__ = Mock(return_value=mock_session)
+        mock_session.__exit__ = Mock(return_value=False)
+        mock_session.add.side_effect = SQLAlchemyError("simulated failure")
+        mock_session.rollback = Mock()
+
+        with patch.object(error_record_repository, "session_factory", return_value=mock_session):
+            with pytest.raises(SQLAlchemyError, match="simulated failure"):
+                error_record_repository.save_error_record(
+                    operation_type="annotation",
+                    error_type="APIError",
+                    error_message="boom",
+                )
+        mock_session.rollback.assert_called()
+
+
+@pytest.mark.unit
+class TestGetErrorCountUnresolved:
+    """`get_error_count_unresolved` の集計動作。"""
+
+    def test_counts_only_unresolved(
+        self, error_record_repository: ErrorRecordRepository, memory_session_factory
+    ) -> None:
+        """resolved_at IS NULL のみカウントする。"""
+        eid1 = _insert_error(error_record_repository)
+        _insert_error(error_record_repository)
+        _insert_error(error_record_repository)
+
+        # eid1 を解決済みにマークする
+        error_record_repository.mark_error_resolved(eid1)
+
+        assert error_record_repository.get_error_count_unresolved() == 2
+
+    def test_filters_by_operation_type(self, error_record_repository: ErrorRecordRepository) -> None:
+        """operation_type 指定で対応分のみカウントする。"""
+        _insert_error(error_record_repository, operation_type="annotation")
+        _insert_error(error_record_repository, operation_type="annotation")
+        _insert_error(error_record_repository, operation_type="registration")
+
+        assert error_record_repository.get_error_count_unresolved(operation_type="annotation") == 2
+        assert error_record_repository.get_error_count_unresolved(operation_type="registration") == 1
+
+    def test_returns_zero_when_empty(self, error_record_repository: ErrorRecordRepository) -> None:
+        """エラーレコードが無いとき 0 を返す (silent return ではなく正常系)。"""
+        assert error_record_repository.get_error_count_unresolved() == 0
+
+
+@pytest.mark.unit
+class TestGetErrorImageIds:
+    """`get_error_image_ids` の動作 (重複除去 / フィルタ)。"""
+
+    def test_returns_distinct_image_ids(self, error_record_repository: ErrorRecordRepository) -> None:
+        """同じ image_id に対して複数エラーがあっても 1 件に集約される。"""
+        _insert_error(error_record_repository, image_id=10)
+        _insert_error(error_record_repository, image_id=10)
+        _insert_error(error_record_repository, image_id=20)
+        _insert_error(error_record_repository, image_id=None)  # None は除外される
+
+        ids = error_record_repository.get_error_image_ids()
+        assert set(ids) == {10, 20}
+
+    def test_filters_by_error_types(self, error_record_repository: ErrorRecordRepository) -> None:
+        """error_types フィルタで特定の error_type のみを抽出する。"""
+        _insert_error(error_record_repository, image_id=1, error_type="SafetyRefusalError")
+        _insert_error(error_record_repository, image_id=2, error_type="APIError")
+
+        ids = error_record_repository.get_error_image_ids(error_types=["SafetyRefusalError"])
+        assert ids == [1]
+
+    def test_resolved_filter(self, error_record_repository: ErrorRecordRepository) -> None:
+        """resolved=True で解決済みのみ、False で未解決のみを返す。"""
+        eid1 = _insert_error(error_record_repository, image_id=100)
+        _insert_error(error_record_repository, image_id=200)
+        error_record_repository.mark_error_resolved(eid1)
+
+        unresolved = error_record_repository.get_error_image_ids(resolved=False)
+        resolved = error_record_repository.get_error_image_ids(resolved=True)
+
+        assert unresolved == [200]
+        assert resolved == [100]
+
+
+@pytest.mark.unit
+class TestGetErrorRecords:
+    """`get_error_records` のページネーション / ソート動作。"""
+
+    def test_returns_records_in_desc_order(self, error_record_repository: ErrorRecordRepository) -> None:
+        """created_at の降順で返る (新しいものが先頭)。"""
+        eid1 = _insert_error(error_record_repository, error_message="first")
+        eid2 = _insert_error(error_record_repository, error_message="second")
+        eid3 = _insert_error(error_record_repository, error_message="third")
+
+        records = error_record_repository.get_error_records()
+        # eid3, eid2, eid1 の順 (desc by created_at) — id は単調増加なので id 降順と一致
+        ids = [r.id for r in records]
+        assert ids == sorted([eid1, eid2, eid3], reverse=True)
+
+    def test_limit_and_offset(self, error_record_repository: ErrorRecordRepository) -> None:
+        """limit / offset がページングに反映される。"""
+        for i in range(5):
+            _insert_error(error_record_repository, error_message=f"msg-{i}")
+
+        page = error_record_repository.get_error_records(limit=2, offset=1)
+        assert len(page) == 2
+
+    def test_resolved_none_returns_all(self, error_record_repository: ErrorRecordRepository) -> None:
+        """resolved=None で解決済み / 未解決を区別せず全件返す。"""
+        eid1 = _insert_error(error_record_repository)
+        _insert_error(error_record_repository)
+        error_record_repository.mark_error_resolved(eid1)
+
+        all_records = error_record_repository.get_error_records(resolved=None)
+        assert len(all_records) == 2
+
+
+@pytest.mark.unit
+class TestMarkErrorResolved:
+    """`mark_error_resolved` の単件解決動作。"""
+
+    def test_sets_resolved_at(
+        self, error_record_repository: ErrorRecordRepository, memory_session_factory
+    ) -> None:
+        """resolved_at が現在時刻に更新される。"""
+        eid = _insert_error(error_record_repository)
+        before = datetime.now(UTC)
+        error_record_repository.mark_error_resolved(eid)
+
+        with memory_session_factory() as session:
+            record = session.execute(select(ErrorRecord).where(ErrorRecord.id == eid)).scalar_one()
+            assert record.resolved_at is not None
+            # SQLite TIMESTAMP は読み出し時に naive datetime になる場合があるので
+            # tz-aware に正規化して比較する。
+            resolved_at = record.resolved_at
+            if resolved_at.tzinfo is None:
+                resolved_at = resolved_at.replace(tzinfo=UTC)
+            assert resolved_at >= before
+
+    def test_unknown_id_does_not_raise(self, error_record_repository: ErrorRecordRepository) -> None:
+        """存在しない ID では warning ログのみで raise しない (正常系)。"""
+        # 例外が出ないことを確認 (logger.warning は副作用なし)
+        error_record_repository.mark_error_resolved(99999)
+
+
+@pytest.mark.unit
+class TestMarkErrorsResolvedBatch:
+    """`mark_errors_resolved_batch` の一括解決動作。"""
+
+    def test_returns_false_zero_for_empty_input(
+        self, error_record_repository: ErrorRecordRepository
+    ) -> None:
+        """空リスト入力では (False, 0) を返す (DB アクセスしない)。"""
+        success, count = error_record_repository.mark_errors_resolved_batch([])
+        assert success is False
+        assert count == 0
+
+    def test_marks_all_in_batch(
+        self, error_record_repository: ErrorRecordRepository, memory_session_factory
+    ) -> None:
+        """対象 ID 全件に resolved_at がセットされる。"""
+        ids = [_insert_error(error_record_repository) for _ in range(3)]
+        success, count = error_record_repository.mark_errors_resolved_batch(ids)
+
+        assert success is True
+        assert count == 3
+        with memory_session_factory() as session:
+            for eid in ids:
+                record = session.execute(select(ErrorRecord).where(ErrorRecord.id == eid)).scalar_one()
+                assert record.resolved_at is not None
+
+    def test_partial_existing_ids(self, error_record_repository: ErrorRecordRepository) -> None:
+        """存在しない ID が混ざっていても、存在するものだけ更新する (count に反映)。"""
+        existing = _insert_error(error_record_repository)
+        success, count = error_record_repository.mark_errors_resolved_batch([existing, 99999])
+        assert success is True
+        assert count == 1
+
+
+@pytest.mark.unit
+class TestFacadeDelegation:
+    """`ImageRepository` の delegating facade が `ErrorRecordRepository` を正しく呼ぶ。"""
+
+    def test_image_repository_holds_error_record_repo(self, memory_session_factory) -> None:
+        """ImageRepository は内部 `_error_record_repo` を保持する (段階移行中の hook)。"""
+        repo = ImageRepository(session_factory=memory_session_factory)
+        assert isinstance(repo._error_record_repo, ErrorRecordRepository)
+        assert repo._error_record_repo.session_factory is repo.session_factory
+
+    def test_save_error_record_via_facade_matches_direct(self, memory_session_factory) -> None:
+        """facade 経由でも直接呼び出しでも同じ動作。"""
+        repo = ImageRepository(session_factory=memory_session_factory)
+
+        id_via_facade = repo.save_error_record(
+            operation_type="annotation",
+            error_type="APIError",
+            error_message="via_facade",
+        )
+        id_via_direct = repo._error_record_repo.save_error_record(
+            operation_type="annotation",
+            error_type="APIError",
+            error_message="via_direct",
+        )
+
+        assert id_via_facade > 0
+        assert id_via_direct > 0
+        assert id_via_facade != id_via_direct
+
+    def test_mark_errors_resolved_batch_via_facade_matches_direct(self, memory_session_factory) -> None:
+        """mark_errors_resolved_batch も facade 経由で同一結果を返す。"""
+        repo = ImageRepository(session_factory=memory_session_factory)
+        eid1 = repo.save_error_record(
+            operation_type="annotation", error_type="APIError", error_message="m1"
+        )
+        eid2 = repo.save_error_record(
+            operation_type="annotation", error_type="APIError", error_message="m2"
+        )
+
+        result_facade = repo.mark_errors_resolved_batch([eid1])
+        result_direct = repo._error_record_repo.mark_errors_resolved_batch([eid2])
+
+        assert result_facade == (True, 1)
+        assert result_direct == (True, 1)
+
+
+@pytest.mark.unit
+class TestImageDatabaseManagerDIContract:
+    """ImageDatabaseManager が injected `error_record_repo` 経由で呼ぶ (DI contract)。
+
+    PR #477 review 教訓: クラス経由 static 呼び出しではなく、インスタンス経由で呼ぶことで
+    テストが mock 注入で動作を制御できる。
+    """
+
+    def test_save_error_record_uses_injected_error_record_repo(self) -> None:
+        """`save_error_record` Manager Facade は self.error_record_repo.save_error_record を呼ぶ。"""
+        mock_repository = Mock(spec=ImageRepository)
+        mock_config_service = Mock(spec=ConfigurationService)
+        mock_error_record_repo = Mock(spec=ErrorRecordRepository)
+        mock_error_record_repo.save_error_record.return_value = 42
+
+        manager = ImageDatabaseManager(
+            repository=mock_repository,
+            config_service=mock_config_service,
+            error_record_repo=mock_error_record_repo,
+        )
+
+        result = manager.save_error_record(
+            operation_type="annotation",
+            error_type="APIError",
+            error_message="timeout",
+            image_id=7,
+        )
+
+        assert result == 42
+        # injected mock 経由で呼ばれることを assert (DI contract)
+        mock_error_record_repo.save_error_record.assert_called_once_with(
+            operation_type="annotation",
+            error_type="APIError",
+            error_message="timeout",
+            image_id=7,
+            stack_trace=None,
+            file_path=None,
+            model_name=None,
+        )
+        # repository (ImageRepository) の save_error_record は呼ばれない
+        mock_repository.save_error_record.assert_not_called()
+
+    def test_save_error_record_returns_minus_one_on_exception(self) -> None:
+        """二次エラー防止 (PR #476): Repository 例外を Manager で sentinel `-1` に畳む。"""
+        mock_repository = Mock(spec=ImageRepository)
+        mock_config_service = Mock(spec=ConfigurationService)
+        mock_error_record_repo = Mock(spec=ErrorRecordRepository)
+        mock_error_record_repo.save_error_record.side_effect = Exception("DB down")
+
+        manager = ImageDatabaseManager(
+            repository=mock_repository,
+            config_service=mock_config_service,
+            error_record_repo=mock_error_record_repo,
+        )
+
+        result = manager.save_error_record(
+            operation_type="registration",
+            error_type="FileNotFoundError",
+            error_message="file missing",
+        )
+
+        assert result == -1
+
+    def test_mark_errors_resolved_batch_uses_injected_repo(self) -> None:
+        """Manager の mark_errors_resolved_batch は self.error_record_repo を呼ぶ。"""
+        mock_repository = Mock(spec=ImageRepository)
+        mock_config_service = Mock(spec=ConfigurationService)
+        mock_error_record_repo = Mock(spec=ErrorRecordRepository)
+        mock_error_record_repo.mark_errors_resolved_batch.return_value = (True, 3)
+
+        manager = ImageDatabaseManager(
+            repository=mock_repository,
+            config_service=mock_config_service,
+            error_record_repo=mock_error_record_repo,
+        )
+
+        result = manager.mark_errors_resolved_batch([1, 2, 3])
+
+        assert result == (True, 3)
+        mock_error_record_repo.mark_errors_resolved_batch.assert_called_once_with([1, 2, 3])
+        mock_repository.mark_errors_resolved_batch.assert_not_called()
+
+    def test_auto_constructs_error_record_repo_when_omitted(self) -> None:
+        """`error_record_repo` 省略時は repository の session_factory を共有して自動生成される。"""
+        mock_repository = Mock(spec=ImageRepository)
+        mock_repository.session_factory = lambda: None  # 任意の callable
+        mock_config_service = Mock(spec=ConfigurationService)
+
+        manager = ImageDatabaseManager(
+            repository=mock_repository,
+            config_service=mock_config_service,
+        )
+
+        assert isinstance(manager.error_record_repo, ErrorRecordRepository)
+        assert manager.error_record_repo.session_factory is mock_repository.session_factory

--- a/tests/unit/database/test_db_manager_core.py
+++ b/tests/unit/database/test_db_manager_core.py
@@ -24,6 +24,7 @@ from sqlalchemy.exc import SQLAlchemyError
 
 from lorairo.database.db_manager import ImageDatabaseManager
 from lorairo.database.db_repository import ImageRepository
+from lorairo.database.repository.error_record import ErrorRecordRepository
 from lorairo.database.repository.model import ModelRepository
 from lorairo.database.repository.project import ProjectRepository
 from lorairo.services.configuration_service import ConfigurationService
@@ -52,6 +53,12 @@ def mock_project_repo() -> Mock:
 
 
 @pytest.fixture
+def mock_error_record_repo() -> Mock:
+    """モック化された ErrorRecordRepository を返す (ADR 0035 段階 3)。"""
+    return Mock(spec=ErrorRecordRepository)
+
+
+@pytest.fixture
 def mock_config_service() -> Mock:
     """モック化された ConfigurationService を返す。"""
     svc = Mock(spec=ConfigurationService)
@@ -65,6 +72,7 @@ def manager(
     mock_config_service: Mock,
     mock_model_repo: Mock,
     mock_project_repo: Mock,
+    mock_error_record_repo: Mock,
 ) -> ImageDatabaseManager:
     """ImageDatabaseManager のインスタンスを返す（依存はすべてモック）。"""
     return ImageDatabaseManager(
@@ -73,6 +81,7 @@ def manager(
         fsm=None,
         model_repo=mock_model_repo,
         project_repo=mock_project_repo,
+        error_record_repo=mock_error_record_repo,
     )
 
 
@@ -422,13 +431,13 @@ class TestDetectDuplicateImage:
 
 @pytest.mark.unit
 class TestSaveErrorRecord:
-    """save_error_record メソッドのテスト"""
+    """save_error_record メソッドのテスト (ADR 0035 段階 3: error_record_repo 経由)"""
 
     def test_returns_error_id_on_success(
-        self, manager: ImageDatabaseManager, mock_repository: Mock
+        self, manager: ImageDatabaseManager, mock_error_record_repo: Mock
     ) -> None:
-        """正常系ではリポジトリが返した error_id を返す。"""
-        mock_repository.save_error_record.return_value = 10
+        """正常系では error_record_repo が返した error_id を返す。"""
+        mock_error_record_repo.save_error_record.return_value = 10
         result = manager.save_error_record(
             operation_type="annotation",
             error_type="APIError",
@@ -437,10 +446,10 @@ class TestSaveErrorRecord:
         assert result == 10
 
     def test_returns_minus_one_on_exception(
-        self, manager: ImageDatabaseManager, mock_repository: Mock
+        self, manager: ImageDatabaseManager, mock_error_record_repo: Mock
     ) -> None:
-        """例外が発生した場合は -1 を返す（二次エラー防止）。"""
-        mock_repository.save_error_record.side_effect = Exception("db error")
+        """例外が発生した場合は -1 を返す (二次エラー防止、PR #476)。"""
+        mock_error_record_repo.save_error_record.side_effect = Exception("db error")
         result = manager.save_error_record(
             operation_type="registration",
             error_type="FileNotFoundError",
@@ -456,19 +465,21 @@ class TestSaveErrorRecord:
 
 @pytest.mark.unit
 class TestMarkErrorsResolvedBatch:
-    """mark_errors_resolved_batch メソッドのテスト"""
+    """mark_errors_resolved_batch メソッドのテスト (ADR 0035 段階 3: error_record_repo 経由)"""
 
     def test_returns_success_tuple_on_success(
-        self, manager: ImageDatabaseManager, mock_repository: Mock
+        self, manager: ImageDatabaseManager, mock_error_record_repo: Mock
     ) -> None:
-        """正常系ではリポジトリの返値をそのまま返す。"""
-        mock_repository.mark_errors_resolved_batch.return_value = (True, 3)
+        """正常系では error_record_repo の返値をそのまま返す。"""
+        mock_error_record_repo.mark_errors_resolved_batch.return_value = (True, 3)
         result = manager.mark_errors_resolved_batch([1, 2, 3])
         assert result == (True, 3)
 
-    def test_raises_on_sqlalchemy_error(self, manager: ImageDatabaseManager, mock_repository: Mock) -> None:
+    def test_raises_on_sqlalchemy_error(
+        self, manager: ImageDatabaseManager, mock_error_record_repo: Mock
+    ) -> None:
         """DB 失敗時は SQLAlchemyError を呼び出し元へ伝播させる。"""
-        mock_repository.mark_errors_resolved_batch.side_effect = SQLAlchemyError("db error")
+        mock_error_record_repo.mark_errors_resolved_batch.side_effect = SQLAlchemyError("db error")
         with pytest.raises(SQLAlchemyError):
             manager.mark_errors_resolved_batch([1, 2, 3])
 
@@ -711,11 +722,15 @@ class TestFilterByAnnotationStatus:
     """filter_by_annotation_status メソッドのテスト"""
 
     def test_returns_empty_list_when_error_mode_has_no_errors(
-        self, manager: ImageDatabaseManager, mock_repository: Mock
+        self,
+        manager: ImageDatabaseManager,
+        mock_repository: Mock,
+        mock_error_record_repo: Mock,
     ) -> None:
         """error=True かつエラー画像 ID が空のとき空リストを返す。"""
         mock_repository.get_session.return_value = MagicMock()
-        mock_repository.get_error_image_ids.return_value = []
+        # ADR 0035 段階 3 (#423): error_record_repo 経由で取得される。
+        mock_error_record_repo.get_error_image_ids.return_value = []
         result = manager.filter_by_annotation_status(error=True)
         assert result == []
 

--- a/tests/unit/database/test_db_manager_extended.py
+++ b/tests/unit/database/test_db_manager_extended.py
@@ -31,6 +31,7 @@ from sqlalchemy.exc import SQLAlchemyError
 
 from lorairo.database.db_manager import ImageDatabaseManager
 from lorairo.database.db_repository import ImageRepository
+from lorairo.database.repository.error_record import ErrorRecordRepository
 from lorairo.database.repository.project import ProjectRepository
 from lorairo.services.configuration_service import ConfigurationService
 
@@ -60,8 +61,17 @@ def mock_project_repo() -> Mock:
 
 
 @pytest.fixture
+def mock_error_record_repo() -> Mock:
+    """モック化された ErrorRecordRepository を返す (ADR 0035 段階 3)。"""
+    return Mock(spec=ErrorRecordRepository)
+
+
+@pytest.fixture
 def manager(
-    mock_repository: Mock, mock_config_service: Mock, mock_project_repo: Mock
+    mock_repository: Mock,
+    mock_config_service: Mock,
+    mock_project_repo: Mock,
+    mock_error_record_repo: Mock,
 ) -> ImageDatabaseManager:
     """ImageDatabaseManager のインスタンスを返す（依存はすべてモック）。"""
     return ImageDatabaseManager(
@@ -69,6 +79,7 @@ def manager(
         config_service=mock_config_service,
         fsm=None,
         project_repo=mock_project_repo,
+        error_record_repo=mock_error_record_repo,
     )
 
 
@@ -716,11 +727,15 @@ class TestGetAnnotationStatusCounts:
         assert result == {"total": 0, "completed": 0, "error": 0, "completion_rate": 0.0}
 
     def test_returns_counts_when_images_exist(
-        self, manager: ImageDatabaseManager, mock_repository: Mock
+        self,
+        manager: ImageDatabaseManager,
+        mock_repository: Mock,
+        mock_error_record_repo: Mock,
     ) -> None:
         """画像が存在するとき、セッションを使ってカウントを返す。"""
         mock_repository.get_total_image_count.return_value = 10
-        mock_repository.get_error_count_unresolved.return_value = 2
+        # ADR 0035 段階 3 (#423): error_record_repo 経由で取得される。
+        mock_error_record_repo.get_error_count_unresolved.return_value = 2
 
         # セッションのモック
         mock_result = Mock()
@@ -797,10 +812,14 @@ class TestFilterByAnnotationStatusExtended:
         assert result[0]["id"] == 2
 
     def test_returns_error_images_when_error_ids_exist(
-        self, manager: ImageDatabaseManager, mock_repository: Mock
+        self,
+        manager: ImageDatabaseManager,
+        mock_repository: Mock,
+        mock_error_record_repo: Mock,
     ) -> None:
         """error=True でエラー ID が存在するとき、get_images_by_ids の結果を返す。"""
-        mock_repository.get_error_image_ids.return_value = [3, 4]
+        # ADR 0035 段階 3 (#423): error_record_repo 経由で取得される。
+        mock_error_record_repo.get_error_image_ids.return_value = [3, 4]
         expected = [{"id": 3}, {"id": 4}]
         mock_repository.get_images_by_ids.return_value = expected
 
@@ -814,10 +833,14 @@ class TestFilterByAnnotationStatusExtended:
         assert result == expected
 
     def test_returns_empty_list_when_error_mode_no_error_ids(
-        self, manager: ImageDatabaseManager, mock_repository: Mock
+        self,
+        manager: ImageDatabaseManager,
+        mock_repository: Mock,
+        mock_error_record_repo: Mock,
     ) -> None:
         """error=True でエラー ID が空のとき、空リストを返す (line 906)。"""
-        mock_repository.get_error_image_ids.return_value = []
+        # ADR 0035 段階 3 (#423): error_record_repo 経由で取得される。
+        mock_error_record_repo.get_error_image_ids.return_value = []
 
         mock_session = MagicMock()
         mock_session.__enter__ = Mock(return_value=mock_session)


### PR DESCRIPTION
## Summary

ADR 0035 §6 移行戦略の **段階 3**: `db_repository.py` から **ErrorRecord 関連 6 メソッド** を `ErrorRecordRepository` として独立 Repository に抽出。段階 1 (#477 Model) / 段階 2 (#479 Project) と同パターン。

### 新規ファイル

- `src/lorairo/database/repository/error_record.py` (269 行): `ErrorRecordRepository(BaseRepository)`
- `__init__.py` 更新: `ErrorRecordRepository` re-export 追加

### 変更ファイル

| ファイル | 変化 |
|---|---|
| `db_repository.py` | **3732 → 3564 行** (-168)。ErrorRecord 6 メソッド (~210 行) を削除し ADR 0035 §5 ファサード方針として ~42 行の delegating wrapper (`ImageRepository.X()` → `self._error_record_repo.X()`) に置換 |
| `db_manager.py` | `__init__` で `self.error_record_repo = ErrorRecordRepository(...)` を composition で保持。`get_error_count_unresolved` (`get_annotation_status_counts` 内) / `get_error_image_ids` (`filter_by_annotation_status` 内) / `save_error_record` / `mark_errors_resolved_batch` の **4 箇所** を `self.repository.X(...)` → `self.error_record_repo.X(...)` に置換 |

### 移設した 6 メソッド (~210 行)

`save_error_record` / `get_error_count_unresolved` / `get_error_image_ids` / `get_error_records` / `mark_error_resolved` / `mark_errors_resolved_batch`

## Test plan

- [x] 新規 unit test **26 件** (`tests/unit/database/repository/test_error_record_repository.py`、6 クラス構成: Structure / SaveErrorRecord / GetErrorCountUnresolved / GetErrorImageIds / GetErrorRecords / MarkErrorResolved / MarkErrorsResolvedBatch / FacadeDelegation / DIContract)
- [x] 既存 test 修正 **6 件** (`test_db_manager_core.py` 3 件 + `test_db_manager_extended.py` 3 件、`mock_error_record_repo` fixture 追加)
- [x] CI-equivalent filter: **3265 passed**, 16 failed (本 refactor と無関係、worktree の `local_packages/image-annotator-lib` submodule 未初期化が原因の pre-existing infrastructure issue), 2 skipped
- [x] Database 関連 test: 483 全 pass
- [x] Coverage: db_manager **98%** / db_repository 56% / error_record.py **90%**
- [x] `ruff format` / `ruff check` / `mypy -p lorairo.database` (33 source files): 全 pass

## ADR 0035 準拠

- **§3 Manager composition**: `self.error_record_repo` を `__init__` で保持、`session_factory` を共有、`error_record_repo=` injection 対応
- **§5 段階移行ファサード**: `ImageRepository` の delegating wrapper で既存 import / callsite 互換維持
- **§6 移行戦略**: 推奨順 3 (ErrorRecord entity) を本 PR で実装

## PR #476 / #477 review 教訓の継承

### #476: `save_error_record` の二次エラー防止 (sentinel `-1` 返却) 維持
- `ErrorRecordRepository.save_error_record` は SQLAlchemyError を raise する責任
- Manager 側 `except Exception` で sentinel `-1` に畳む構造を保持 (二次エラー防止の境界層変換)
- test `test_returns_minus_one_on_exception` で検証

### #477: DI contract 維持
- Manager 内 4 箇所すべて `self.error_record_repo.X(...)` (instance 経由) で呼び出し
- test で `mock_error_record_repo.save_error_record.assert_called_once_with(...)` 等により DI contract を固定
- クラス経由 static 呼び出しは新規追加なし、全 6 メソッドは instance method

## Commit 一覧

| Hash | Subject |
|---|---|
| `c12b0de1` | refactor: extract ErrorRecordRepository (#423 段階 3, ADR 0035) |
| `96e3fe6c` | refactor: convert ErrorRecord methods to delegating wrappers (#423 段階 3) |
| `390553f9` | refactor: inject ErrorRecordRepository into ImageDatabaseManager (#423 段階 3) |
| `1659fb35` | test: cover ErrorRecordRepository extraction (#423 段階 3) |

Refs: #423 (段階 3 のみ、残 2 段階 Image / Annotation は別 PR で順次)
Refs: #418, ADR 0035