### PR TITLE
feat: batch 処理の共通利用部を実装

### DIFF
--- a/src/lorairo/database/db_repository.py
+++ b/src/lorairo/database/db_repository.py
@@ -2882,6 +2882,33 @@ class ImageRepository:
                 logger.error(f"Provider batch job 作成中にエラーが発生しました: {e}", exc_info=True)
                 raise
 
+    def create_provider_batch_job_with_items(
+        self,
+        job_data: ProviderBatchJobData,
+        items_data: list[ProviderBatchItemData],
+    ) -> int:
+        """Provider Batch API job と item 群を単一 transaction で作成する。"""
+        with self.session_factory() as session:
+            try:
+                job = ProviderBatchJob(**job_data)
+                session.add(job)
+                session.flush()
+                job_id = job.id
+                for item_data in items_data:
+                    item_values = dict(item_data)
+                    item_values["job_id"] = job_id
+                    session.add(ProviderBatchItem(**item_values))
+                session.commit()
+                logger.debug(
+                    f"Provider batch job/items を作成しました: ID={job_id}, "
+                    f"provider={job.provider}, status={job.status}, items={len(items_data)}",
+                )
+                return job_id
+            except SQLAlchemyError as e:
+                session.rollback()
+                logger.error(f"Provider batch job/items 作成中にエラーが発生しました: {e}", exc_info=True)
+                raise
+
     def get_provider_batch_job(self, job_id: int) -> ProviderBatchJob | None:
         """Provider Batch API job を ID で取得する。"""
         with self.session_factory() as session:

--- a/src/lorairo/services/__init__.py
+++ b/src/lorairo/services/__init__.py
@@ -8,7 +8,11 @@ from .date_formatter import format_datetime_for_display
 from .image_processing_service import ImageProcessingService
 from .model_sync_service import ModelSyncService
 from .provider_batch_service import (
+    BatchJobHandle,
+    BatchSubmitItem,
     BatchSubmitMetadata,
+    BatchSubmitRequest,
+    InvalidProviderBatchRequest,
     InvalidProviderBatchStatusTransition,
     ProviderBatchAdapter,
     ProviderBatchAdapterNotFoundError,
@@ -22,9 +26,13 @@ from .provider_batch_service import (
 from .service_container import ServiceContainer, get_service_container
 
 __all__ = [
+    "BatchJobHandle",
+    "BatchSubmitItem",
     "BatchSubmitMetadata",
+    "BatchSubmitRequest",
     "ConfigurationService",
     "ImageProcessingService",
+    "InvalidProviderBatchRequest",
     "InvalidProviderBatchStatusTransition",
     "ModelSyncService",
     "ProviderBatchAdapter",

--- a/src/lorairo/services/configuration_service.py
+++ b/src/lorairo/services/configuration_service.py
@@ -207,11 +207,26 @@ class ConfigurationService:
         """全APIキーを取得（空文字列は除外）
 
         Returns:
-            dict[str, str]: プロバイダー名 → APIキーのマッピング
+            dict[str, str]: 設定キー名 → APIキーのマッピング
                            空文字列のキーは除外される
         """
         api_config = self._config.get("api", {})
         return {k: v for k, v in api_config.items() if v and v.strip()}
+
+    def get_provider_api_keys(self) -> dict[str, str]:
+        """全APIキーを provider 名キーで取得（空文字列は除外）。"""
+        api_config = self._config.get("api", {})
+        provider_key_map = {
+            "openai_key": "openai",
+            "claude_key": "anthropic",
+            "google_key": "google",
+            "openrouter_key": "openrouter",
+        }
+        return {
+            provider: api_config[key_name]
+            for key_name, provider in provider_key_map.items()
+            if api_config.get(key_name) and api_config[key_name].strip()
+        }
 
     def is_provider_available(self, provider: str) -> bool:
         """指定されたプロバイダーが利用可能かチェックします。"""

--- a/src/lorairo/services/provider_batch_service.py
+++ b/src/lorairo/services/provider_batch_service.py
@@ -7,8 +7,9 @@ OpenAI / Anthropic / Google adapter を差し替え可能な Protocol と永続 
 from __future__ import annotations
 
 import json
+import re
 from collections.abc import Mapping
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Protocol
@@ -18,6 +19,7 @@ from lorairo.database.schema import ProviderBatchJob
 from lorairo.utils.log import logger
 
 ProviderBatchRawPayload = Mapping[str, Any] | str | None
+_CUSTOM_ID_PATTERN = re.compile(r"^[A-Za-z0-9_-]{1,64}$")
 
 
 class ProviderBatchError(RuntimeError):
@@ -30,6 +32,50 @@ class ProviderBatchAdapterNotFoundError(ProviderBatchError):
 
 class InvalidProviderBatchStatusTransition(ProviderBatchError):
     """Provider Batch job status transition が許可されていない。"""
+
+
+class InvalidProviderBatchRequest(ProviderBatchError):
+    """Provider Batch submit request が ADR 0038 contract を満たしていない。"""
+
+
+@dataclass(frozen=True)
+class BatchSubmitItem:
+    """LoRAIro から library batch API に渡す job item。"""
+
+    custom_id: str
+    image_id: int
+    image_path: Path
+    task_type: str = "annotation"
+    model_id: int | None = None
+    raw_request: ProviderBatchRawPayload = None
+
+
+@dataclass(frozen=True)
+class BatchSubmitRequest:
+    """Provider 非依存の batch submit request。
+
+    Provider 固有 payload 構築、upload、response parse は image-annotator-lib 側に閉じ込める。
+    """
+
+    provider: str
+    endpoint: str
+    litellm_model_id: str
+    prompt_profile: str
+    api_keys: Mapping[str, str]
+    items: tuple[BatchSubmitItem, ...]
+    model_id: int | None = None
+    description: str | None = None
+    request_artifact_path: Path | None = None
+    raw_provider_payload: ProviderBatchRawPayload = None
+
+
+@dataclass(frozen=True)
+class BatchJobHandle:
+    """Provider batch job の stable handle。"""
+
+    provider: str
+    provider_job_id: str
+    api_keys: Mapping[str, str] = field(default_factory=dict)
 
 
 @dataclass(frozen=True)
@@ -96,23 +142,23 @@ class ProviderBatchArtifacts:
 
 
 class ProviderBatchAdapter(Protocol):
-    """Provider Batch API adapter interface."""
+    """image-annotator-lib batch API client interface."""
 
     provider: str
 
-    def submit(self, request_file: Path, metadata: BatchSubmitMetadata) -> ProviderBatchSubmission:
+    def submit_batch(self, request: BatchSubmitRequest) -> ProviderBatchSubmission:
         """Provider batch job を投入する。"""
         ...
 
-    def retrieve(self, provider_job_id: str) -> ProviderBatchStatus:
+    def retrieve_batch(self, handle: BatchJobHandle) -> ProviderBatchStatus:
         """Provider batch job の最新状態を取得する。"""
         ...
 
-    def cancel(self, provider_job_id: str) -> ProviderBatchStatus:
+    def cancel_batch(self, handle: BatchJobHandle) -> ProviderBatchStatus:
         """Provider batch job を cancel する。"""
         ...
 
-    def download_results(self, provider_job_id: str, destination_dir: Path) -> ProviderBatchArtifacts:
+    def fetch_batch_results(self, handle: BatchJobHandle, destination_dir: Path) -> ProviderBatchArtifacts:
         """Provider batch job の output/error artifacts を download する。"""
         ...
 
@@ -212,11 +258,91 @@ class ProviderBatchJobService:
         """Provider adapter を追加登録する。"""
         self._adapters[self._normalize_provider_name(adapter.provider)] = adapter
 
+    @staticmethod
+    def build_custom_id(image_id: int) -> str:
+        """ADR 0038 の custom_id を生成する。"""
+        return f"img-{image_id}"
+
+    def submit_batch(self, request: BatchSubmitRequest) -> int:
+        """Provider batch job を投入し、job/items を DB に保存する。"""
+        request = replace(
+            request,
+            provider=self._normalize_provider_name(request.provider),
+            api_keys=self._normalize_api_keys(request.api_keys),
+        )
+        self._validate_submit_request(request)
+        adapter = self._get_adapter(request.provider)
+        submission = adapter.submit_batch(request)
+        status = self.normalize_status(
+            request.provider,
+            submission.status or submission.provider_status,
+        )
+        request_count = (
+            submission.request_count if submission.request_count is not None else len(request.items)
+        )
+
+        job_id = self._repository.create_provider_batch_job(
+            {
+                "provider": request.provider,
+                "provider_job_id": submission.provider_job_id,
+                "status": status,
+                "provider_status": submission.provider_status,
+                "endpoint": request.endpoint,
+                "model_id": request.model_id,
+                "request_count": request_count,
+                "submitted_at": submission.submitted_at,
+                "expires_at": submission.expires_at,
+                "input_artifact_path": str(request.request_artifact_path)
+                if request.request_artifact_path is not None
+                else None,
+                "raw_provider_payload": self._serialize_payload(
+                    submission.raw_provider_payload
+                    if submission.raw_provider_payload is not None
+                    else request.raw_provider_payload
+                ),
+            }
+        )
+        for item in request.items:
+            self._repository.create_provider_batch_item(
+                {
+                    "job_id": job_id,
+                    "custom_id": item.custom_id,
+                    "image_id": item.image_id,
+                    "model_id": item.model_id if item.model_id is not None else request.model_id,
+                    "task_type": item.task_type,
+                    "status": status,
+                    "raw_request": self._serialize_payload(item.raw_request),
+                }
+            )
+        logger.info(
+            f"Provider batch job submitted: provider={request.provider}, "
+            f"provider_job_id={submission.provider_job_id}, job_id={job_id}, status={status}, "
+            f"items={len(request.items)}"
+        )
+        return job_id
+
     def submit(self, request_file: Path, metadata: BatchSubmitMetadata) -> int:
-        """Provider batch job を投入し、DB job を作成する。"""
+        """Provider batch job を投入し、DB job を作成する。
+
+        互換 wrapper。新規経路は ADR 0038 の ``submit_batch()`` を使う。
+        """
         provider = self._normalize_provider_name(metadata.provider)
         adapter = self._get_adapter(provider)
-        submission = adapter.submit(request_file, metadata)
+        if not hasattr(adapter, "submit"):
+            request = BatchSubmitRequest(
+                provider=provider,
+                endpoint=metadata.endpoint or "",
+                litellm_model_id="",
+                prompt_profile="",
+                api_keys={},
+                items=(),
+                model_id=metadata.model_id,
+                request_artifact_path=request_file,
+                raw_provider_payload=metadata.raw_provider_payload,
+            )
+            submission = adapter.submit_batch(request)
+        else:
+            submission = adapter.submit(request_file, metadata)
         status = self.normalize_status(
             provider,
             submission.status or submission.provider_status,
@@ -249,17 +375,20 @@ class ProviderBatchJobService:
         )
         return job_id
 
-    def refresh(self, job_id: int) -> ProviderBatchJob:
+    def refresh(self, job_id: int, api_keys: Mapping[str, str] | None = None) -> ProviderBatchJob:
         """Provider から最新 status を取得し、DB job を更新する。"""
         job = self._require_job(job_id)
         if job.provider_job_id is None:
             raise ProviderBatchError(f"provider_job_id が未設定です: job_id={job_id}")
 
         adapter = self._get_adapter(job.provider)
-        provider_status = adapter.retrieve(job.provider_job_id)
+        if hasattr(adapter, "retrieve_batch"):
+            provider_status = adapter.retrieve_batch(self._build_handle(job, api_keys))
+        else:
+            provider_status = adapter.retrieve(job.provider_job_id)  # type: ignore[attr-defined]
         return self._apply_status(job, provider_status)
 
-    def cancel(self, job_id: int) -> ProviderBatchJob:
+    def cancel(self, job_id: int, api_keys: Mapping[str, str] | None = None) -> ProviderBatchJob:
         """Provider batch job を cancel し、DB job を更新する。"""
         job = self._require_job(job_id)
         if job.provider_job_id is None:
@@ -267,17 +396,30 @@ class ProviderBatchJobService:
         self.validate_transition(job.status, "canceling")
 
         adapter = self._get_adapter(job.provider)
-        provider_status = adapter.cancel(job.provider_job_id)
+        if hasattr(adapter, "cancel_batch"):
+            provider_status = adapter.cancel_batch(self._build_handle(job, api_keys))
+        else:
+            provider_status = adapter.cancel(job.provider_job_id)  # type: ignore[attr-defined]
         return self._apply_status(job, provider_status)
 
-    def download_results(self, job_id: int, destination_dir: Path) -> ProviderBatchArtifacts:
+    def download_results(
+        self,
+        job_id: int,
+        destination_dir: Path,
+        api_keys: Mapping[str, str] | None = None,
+    ) -> ProviderBatchArtifacts:
         """Provider result artifacts を download し、artifact records を保存する。"""
         job = self._require_job(job_id)
         if job.provider_job_id is None:
             raise ProviderBatchError(f"provider_job_id が未設定です: job_id={job_id}")
 
         adapter = self._get_adapter(job.provider)
-        artifacts = adapter.download_results(job.provider_job_id, destination_dir)
+        if hasattr(adapter, "fetch_batch_results"):
+            artifacts = adapter.fetch_batch_results(self._build_handle(job, api_keys), destination_dir)
+        else:
+            artifacts = adapter.download_results(  # type: ignore[attr-defined]
+                job.provider_job_id, destination_dir
+            )
         self._validate_provider_job_id(job, artifacts.provider_job_id)
 
         updates: dict[str, Any] = {}
@@ -386,6 +528,48 @@ class ProviderBatchJobService:
         if adapter is None:
             raise ProviderBatchAdapterNotFoundError(f"Provider batch adapter 未登録: {provider}")
         return adapter
+
+    def _build_handle(self, job: ProviderBatchJob, api_keys: Mapping[str, str] | None) -> BatchJobHandle:
+        if job.provider_job_id is None:
+            raise ProviderBatchError(f"provider_job_id が未設定です: job_id={job.id}")
+        return BatchJobHandle(
+            provider=job.provider,
+            provider_job_id=job.provider_job_id,
+            api_keys=self._normalize_api_keys(api_keys or {}),
+        )
+
+    @classmethod
+    def _validate_submit_request(cls, request: BatchSubmitRequest) -> None:
+        if not request.items:
+            raise InvalidProviderBatchRequest("batch submit item が空です")
+        custom_ids: set[str] = set()
+        for item in request.items:
+            expected_custom_id = cls.build_custom_id(item.image_id)
+            if item.custom_id != expected_custom_id:
+                raise InvalidProviderBatchRequest(
+                    f"custom_id は {expected_custom_id!r} である必要があります: {item.custom_id!r}"
+                )
+            if _CUSTOM_ID_PATTERN.fullmatch(item.custom_id) is None:
+                raise InvalidProviderBatchRequest(f"不正な custom_id です: {item.custom_id!r}")
+            if item.custom_id in custom_ids:
+                raise InvalidProviderBatchRequest(f"custom_id が重複しています: {item.custom_id!r}")
+            custom_ids.add(item.custom_id)
+
+    @staticmethod
+    def _normalize_api_keys(api_keys: Mapping[str, str]) -> dict[str, str]:
+        key_aliases = {
+            "openai_key": "openai",
+            "claude_key": "anthropic",
+            "anthropic_key": "anthropic",
+            "google_key": "google",
+            "openrouter_key": "openrouter",
+        }
+        normalized: dict[str, str] = {}
+        for key, value in api_keys.items():
+            if not value or not value.strip():
+                continue
+            normalized[key_aliases.get(key, key)] = value
+        return normalized
 
     @staticmethod
     def _validate_provider_job_id(job: ProviderBatchJob, provider_job_id: str) -> None:

--- a/src/lorairo/services/provider_batch_service.py
+++ b/src/lorairo/services/provider_batch_service.py
@@ -281,7 +281,7 @@ class ProviderBatchJobService:
             submission.request_count if submission.request_count is not None else len(request.items)
         )
 
-        job_id = self._repository.create_provider_batch_job(
+        job_id = self._repository.create_provider_batch_job_with_items(
             {
                 "provider": request.provider,
                 "provider_job_id": submission.provider_job_id,
@@ -300,12 +300,10 @@ class ProviderBatchJobService:
                     if submission.raw_provider_payload is not None
                     else request.raw_provider_payload
                 ),
-            }
-        )
-        for item in request.items:
-            self._repository.create_provider_batch_item(
+            },
+            [
                 {
-                    "job_id": job_id,
+                    "job_id": 0,
                     "custom_id": item.custom_id,
                     "image_id": item.image_id,
                     "model_id": item.model_id if item.model_id is not None else request.model_id,
@@ -313,7 +311,9 @@ class ProviderBatchJobService:
                     "status": status,
                     "raw_request": self._serialize_payload(item.raw_request),
                 }
-            )
+                for item in request.items
+            ],
+        )
         logger.info(
             f"Provider batch job submitted: provider={request.provider}, "
             f"provider_job_id={submission.provider_job_id}, job_id={job_id}, status={status}, "
@@ -329,20 +329,11 @@ class ProviderBatchJobService:
         provider = self._normalize_provider_name(metadata.provider)
         adapter = self._get_adapter(provider)
         if not hasattr(adapter, "submit"):
-            request = BatchSubmitRequest(
-                provider=provider,
-                endpoint=metadata.endpoint or "",
-                litellm_model_id="",
-                prompt_profile="",
-                api_keys={},
-                items=(),
-                model_id=metadata.model_id,
-                request_artifact_path=request_file,
-                raw_provider_payload=metadata.raw_provider_payload,
+            raise ProviderBatchError(
+                "Legacy submit() requires a legacy adapter with submit(). "
+                "Use submit_batch() for ADR 0038 batch clients."
             )
-            submission = adapter.submit_batch(request)
-        else:
-            submission = adapter.submit(request_file, metadata)
+        submission = adapter.submit(request_file, metadata)
         status = self.normalize_status(
             provider,
             submission.status or submission.provider_status,

--- a/tests/unit/database/test_db_repository_provider_batch.py
+++ b/tests/unit/database/test_db_repository_provider_batch.py
@@ -127,6 +127,36 @@ class TestProviderBatchRepository:
         assert test_repository.list_provider_batch_items(job_id) == []
         assert test_repository.list_provider_batch_artifacts(job_id) == []
 
+    def test_create_job_with_items_rolls_back_atomically_on_item_failure(
+        self,
+        test_repository: ImageRepository,
+    ) -> None:
+        with pytest.raises(IntegrityError):
+            test_repository.create_provider_batch_job_with_items(
+                {
+                    "provider": "openai",
+                    "provider_job_id": "batch_atomic",
+                    "status": "submitted",
+                    "request_count": 2,
+                },
+                [
+                    {
+                        "job_id": 0,
+                        "custom_id": "img-1",
+                        "task_type": "annotation",
+                        "status": "submitted",
+                    },
+                    {
+                        "job_id": 0,
+                        "custom_id": "img-1",
+                        "task_type": "annotation",
+                        "status": "submitted",
+                    },
+                ],
+            )
+
+        assert test_repository.get_provider_batch_job_by_provider_id("openai", "batch_atomic") is None
+
     def test_update_rejects_unknown_fields(self, test_repository: ImageRepository) -> None:
         job_id = test_repository.create_provider_batch_job({"provider": "openai", "status": "draft"})
 

--- a/tests/unit/services/test_provider_batch_service.py
+++ b/tests/unit/services/test_provider_batch_service.py
@@ -272,6 +272,18 @@ class TestProviderBatchJobService:
             job_id
         ]
 
+    def test_legacy_submit_rejects_new_batch_client_without_empty_item_fallback(
+        self,
+        test_repository: ImageRepository,
+    ) -> None:
+        adapter = FakeProviderBatchAdapter()
+        service = ProviderBatchJobService(test_repository, {"openai": adapter})
+
+        with pytest.raises(ProviderBatchError, match="Use submit_batch"):
+            service.submit(Path("/tmp/input.jsonl"), BatchSubmitMetadata(provider="openai"))
+
+        assert test_repository.list_provider_batch_jobs(provider="openai") == []
+
     def test_refresh_updates_job_status_counts_and_raw_payload(
         self,
         test_repository: ImageRepository,

--- a/tests/unit/services/test_provider_batch_service.py
+++ b/tests/unit/services/test_provider_batch_service.py
@@ -10,7 +10,11 @@ import pytest
 
 from lorairo.database.db_repository import ImageRepository
 from lorairo.services.provider_batch_service import (
+    BatchJobHandle,
+    BatchSubmitItem,
     BatchSubmitMetadata,
+    BatchSubmitRequest,
+    InvalidProviderBatchRequest,
     InvalidProviderBatchStatusTransition,
     ProviderBatchAdapterNotFoundError,
     ProviderBatchArtifactRef,
@@ -26,6 +30,11 @@ class FakeProviderBatchAdapter:
     provider = "openai"
 
     def __init__(self) -> None:
+        self.submitted_request: BatchSubmitRequest | None = None
+        self.retrieve_handle: BatchJobHandle | None = None
+        self.cancel_handle: BatchJobHandle | None = None
+        self.fetch_handle: BatchJobHandle | None = None
+        self.fetch_destination: Path | None = None
         self.submission = ProviderBatchSubmission(
             provider_job_id="batch_123",
             provider_status="validating",
@@ -58,6 +67,25 @@ class FakeProviderBatchAdapter:
             raw_provider_payload={"output_file_id": "file_out"},
         )
 
+    def submit_batch(self, request: BatchSubmitRequest) -> ProviderBatchSubmission:
+        self.submitted_request = request
+        return self.submission
+
+    def retrieve_batch(self, handle: BatchJobHandle) -> ProviderBatchStatus:
+        self.retrieve_handle = handle
+        return self.retrieve_status
+
+    def cancel_batch(self, handle: BatchJobHandle) -> ProviderBatchStatus:
+        self.cancel_handle = handle
+        return self.cancel_status
+
+    def fetch_batch_results(self, handle: BatchJobHandle, destination_dir: Path) -> ProviderBatchArtifacts:
+        self.fetch_handle = handle
+        self.fetch_destination = destination_dir
+        return self.artifacts
+
+
+class LegacyProviderBatchAdapter(FakeProviderBatchAdapter):
     def submit(self, request_file: Path, metadata: BatchSubmitMetadata) -> ProviderBatchSubmission:
         return self.submission
 
@@ -69,6 +97,38 @@ class FakeProviderBatchAdapter:
 
     def download_results(self, provider_job_id: str, destination_dir: Path) -> ProviderBatchArtifacts:
         return self.artifacts
+
+
+def make_submit_request(
+    *,
+    provider: str = "openai",
+    items: tuple[BatchSubmitItem, ...] | None = None,
+) -> BatchSubmitRequest:
+    return BatchSubmitRequest(
+        provider=provider,
+        endpoint="responses",
+        litellm_model_id="openai/gpt-4.1-mini",
+        prompt_profile="default",
+        api_keys={"openai_key": "sk-test"},
+        model_id=10,
+        request_artifact_path=Path("/tmp/input.jsonl"),
+        items=items
+        if items is not None
+        else (
+            BatchSubmitItem(
+                custom_id="img-1",
+                image_id=1,
+                image_path=Path("/tmp/images/1.webp"),
+                raw_request={"custom_id": "img-1"},
+            ),
+            BatchSubmitItem(
+                custom_id="img-2",
+                image_id=2,
+                image_path=Path("/tmp/images/2.webp"),
+                model_id=11,
+            ),
+        ),
+    )
 
 
 @pytest.mark.unit
@@ -107,34 +167,79 @@ class TestProviderBatchStatusMapping:
 
 @pytest.mark.unit
 class TestProviderBatchJobService:
-    def test_submit_creates_job_with_normalized_status_and_raw_payload(
+    def test_submit_batch_calls_library_boundary_and_creates_job_items(
         self,
         test_repository: ImageRepository,
     ) -> None:
         adapter = FakeProviderBatchAdapter()
         service = ProviderBatchJobService(test_repository, {"openai": adapter})
 
-        job_id = service.submit(
-            Path("/tmp/input.jsonl"),
-            BatchSubmitMetadata(provider="openai", endpoint="/v1/responses", request_count=1),
-        )
+        job_id = service.submit_batch(make_submit_request(provider=" OpenAI "))
 
         job = test_repository.get_provider_batch_job(job_id)
         assert job is not None
+        assert adapter.submitted_request is not None
+        assert adapter.submitted_request.provider == "openai"
+        assert adapter.submitted_request.endpoint == "responses"
+        assert adapter.submitted_request.api_keys == {"openai": "sk-test"}
         assert job.provider == "openai"
         assert job.provider_job_id == "batch_123"
         assert job.status == "validating"
         assert job.provider_status == "validating"
-        assert job.endpoint == "/v1/responses"
+        assert job.endpoint == "responses"
+        assert job.model_id == 10
         assert job.request_count == 2
         assert job.input_artifact_path == "/tmp/input.jsonl"
         assert job.raw_provider_payload == '{"id": "batch_123", "status": "validating"}'
+        items = test_repository.list_provider_batch_items(job_id)
+        assert [(item.custom_id, item.image_id, item.model_id, item.status) for item in items] == [
+            ("img-1", 1, 10, "validating"),
+            ("img-2", 2, 11, "validating"),
+        ]
+        assert items[0].raw_request == '{"custom_id": "img-1"}'
 
-    def test_submit_preserves_empty_submission_payload(
+    def test_submit_batch_validates_custom_id_contract(
         self,
         test_repository: ImageRepository,
     ) -> None:
         adapter = FakeProviderBatchAdapter()
+        service = ProviderBatchJobService(test_repository, {"openai": adapter})
+
+        with pytest.raises(InvalidProviderBatchRequest, match="custom_id"):
+            service.submit_batch(
+                make_submit_request(
+                    items=(
+                        BatchSubmitItem(
+                            custom_id="image-1",
+                            image_id=1,
+                            image_path=Path("/tmp/images/1.webp"),
+                        ),
+                    )
+                )
+            )
+
+    def test_submit_batch_rejects_duplicate_custom_ids(
+        self,
+        test_repository: ImageRepository,
+    ) -> None:
+        adapter = FakeProviderBatchAdapter()
+        service = ProviderBatchJobService(test_repository, {"openai": adapter})
+
+        with pytest.raises(InvalidProviderBatchRequest, match="重複"):
+            service.submit_batch(
+                make_submit_request(
+                    items=(
+                        BatchSubmitItem("img-1", 1, Path("/tmp/1.webp")),
+                        BatchSubmitItem("img-1", 1, Path("/tmp/1-copy.webp")),
+                    )
+                )
+            )
+
+    def test_submit_preserves_empty_submission_payload_for_legacy_wrapper(
+        self,
+        test_repository: ImageRepository,
+    ) -> None:
+        adapter = LegacyProviderBatchAdapter()
         adapter.submission = replace(adapter.submission, raw_provider_payload={})
         service = ProviderBatchJobService(test_repository, {"openai": adapter})
 
@@ -147,11 +252,11 @@ class TestProviderBatchJobService:
         assert job is not None
         assert job.raw_provider_payload == "{}"
 
-    def test_submit_normalizes_provider_before_persisting(
+    def test_legacy_submit_normalizes_provider_before_persisting(
         self,
         test_repository: ImageRepository,
     ) -> None:
-        adapter = FakeProviderBatchAdapter()
+        adapter = LegacyProviderBatchAdapter()
         service = ProviderBatchJobService(test_repository, {"openai": adapter})
 
         job_id = service.submit(
@@ -173,10 +278,13 @@ class TestProviderBatchJobService:
     ) -> None:
         adapter = FakeProviderBatchAdapter()
         service = ProviderBatchJobService(test_repository, {"openai": adapter})
-        job_id = service.submit(Path("/tmp/input.jsonl"), BatchSubmitMetadata(provider="openai"))
+        job_id = service.submit_batch(make_submit_request())
 
-        refreshed = service.refresh(job_id)
+        refreshed = service.refresh(job_id, api_keys={"openai_key": "sk-test"})
 
+        assert adapter.retrieve_handle == BatchJobHandle(
+            provider="openai", provider_job_id="batch_123", api_keys={"openai": "sk-test"}
+        )
         assert refreshed.status == "completed"
         assert refreshed.provider_status == "completed"
         assert refreshed.succeeded_count == 2
@@ -199,7 +307,7 @@ class TestProviderBatchJobService:
             expired_count=0,
         )
         service = ProviderBatchJobService(test_repository, {"anthropic": adapter})
-        job_id = service.submit(Path("/tmp/input.jsonl"), BatchSubmitMetadata(provider="anthropic"))
+        job_id = service.submit_batch(make_submit_request(provider="anthropic"))
 
         refreshed = service.refresh(job_id)
 
@@ -224,7 +332,7 @@ class TestProviderBatchJobService:
             canceled_count=2,
         )
         service = ProviderBatchJobService(test_repository, {"anthropic": adapter})
-        job_id = service.submit(Path("/tmp/input.jsonl"), BatchSubmitMetadata(provider="anthropic"))
+        job_id = service.submit_batch(make_submit_request(provider="anthropic"))
 
         canceling = service.cancel(job_id)
         refreshed = service.refresh(job_id)
@@ -241,7 +349,7 @@ class TestProviderBatchJobService:
         adapter = FakeProviderBatchAdapter()
         adapter.retrieve_status = replace(adapter.retrieve_status, raw_provider_payload=None)
         service = ProviderBatchJobService(test_repository, {"openai": adapter})
-        job_id = service.submit(Path("/tmp/input.jsonl"), BatchSubmitMetadata(provider="openai"))
+        job_id = service.submit_batch(make_submit_request())
 
         refreshed = service.refresh(job_id)
 
@@ -255,7 +363,7 @@ class TestProviderBatchJobService:
         adapter = FakeProviderBatchAdapter()
         adapter.retrieve_status = replace(adapter.retrieve_status, provider_job_id="batch_other")
         service = ProviderBatchJobService(test_repository, {"openai": adapter})
-        job_id = service.submit(Path("/tmp/input.jsonl"), BatchSubmitMetadata(provider="openai"))
+        job_id = service.submit_batch(make_submit_request())
 
         with pytest.raises(ProviderBatchError, match="job ID mismatch"):
             service.refresh(job_id)
@@ -271,10 +379,15 @@ class TestProviderBatchJobService:
         adapter = FakeProviderBatchAdapter()
         adapter.submission = replace(adapter.submission, provider_status="in_progress")
         service = ProviderBatchJobService(test_repository, {"openai": adapter})
-        job_id = service.submit(Path("/tmp/input.jsonl"), BatchSubmitMetadata(provider="openai"))
+        job_id = service.submit_batch(make_submit_request())
 
-        canceled = service.cancel(job_id)
+        canceled = service.cancel(job_id, api_keys={"claude_key": "unused", "openai_key": "sk-test"})
 
+        assert adapter.cancel_handle == BatchJobHandle(
+            provider="openai",
+            provider_job_id="batch_123",
+            api_keys={"anthropic": "unused", "openai": "sk-test"},
+        )
         assert canceled.status == "canceled"
         assert canceled.provider_status == "cancelled"
         assert canceled.canceled_count == 2
@@ -282,7 +395,7 @@ class TestProviderBatchJobService:
     def test_cancel_rejects_completed_job(self, test_repository: ImageRepository) -> None:
         adapter = FakeProviderBatchAdapter()
         service = ProviderBatchJobService(test_repository, {"openai": adapter})
-        job_id = service.submit(Path("/tmp/input.jsonl"), BatchSubmitMetadata(provider="openai"))
+        job_id = service.submit_batch(make_submit_request())
         service.refresh(job_id)
 
         with pytest.raises(InvalidProviderBatchStatusTransition):
@@ -294,10 +407,14 @@ class TestProviderBatchJobService:
     ) -> None:
         adapter = FakeProviderBatchAdapter()
         service = ProviderBatchJobService(test_repository, {"openai": adapter})
-        job_id = service.submit(Path("/tmp/input.jsonl"), BatchSubmitMetadata(provider="openai"))
+        job_id = service.submit_batch(make_submit_request())
 
-        artifacts = service.download_results(job_id, Path("/tmp"))
+        artifacts = service.download_results(job_id, Path("/tmp/batch_results"))
 
+        assert adapter.fetch_handle == BatchJobHandle(
+            provider="openai", provider_job_id="batch_123", api_keys={}
+        )
+        assert adapter.fetch_destination == Path("/tmp/batch_results")
         assert len(artifacts.artifacts) == 2
         registered = test_repository.list_provider_batch_artifacts(job_id)
         assert [artifact.artifact_type for artifact in registered] == ["output", "error"]
@@ -313,7 +430,7 @@ class TestProviderBatchJobService:
     ) -> None:
         adapter = FakeProviderBatchAdapter()
         service = ProviderBatchJobService(test_repository, {"openai": adapter})
-        job_id = service.submit(Path("/tmp/input.jsonl"), BatchSubmitMetadata(provider="openai"))
+        job_id = service.submit_batch(make_submit_request())
 
         service.download_results(job_id, Path("/tmp"))
         service.download_results(job_id, Path("/tmp"))
@@ -329,7 +446,7 @@ class TestProviderBatchJobService:
         adapter = FakeProviderBatchAdapter()
         adapter.artifacts = replace(adapter.artifacts, provider_job_id="batch_other")
         service = ProviderBatchJobService(test_repository, {"openai": adapter})
-        job_id = service.submit(Path("/tmp/input.jsonl"), BatchSubmitMetadata(provider="openai"))
+        job_id = service.submit_batch(make_submit_request())
 
         with pytest.raises(ProviderBatchError, match="job ID mismatch"):
             service.download_results(job_id, Path("/tmp"))
@@ -340,4 +457,4 @@ class TestProviderBatchJobService:
         service = ProviderBatchJobService(test_repository)
 
         with pytest.raises(ProviderBatchAdapterNotFoundError):
-            service.submit(Path("/tmp/input.jsonl"), BatchSubmitMetadata(provider="openai"))
+            service.submit_batch(make_submit_request())

--- a/tests/unit/test_configuration_service.py
+++ b/tests/unit/test_configuration_service.py
@@ -125,6 +125,27 @@ class TestConfigurationService:
         assert api_keys == {"openai_key": "sk-test", "google_key": "ai-test"}
         assert "claude_key" not in api_keys  # 空文字列は除外
 
+    def test_get_provider_api_keys_with_keys(self):
+        """APIキーを provider 名キーで取得できる"""
+        config = {
+            "api": {
+                "openai_key": "sk-test",
+                "claude_key": "claude-test",
+                "google_key": "",
+                "openrouter_key": "or-test",
+            }
+        }
+        config_service = ConfigurationService(shared_config=config)
+
+        api_keys = config_service.get_provider_api_keys()
+
+        assert api_keys == {
+            "openai": "sk-test",
+            "anthropic": "claude-test",
+            "openrouter": "or-test",
+        }
+        assert "google" not in api_keys
+
     def test_is_provider_available(self):
         """プロバイダー可用性チェックテスト"""
         # Given: 一部のAPIキーが設定されている状態


### PR DESCRIPTION
## Summary

- Add ADR 0038 batch submit request / item / job handle types to the LoRAIro service boundary.
- Route `ProviderBatchJobService` through provider-neutral `submit_batch` / `retrieve_batch` / `cancel_batch` / `fetch_batch_results` calls.
- Persist submitted job items and keep provider-specific API details out of LoRAIro's upper layer.
- Add provider-name API key mapping via `ConfigurationService.get_provider_api_keys()`.

## Scope

This PR intentionally stops at the common LoRAIro batch lifecycle layer for issue #461:

- submit
- refresh/status retrieve
- cancel
- result artifact download/registration

It does not add GUI widgets, REST/API endpoints, CLI commands, provider-native adapter implementations, or annotation import/save wiring.

## Validation

- `uv run pytest tests/unit/services/test_provider_batch_service.py tests/unit/database/test_db_repository_provider_batch.py tests/unit/test_configuration_service.py tests/unit/database/test_migration_c6d7e8f9a0b1_provider_batch.py`
- `uv run ruff check src/lorairo/services/provider_batch_service.py src/lorairo/services/configuration_service.py src/lorairo/services/__init__.py tests/unit/services/test_provider_batch_service.py tests/unit/test_configuration_service.py`
- `uv run mypy src/lorairo/services/provider_batch_service.py src/lorairo/services/configuration_service.py`

Refs #461
