### PR TITLE
refactor: extract ImageRepository (#423 段階 4, ADR 0035)

### DIFF
--- a/src/lorairo/database/db_manager.py
+++ b/src/lorairo/database/db_manager.py
@@ -23,6 +23,7 @@ from .db_repository import (
 )
 from .filter_criteria import ImageFilterCriteria
 from .repository.error_record import ErrorRecordRepository
+from .repository.image import ImageRepository as _ImageRepositoryNew
 from .repository.model import ModelRepository
 from .repository.project import ProjectRepository
 
@@ -44,6 +45,7 @@ class ImageDatabaseManager:
         model_repo: ModelRepository | None = None,
         project_repo: ProjectRepository | None = None,
         error_record_repo: ErrorRecordRepository | None = None,
+        image_repo: _ImageRepositoryNew | None = None,
     ):
         """ImageDatabaseManagerのコンストラクタ。
 
@@ -60,6 +62,9 @@ class ImageDatabaseManager:
             error_record_repo (ErrorRecordRepository): ErrorRecord 関連の Repository
                 (ADR 0035 段階 3)。None の場合は `repository` の `session_factory` を
                 流用して生成する。テスト時にモック化可能。
+            image_repo (ImageRepository): Image / ProcessedImage / FilenameAlias 関連の
+                新 Repository (ADR 0035 段階 4)。None の場合は `repository` の
+                `session_factory` を流用して生成する。テスト時にモック化可能。
 
         """
         self.repository = repository
@@ -88,6 +93,12 @@ class ImageDatabaseManager:
         if error_record_repo is None:
             error_record_repo = ErrorRecordRepository(session_factory=session_factory)
         self.error_record_repo: ErrorRecordRepository = error_record_repo
+        # ADR 0035 段階 4 (#423): Image / ProcessedImage / FilenameAlias 関連を
+        # 新 ImageRepository (`repository/image.py`) に集約。
+        # session_factory は他 Repository と同様に repository から取得する。
+        if image_repo is None:
+            image_repo = _ImageRepositoryNew(session_factory=session_factory)
+        self.image_repo: _ImageRepositoryNew = image_repo
         self._cached_project_id: int | None = None
         logger.info("ImageDatabaseManager initialized.")
 

--- a/src/lorairo/database/db_repository.py
+++ b/src/lorairo/database/db_repository.py
@@ -142,6 +142,37 @@ class ImageRepository:
         # TagRegisterServiceは遅延初期化（登録時のみ必要）
         self.tag_register_service: TagRegisterService | None = None
 
+    # ADR 0035 段階 4 (#423, PR #488 Codex review P2 / P3):
+    # `session_factory` および `BATCH_CHUNK_SIZE` をテストやランタイムで facade に
+    # 書き戻すケース (例: `repository.session_factory = MagicMock(...)`) で、内部
+    # delegating repos (`_image_repo` 等) の同名属性が古い snapshot のまま drift
+    # しないように propagate する。__init__ 内で先に `_*_repo` が生成されている
+    # 必要があるため、`__init__` の組み立て順 (session_factory → _model_repo →
+    # _project_repo → _error_record_repo → _image_repo) を保つこと。
+    _DELEGATED_REPO_ATTRS: ClassVar[tuple[str, ...]] = (
+        "_model_repo",
+        "_project_repo",
+        "_error_record_repo",
+        "_image_repo",
+    )
+    _PROPAGATED_ATTRS: ClassVar[frozenset[str]] = frozenset({"session_factory", "BATCH_CHUNK_SIZE"})
+
+    def __setattr__(self, name: str, value: Any) -> None:
+        """facade に書き戻された共有属性を内部 delegating repos に伝播する。
+
+        `session_factory` / `BATCH_CHUNK_SIZE` は本クラス自身の動作 (stage 5
+        領域の `save_annotations` / `update_*_batch` 等) と内部 `_image_repo`
+        の両方で参照される。書き換え後の drift を防ぐため、本 `__setattr__` で
+        透過的に propagate する。`_*_repo` 属性そのものを置き換える代入では
+        propagate しない (循環を避ける目的)。
+        """
+        super().__setattr__(name, value)
+        if name in self._PROPAGATED_ATTRS:
+            for repo_attr in self._DELEGATED_REPO_ATTRS:
+                repo = self.__dict__.get(repo_attr)
+                if repo is not None:
+                    object.__setattr__(repo, name, value)
+
     def _initialize_merged_reader(self) -> MergedTagReader | None:
         """外部タグDBリーダーを初期化（遅延初期化対応）。
 

--- a/src/lorairo/database/db_repository.py
+++ b/src/lorairo/database/db_repository.py
@@ -20,6 +20,7 @@ from ..utils.log import logger
 from .db_core import DefaultSessionLocal
 from .filter_criteria import ImageFilterCriteria
 from .repository.error_record import ErrorRecordRepository
+from .repository.image import ImageRepository as _ImageRepositoryNew
 from .repository.model import ModelRepository
 from .repository.project import ProjectRepository
 from .schema import (
@@ -127,6 +128,12 @@ class ImageRepository:
         # 既存呼び出し (`image_repository.save_error_record()` 等) との互換性のため、
         # ImageRepository は内部で ErrorRecordRepository への delegating facade を保持する。
         self._error_record_repo = ErrorRecordRepository(session_factory=session_factory)
+        # ADR 0035 段階 4 (#423): Image / ProcessedImage / FilenameAlias は
+        # `repository/image.py` の新 `ImageRepository` (`_ImageRepositoryNew`) に移設。
+        # 既存呼び出し (`image_repository.add_original_image()` 等) との互換性のため、
+        # 本 facade は内部で新 ImageRepository への delegating wrapper を保持する。
+        # 段階 5 で `manager.image_repo` 経由の直接参照に切り替われば、本 facade は削除可能。
+        self._image_repo = _ImageRepositoryNew(session_factory=session_factory)
         logger.info("ImageRepository initialized.")
 
         # 外部tag_db統合（公開API経由、グレースフルデグラデーション対応）
@@ -203,61 +210,12 @@ class ImageRepository:
         return self._model_repo.get_models_by_litellm_ids(litellm_model_ids)
 
     def get_all_image_filename_index(self) -> dict[str, int]:
-        """全画像のfilename stem → image_id インデックスを構築する。
-
-        バッチインポート時のcustom_id照合用。N+1クエリを回避するため
-        1回のクエリで全画像のファイル名とIDを取得する。
-
-        Returns:
-            {filename_stem: image_id} の辞書。重複stem時は最新IDを優先。
-
-        Raises:
-            SQLAlchemyError: データベース操作でエラーが発生した場合。
-        """
-        with self.session_factory() as session:
-            try:
-                stmt = select(Image.id, Image.filename).where(Image.filename.isnot(None))
-                results = session.execute(stmt).all()
-                index: dict[str, int] = {}
-                for image_id, filename in results:
-                    stem = Path(filename).stem
-                    index[stem] = image_id
-
-                # エイリアス（重複スキップされた画像のファイル名）もインデックスに追加
-                alias_stmt = select(ImageFilenameAlias.image_id, ImageFilenameAlias.stem)
-                alias_results = session.execute(alias_stmt).all()
-                for image_id, stem in alias_results:
-                    if stem not in index:
-                        index[stem] = image_id
-
-                return index
-            except SQLAlchemyError as e:
-                logger.error(f"ファイル名インデックス構築エラー: {e}", exc_info=True)
-                raise
+        """``_ImageRepositoryNew.get_all_image_filename_index`` への delegate (ADR 0035 段階 4)。"""
+        return self._image_repo.get_all_image_filename_index()
 
     def add_filename_alias(self, image_id: int, stem: str) -> None:
-        """重複スキップされた画像のファイル名エイリアスを登録する。
-
-        Args:
-            image_id: 重複元の画像ID。
-            stem: スキップされた画像のファイル名stem。
-
-        Raises:
-            SQLAlchemyError: データベース操作でエラーが発生した場合。
-        """
-        with self.session_factory() as session:
-            try:
-                alias = ImageFilenameAlias(image_id=image_id, stem=stem)
-                session.add(alias)
-                session.commit()
-                logger.debug(f"ファイル名エイリアス登録: {stem} → image_id={image_id}")
-            except IntegrityError:
-                session.rollback()
-                logger.debug(f"エイリアス既存のためスキップ: {stem}")
-            except SQLAlchemyError as e:
-                session.rollback()
-                logger.error(f"エイリアス登録エラー: {e}", exc_info=True)
-                raise
+        """``_ImageRepositoryNew.add_filename_alias`` への delegate (ADR 0035 段階 4)。"""
+        return self._image_repo.add_filename_alias(image_id=image_id, stem=stem)
 
     def _get_or_create_manual_edit_model(self, session: Session) -> int:
         """ModelRepository._get_or_create_manual_edit_model への delegate (ADR 0035)。
@@ -335,219 +293,24 @@ class ImageRepository:
         )
 
     def _image_exists(self, image_id: int) -> bool:
-        """指定された画像IDが images テーブルに存在するかを確認します。
-
-        Args:
-            image_id (int): 確認する画像のID。
-
-        Returns:
-            bool: 画像が存在する場合はTrue、存在しない場合はFalse。
-
-        """
-        with self.session_factory() as session:
-            try:
-                stmt = select(Image.id).where(Image.id == image_id)
-                # exists() など、より効率的な方法も検討できるが、まずはシンプルに
-                result = session.execute(stmt).scalar_one_or_none()
-                return result is not None
-            except SQLAlchemyError as e:
-                logger.error(
-                    f"画像存在チェック中にエラーが発生しました (ID: {image_id}): {e}",
-                    exc_info=True,
-                )
-                raise
+        """``_ImageRepositoryNew._image_exists`` への delegate (ADR 0035 段階 4)。"""
+        return self._image_repo._image_exists(image_id=image_id)
 
     def find_duplicate_image_by_phash(self, phash: str) -> int | None:
-        """指定されたpHashに一致する画像をデータベースから検索し、Image IDを返します。
-        pHashはNULL不可のため、完全一致で検索します。
-
-        Args:
-            phash (str): 検索するpHash。
-
-        Returns:
-            int | None: 重複する画像のID。見つからない場合はNone。
-
-        """
-        if not phash:  # pHashが空文字列やNoneの場合は検索しない
-            return None
-        with self.session_factory() as session:
-            try:
-                # ID を返す必要があるので、ID を SELECT するように修正
-                stmt_id = select(Image.id).where(Image.phash == phash).limit(1)
-                image_id = session.execute(stmt_id).scalar_one_or_none()
-                if image_id:
-                    logger.debug(f"pHashによる重複画像が見つかりました: ID {image_id}, pHash {phash}")
-                return image_id
-            except SQLAlchemyError as e:
-                logger.error(f"pHashによる重複画像の検索中にエラーが発生しました: {e}", exc_info=True)
-                raise
+        """``_ImageRepositoryNew.find_duplicate_image_by_phash`` への delegate (ADR 0035 段階 4)。"""
+        return self._image_repo.find_duplicate_image_by_phash(phash=phash)
 
     def find_image_ids_by_phashes(self, phashes: set[str]) -> dict[str, int]:
-        """複数pHashに対応する画像IDを一括取得する。
-
-        BATCH_CHUNK_SIZE を超える場合はチャンク分割してクエリを実行する。
-
-        Args:
-            phashes: 検索するpHashのセット。
-
-        Returns:
-            pHash → image_id のマッピング。見つからなかったpHashは含まれない。
-
-        Raises:
-            SQLAlchemyError: データベース操作でエラーが発生した場合。
-
-        """
-        if not phashes:
-            return {}
-
-        phash_list = list(phashes)
-
-        with self.session_factory() as session:
-            try:
-                phash_to_id: dict[str, int] = {}
-                for i in range(0, len(phash_list), self.BATCH_CHUNK_SIZE):
-                    chunk = phash_list[i : i + self.BATCH_CHUNK_SIZE]
-                    stmt = select(Image.phash, Image.id).where(Image.phash.in_(chunk))
-                    results = session.execute(stmt).all()
-                    phash_to_id.update({row.phash: row.id for row in results})
-                logger.debug(f"pHash一括検索: {len(phash_to_id)}/{len(phashes)}件見つかりました")
-                return phash_to_id
-            except SQLAlchemyError as e:
-                logger.error(f"pHash一括検索中にエラー: {e}", exc_info=True)
-                raise
+        """``_ImageRepositoryNew.find_image_ids_by_phashes`` への delegate (ADR 0035 段階 4)。"""
+        return self._image_repo.find_image_ids_by_phashes(phashes=phashes)
 
     def get_annotated_image_ids(self, image_ids: list[int]) -> set[int]:
-        """指定IDリストからアノテーション済み画像IDを一括取得する。
-
-        タグまたはキャプションが存在する画像IDのセットを返す。
-        BATCH_CHUNK_SIZE を超える場合はチャンク分割してクエリを実行する。
-
-        Args:
-            image_ids: 検査対象の画像IDリスト。
-
-        Returns:
-            アノテーションが存在する画像IDのセット。
-
-        Raises:
-            SQLAlchemyError: データベース操作でエラーが発生した場合。
-
-        """
-        if not image_ids:
-            return set()
-
-        with self.session_factory() as session:
-            try:
-                annotated_ids: set[int] = set()
-                for i in range(0, len(image_ids), self.BATCH_CHUNK_SIZE):
-                    chunk = image_ids[i : i + self.BATCH_CHUNK_SIZE]
-                    # EXISTS サブクエリでタグまたはキャプションの存在を判定
-                    stmt = (
-                        select(Image.id)
-                        .where(Image.id.in_(chunk))
-                        .where(
-                            or_(
-                                exists().where(Tag.image_id == Image.id),
-                                exists().where(Caption.image_id == Image.id),
-                            ),
-                        )
-                    )
-                    result = session.execute(stmt).scalars().all()
-                    annotated_ids.update(result)
-                logger.debug(
-                    f"アノテーション存在一括チェック: "
-                    f"{len(annotated_ids)}/{len(image_ids)}件にアノテーションあり",
-                )
-                return annotated_ids
-            except SQLAlchemyError as e:
-                logger.error(
-                    f"アノテーション存在一括チェック中にエラー: {e}",
-                    exc_info=True,
-                )
-                raise
+        """``_ImageRepositoryNew.get_annotated_image_ids`` への delegate (ADR 0035 段階 4)。"""
+        return self._image_repo.get_annotated_image_ids(image_ids=image_ids)
 
     def add_original_image(self, info: dict[str, Any]) -> int:
-        """オリジナル画像のメタデータを images テーブルに追加します。
-        pHashによる重複チェックを行い、重複がある場合は既存IDを返します。
-        pHash計算失敗時は例外を送出します。
-
-        Args:
-            info (dict[str, Any]): 画像情報を含む辞書。
-                                   `calculate_phash` が成功した前提で `phash` キーも含まれる想定。
-                                   以下のキーが必須: uuid, phash, original_image_path,
-                                   stored_image_path, width, height, format, extension。
-                                   その他は Optional。
-
-        Returns:
-            int: 挿入された画像のID、または重複していた既存画像のID。
-
-        Raises:
-            ValueError: 必須情報が不足している場合、またはpHash計算済みでない場合。
-            SQLAlchemyError: データベース操作でエラーが発生した場合。
-
-        """
-        required_keys = {
-            "uuid",
-            "phash",
-            "original_image_path",
-            "stored_image_path",
-            "width",
-            "height",
-            "format",
-            "extension",
-        }
-        if not required_keys.issubset(info.keys()):
-            missing_keys = required_keys - info.keys()
-            raise ValueError(f"必須情報が不足しています: {', '.join(missing_keys)}")
-
-        phash = info["phash"]
-
-        # pHashで重複チェック
-        existing_id = self.find_duplicate_image_by_phash(phash)
-        if existing_id is not None:
-            logger.warning(f"pHashが一致する画像が既に存在します: ID {existing_id} (pHash: {phash})")
-            return existing_id
-
-        # 新しい Image オブジェクトを作成
-        new_image = Image(
-            uuid=info["uuid"],
-            phash=phash,
-            original_image_path=str(info["original_image_path"]),  # Pathオブジェクトを文字列に
-            stored_image_path=str(info["stored_image_path"]),  # Pathオブジェクトを文字列に
-            width=info["width"],
-            height=info["height"],
-            format=info["format"],
-            mode=info.get("mode"),
-            has_alpha=info.get("has_alpha"),
-            filename=info.get("filename"),
-            extension=info["extension"],
-            color_space=info.get("color_space"),
-            icc_profile=info.get("icc_profile"),
-            project_id=info.get("project_id"),
-            # created_at, updated_at は server_default で設定される
-        )
-
-        with self.session_factory() as session:
-            try:
-                session.add(new_image)
-                session.flush()  # ID を取得するために flush
-                image_id = new_image.id
-                session.commit()  # コミットは flush 後でもOK
-                logger.debug(f"オリジナル画像をDBに追加しました: ID={image_id}, UUID={new_image.uuid}")
-                return image_id
-            except IntegrityError as e:
-                # uuid の UNIQUE 制約違反など
-                session.rollback()
-                logger.error(f"オリジナル画像の追加中に整合性エラーが発生しました: {e}", exc_info=True)
-                # uuid重複の場合、既存IDを探して返すか、あるいは単にエラーとするか?
-                # ここではエラーを再発生させる
-                raise
-            except SQLAlchemyError as e:
-                session.rollback()
-                logger.error(
-                    f"オリジナル画像の追加中にデータベースエラーが発生しました: {e}",
-                    exc_info=True,
-                )
-                raise
+        """``_ImageRepositoryNew.add_original_image`` への delegate (ADR 0035 段階 4)。"""
+        return self._image_repo.add_original_image(info=info)
 
     def _find_existing_processed_image_id(
         self,
@@ -556,120 +319,14 @@ class ImageRepository:
         height: int,
         filename: str | None,
     ) -> int | None:
-        """指定された条件に一致する既存の processed_image の ID を検索します。
-        add_processed_image で IntegrityError が発生した場合に使用します。
-
-        Args:
-            image_id (int): 元画像の ID。
-            width (int): 幅。
-            height (int): 高さ。
-            filename (Optional[str]): ファイル名。
-
-        Returns:
-            Optional[int]: 既存レコードの ID。見つからない場合は None。
-
-        """
-        with self.session_factory() as session:
-            try:
-                stmt = select(ProcessedImage.id).where(
-                    ProcessedImage.image_id == image_id,
-                    ProcessedImage.width == width,
-                    ProcessedImage.height == height,
-                    # filename が None の場合も考慮して比較
-                    (ProcessedImage.filename == filename)
-                    if filename is not None
-                    else (ProcessedImage.filename.is_(None)),
-                )
-                existing_id = session.execute(stmt).scalar_one_or_none()
-                return existing_id
-            except SQLAlchemyError as e:
-                logger.error(f"既存の処理済み画像ID検索中にエラー: {e}", exc_info=True)
-                # この検索自体が失敗した場合は None を返すか、エラーを再発生させるか検討
-                return None  # ここでは None を返す
-
-    def add_processed_image(self, info: dict[str, Any]) -> int | None:
-        """処理済み画像のメタデータを processed_images テーブルに追加します。
-        重複する場合は既存の ID を返します。
-
-        Args:
-            info (dict[str, Any]): 処理済み画像情報を含む辞書。
-                                   必須キー: image_id, stored_image_path, width, height, has_alpha。
-                                   その他は Optional。
-
-        Returns:
-            int | None: 挿入された処理済み画像のID、または重複していた既存画像のID。
-                        検索に失敗した場合は None を返す可能性あり。
-
-        Raises:
-            ValueError: 必須情報が不足している場合、または関連する Image が存在しない場合。
-            SQLAlchemyError: 予期せぬデータベース操作でエラーが発生した場合 (IntegrityError 以外)。
-
-        """
-        required_keys = {"image_id", "stored_image_path", "width", "height", "has_alpha"}
-        if not required_keys.issubset(info.keys()):
-            missing_keys = required_keys - info.keys()
-            raise ValueError(f"必須情報が不足しています: {', '.join(missing_keys)}")
-
-        image_id = info["image_id"]
-        width = info["width"]
-        height = info["height"]
-        filename = info.get("filename")  # filename は Optional
-
-        # 関連する Image レコードが存在するか確認 (FK制約のため)
-        if not self._image_exists(image_id):
-            raise ValueError(f"関連するオリジナル画像が見つかりません: image_id={image_id}")
-
-        # 新しい ProcessedImage オブジェクトを作成
-        new_processed_image = ProcessedImage(
-            image_id=image_id,
-            stored_image_path=str(info["stored_image_path"]),  # Pathオブジェクトを文字列に
-            width=width,
-            height=height,
-            mode=info.get("mode"),
-            has_alpha=info["has_alpha"],
-            filename=filename,
-            color_space=info.get("color_space"),
-            icc_profile=info.get("icc_profile"),
-            upscaler_used=info.get("upscaler_used"),  # アップスケーラー情報を追加
-            # created_at, updated_at は server_default で設定される
+        """``_ImageRepositoryNew._find_existing_processed_image_id`` への delegate (ADR 0035 段階 4)。"""
+        return self._image_repo._find_existing_processed_image_id(
+            image_id=image_id, width=width, height=height, filename=filename
         )
 
-        with self.session_factory() as session:
-            try:
-                session.add(new_processed_image)
-                session.flush()  # ID を取得するために flush
-                processed_image_id = new_processed_image.id
-                session.commit()
-                logger.debug(
-                    f"処理済み画像をDBに追加しました: ID={processed_image_id}, 親画像ID={image_id}",
-                )
-                return processed_image_id
-            except IntegrityError:
-                # UNIQUE 制約違反 (image_id, width, height, filename)
-                session.rollback()
-                logger.warning(
-                    f"処理済み画像の追加中に整合性エラーが発生しました。"
-                    f" (おそらく重複: image_id={image_id}, width={width}, height={height}, filename={filename})."
-                    f" 既存のIDを検索します。",
-                )
-                # 既存のIDを検索して返す
-                existing_id = self._find_existing_processed_image_id(image_id, width, height, filename)
-                if existing_id:
-                    logger.debug(f"既存の処理済み画像IDが見つかりました: {existing_id}")
-                else:
-                    # 通常ここには来ないはずだが、もし検索でも見つからなければ警告
-                    logger.error(
-                        f"整合性エラー後、既存の処理済み画像が見つかりませんでした。"
-                        f" 条件: image_id={image_id}, width={width}, height={height}, filename={filename}",
-                    )
-                return existing_id  # None の可能性もある
-            except SQLAlchemyError as e:
-                session.rollback()
-                logger.error(
-                    f"処理済み画像の追加中に予期せぬデータベースエラーが発生しました: {e}",
-                    exc_info=True,
-                )
-                raise  # IntegrityError 以外の DB エラーは再発生させる
+    def add_processed_image(self, info: dict[str, Any]) -> int | None:
+        """``_ImageRepositoryNew.add_processed_image`` への delegate (ADR 0035 段階 4)。"""
+        return self._image_repo.add_processed_image(info=info)
 
     # --- Annotation Saving Methods ---
 
@@ -1317,132 +974,16 @@ class ImageRepository:
     # --- Data Retrieval Methods ---
 
     def get_image_metadata(self, image_id: int) -> dict[str, Any] | None:
-        """指定されたIDのオリジナル画像メタデータを辞書形式で取得します。
-
-        Args:
-            image_id (int): 取得する画像のID。
-
-        Returns:
-            Optional[dict[str, Any]]: 画像メタデータを含む辞書。画像が見つからない場合はNone。
-                - rating_value: 最新のRating値（ratingsテーブルから取得）
-                - score_value: 最新のScore値（scoresテーブルから取得）
-
-        Raises:
-            SQLAlchemyError: データベース操作でエラーが発生した場合。
-
-        """
-        with self.session_factory() as session:
-            try:
-                # 主キー検索には session.get が効率的
-                # relationshipをeager loadingで取得（ratings, scores）
-                stmt = (
-                    select(Image)
-                    .where(Image.id == image_id)
-                    .options(
-                        selectinload(Image.ratings).selectinload(Rating.model),
-                        selectinload(Image.scores),
-                    )
-                )
-                image: Image | None = session.execute(stmt).scalar_one_or_none()
-
-                if image is None:
-                    logger.warning(f"画像メタデータが見つかりません: image_id={image_id}")
-                    return None
-
-                # SQLAlchemy オブジェクトを辞書に変換
-                metadata = {c.name: getattr(image, c.name) for c in image.__table__.columns}
-
-                # Rating/Score情報を整形して追加（Issue #4対応）
-                annotations = self._format_annotations_for_metadata(image)
-                metadata.update(annotations)
-
-                logger.debug(f"画像メタデータを取得しました: image_id={image_id}")
-                return metadata
-
-            except SQLAlchemyError as e:
-                logger.error(
-                    f"画像メタデータの取得中にエラーが発生しました (ID: {image_id}): {e}",
-                    exc_info=True,
-                )
-                raise
+        """``_ImageRepositoryNew.get_image_metadata`` への delegate (ADR 0035 段階 4)。"""
+        return self._image_repo.get_image_metadata(image_id=image_id)
 
     def get_images_metadata_batch(self, image_ids: list[int]) -> list[dict[str, Any]]:
-        """指定された複数IDのオリジナル画像メタデータを一括取得する。
-
-        内部的に _fetch_filtered_metadata() を使用し、joinedloadで取得する。
-        BATCH_CHUNK_SIZE を超える場合はチャンク分割してクエリを実行する。
-
-        Args:
-            image_ids: 取得する画像IDのリスト。
-
-        Returns:
-            画像メタデータ辞書のリスト。見つからなかったIDは結果に含まれない。
-
-        Raises:
-            SQLAlchemyError: データベース操作でエラーが発生した場合。
-
-        """
-        if not image_ids:
-            return []
-
-        with self.session_factory() as session:
-            try:
-                # チャンク分割でSQLiteバインド変数上限を回避
-                result: list[dict[str, Any]] = []
-                for i in range(0, len(image_ids), self.BATCH_CHUNK_SIZE):
-                    chunk = image_ids[i : i + self.BATCH_CHUNK_SIZE]
-                    result.extend(self._fetch_filtered_metadata(session, chunk, resolution=0))
-                return result
-            except SQLAlchemyError as e:
-                logger.error(
-                    f"画像メタデータの一括取得中にエラーが発生しました: {e}",
-                    exc_info=True,
-                )
-                raise
+        """``_ImageRepositoryNew.get_images_metadata_batch`` への delegate (ADR 0035 段階 4)。"""
+        return self._image_repo.get_images_metadata_batch(image_ids=image_ids)
 
     def get_batch_available_resolutions(self, image_ids: list[int]) -> dict[int, list[int]]:
-        """複数画像の利用可能な処理済み解像度を一括取得する。
-
-        1クエリで全 ProcessedImage を取得し、Python側で解像度マッピングを構築する。
-        N+1ループ（image_id × resolution の組み合わせ）の代替として使用する。
-
-        Args:
-            image_ids: 画像IDリスト
-
-        Returns:
-            image_id -> 利用可能な解像度リスト のマッピング。
-            ProcessedImage が存在しない image_id は空リストになる。
-
-        Raises:
-            SQLAlchemyError: データベース操作でエラーが発生した場合。
-
-        """
-        if not image_ids:
-            return {}
-
-        by_image: dict[int, list[dict[str, Any]]] = {image_id: [] for image_id in image_ids}
-        with self.session_factory() as session:
-            for i in range(0, len(image_ids), self.BATCH_CHUNK_SIZE):
-                chunk = image_ids[i : i + self.BATCH_CHUNK_SIZE]
-                rows = (
-                    session.execute(select(ProcessedImage).where(ProcessedImage.image_id.in_(chunk)))
-                    .scalars()
-                    .all()
-                )
-                for row in rows:
-                    metadata = {c.name: getattr(row, c.name) for c in row.__table__.columns}
-                    if row.image_id in by_image:
-                        by_image[row.image_id].append(metadata)
-
-        target_resolutions = [512, 768, 1024, 1536]
-        return {
-            image_id: [
-                target
-                for target in target_resolutions
-                if self._filter_by_resolution(by_image[image_id], target) is not None
-            ]
-            for image_id in image_ids
-        }
+        """``_ImageRepositoryNew.get_batch_available_resolutions`` への delegate (ADR 0035 段階 4)。"""
+        return self._image_repo.get_batch_available_resolutions(image_ids=image_ids)
 
     def get_processed_image(
         self,
@@ -1450,409 +991,55 @@ class ImageRepository:
         resolution: int = 0,
         all_data: bool = False,
     ) -> dict[str, Any] | list[dict[str, Any]] | None:  # 戻り値の型を調整
-        """指定された image_id に関連する処理済み画像のメタデータを取得します。
-        resolution に基づいてフィルタリングするか、all_data=True で全て取得します。
-
-        Args:
-            image_id (int): 元画像のID。
-            resolution (int): フィルタリングの基準となる解像度 (長辺)。
-                              0 の場合は最も解像度が低いものを返します。
-            all_data (bool): True の場合はフィルタリングせず、関連する全ての
-                             処理済み画像メタデータをリストで返します。
-
-        Returns:
-            Optional[Union[dict[str, Any], list[dict[str, Any]]]]:
-                - all_data=True: 処理済み画像メタデータの辞書のリスト。見つからない場合は空リスト。
-                - all_data=False: 条件に一致した処理済み画像メタデータの辞書。見つからない場合は None。
-
-        Raises:
-            SQLAlchemyError: データベース操作でエラーが発生した場合。
-
-        """
-        with self.session_factory() as session:
-            try:
-                # image_id に紐づく全ての処理済み画像を取得
-                stmt = select(ProcessedImage).where(ProcessedImage.image_id == image_id)
-                results: list[ProcessedImage] = list(session.execute(stmt).scalars().all())
-
-                if not results:
-                    logger.warning(f"処理済み画像が見つかりません: image_id={image_id}")
-                    return [] if all_data else None
-
-                # モデルオブジェクトを辞書のリストに変換
-                metadata_list = [
-                    {c.name: getattr(img, c.name) for c in img.__table__.columns} for img in results
-                ]
-
-                if all_data:
-                    logger.debug(
-                        f"全 {len(metadata_list)} 件の処理済み画像メタデータを取得しました: image_id={image_id}",
-                    )
-                    return metadata_list
-
-                # 解像度に基づいてフィルタリング
-                selected_metadata: dict[str, Any] | None = None
-                if resolution == 0:
-                    # 最も解像度が低いもの (面積で比較)
-                    selected_metadata = min(metadata_list, key=lambda x: x["width"] * x["height"])
-                    logger.debug(
-                        f"最低解像度の処理済み画像を選択しました: image_id={image_id}, id={selected_metadata['id']}",
-                    )
-                else:
-                    # 指定解像度に最も近いものを選択
-                    selected_metadata = self._filter_by_resolution(metadata_list, resolution)
-
-                # all_data=False の場合、ここで選択されたメタデータ (またはNone) を返す
-                if not all_data:
-                    if selected_metadata:
-                        logger.debug(
-                            f"解像度 {resolution} に一致する処理済み画像を選択しました: image_id={image_id}, id={selected_metadata.get('id')}",
-                        )
-                    else:
-                        logger.warning(
-                            f"解像度 {resolution} に一致する処理済み画像が見つかりませんでした: image_id={image_id}",
-                        )
-                    return selected_metadata
-
-            except SQLAlchemyError as e:
-                logger.error(
-                    f"処理済み画像の取得中にエラーが発生しました (ID: {image_id}): {e}",
-                    exc_info=True,
-                )
-                raise
+        """``_ImageRepositoryNew.get_processed_image`` への delegate (ADR 0035 段階 4)。"""
+        return self._image_repo.get_processed_image(
+            image_id=image_id, resolution=resolution, all_data=all_data
+        )
 
     def _filter_by_resolution(
         self,
         metadata_list: list[dict[str, Any]],
         resolution: int,
     ) -> dict[str, Any] | None:
-        """解像度に基づいてメタデータをフィルタリングします。
-        指定された解像度に最も近いもの (面積比で許容誤差20%以内) を返します。
-
-        Args:
-            metadata_list (list[dict[str, Any]]): ProcessedImageのメタデータの辞書のリスト。
-            resolution (int): 目標解像度 (長辺)。
-
-        Returns:
-            dict[str, Any] | None: フィルタリングされたメタデータの辞書。見つからない場合はNone。
-
-        """
-        # 型安全性チェック: resolution が文字列の場合は int に変換
-        if isinstance(resolution, str):
-            try:
-                resolution = int(resolution)
-                logger.warning(
-                    f"解像度パラメータが文字列として渡されました: '{resolution}' -> {resolution}",
-                )
-            except ValueError:
-                logger.error(f"解像度パラメータの変換に失敗しました: '{resolution}'")
-                return None
-
-        best_match: dict[str, Any] | None = None
-        min_error_ratio = float("inf")
-
-        target_area = resolution * resolution  # Target area based on square of the long side
-
-        for metadata in metadata_list:
-            width = metadata.get("width", 0)
-            height = metadata.get("height", 0)
-            if not width or not height:
-                continue
-
-            # 1. Check for exact match on the longer side
-            long_side = max(width, height)
-            if long_side == resolution:
-                logger.debug(f"Exact resolution match found: {metadata['id']}")
-                return metadata  # Exact match found, return immediately
-
-            # 2. Calculate area ratio difference if no exact match yet
-            short_side = min(width, height)
-            actual_area = long_side * short_side
-
-            # Avoid division by zero if target_area is 0 (resolution is 0)
-            # Though resolution=0 should be handled before calling this function
-            if target_area == 0:
-                error_ratio = float("inf")  # Or handle as a special case if needed
-            else:
-                error_ratio = abs(target_area - actual_area) / target_area
-
-            # Check if within 20% tolerance and better than the current best match
-            if error_ratio <= 0.2 and error_ratio < min_error_ratio:
-                min_error_ratio = error_ratio
-                best_match = metadata
-
-        if best_match:
-            logger.debug(
-                f"Closest resolution match found (error: {min_error_ratio:.2f}): {best_match['id']}",
-            )
-        else:
-            logger.debug(f"No suitable processed image found for resolution {resolution}")
-
-        return best_match  # Return the best match found within tolerance, or None
+        """``_ImageRepositoryNew._filter_by_resolution`` への delegate (ADR 0035 段階 4)。"""
+        return self._image_repo._filter_by_resolution(metadata_list=metadata_list, resolution=resolution)
 
     @staticmethod
     def _format_tag_annotation(tag: Any) -> dict[str, Any]:
-        """タグアノテーションをdict形式にフォーマットする。
-
-        Args:
-            tag: タグORMオブジェクト。
-
-        Returns:
-            フォーマット済み辞書。
-
-        """
-        return {
-            "id": tag.id,
-            "tag": tag.tag,
-            "tag_id": tag.tag_id,
-            "model_id": tag.model_id,
-            "existing": tag.existing,
-            "is_edited_manually": tag.is_edited_manually,
-            "confidence_score": tag.confidence_score,
-            "created_at": tag.created_at,
-            "updated_at": tag.updated_at,
-        }
+        """``_ImageRepositoryNew._format_tag_annotation`` への delegate (ADR 0035 段階 4)。"""
+        return _ImageRepositoryNew._format_tag_annotation(tag=tag)
 
     @staticmethod
     def _format_caption_annotation(caption: Any) -> dict[str, Any]:
-        """キャプションアノテーションをdict形式にフォーマットする。
-
-        Args:
-            caption: キャプションORMオブジェクト。
-
-        Returns:
-            フォーマット済み辞書。
-
-        """
-        return {
-            "id": caption.id,
-            "caption": caption.caption,
-            "model_id": caption.model_id,
-            "existing": caption.existing,
-            "is_edited_manually": caption.is_edited_manually,
-            "created_at": caption.created_at,
-            "updated_at": caption.updated_at,
-        }
+        """``_ImageRepositoryNew._format_caption_annotation`` への delegate (ADR 0035 段階 4)。"""
+        return _ImageRepositoryNew._format_caption_annotation(caption=caption)
 
     @staticmethod
     def _format_score_annotation(score: Any) -> dict[str, Any]:
-        """スコアアノテーションをdict形式にフォーマットする。
-
-        Args:
-            score: スコアORMオブジェクト。
-
-        Returns:
-            フォーマット済み辞書。
-
-        """
-        return {
-            "id": score.id,
-            "score": score.score,
-            "model_id": score.model_id,
-            "is_edited_manually": score.is_edited_manually,
-            "created_at": score.created_at,
-            "updated_at": score.updated_at,
-        }
+        """``_ImageRepositoryNew._format_score_annotation`` への delegate (ADR 0035 段階 4)。"""
+        return _ImageRepositoryNew._format_score_annotation(score=score)
 
     @staticmethod
     def _format_rating_annotation(rating: Any) -> dict[str, Any]:
-        """レーティングアノテーションをdict形式にフォーマットする。
-
-        Args:
-            rating: レーティングORMオブジェクト。
-
-        Returns:
-            フォーマット済み辞書。
-
-        """
-        model_name = rating.model.name if rating.model else "Unknown"
-        litellm_model_id = rating.model.litellm_model_id if rating.model else None
-        is_manual = litellm_model_id == MANUAL_EDIT_LITELLM_ID or model_name == MANUAL_EDIT_NAME
-        return {
-            "id": rating.id,
-            "raw_rating_value": rating.raw_rating_value,
-            "normalized_rating": rating.normalized_rating,
-            "model_id": rating.model_id,
-            "model": model_name,
-            "model_name": model_name,
-            "source": "Manual" if is_manual else "AI",
-            "confidence_score": rating.confidence_score,
-            "created_at": rating.created_at,
-            "updated_at": rating.updated_at,
-        }
+        """``_ImageRepositoryNew._format_rating_annotation`` への delegate (ADR 0035 段階 4)。"""
+        return _ImageRepositoryNew._format_rating_annotation(rating=rating)
 
     @staticmethod
     def _format_score_label_annotation(sl: Any) -> dict[str, Any]:
-        """スコアラベルアノテーション (ADR 0028) を dict 形式にフォーマットする。
-
-        ADR 0028 で「常に model 名と組で保持」と決定したため、他 per-item helper と
-        異なり ``model`` (model.name) を含める。``sl.model`` relationship が eager
-        load されている前提 (``joinedload(ScoreLabel.model)`` 等)。
-
-        Args:
-            sl: ScoreLabel ORM オブジェクト。
-
-        Returns:
-            フォーマット済み辞書 (model 含む)。
-        """
-        return {
-            "id": sl.id,
-            "label": sl.label,
-            "model_id": sl.model_id,
-            "model": sl.model.name if sl.model else "Unknown",
-            "is_edited_manually": sl.is_edited_manually,
-            "created_at": sl.created_at,
-            "updated_at": sl.updated_at,
-        }
+        """``_ImageRepositoryNew._format_score_label_annotation`` への delegate (ADR 0035 段階 4)。"""
+        return _ImageRepositoryNew._format_score_label_annotation(sl=sl)
 
     def get_image_annotations(self, image_id: int) -> dict[str, Any]:
-        """指定された画像IDのアノテーション(タグ、キャプション、スコア、スコアラベル、レーティング)を取得する。
-
-        Eager Loadingを使用して関連データを効率的に取得する。
-
-        Args:
-            image_id: アノテーションを取得する画像のID。
-
-        Returns:
-            アノテーションデータを含む辞書。
-            キー: 'tags', 'captions', 'scores', 'score_labels', 'ratings',
-            'quality_summary' (ADR 0029、derived view)
-            画像が存在しない場合は空のリストを持つ辞書を返す。
-
-        Raises:
-            SQLAlchemyError: データベース操作でエラーが発生した場合。
-
-        """
-        from sqlalchemy.orm import joinedload
-
-        logger.debug(f"Getting annotations for image_id: {image_id}")
-        annotations: dict[str, Any] = {
-            "tags": [],
-            "captions": [],
-            "scores": [],
-            "score_labels": [],
-            "ratings": [],
-            "quality_summary": {},
-        }
-
-        with self.session_factory() as session:
-            try:
-                stmt = (
-                    select(Image)
-                    .where(Image.id == image_id)
-                    .options(
-                        joinedload(Image.tags),
-                        joinedload(Image.captions),
-                        joinedload(Image.scores),
-                        # ADR 0028: score_labels は model 名と組で返すため
-                        # ScoreLabel.model も eager load する
-                        joinedload(Image.score_labels).joinedload(ScoreLabel.model),
-                        joinedload(Image.ratings).joinedload(Rating.model),
-                        joinedload(Image.processed_images),
-                    )
-                )
-                image = session.execute(stmt).unique().scalar_one_or_none()
-
-                if image is None:
-                    logger.warning(f"画像が見つかりません: image_id={image_id}")
-                    return annotations
-
-                if image.tags:
-                    annotations["tags"] = [self._format_tag_annotation(t) for t in image.tags]
-                if image.captions:
-                    annotations["captions"] = [self._format_caption_annotation(c) for c in image.captions]
-                if image.scores:
-                    annotations["scores"] = [self._format_score_annotation(s) for s in image.scores]
-                if image.score_labels:
-                    annotations["score_labels"] = [
-                        self._format_score_label_annotation(sl) for sl in image.score_labels
-                    ]
-                if image.ratings:
-                    annotations["ratings"] = [self._format_rating_annotation(r) for r in image.ratings]
-
-                # ADR 0029: derived view、永続化しない。raw annotation から毎回計算する。
-                annotations["quality_summary"] = compute_quality_summary(
-                    annotations["score_labels"], annotations["scores"]
-                )
-
-                logger.info(
-                    f"取得したアノテーション数: tags={len(annotations['tags'])}, "
-                    f"captions={len(annotations['captions'])}, scores={len(annotations['scores'])}, "
-                    f"score_labels={len(annotations['score_labels'])}, "
-                    f"ratings={len(annotations['ratings'])} for image_id={image_id}",
-                )
-                return annotations
-
-            except SQLAlchemyError as e:
-                logger.error(
-                    f"画像ID {image_id} のアノテーション取得中にエラーが発生しました: {e}",
-                    exc_info=True,
-                )
-                raise
+        """``_ImageRepositoryNew.get_image_annotations`` への delegate (ADR 0035 段階 4)。"""
+        return self._image_repo.get_image_annotations(image_id=image_id)
 
     def _parse_datetime_str(self, date_str: str | None) -> datetime.datetime | None:
-        """日付文字列を UTC timezone-aware datetime オブジェクトに変換。
-
-        アプリケーション全体でUTC統一方針に従い、入力文字列をUTCとして解釈します。
-        データベースは TIMESTAMP(timezone=True) でUTC保存されているため、
-        フィルタリング時の比較もUTC基準で行います。
-
-        Args:
-            date_str: ISO 8601形式の日付文字列 (YYYY-MM-DDTHH:MM:SS or YYYY-MM-DD HH:MM:SS)
-
-        Returns:
-            datetime.datetime | None: UTC timezone-aware datetime オブジェクト、無効な場合は None
-
-        """
-        if not date_str:
-            return None
-        try:
-            # ISO 8601形式 (YYYY-MM-DDTHH:MM:SS or YYYY-MM-DD HH:MM:SS) を想定
-            # スペース区切りも考慮
-            date_str = date_str.replace(" ", "T")
-            # マイクロ秒以下を削除 (存在する場合)
-            if "." in date_str:
-                date_str = date_str.split(".")[0]
-
-            # naive datetime としてパースしてからUTCタイムゾーンを設定
-            # 入力文字列はUTC時刻として解釈する（アプリケーション統一方針）
-            parsed_dt = datetime.datetime.fromisoformat(date_str)
-
-            # タイムゾーン情報がない場合はUTCとして扱う
-            if parsed_dt.tzinfo is None:
-                from datetime import UTC
-
-                parsed_dt = parsed_dt.replace(tzinfo=UTC)
-
-            return parsed_dt
-        except ValueError:
-            logger.warning(f"無効な日付形式です: {date_str}。無視されます。")
-            return None
+        """``_ImageRepositoryNew._parse_datetime_str`` への delegate (ADR 0035 段階 4)。"""
+        return self._image_repo._parse_datetime_str(date_str=date_str)
 
     def _prepare_like_pattern(self, term: str) -> tuple[str, bool]:
-        """検索語からLIKEパターンと完全一致フラグを準備します。"""
-        is_exact = False
-        pattern = term.strip()  # 前後の空白を除去
-
-        if pattern.startswith('"') and pattern.endswith('"') and len(pattern) > 1:
-            # ダブルクォートで囲まれている場合は完全一致
-            is_exact = True
-            pattern = pattern[1:-1]  # クォートを除去
-            # クォート内のワイルドカードはリテラルとして扱う
-            pattern = pattern.replace("%", "\\%").replace("_", "\\_").replace("*", "*")
-        elif "*" in pattern:
-            # アスタリスクがあれば LIKE 検索 (部分一致)
-            # アスタリスクを SQL の % に置換
-            pattern = pattern.replace("%", "\\%").replace("_", "\\_").replace("*", "%")
-            is_exact = False
-        else:
-            # デフォルトは部分一致 (LIKE)
-            is_exact = False
-            # 前後に % を追加
-            pattern = f"%{pattern.replace('%', '\\%').replace('_', '\\_')}%"
-
-        # logger.debug(f"Prepared pattern: '{pattern}', is_exact: {is_exact} for term: '{term}'")
-        return pattern, is_exact
+        """``_ImageRepositoryNew._prepare_like_pattern`` への delegate (ADR 0035 段階 4)。"""
+        return self._image_repo._prepare_like_pattern(term=term)
 
     # --- Filtering Helper Methods ---
 
@@ -1862,20 +1049,8 @@ class ImageRepository:
         start_dt: datetime.datetime | None,
         end_dt: datetime.datetime | None,
     ) -> Select[Any]:
-        """クエリに日付フィルタを適用します (画像またはアノテーションの更新日時)。"""
-        if not start_dt and not end_dt:
-            return query
-
-        # 画像自体の作成/更新日時のみを考慮
-        img_date_conds = []
-        if start_dt:
-            img_date_conds.append(Image.updated_at >= start_dt)
-        if end_dt:
-            img_date_conds.append(Image.updated_at <= end_dt)
-        if img_date_conds:
-            query = query.where(and_(*img_date_conds))
-
-        return query
+        """``_ImageRepositoryNew._apply_date_filter`` への delegate (ADR 0035 段階 4)。"""
+        return self._image_repo._apply_date_filter(query=query, start_dt=start_dt, end_dt=end_dt)
 
     def _apply_tag_filter(
         self,
@@ -1885,214 +1060,30 @@ class ImageRepository:
         use_and: bool,
         include_untagged: bool,
     ) -> Select[Any]:
-        """クエリにタグフィルタを適用します。"""
-        if include_untagged:
-            # タグが存在しない画像 (outerjoinしてTag.idがNULL)
-            # 注: この条件は他のタグ/キャプション条件と併用されない前提 (Manager側で制御想定)
-            query = query.outerjoin(Tag, Image.id == Tag.image_id).where(Tag.id.is_(None))
-        elif tags:
-            # use_and (AND検索) の場合、タグごとにJOIN条件を追加する
-            if use_and:
-                logger.debug(f"Applying AND tag filter (EXISTS) for tags: {tags}")
-                for _i, tag_term in enumerate(tags):
-                    pattern, is_exact = self._prepare_like_pattern(tag_term)
-                    # is_exact フラグに基づいて条件を選択
-                    subquery_condition = (Tag.tag == pattern) if is_exact else Tag.tag.like(pattern)
-                    # EXISTS サブクエリを作成
-                    exists_subquery = (
-                        select(Tag.id)  # SELECT句は何でもよい (通常は 1 や PK)
-                        .where(
-                            Tag.image_id == Image.id,  # WHERE句に明示的な相関条件は残す
-                            subquery_condition,
-                        )
-                        .correlate(Image)  # 明示的に相関させる
-                        .exists()
-                    )
-                    # メインクエリに EXISTS 条件を追加
-                    query = query.where(exists_subquery)
-            else:
-                # use_and=False (OR検索) の場合、単一のJOINとOR条件
-                logger.debug(f"Applying OR tag filter for tags: {tags}")
-                tag_criteria = []
-                for t in tags:
-                    pattern, is_exact = self._prepare_like_pattern(t)
-                    if is_exact:
-                        tag_criteria.append(Tag.tag == pattern)
-                    else:
-                        tag_criteria.append(Tag.tag.like(pattern))
-                if tag_criteria:
-                    query = query.join(Tag, Image.id == Tag.image_id).where(or_(*tag_criteria))
-                    # logger.debug(f"Query after OR tag join: {query}") # クエリ確認用
-
-        if excluded_tags and not include_untagged:
-            logger.debug(f"Applying excluded tag filter (NOT EXISTS) for tags: {excluded_tags}")
-            for excluded_tag in excluded_tags:
-                pattern, is_exact = self._prepare_like_pattern(excluded_tag)
-                excluded_condition = (Tag.tag == pattern) if is_exact else Tag.tag.like(pattern)
-                not_exists_subquery = (
-                    select(Tag.id)
-                    .where(
-                        Tag.image_id == Image.id,
-                        excluded_condition,
-                    )
-                    .correlate(Image)
-                    .exists()
-                )
-                query = query.where(not_(not_exists_subquery))
-
-        return query
+        """``_ImageRepositoryNew._apply_tag_filter`` への delegate (ADR 0035 段階 4)。"""
+        return self._image_repo._apply_tag_filter(
+            query=query,
+            tags=tags,
+            excluded_tags=excluded_tags,
+            use_and=use_and,
+            include_untagged=include_untagged,
+        )
 
     def _apply_caption_filter(self, query: Select[Any], caption: str | None) -> Select[Any]:
-        """クエリにキャプションフィルタを適用します (EXISTSを使用)。"""
-        if caption:
-            logger.debug(f"Applying caption filter (EXISTS) for caption: '{caption}'")
-            pattern, is_exact = self._prepare_like_pattern(caption)
-
-            caption_filter = (Caption.caption == pattern) if is_exact else (Caption.caption.like(pattern))
-
-            # EXISTS サブクエリを作成
-            exists_subquery = (
-                select(Caption.id)
-                .where(
-                    Caption.image_id == Image.id,  # メインクエリの Image と相関させる
-                    caption_filter,
-                )
-                .correlate(Image)  # 明示的に相関させる
-                .exists()
-            )
-            # メインクエリに EXISTS 条件を追加
-            query = query.where(exists_subquery)
-        return query
+        """``_ImageRepositoryNew._apply_caption_filter`` への delegate (ADR 0035 段階 4)。"""
+        return self._image_repo._apply_caption_filter(query=query, caption=caption)
 
     def _apply_ai_rating_filter(self, query: Select[Any], ai_rating_filter: str) -> Select[Any]:
-        """クエリにAI評価レーティングフィルタを適用します (多数決ロジック)。
-
-        1つの画像に複数のAIモデルによる異なる評価がある場合、
-        50%以上のAI評価が指定されたレーティングと一致する画像のみを返します。
-
-        Args:
-            query (Select): 適用対象のクエリ
-            ai_rating_filter (str): フィルタリングするレーティング値 (PG, PG-13, R, X, XXX, UNRATED)
-
-        Returns:
-            Select: AIレーティングフィルタが適用されたクエリ
-
-        """
-        logger.debug(f"Applying AI rating filter (majority vote) for rating: '{ai_rating_filter}'")
-
-        # MANUAL_EDIT は AI フィルタから除外（AI 判定行のみを対象とする）
-        ai_only = Rating.model_id.in_(select(Model.id).where(Model.name != "MANUAL_EDIT"))
-
-        # UNRATED: AI レーティングが存在しない画像をフィルタ
-        if ai_rating_filter == "UNRATED":
-            has_any_ai_rating = exists(
-                select(Rating.id).where(Rating.image_id == Image.id, ai_only)
-            ).correlate(Image)
-            query = query.where(not_(has_any_ai_rating))
-            logger.debug("AI rating filter applied: UNRATED (no AI ratings)")
-            return query
-
-        # 多数決ロジック: 画像ごとに総AI評価数とマッチング数を計算
-        # マッチング数 >= 総評価数 / 2.0 の画像のみを返す
-
-        # サブクエリ1: 画像ごとの総AI評価数（MANUAL_EDIT 除外）
-        total_ratings_subquery = (
-            select(Rating.image_id, func.count(Rating.id).label("total_count"))
-            .where(ai_only)
-            .group_by(Rating.image_id)
-            .subquery()
-        )
-
-        # サブクエリ2: 画像ごとのマッチング評価数（MANUAL_EDIT 除外）
-        matching_ratings_subquery = (
-            select(Rating.image_id, func.count(Rating.id).label("matching_count"))
-            .where(func.lower(Rating.normalized_rating) == ai_rating_filter.lower(), ai_only)
-            .group_by(Rating.image_id)
-            .subquery()
-        )
-
-        # EXISTS条件: マッチング数 >= 総評価数 / 2.0
-        # COALESCE(matching_count, 0) で、マッチが0件の画像も処理
-        majority_vote_condition = exists(
-            select(1)
-            .select_from(total_ratings_subquery)
-            .outerjoin(
-                matching_ratings_subquery,
-                total_ratings_subquery.c.image_id == matching_ratings_subquery.c.image_id,
-            )
-            .where(
-                total_ratings_subquery.c.image_id == Image.id,
-                func.coalesce(matching_ratings_subquery.c.matching_count, 0)
-                >= (total_ratings_subquery.c.total_count / 2.0),
-            ),
-        ).correlate(Image)
-
-        query = query.where(majority_vote_condition)
-        logger.debug("AI rating filter applied with majority vote logic")
-        return query
+        """``_ImageRepositoryNew._apply_ai_rating_filter`` への delegate (ADR 0035 段階 4)。"""
+        return self._image_repo._apply_ai_rating_filter(query=query, ai_rating_filter=ai_rating_filter)
 
     def _apply_unrated_filter(self, query: Select[Any], include_unrated: bool) -> Select[Any]:
-        """クエリに未評価画像フィルタを適用します (Either-based ロジック)。
-
-        include_unrated=False の場合、手動評価またはAI評価のいずれか1つ以上を持つ画像のみを返します。
-        include_unrated=True の場合、フィルタリングを行いません。
-
-        Args:
-            query (Select): 適用対象のクエリ
-            include_unrated (bool): 未評価画像を含めるかどうか
-
-        Returns:
-            Select: 未評価フィルタが適用されたクエリ
-
-        """
-        if not include_unrated:
-            # MANUAL_EDIT も含む Rating テーブルに行が存在する画像のみを返す
-            # (manual rating も Rating テーブルに統一されたため OR は不要)
-            has_any_rating = exists().where(Rating.image_id == Image.id).correlate(Image)
-            query = query.where(has_any_rating)
-            logger.debug("Unrated filter applied: images must have at least one rating")
-
-        return query
+        """``_ImageRepositoryNew._apply_unrated_filter`` への delegate (ADR 0035 段階 4)。"""
+        return self._image_repo._apply_unrated_filter(query=query, include_unrated=include_unrated)
 
     def _apply_nsfw_filter(self, query: Select[Any], include_nsfw: bool, session: Session) -> Select[Any]:
-        """クエリにNSFWフィルタを適用します。"""
-        if not include_nsfw:
-            # NSFWとみなすレーティング値 (小文字にして比較)
-            nsfw_ratings = ["r", "x", "xxx"]
-
-            # AIによるレーティングに基づく除外条件
-            # Rating テーブルを LEFT JOIN する (なければ Rating.id is NULL)
-            # query = query.outerjoin(Rating, Image.id == Rating.image_id)
-            # 条件: Rating が存在し、かつ normalized_rating が NSFW リストに含まれる
-            ai_nsfw_condition = (
-                exists()
-                .where(Rating.image_id == Image.id, func.lower(Rating.normalized_rating).in_(nsfw_ratings))
-                .correlate(Image)
-            )
-
-            # 手動レーティングに基づく除外条件（ratingsテーブルから最新のMANUAL_EDIT ratingを参照）
-            manual_edit_model_id = self._get_or_create_manual_edit_model(session)
-            manual_nsfw_condition = (
-                exists()
-                .where(
-                    Rating.image_id == Image.id,
-                    Rating.model_id == manual_edit_model_id,
-                    func.lower(Rating.normalized_rating).in_(nsfw_ratings),
-                )
-                .correlate(Image)
-            )
-
-            # タグベースのNSFW判定（"nsfw" / "explicit" タグが付いている画像を除外）
-            tag_nsfw_condition = (
-                exists()
-                .where(Tag.image_id == Image.id, func.lower(Tag.tag).in_(["nsfw", "explicit"]))
-                .correlate(Image)
-            )
-
-            # AIレーティング、手動レーティング、またはタグがNSFWである画像を除外
-            query = query.where(not_(or_(ai_nsfw_condition, manual_nsfw_condition, tag_nsfw_condition)))
-            # レーティング情報がない (NULL) 画像は除外しない
-        return query
+        """``_ImageRepositoryNew._apply_nsfw_filter`` への delegate (ADR 0035 段階 4)。"""
+        return self._image_repo._apply_nsfw_filter(query=query, include_nsfw=include_nsfw, session=session)
 
     def _apply_score_filter(
         self,
@@ -2100,43 +1091,8 @@ class ImageRepository:
         score_min: float | None,
         score_max: float | None,
     ) -> Select[Any]:
-        """クエリにスコア範囲フィルタを適用します。
-
-        Args:
-            query: 適用対象のクエリ
-            score_min: 最小スコア値（0.0-10.0）
-            score_max: 最大スコア値（0.0-10.0）
-
-        Returns:
-            フィルタ適用済みのクエリ
-
-        """
-        if score_min is None and score_max is None:
-            return query
-
-        from lorairo.database.schema import Score
-
-        # DB値（0.0-10.0）で直接比較
-        db_min = score_min if score_min is not None else 0.0
-        db_max = score_max if score_max is not None else 10.0
-
-        # 指定範囲内のスコアを持つ画像のみを含める
-        score_condition = (
-            exists()
-            .where(
-                Score.image_id == Image.id,
-                Score.score >= db_min,
-                Score.score <= db_max,
-            )
-            .correlate(Image)
-        )
-
-        query = query.where(score_condition)
-        logger.debug(
-            f"Score filter applied: {db_min:.2f} - {db_max:.2f}",
-        )
-
-        return query
+        """``_ImageRepositoryNew._apply_score_filter`` への delegate (ADR 0035 段階 4)。"""
+        return self._image_repo._apply_score_filter(query=query, score_min=score_min, score_max=score_max)
 
     def _apply_manual_filters(
         self,
@@ -2145,236 +1101,45 @@ class ImageRepository:
         manual_edit_filter: bool | None,
         session: Session,
     ) -> Select[Any]:
-        """クエリに手動評価と手動編集フラグのフィルタを適用します。"""
-        if manual_rating_filter:
-            manual_edit_model_id = self._get_or_create_manual_edit_model(session)
-
-            if manual_rating_filter == "UNRATED":
-                # 手動レーティングが設定されていない画像をフィルタ
-                has_manual_rating_subq = (
-                    select(Rating.image_id).where(Rating.model_id == manual_edit_model_id).distinct()
-                )
-                query = query.where(Image.id.notin_(has_manual_rating_subq))
-            else:
-                # 特定の手動レーティングを持つ画像をフィルタ
-                manual_rating_subq = (
-                    select(Rating.image_id)
-                    .where(Rating.normalized_rating == manual_rating_filter)
-                    .where(Rating.model_id == manual_edit_model_id)
-                    .distinct()
-                )
-                query = query.where(Image.id.in_(manual_rating_subq))
-
-        if manual_edit_filter is not None:
-            has_manual_edit = or_(
-                exists().where(Tag.image_id == Image.id, Tag.is_edited_manually.is_(True)).correlate(Image),
-                exists()
-                .where(Caption.image_id == Image.id, Caption.is_edited_manually.is_(True))
-                .correlate(Image),
-                exists().where(Score.image_id == Image.id, Score.is_edited_manually).correlate(Image),
-            )
-
-            if manual_edit_filter:
-                query = query.where(has_manual_edit)
-            else:
-                query = query.where(not_(has_manual_edit))
-
-        return query
+        """``_ImageRepositoryNew._apply_manual_filters`` への delegate (ADR 0035 段階 4)。"""
+        return self._image_repo._apply_manual_filters(
+            query=query,
+            manual_rating_filter=manual_rating_filter,
+            manual_edit_filter=manual_edit_filter,
+            session=session,
+        )
 
     def _format_tags(self, image: Image, annotations: dict[str, Any]) -> None:
-        """タグアノテーション情報をフォーマットする。
-
-        Args:
-            image: 画像オブジェクト。
-            annotations: フォーマット結果を格納する辞書（直接更新される）。
-
-        """
-        if image.tags:
-            annotations["tags"] = [
-                {
-                    "id": tag.id,
-                    "tag": tag.tag,
-                    "tag_id": tag.tag_id,
-                    "model_id": tag.model_id,
-                    "model_name": tag.model.name if tag.model else "Unknown",
-                    "source": "Manual" if (tag.is_edited_manually or tag.existing) else "AI",
-                    "existing": tag.existing,
-                    "is_edited_manually": tag.is_edited_manually,
-                    "confidence_score": tag.confidence_score,
-                    "created_at": tag.created_at,
-                    "updated_at": tag.updated_at,
-                }
-                for tag in image.tags
-            ]
-            annotations["tags_text"] = ", ".join([tag.tag for tag in image.tags])
-        else:
-            annotations["tags"] = []
-            annotations["tags_text"] = ""
+        """``_ImageRepositoryNew._format_tags`` への delegate (ADR 0035 段階 4)。"""
+        return self._image_repo._format_tags(image=image, annotations=annotations)
 
     def _format_captions(self, image: Image, annotations: dict[str, Any]) -> None:
-        """キャプションアノテーション情報をフォーマットする。
-
-        Args:
-            image: 画像オブジェクト。
-            annotations: フォーマット結果を格納する辞書（直接更新される）。
-
-        """
-        if image.captions:
-            annotations["captions"] = [
-                {
-                    "id": caption.id,
-                    "caption": caption.caption,
-                    "model_id": caption.model_id,
-                    "model_name": caption.model.name if caption.model else "Unknown",
-                    "existing": caption.existing,
-                    "is_edited_manually": caption.is_edited_manually,
-                    "created_at": caption.created_at,
-                    "updated_at": caption.updated_at,
-                }
-                for caption in image.captions
-            ]
-            from datetime import datetime
-
-            latest_caption = max(
-                image.captions,
-                key=lambda c: c.created_at if c.created_at else datetime.min,
-            )
-            annotations["caption_text"] = latest_caption.caption
-        else:
-            annotations["captions"] = []
-            annotations["caption_text"] = ""
+        """``_ImageRepositoryNew._format_captions`` への delegate (ADR 0035 段階 4)。"""
+        return self._image_repo._format_captions(image=image, annotations=annotations)
 
     def _format_scores(self, image: Image, annotations: dict[str, Any]) -> None:
-        """スコアアノテーション情報をフォーマットする。
-
-        Args:
-            image: 画像オブジェクト。
-            annotations: フォーマット結果を格納する辞書（直接更新される）。
-
-        """
-        if image.scores:
-            annotations["scores"] = [
-                {
-                    "id": score.id,
-                    "score": score.score,
-                    "model_id": score.model_id,
-                    "model_name": score.model.name if score.model else "Unknown",
-                    "is_edited_manually": score.is_edited_manually,
-                    "created_at": score.created_at,
-                    "updated_at": score.updated_at,
-                }
-                for score in image.scores
-            ]
-            latest_score = max(image.scores, key=lambda s: s.created_at)
-            annotations["score_value"] = latest_score.score
-        else:
-            annotations["scores"] = []
-            annotations["score_value"] = 0.0
+        """``_ImageRepositoryNew._format_scores`` への delegate (ADR 0035 段階 4)。"""
+        return self._image_repo._format_scores(image=image, annotations=annotations)
 
     def _format_score_labels(self, image: Image, annotations: dict[str, Any]) -> None:
-        """スコアラベル (canonical scorer の categorical 分類) をフォーマットする。
-
-        ADR 0028 に基づき、各 entry は {model, label} ペアで保持し、scalar shorthand
-        は持たない (multi-scorer の集約 / 多数決方式の前提)。
-
-        Args:
-            image: 画像オブジェクト。
-            annotations: フォーマット結果を格納する辞書（直接更新される）。
-
-        """
-        if image.score_labels:
-            annotations["score_labels"] = [
-                self._format_score_label_annotation(sl) for sl in image.score_labels
-            ]
-        else:
-            annotations["score_labels"] = []
+        """``_ImageRepositoryNew._format_score_labels`` への delegate (ADR 0035 段階 4)。"""
+        return self._image_repo._format_score_labels(image=image, annotations=annotations)
 
     def _format_ratings(self, image: Image, annotations: dict[str, Any]) -> None:
-        """レーティングアノテーション情報をフォーマットする。
-
-        Args:
-            image: 画像オブジェクト。
-            annotations: フォーマット結果を格納する辞書（直接更新される）。
-
-        """
-        if image.ratings:
-            annotations["ratings"] = [self._format_rating_annotation(rating) for rating in image.ratings]
-            latest_rating = max(image.ratings, key=lambda r: r.created_at)
-            annotations["rating_value"] = latest_rating.normalized_rating
-        else:
-            annotations["ratings"] = []
-            annotations["rating_value"] = ""
+        """``_ImageRepositoryNew._format_ratings`` への delegate (ADR 0035 段階 4)。"""
+        return self._image_repo._format_ratings(image=image, annotations=annotations)
 
     def _format_annotations_for_metadata(self, image: Image) -> dict[str, Any]:
-        """画像のアノテーション情報を辞書形式にフォーマット。
-
-        Args:
-            image: 画像オブジェクト。
-
-        Returns:
-            フォーマット済みアノテーション情報辞書。
-
-        """
-        annotations: dict[str, Any] = {}
-
-        self._format_tags(image, annotations)
-        self._format_captions(image, annotations)
-        self._format_scores(image, annotations)
-        self._format_score_labels(image, annotations)
-        self._format_ratings(image, annotations)
-
-        # ADR 0029: derived view。GUI のメタデータ経路 (SelectedImageDetailsWidget) も
-        # quality_summary を受け取れるよう、get_image_annotations と同じく派生計算する。
-        annotations["quality_summary"] = compute_quality_summary(
-            annotations.get("score_labels", []), annotations.get("scores", [])
-        )
-
-        logger.debug(
-            f"Formatted annotations: tags={len(annotations.get('tags', []))}, "
-            f"captions={len(annotations.get('captions', []))}, "
-            f"scores={len(annotations.get('scores', []))}, "
-            f"score_labels={len(annotations.get('score_labels', []))}, "
-            f"ratings={len(annotations.get('ratings', []))}",
-        )
-
-        return annotations
+        """``_ImageRepositoryNew._format_annotations_for_metadata`` への delegate (ADR 0035 段階 4)。"""
+        return self._image_repo._format_annotations_for_metadata(image=image)
 
     def _fetch_original_image_metadata(
         self,
         session: Session,
         image_ids: list[int],
     ) -> list[dict[str, Any]]:
-        """オリジナル画像のメタデータをアノテーション付きで取得する。
-
-        Args:
-            session: SQLAlchemyセッション。
-            image_ids: 画像IDリスト。
-
-        Returns:
-            メタデータ辞書のリスト。
-
-        """
-        from sqlalchemy.orm import selectinload
-
-        orig_stmt = (
-            select(Image)
-            .where(Image.id.in_(image_ids))
-            .options(
-                selectinload(Image.tags).selectinload(Tag.model),
-                selectinload(Image.captions).selectinload(Caption.model),
-                selectinload(Image.scores).selectinload(Score.model),
-                selectinload(Image.score_labels).selectinload(ScoreLabel.model),
-                selectinload(Image.ratings).selectinload(Rating.model),
-            )
-        )
-        orig_results: list[Image] = list(session.execute(orig_stmt).scalars().all())
-
-        result = []
-        for img in orig_results:
-            metadata = {c.name: getattr(img, c.name) for c in img.__table__.columns}
-            metadata.update(self._format_annotations_for_metadata(img))
-            result.append(metadata)
-        return result
+        """``_ImageRepositoryNew._fetch_original_image_metadata`` への delegate (ADR 0035 段階 4)。"""
+        return self._image_repo._fetch_original_image_metadata(session=session, image_ids=image_ids)
 
     def _fetch_processed_image_metadata(
         self,
@@ -2382,61 +1147,10 @@ class ImageRepository:
         image_ids: list[int],
         resolution: int,
     ) -> list[dict[str, Any]]:
-        """処理済み画像のメタデータをアノテーション付きで取得する。
-
-        Args:
-            session: SQLAlchemyセッション。
-            image_ids: 画像IDリスト。
-            resolution: 対象解像度。
-
-        Returns:
-            メタデータ辞書のリスト。
-
-        """
-        from sqlalchemy.orm import selectinload
-
-        proc_stmt = select(ProcessedImage).where(ProcessedImage.image_id.in_(image_ids))
-        all_proc_images = session.execute(proc_stmt).scalars().all()
-
-        # Original Imageのアノテーション情報を一括取得
-        orig_annotations_stmt = (
-            select(Image)
-            .where(Image.id.in_(image_ids))
-            .options(
-                selectinload(Image.tags).selectinload(Tag.model),
-                selectinload(Image.captions).selectinload(Caption.model),
-                selectinload(Image.scores).selectinload(Score.model),
-                selectinload(Image.score_labels).selectinload(ScoreLabel.model),
-                selectinload(Image.ratings).selectinload(Rating.model),
-            )
+        """``_ImageRepositoryNew._fetch_processed_image_metadata`` への delegate (ADR 0035 段階 4)。"""
+        return self._image_repo._fetch_processed_image_metadata(
+            session=session, image_ids=image_ids, resolution=resolution
         )
-        orig_images = session.execute(orig_annotations_stmt).scalars().all()
-        annotations_by_image_id = {
-            img.id: self._format_annotations_for_metadata(img) for img in orig_images
-        }
-
-        # image_id ごとにグループ化
-        proc_images_by_id: dict[int, list[dict[str, Any]]] = {}
-        for img in all_proc_images:
-            if img.image_id not in proc_images_by_id:
-                proc_images_by_id[img.image_id] = []
-            proc_metadata = {c.name: getattr(img, c.name) for c in img.__table__.columns}
-            # idをimages.idに統一（GUI全体で「画像ID」として使われるため）
-            # processed_images.idはprocessed_image_idとして保持
-            proc_metadata["processed_image_id"] = proc_metadata["id"]
-            proc_metadata["id"] = img.image_id
-            if img.image_id in annotations_by_image_id:
-                proc_metadata.update(annotations_by_image_id[img.image_id])
-            proc_images_by_id[img.image_id].append(proc_metadata)
-
-        result = []
-        for image_id in image_ids:
-            metadata_list = proc_images_by_id.get(image_id, [])
-            if metadata_list:
-                selected = self._filter_by_resolution(metadata_list, resolution)
-                if selected:
-                    result.append(selected)
-        return result
 
     def _fetch_filtered_metadata(
         self,
@@ -2444,23 +1158,10 @@ class ImageRepository:
         image_ids: list[int],
         resolution: int,
     ) -> list[dict[str, Any]]:
-        """フィルタリングされたIDリストに基づき、指定解像度のメタデータを取得する。
-
-        Args:
-            session: SQLAlchemyセッション。
-            image_ids: 画像IDリスト。
-            resolution: 対象解像度(0はオリジナル)。
-
-        Returns:
-            メタデータ辞書のリスト。
-
-        """
-        if not image_ids:
-            return []
-
-        if resolution == 0:
-            return self._fetch_original_image_metadata(session, image_ids)
-        return self._fetch_processed_image_metadata(session, image_ids, resolution)
+        """``_ImageRepositoryNew._fetch_filtered_metadata`` への delegate (ADR 0035 段階 4)。"""
+        return self._image_repo._fetch_filtered_metadata(
+            session=session, image_ids=image_ids, resolution=resolution
+        )
 
     def _apply_project_filter(
         self,
@@ -2468,24 +1169,10 @@ class ImageRepository:
         project_name: str | None,
         project_id: int | None,
     ) -> Select[Any]:
-        """プロジェクトフィルタを適用する。
-
-        Args:
-            query: 適用対象の SQLAlchemy Select クエリ。
-            project_name: フィルタ対象プロジェクト名。
-            project_id: フィルタ対象プロジェクトID（project_name より優先）。
-
-        Returns:
-            フィルタ適用済みクエリ。
-        """
-        if project_id is not None:
-            query = query.where(Image.project_id == project_id)
-            logger.debug(f"Project filter applied: project_id={project_id}")
-        elif project_name is not None:
-            project_id_subq = select(Project.id).where(Project.name == project_name).scalar_subquery()
-            query = query.where(Image.project_id == project_id_subq)
-            logger.debug(f"Project filter applied: project_name='{project_name}'")
-        return query
+        """``_ImageRepositoryNew._apply_project_filter`` への delegate (ADR 0035 段階 4)。"""
+        return self._image_repo._apply_project_filter(
+            query=query, project_name=project_name, project_id=project_id
+        )
 
     # --- Project methods (delegating facade, ADR 0035 段階 2) ---
     # 実装は src/lorairo/database/repository/project.py の ProjectRepository に移設済み。
@@ -2531,197 +1218,42 @@ class ImageRepository:
         project_name: str | None = None,
         project_id: int | None = None,
     ) -> Select[Any]:
-        """画像フィルタ条件を適用したクエリを構築する。
-
-        Args:
-            session: SQLAlchemyセッション。
-            tags: 検索タグリスト。
-            excluded_tags: 除外検索タグリスト。
-            caption: 検索キャプション文字列。
-            use_and: 複数タグのAND/OR指定。
-            start_date: 検索開始日時(ISO 8601)。
-            end_date: 検索終了日時(ISO 8601)。
-            include_untagged: タグなし画像のみ対象とするか。
-            include_nsfw: NSFWコンテンツを含むか。
-            include_unrated: 未評価画像を含むか。
-            manual_rating_filter: 手動レーティングフィルタ。
-            ai_rating_filter: AI評価フィルタ。
-            manual_edit_filter: 手動編集フラグフィルタ。
-            score_min: 最小スコア値（0.0-10.0）。
-            score_max: 最大スコア値（0.0-10.0）。
-            project_name: プロジェクト名フィルタ（Phase C完了後に有効化）。
-            project_id: プロジェクトIDフィルタ（Phase C完了後に有効化）。
-
-        Returns:
-            フィルタ適用済みのSelectクエリ。
-
-        """
-        query = select(Image.id)
-
-        start_dt = self._parse_datetime_str(start_date)
-        end_dt = self._parse_datetime_str(end_date)
-        query = self._apply_date_filter(query, start_dt, end_dt)
-
-        if include_untagged and (tags or caption):
-            logger.warning("検索語句と include_untagged が同時に指定されたため、検索語句は無視されます。")
-
-        query = self._apply_tag_filter(query, tags, excluded_tags, use_and, include_untagged)
-        query = self._apply_caption_filter(query, caption)
-
-        # Rating Filters (Priority-based: manual > AI)
-        if manual_rating_filter:
-            logger.debug("Applying manual rating filter (priority over AI rating filter)")
-            query = self._apply_manual_filters(query, manual_rating_filter, manual_edit_filter, session)
-        elif ai_rating_filter:
-            logger.debug("Applying AI rating filter (no manual rating filter specified)")
-            query = self._apply_ai_rating_filter(query, ai_rating_filter)
-            query = self._apply_manual_filters(query, None, manual_edit_filter, session)
-        else:
-            query = self._apply_manual_filters(query, None, manual_edit_filter, session)
-
-        # Unrated Filter
-        query = self._apply_unrated_filter(query, include_unrated)
-
-        # NSFW Filter
-        nsfw_values_to_exclude = {"r", "x", "xxx"}
-        apply_nsfw_exclusion = not include_nsfw and (
-            (manual_rating_filter is None or manual_rating_filter.lower() not in nsfw_values_to_exclude)
-            and (ai_rating_filter is None or ai_rating_filter.lower() not in nsfw_values_to_exclude)
+        """``_ImageRepositoryNew._build_image_filter_query`` への delegate (ADR 0035 段階 4)。"""
+        return self._image_repo._build_image_filter_query(
+            session=session,
+            tags=tags,
+            excluded_tags=excluded_tags,
+            caption=caption,
+            use_and=use_and,
+            start_date=start_date,
+            end_date=end_date,
+            include_untagged=include_untagged,
+            include_nsfw=include_nsfw,
+            include_unrated=include_unrated,
+            manual_rating_filter=manual_rating_filter,
+            ai_rating_filter=ai_rating_filter,
+            manual_edit_filter=manual_edit_filter,
+            score_min=score_min,
+            score_max=score_max,
+            project_name=project_name,
+            project_id=project_id,
         )
-        if apply_nsfw_exclusion:
-            query = self._apply_nsfw_filter(query, include_nsfw=False, session=session)
-        elif include_nsfw:
-            query = self._apply_nsfw_filter(query, include_nsfw=True, session=session)
-
-        # Score Filter
-        query = self._apply_score_filter(query, score_min, score_max)
-
-        # Project Filter (Phase C完了後に有効化)
-        query = self._apply_project_filter(query, project_name, project_id)
-
-        return query.distinct()
 
     def get_images_by_filter(
         self,
         criteria: ImageFilterCriteria | None = None,
         **kwargs: Any,
     ) -> tuple[list[dict[str, Any]], int]:
-        """指定された条件に基づいて画像をフィルタリングし、メタデータと件数を返す。
-
-        Args:
-            criteria: ImageFilterCriteria形式のフィルター条件（推奨）
-            **kwargs: レガシー形式のキーワード引数（後方互換性用）
-
-        Returns:
-            条件にマッチした画像メタデータのリストとその総数。
-        """
-        # criteriaが指定されていればそれを使用、なければkwargsから生成
-        filter_criteria = criteria if criteria else ImageFilterCriteria.from_kwargs(**kwargs)
-
-        # 型安全性チェック: resolution が文字列の場合は int に変換
-        if isinstance(filter_criteria.resolution, str):
-            try:
-                filter_criteria.resolution = int(filter_criteria.resolution)
-                logger.warning(
-                    f"解像度パラメータが文字列として渡されました: '{filter_criteria.resolution}' -> "
-                    f"{filter_criteria.resolution}",
-                )
-            except ValueError:
-                logger.error(f"解像度パラメータの変換に失敗しました: '{filter_criteria.resolution}'")
-                return [], 0
-
-        with self.session_factory() as session:
-            try:
-                query = self._build_image_filter_query(
-                    session=session,
-                    tags=filter_criteria.tags,
-                    excluded_tags=filter_criteria.excluded_tags,
-                    caption=filter_criteria.caption,
-                    use_and=filter_criteria.use_and,
-                    start_date=filter_criteria.start_date,
-                    end_date=filter_criteria.end_date,
-                    include_untagged=filter_criteria.include_untagged,
-                    include_nsfw=filter_criteria.include_nsfw,
-                    include_unrated=filter_criteria.include_unrated,
-                    manual_rating_filter=filter_criteria.manual_rating_filter,
-                    ai_rating_filter=filter_criteria.ai_rating_filter,
-                    manual_edit_filter=filter_criteria.manual_edit_filter,
-                    score_min=filter_criteria.score_min,
-                    score_max=filter_criteria.score_max,
-                    project_name=filter_criteria.project_name,
-                    project_id=filter_criteria.project_id,
-                )
-
-                filtered_image_ids: list[int] = list(session.execute(query).scalars().all())
-
-                if not filtered_image_ids:
-                    logger.info("指定された条件に一致する画像が見つかりませんでした。")
-                    return [], 0
-
-                logger.debug(f"フィルタリングで {len(filtered_image_ids)} 件の候補画像IDを取得しました。")
-
-                final_metadata_list = self._fetch_filtered_metadata(
-                    session, filtered_image_ids, filter_criteria.resolution
-                )
-                list_count = len(final_metadata_list)
-                logger.info(f"最終的な検索結果: {list_count} 件")
-
-                return final_metadata_list, list_count
-
-            except SQLAlchemyError as e:
-                logger.error(f"画像フィルタリング検索中にエラーが発生しました: {e}", exc_info=True)
-                raise
+        """``_ImageRepositoryNew.get_images_by_filter`` への delegate (ADR 0035 段階 4)。"""
+        return self._image_repo.get_images_by_filter(criteria=criteria, **kwargs)
 
     def get_images_count_only(
         self,
         criteria: ImageFilterCriteria | None = None,
         **kwargs: Any,
     ) -> int:
-        """指定された条件に基づいて画像件数のみを取得する。
-
-        フィルター式は ``get_images_by_filter`` と同一ロジックを使用し、
-        メタデータ取得を行わない軽量な件数集計を実行する。
-
-        Args:
-            criteria: ImageFilterCriteria形式のフィルター条件（推奨）
-            **kwargs: レガシー形式のキーワード引数（後方互換性用）
-
-        Returns:
-            条件に一致した画像件数。
-
-        """
-        filter_criteria = criteria if criteria else ImageFilterCriteria.from_kwargs(**kwargs)
-
-        with self.session_factory() as session:
-            try:
-                filtered_query = self._build_image_filter_query(
-                    session=session,
-                    tags=filter_criteria.tags,
-                    excluded_tags=filter_criteria.excluded_tags,
-                    caption=filter_criteria.caption,
-                    use_and=filter_criteria.use_and,
-                    start_date=filter_criteria.start_date,
-                    end_date=filter_criteria.end_date,
-                    include_untagged=filter_criteria.include_untagged,
-                    include_nsfw=filter_criteria.include_nsfw,
-                    include_unrated=filter_criteria.include_unrated,
-                    manual_rating_filter=filter_criteria.manual_rating_filter,
-                    ai_rating_filter=filter_criteria.ai_rating_filter,
-                    manual_edit_filter=filter_criteria.manual_edit_filter,
-                    score_min=filter_criteria.score_min,
-                    score_max=filter_criteria.score_max,
-                    project_name=filter_criteria.project_name,
-                    project_id=filter_criteria.project_id,
-                )
-
-                count_query = select(func.count()).select_from(filtered_query.subquery())
-                count = session.execute(count_query).scalar_one()
-                logger.debug(f"フィルター件数のみ取得: {count} 件")
-                return count
-
-            except SQLAlchemyError as e:
-                logger.error(f"画像件数取得中にエラーが発生しました: {e}", exc_info=True)
-                raise
+        """``_ImageRepositoryNew.get_images_count_only`` への delegate (ADR 0035 段階 4)。"""
+        return self._image_repo.get_images_count_only(criteria=criteria, **kwargs)
 
     # --- Model Information Retrieval (delegating facade, ADR 0035 段階 1) ---
 
@@ -2740,15 +1272,8 @@ class ImageRepository:
     # --- Count Methods ---
 
     def get_total_image_count(self) -> int:
-        """データベース内のオリジナル画像の総数を取得します。"""
-        with self.session_factory() as session:
-            try:
-                stmt = select(func.count(Image.id))
-                count = session.execute(stmt).scalar_one()
-                return count
-            except SQLAlchemyError as e:
-                logger.error(f"総画像数の取得中にエラーが発生しました: {e}", exc_info=True)
-                raise  # または、目的のエラー処理に応じて0を返します
+        """``_ImageRepositoryNew.get_total_image_count`` への delegate (ADR 0035 段階 4)。"""
+        return self._image_repo.get_total_image_count()
 
     # --- Update Methods (Manual Edits) ---
 
@@ -3158,51 +1683,8 @@ class ImageRepository:
         )
 
     def get_images_by_ids(self, image_ids: list[int]) -> list[dict[str, Any]]:
-        """画像IDリストから画像メタデータを取得
-
-        Args:
-            image_ids: 画像IDリスト
-
-        Returns:
-            list[dict]: 画像メタデータリスト（既存フォーマット互換）
-
-        Raises:
-            SQLAlchemyError: データベース操作でエラーが発生した場合
-
-        """
-        if not image_ids:
-            return []
-
-        with self.session_factory() as session:
-            try:
-                # アノテーション情報を含めて取得
-                from sqlalchemy.orm import joinedload
-
-                stmt = (
-                    select(Image)
-                    .where(Image.id.in_(image_ids))
-                    .options(
-                        joinedload(Image.tags).joinedload(Tag.model),
-                        joinedload(Image.captions).joinedload(Caption.model),
-                        joinedload(Image.scores).joinedload(Score.model),
-                        joinedload(Image.ratings).joinedload(Rating.model),
-                    )
-                )
-                images = session.execute(stmt).unique().scalars().all()
-
-                # 既存の get_images_by_filter と同じフォーマットで返す
-                metadata_list = []
-                for img in images:
-                    metadata = {c.name: getattr(img, c.name) for c in img.__table__.columns}
-                    # アノテーション情報を追加
-                    metadata.update(self._format_annotations_for_metadata(img))
-                    metadata_list.append(metadata)
-
-                logger.debug(f"画像メタデータを取得: {len(metadata_list)}件")
-                return metadata_list
-            except SQLAlchemyError as e:
-                logger.error(f"画像メタデータの取得中にエラーが発生しました: {e}", exc_info=True)
-                raise
+        """``_ImageRepositoryNew.get_images_by_ids`` への delegate (ADR 0035 段階 4)。"""
+        return self._image_repo.get_images_by_ids(image_ids=image_ids)
 
     def get_error_records(
         self,
@@ -3237,202 +1719,34 @@ class ImageRepository:
         return self.session_factory()
 
     def get_image_id_by_filepath(self, filepath: str) -> int | None:
-        """ファイルパスから画像IDを取得
-
-        Args:
-            filepath: 画像ファイルの絶対パスまたは相対パス
-
-        Returns:
-            int | None: 画像ID（見つからない場合は None）
-
-        """
-        with self.session_factory() as session:
-            try:
-                from pathlib import Path
-
-                from ..database.db_core import resolve_stored_path
-
-                input_path = Path(filepath).resolve()
-                filename = input_path.name
-
-                # filenameで候補を検索
-                stmt = select(Image).where(Image.filename == filename)
-                results = session.execute(stmt).scalars().all()
-
-                # 候補が見つかった場合、stored_image_pathを正規化して比較
-                for image in results:
-                    resolved_stored_path = resolve_stored_path(image.stored_image_path)
-                    if resolved_stored_path.resolve() == input_path:
-                        return image.id
-
-                return None
-
-            except Exception as e:
-                logger.error(f"ファイルパスからの画像ID取得エラー: {filepath}, {e}")
-                return None
+        """``_ImageRepositoryNew.get_image_id_by_filepath`` への delegate (ADR 0035 段階 4)。"""
+        return self._image_repo.get_image_id_by_filepath(filepath=filepath)
 
     @staticmethod
     def _normalize_input_paths(filepaths: list[str]) -> tuple[dict[str, Path], set[str]]:
-        """入力 path リストを resolve した dict と filename set に変換する helper。
-
-        Args:
-            filepaths: 解決対象の path リスト。
-
-        Returns:
-            (input_path -> resolved Path の dict, filename set)。
-            resolve できなかった path は元 Path object のまま dict に入れ、
-            filename set には含めない (DB 検索対象から除外)。
-        """
-        path_resolved: dict[str, Path] = {}
-        filenames: set[str] = set()
-        for raw in filepaths:
-            try:
-                resolved = Path(raw).resolve()
-            except (OSError, RuntimeError, ValueError):
-                path_resolved[raw] = Path(raw)
-                continue
-            path_resolved[raw] = resolved
-            filenames.add(resolved.name)
-        return path_resolved, filenames
+        """``_ImageRepositoryNew._normalize_input_paths`` への delegate (ADR 0035 段階 4)。"""
+        return _ImageRepositoryNew._normalize_input_paths(filepaths=filepaths)
 
     def _build_candidates_by_filename(
         self, candidates: list[Image]
     ) -> dict[str, list[tuple[Path, int, str]]]:
-        """candidates を filename をキーとする dict に集約する helper。
-
-        ADR 0023 Phase 1.5 (Codex P2 r3209511028): row-level resolve guard 経由で
-        corrupted 行は skip し、健全な行のみ集約する。
-
-        Args:
-            candidates: filename IN 句で取得した Image ORM 行のリスト。
-
-        Returns:
-            filename -> [(resolved_abs Path, image_id, phash), ...] の dict。
-            同じ filename で複数 image (別ディレクトリ) があり得るため list 値。
-        """
-        by_filename: dict[str, list[tuple[Path, int, str]]] = {}
-        for img in candidates:
-            if img.filename is None:
-                continue
-            resolved_abs = self._safe_resolve_stored_path(img.id, img.stored_image_path)
-            if resolved_abs is None:
-                continue
-            by_filename.setdefault(img.filename, []).append((resolved_abs, img.id, img.phash))
-        return by_filename
+        """``_ImageRepositoryNew._build_candidates_by_filename`` への delegate (ADR 0035 段階 4)。"""
+        return self._image_repo._build_candidates_by_filename(candidates=candidates)
 
     @staticmethod
     def _safe_resolve_stored_path(image_id: int, stored_image_path: str) -> Path | None:
-        """`stored_image_path` を絶対 Path に解決する row-level guard 付き helper。
-
-        ADR 0023 Phase 1.5 (Codex P2 r3209511028): 1 行の corrupted path
-        (シンボリックループ / 解決不能 path 等) で batch 全体を落とさないため、
-        row-level で例外を吸収する。失敗時は warning + None を返す。
-
-        Args:
-            image_id: 対象画像 ID (logging 用)。
-            stored_image_path: DB に保存された生 path。
-
-        Returns:
-            解決済みの絶対 Path、または resolve 失敗時 None。
-        """
-        from ..database.db_core import resolve_stored_path
-
-        try:
-            resolved_stored = resolve_stored_path(stored_image_path)
-            return resolved_stored.resolve()
-        except (OSError, ValueError, RuntimeError) as exc:
-            logger.warning(
-                f"バッチ画像 ID 解決: stored_image_path resolve 失敗を skip: "
-                f"image_id={image_id}, path={stored_image_path!r}, error={exc}"
-            )
-            return None
+        """``_ImageRepositoryNew._safe_resolve_stored_path`` への delegate (ADR 0035 段階 4)。"""
+        return _ImageRepositoryNew._safe_resolve_stored_path(
+            image_id=image_id, stored_image_path=stored_image_path
+        )
 
     def get_image_ids_by_filepaths(self, filepaths: list[str]) -> dict[str, int | None]:
-        """複数のファイルパスから画像 ID をバッチ解決する。
-
-        ADR 0023 Phase 1.5 (Issue #42, Codex P2 r3209342204): N+1 クエリ回避。
-        `get_image_id_by_filepath()` を N 回呼ぶ代わりに、filename を IN 句で
-        一括取得して input path と stored_image_path の resolve 比較を Python 側
-        で行う。GUI スレッドや Worker 内のループ内で大量パスを引く場合に使用。
-
-        Args:
-            filepaths: 解決対象の画像 path リスト (絶対 / 相対パス混在可)。
-
-        Returns:
-            dict[str, int | None]: 入力 path をキーに、対応する image_id (見つから
-                なければ None) を値とする辞書。入力 path はそのまま辞書キーとして
-                使われる (caller が input list との対応を辿りやすくするため)。
-        """
-        if not filepaths:
-            return {}
-
-        path_resolved, filenames = self._normalize_input_paths(filepaths)
-        result: dict[str, int | None] = dict.fromkeys(filepaths)
-
-        if not filenames:
-            return result
-
-        with self.session_factory() as session:
-            try:
-                # filename IN (...) で 1 クエリ取得 (重複 filename もまとめて)
-                stmt = select(Image).where(Image.filename.in_(filenames))
-                candidates = list(session.execute(stmt).scalars().all())
-                by_filename = self._build_candidates_by_filename(candidates)
-
-                # input path ごとに対応する image_id を resolve 比較で確定
-                for raw, resolved_input in path_resolved.items():
-                    matches = by_filename.get(resolved_input.name, [])
-                    for stored_resolved, image_id, _phash in matches:
-                        if stored_resolved == resolved_input:
-                            result[raw] = image_id
-                            break
-
-                logger.debug(
-                    f"バッチ画像 ID 解決: 入力 {len(filepaths)}件 → "
-                    f"解決 {sum(1 for v in result.values() if v is not None)}件"
-                )
-                return result
-            except Exception as e:
-                logger.error(f"バッチ画像 ID 解決エラー: {e}", exc_info=True)
-                return result
+        """``_ImageRepositoryNew.get_image_ids_by_filepaths`` への delegate (ADR 0035 段階 4)。"""
+        return self._image_repo.get_image_ids_by_filepaths(filepaths=filepaths)
 
     def get_phashes_by_filepaths(self, filepaths: list[str]) -> dict[str, str | None]:
-        """複数のファイルパスから pHash をバッチ解決する。
-
-        `get_image_ids_by_filepaths()` と同じ path resolve 規則で、登録済み画像の
-        pHash を input path 順に引けるようにする。未登録または resolve 不能な path
-        は None を返す。
-        """
-        if not filepaths:
-            return {}
-
-        path_resolved, filenames = self._normalize_input_paths(filepaths)
-        result: dict[str, str | None] = dict.fromkeys(filepaths)
-
-        if not filenames:
-            return result
-
-        with self.session_factory() as session:
-            try:
-                stmt = select(Image).where(Image.filename.in_(filenames))
-                candidates = list(session.execute(stmt).scalars().all())
-                by_filename = self._build_candidates_by_filename(candidates)
-
-                for raw, resolved_input in path_resolved.items():
-                    matches = by_filename.get(resolved_input.name, [])
-                    for stored_resolved, _image_id, phash in matches:
-                        if stored_resolved == resolved_input:
-                            result[raw] = phash
-                            break
-
-                logger.debug(
-                    f"バッチ pHash 解決: 入力 {len(filepaths)}件 → "
-                    f"解決 {sum(1 for v in result.values() if v is not None)}件"
-                )
-                return result
-            except Exception as e:
-                logger.error(f"バッチ pHash 解決エラー: {e}", exc_info=True)
-                return result
+        """``_ImageRepositoryNew.get_phashes_by_filepaths`` への delegate (ADR 0035 段階 4)。"""
+        return self._image_repo.get_phashes_by_filepaths(filepaths=filepaths)
 
     def update_rating_batch(
         self,

--- a/src/lorairo/database/repository/__init__.py
+++ b/src/lorairo/database/repository/__init__.py
@@ -6,17 +6,20 @@
 段階 1 (#423): `ModelRepository`
 段階 2 (#423): `ProjectRepository`
 段階 3 (#423): `ErrorRecordRepository`
-段階 4 以降: `ImageRepository`, `AnnotationRepository`
+段階 4 (#423): `ImageRepository`
+段階 5 (#423): `AnnotationRepository` (予定)
 """
 
 from .base import BaseRepository
 from .error_record import ErrorRecordRepository
+from .image import ImageRepository
 from .model import ModelRepository
 from .project import ProjectRepository
 
 __all__ = [
     "BaseRepository",
     "ErrorRecordRepository",
+    "ImageRepository",
     "ModelRepository",
     "ProjectRepository",
 ]

--- a/src/lorairo/database/repository/image.py
+++ b/src/lorairo/database/repository/image.py
@@ -1,0 +1,2116 @@
+"""Image / ProcessedImage / FilenameAlias 永続化担当 Repository (ADR 0035 §1)。
+
+`ImageRepository` god class 分割の段階 4 として、Image エンティティおよび
+関連する ProcessedImage / FilenameAlias の CRUD・検索・フィルタ・メタデータ取得を
+本 Repository に集約する。
+
+管轄 entity:
+  - `Image` (CRUD、pHash 重複検出、フィルタリング検索)
+  - `ProcessedImage` (CRUD、解像度別 lookup、batch resolution map)
+  - `ImageFilenameAlias` (重複スキップ画像の filename alias)
+
+カバー領域:
+  - 画像 CRUD: 登録 / 存在チェック / Processed 画像追加
+  - 検索: pHash 一致 / annotated 画像 ID / filename index
+  - メタデータ取得: 単体 / バッチ / 解像度別 (annotation 読み込み込み)
+  - フィルタリング: タグ / キャプション / 評価 / NSFW / スコア / 日付 / project
+  - File path 解決: 単体 / batch (N+1 回避)
+
+段階 5 領域 (本 Repository には含めない):
+  - Annotation 書き込み (`save_annotations`, `_save_*`, `update_*_batch`)
+  - Tag DB 統合 (`MergedTagReader` / `TagRegisterService`)
+  - genai-tag-db-tools 連携 (`batch_resolve_tag_ids`, `_register_*`)
+
+段階 1 で確立した `BaseRepository` (`session_factory` + `BATCH_CHUNK_SIZE`) を継承する。
+"""
+
+from __future__ import annotations
+
+import datetime
+from pathlib import Path
+from typing import Any
+
+from sqlalchemy import (
+    Select,
+    and_,
+    exists,
+    func,
+    not_,
+    or_,
+    select,
+)
+from sqlalchemy.exc import IntegrityError, SQLAlchemyError
+from sqlalchemy.orm import Session, joinedload, selectinload
+
+from ...domain.quality_tier import compute_quality_summary
+from ...utils.log import logger
+from ..filter_criteria import ImageFilterCriteria
+from ..schema import (
+    MANUAL_EDIT_LITELLM_ID,
+    MANUAL_EDIT_NAME,
+    Caption,
+    Image,
+    ImageFilenameAlias,
+    Model,
+    ProcessedImage,
+    Project,
+    Rating,
+    Score,
+    ScoreLabel,
+    Tag,
+)
+from .base import BaseRepository
+from .model import ModelRepository
+
+
+class ImageRepository(BaseRepository):
+    """Image / ProcessedImage / FilenameAlias の永続化を担当する Repository (ADR 0035 §1)。
+
+    管轄 entity:
+      - `Image` (CRUD・検索・フィルタ・メタデータ)
+      - `ProcessedImage` (CRUD・解像度別 lookup)
+      - `ImageFilenameAlias` (filename alias)
+    """
+
+    # --- Filename Alias ---
+
+    def get_all_image_filename_index(self) -> dict[str, int]:
+        """全画像のfilename stem → image_id インデックスを構築する。
+
+        バッチインポート時のcustom_id照合用。N+1クエリを回避するため
+        1回のクエリで全画像のファイル名とIDを取得する。
+
+        Returns:
+            {filename_stem: image_id} の辞書。重複stem時は最新IDを優先。
+
+        Raises:
+            SQLAlchemyError: データベース操作でエラーが発生した場合。
+        """
+        with self.session_factory() as session:
+            try:
+                stmt = select(Image.id, Image.filename).where(Image.filename.isnot(None))
+                results = session.execute(stmt).all()
+                index: dict[str, int] = {}
+                for image_id, filename in results:
+                    stem = Path(filename).stem
+                    index[stem] = image_id
+
+                # エイリアス（重複スキップされた画像のファイル名）もインデックスに追加
+                alias_stmt = select(ImageFilenameAlias.image_id, ImageFilenameAlias.stem)
+                alias_results = session.execute(alias_stmt).all()
+                for image_id, stem in alias_results:
+                    if stem not in index:
+                        index[stem] = image_id
+
+                return index
+            except SQLAlchemyError as e:
+                logger.error(f"ファイル名インデックス構築エラー: {e}", exc_info=True)
+                raise
+
+    def add_filename_alias(self, image_id: int, stem: str) -> None:
+        """重複スキップされた画像のファイル名エイリアスを登録する。
+
+        Args:
+            image_id: 重複元の画像ID。
+            stem: スキップされた画像のファイル名stem。
+
+        Raises:
+            SQLAlchemyError: データベース操作でエラーが発生した場合。
+        """
+        with self.session_factory() as session:
+            try:
+                alias = ImageFilenameAlias(image_id=image_id, stem=stem)
+                session.add(alias)
+                session.commit()
+                logger.debug(f"ファイル名エイリアス登録: {stem} → image_id={image_id}")
+            except IntegrityError:
+                session.rollback()
+                logger.debug(f"エイリアス既存のためスキップ: {stem}")
+            except SQLAlchemyError as e:
+                session.rollback()
+                logger.error(f"エイリアス登録エラー: {e}", exc_info=True)
+                raise
+
+    # --- Image CRUD ---
+
+    def _image_exists(self, image_id: int) -> bool:
+        """指定された画像IDが images テーブルに存在するかを確認します。
+
+        Args:
+            image_id (int): 確認する画像のID。
+
+        Returns:
+            bool: 画像が存在する場合はTrue、存在しない場合はFalse。
+
+        """
+        with self.session_factory() as session:
+            try:
+                stmt = select(Image.id).where(Image.id == image_id)
+                # exists() など、より効率的な方法も検討できるが、まずはシンプルに
+                result = session.execute(stmt).scalar_one_or_none()
+                return result is not None
+            except SQLAlchemyError as e:
+                logger.error(
+                    f"画像存在チェック中にエラーが発生しました (ID: {image_id}): {e}",
+                    exc_info=True,
+                )
+                raise
+
+    def find_duplicate_image_by_phash(self, phash: str) -> int | None:
+        """指定されたpHashに一致する画像をデータベースから検索し、Image IDを返します。
+        pHashはNULL不可のため、完全一致で検索します。
+
+        Args:
+            phash (str): 検索するpHash。
+
+        Returns:
+            int | None: 重複する画像のID。見つからない場合はNone。
+
+        """
+        if not phash:  # pHashが空文字列やNoneの場合は検索しない
+            return None
+        with self.session_factory() as session:
+            try:
+                # ID を返す必要があるので、ID を SELECT するように修正
+                stmt_id = select(Image.id).where(Image.phash == phash).limit(1)
+                image_id = session.execute(stmt_id).scalar_one_or_none()
+                if image_id:
+                    logger.debug(f"pHashによる重複画像が見つかりました: ID {image_id}, pHash {phash}")
+                return image_id
+            except SQLAlchemyError as e:
+                logger.error(f"pHashによる重複画像の検索中にエラーが発生しました: {e}", exc_info=True)
+                raise
+
+    def find_image_ids_by_phashes(self, phashes: set[str]) -> dict[str, int]:
+        """複数pHashに対応する画像IDを一括取得する。
+
+        BATCH_CHUNK_SIZE を超える場合はチャンク分割してクエリを実行する。
+
+        Args:
+            phashes: 検索するpHashのセット。
+
+        Returns:
+            pHash → image_id のマッピング。見つからなかったpHashは含まれない。
+
+        Raises:
+            SQLAlchemyError: データベース操作でエラーが発生した場合。
+
+        """
+        if not phashes:
+            return {}
+
+        phash_list = list(phashes)
+
+        with self.session_factory() as session:
+            try:
+                phash_to_id: dict[str, int] = {}
+                for i in range(0, len(phash_list), self.BATCH_CHUNK_SIZE):
+                    chunk = phash_list[i : i + self.BATCH_CHUNK_SIZE]
+                    stmt = select(Image.phash, Image.id).where(Image.phash.in_(chunk))
+                    results = session.execute(stmt).all()
+                    phash_to_id.update({row.phash: row.id for row in results})
+                logger.debug(f"pHash一括検索: {len(phash_to_id)}/{len(phashes)}件見つかりました")
+                return phash_to_id
+            except SQLAlchemyError as e:
+                logger.error(f"pHash一括検索中にエラー: {e}", exc_info=True)
+                raise
+
+    def get_annotated_image_ids(self, image_ids: list[int]) -> set[int]:
+        """指定IDリストからアノテーション済み画像IDを一括取得する。
+
+        タグまたはキャプションが存在する画像IDのセットを返す。
+        BATCH_CHUNK_SIZE を超える場合はチャンク分割してクエリを実行する。
+
+        Args:
+            image_ids: 検査対象の画像IDリスト。
+
+        Returns:
+            アノテーションが存在する画像IDのセット。
+
+        Raises:
+            SQLAlchemyError: データベース操作でエラーが発生した場合。
+
+        """
+        if not image_ids:
+            return set()
+
+        with self.session_factory() as session:
+            try:
+                annotated_ids: set[int] = set()
+                for i in range(0, len(image_ids), self.BATCH_CHUNK_SIZE):
+                    chunk = image_ids[i : i + self.BATCH_CHUNK_SIZE]
+                    # EXISTS サブクエリでタグまたはキャプションの存在を判定
+                    stmt = (
+                        select(Image.id)
+                        .where(Image.id.in_(chunk))
+                        .where(
+                            or_(
+                                exists().where(Tag.image_id == Image.id),
+                                exists().where(Caption.image_id == Image.id),
+                            ),
+                        )
+                    )
+                    result = session.execute(stmt).scalars().all()
+                    annotated_ids.update(result)
+                logger.debug(
+                    f"アノテーション存在一括チェック: "
+                    f"{len(annotated_ids)}/{len(image_ids)}件にアノテーションあり",
+                )
+                return annotated_ids
+            except SQLAlchemyError as e:
+                logger.error(
+                    f"アノテーション存在一括チェック中にエラー: {e}",
+                    exc_info=True,
+                )
+                raise
+
+    def add_original_image(self, info: dict[str, Any]) -> int:
+        """オリジナル画像のメタデータを images テーブルに追加します。
+        pHashによる重複チェックを行い、重複がある場合は既存IDを返します。
+        pHash計算失敗時は例外を送出します。
+
+        Args:
+            info (dict[str, Any]): 画像情報を含む辞書。
+                                   `calculate_phash` が成功した前提で `phash` キーも含まれる想定。
+                                   以下のキーが必須: uuid, phash, original_image_path,
+                                   stored_image_path, width, height, format, extension。
+                                   その他は Optional。
+
+        Returns:
+            int: 挿入された画像のID、または重複していた既存画像のID。
+
+        Raises:
+            ValueError: 必須情報が不足している場合、またはpHash計算済みでない場合。
+            SQLAlchemyError: データベース操作でエラーが発生した場合。
+
+        """
+        required_keys = {
+            "uuid",
+            "phash",
+            "original_image_path",
+            "stored_image_path",
+            "width",
+            "height",
+            "format",
+            "extension",
+        }
+        if not required_keys.issubset(info.keys()):
+            missing_keys = required_keys - info.keys()
+            raise ValueError(f"必須情報が不足しています: {', '.join(missing_keys)}")
+
+        phash = info["phash"]
+
+        # pHashで重複チェック
+        existing_id = self.find_duplicate_image_by_phash(phash)
+        if existing_id is not None:
+            logger.warning(f"pHashが一致する画像が既に存在します: ID {existing_id} (pHash: {phash})")
+            return existing_id
+
+        # 新しい Image オブジェクトを作成
+        new_image = Image(
+            uuid=info["uuid"],
+            phash=phash,
+            original_image_path=str(info["original_image_path"]),  # Pathオブジェクトを文字列に
+            stored_image_path=str(info["stored_image_path"]),  # Pathオブジェクトを文字列に
+            width=info["width"],
+            height=info["height"],
+            format=info["format"],
+            mode=info.get("mode"),
+            has_alpha=info.get("has_alpha"),
+            filename=info.get("filename"),
+            extension=info["extension"],
+            color_space=info.get("color_space"),
+            icc_profile=info.get("icc_profile"),
+            project_id=info.get("project_id"),
+            # created_at, updated_at は server_default で設定される
+        )
+
+        with self.session_factory() as session:
+            try:
+                session.add(new_image)
+                session.flush()  # ID を取得するために flush
+                image_id = new_image.id
+                session.commit()  # コミットは flush 後でもOK
+                logger.debug(f"オリジナル画像をDBに追加しました: ID={image_id}, UUID={new_image.uuid}")
+                return image_id
+            except IntegrityError as e:
+                # uuid の UNIQUE 制約違反など
+                session.rollback()
+                logger.error(f"オリジナル画像の追加中に整合性エラーが発生しました: {e}", exc_info=True)
+                # uuid重複の場合、既存IDを探して返すか、あるいは単にエラーとするか?
+                # ここではエラーを再発生させる
+                raise
+            except SQLAlchemyError as e:
+                session.rollback()
+                logger.error(
+                    f"オリジナル画像の追加中にデータベースエラーが発生しました: {e}",
+                    exc_info=True,
+                )
+                raise
+
+    def _find_existing_processed_image_id(
+        self,
+        image_id: int,
+        width: int,
+        height: int,
+        filename: str | None,
+    ) -> int | None:
+        """指定された条件に一致する既存の processed_image の ID を検索します。
+        add_processed_image で IntegrityError が発生した場合に使用します。
+
+        Args:
+            image_id (int): 元画像の ID。
+            width (int): 幅。
+            height (int): 高さ。
+            filename (Optional[str]): ファイル名。
+
+        Returns:
+            Optional[int]: 既存レコードの ID。見つからない場合は None。
+
+        """
+        with self.session_factory() as session:
+            try:
+                stmt = select(ProcessedImage.id).where(
+                    ProcessedImage.image_id == image_id,
+                    ProcessedImage.width == width,
+                    ProcessedImage.height == height,
+                    # filename が None の場合も考慮して比較
+                    (ProcessedImage.filename == filename)
+                    if filename is not None
+                    else (ProcessedImage.filename.is_(None)),
+                )
+                existing_id = session.execute(stmt).scalar_one_or_none()
+                return existing_id
+            except SQLAlchemyError as e:
+                logger.error(f"既存の処理済み画像ID検索中にエラー: {e}", exc_info=True)
+                # この検索自体が失敗した場合は None を返すか、エラーを再発生させるか検討
+                return None  # ここでは None を返す
+
+    def add_processed_image(self, info: dict[str, Any]) -> int | None:
+        """処理済み画像のメタデータを processed_images テーブルに追加します。
+        重複する場合は既存の ID を返します。
+
+        Args:
+            info (dict[str, Any]): 処理済み画像情報を含む辞書。
+                                   必須キー: image_id, stored_image_path, width, height, has_alpha。
+                                   その他は Optional。
+
+        Returns:
+            int | None: 挿入された処理済み画像のID、または重複していた既存画像のID。
+                        検索に失敗した場合は None を返す可能性あり。
+
+        Raises:
+            ValueError: 必須情報が不足している場合、または関連する Image が存在しない場合。
+            SQLAlchemyError: 予期せぬデータベース操作でエラーが発生した場合 (IntegrityError 以外)。
+
+        """
+        required_keys = {"image_id", "stored_image_path", "width", "height", "has_alpha"}
+        if not required_keys.issubset(info.keys()):
+            missing_keys = required_keys - info.keys()
+            raise ValueError(f"必須情報が不足しています: {', '.join(missing_keys)}")
+
+        image_id = info["image_id"]
+        width = info["width"]
+        height = info["height"]
+        filename = info.get("filename")  # filename は Optional
+
+        # 関連する Image レコードが存在するか確認 (FK制約のため)
+        if not self._image_exists(image_id):
+            raise ValueError(f"関連するオリジナル画像が見つかりません: image_id={image_id}")
+
+        # 新しい ProcessedImage オブジェクトを作成
+        new_processed_image = ProcessedImage(
+            image_id=image_id,
+            stored_image_path=str(info["stored_image_path"]),  # Pathオブジェクトを文字列に
+            width=width,
+            height=height,
+            mode=info.get("mode"),
+            has_alpha=info["has_alpha"],
+            filename=filename,
+            color_space=info.get("color_space"),
+            icc_profile=info.get("icc_profile"),
+            upscaler_used=info.get("upscaler_used"),  # アップスケーラー情報を追加
+            # created_at, updated_at は server_default で設定される
+        )
+
+        with self.session_factory() as session:
+            try:
+                session.add(new_processed_image)
+                session.flush()  # ID を取得するために flush
+                processed_image_id = new_processed_image.id
+                session.commit()
+                logger.debug(
+                    f"処理済み画像をDBに追加しました: ID={processed_image_id}, 親画像ID={image_id}",
+                )
+                return processed_image_id
+            except IntegrityError:
+                # UNIQUE 制約違反 (image_id, width, height, filename)
+                session.rollback()
+                logger.warning(
+                    f"処理済み画像の追加中に整合性エラーが発生しました。"
+                    f" (おそらく重複: image_id={image_id}, width={width}, height={height}, filename={filename})."
+                    f" 既存のIDを検索します。",
+                )
+                # 既存のIDを検索して返す
+                existing_id = self._find_existing_processed_image_id(image_id, width, height, filename)
+                if existing_id:
+                    logger.debug(f"既存の処理済み画像IDが見つかりました: {existing_id}")
+                else:
+                    # 通常ここには来ないはずだが、もし検索でも見つからなければ警告
+                    logger.error(
+                        f"整合性エラー後、既存の処理済み画像が見つかりませんでした。"
+                        f" 条件: image_id={image_id}, width={width}, height={height}, filename={filename}",
+                    )
+                return existing_id  # None の可能性もある
+            except SQLAlchemyError as e:
+                session.rollback()
+                logger.error(
+                    f"処理済み画像の追加中に予期せぬデータベースエラーが発生しました: {e}",
+                    exc_info=True,
+                )
+                raise  # IntegrityError 以外の DB エラーは再発生させる
+
+    # --- Metadata ---
+
+    def get_image_metadata(self, image_id: int) -> dict[str, Any] | None:
+        """指定されたIDのオリジナル画像メタデータを辞書形式で取得します。
+
+        Args:
+            image_id (int): 取得する画像のID。
+
+        Returns:
+            Optional[dict[str, Any]]: 画像メタデータを含む辞書。画像が見つからない場合はNone。
+                - rating_value: 最新のRating値（ratingsテーブルから取得）
+                - score_value: 最新のScore値（scoresテーブルから取得）
+
+        Raises:
+            SQLAlchemyError: データベース操作でエラーが発生した場合。
+
+        """
+        with self.session_factory() as session:
+            try:
+                # 主キー検索には session.get が効率的
+                # relationshipをeager loadingで取得（ratings, scores）
+                stmt = (
+                    select(Image)
+                    .where(Image.id == image_id)
+                    .options(
+                        selectinload(Image.ratings).selectinload(Rating.model),
+                        selectinload(Image.scores),
+                    )
+                )
+                image: Image | None = session.execute(stmt).scalar_one_or_none()
+
+                if image is None:
+                    logger.warning(f"画像メタデータが見つかりません: image_id={image_id}")
+                    return None
+
+                # SQLAlchemy オブジェクトを辞書に変換
+                metadata = {c.name: getattr(image, c.name) for c in image.__table__.columns}
+
+                # Rating/Score情報を整形して追加（Issue #4対応）
+                annotations = self._format_annotations_for_metadata(image)
+                metadata.update(annotations)
+
+                logger.debug(f"画像メタデータを取得しました: image_id={image_id}")
+                return metadata
+
+            except SQLAlchemyError as e:
+                logger.error(
+                    f"画像メタデータの取得中にエラーが発生しました (ID: {image_id}): {e}",
+                    exc_info=True,
+                )
+                raise
+
+    def get_images_metadata_batch(self, image_ids: list[int]) -> list[dict[str, Any]]:
+        """指定された複数IDのオリジナル画像メタデータを一括取得する。
+
+        内部的に _fetch_filtered_metadata() を使用し、joinedloadで取得する。
+        BATCH_CHUNK_SIZE を超える場合はチャンク分割してクエリを実行する。
+
+        Args:
+            image_ids: 取得する画像IDのリスト。
+
+        Returns:
+            画像メタデータ辞書のリスト。見つからなかったIDは結果に含まれない。
+
+        Raises:
+            SQLAlchemyError: データベース操作でエラーが発生した場合。
+
+        """
+        if not image_ids:
+            return []
+
+        with self.session_factory() as session:
+            try:
+                # チャンク分割でSQLiteバインド変数上限を回避
+                result: list[dict[str, Any]] = []
+                for i in range(0, len(image_ids), self.BATCH_CHUNK_SIZE):
+                    chunk = image_ids[i : i + self.BATCH_CHUNK_SIZE]
+                    result.extend(self._fetch_filtered_metadata(session, chunk, resolution=0))
+                return result
+            except SQLAlchemyError as e:
+                logger.error(
+                    f"画像メタデータの一括取得中にエラーが発生しました: {e}",
+                    exc_info=True,
+                )
+                raise
+
+    def get_batch_available_resolutions(self, image_ids: list[int]) -> dict[int, list[int]]:
+        """複数画像の利用可能な処理済み解像度を一括取得する。
+
+        1クエリで全 ProcessedImage を取得し、Python側で解像度マッピングを構築する。
+        N+1ループ（image_id × resolution の組み合わせ）の代替として使用する。
+
+        Args:
+            image_ids: 画像IDリスト
+
+        Returns:
+            image_id -> 利用可能な解像度リスト のマッピング。
+            ProcessedImage が存在しない image_id は空リストになる。
+
+        Raises:
+            SQLAlchemyError: データベース操作でエラーが発生した場合。
+
+        """
+        if not image_ids:
+            return {}
+
+        by_image: dict[int, list[dict[str, Any]]] = {image_id: [] for image_id in image_ids}
+        with self.session_factory() as session:
+            for i in range(0, len(image_ids), self.BATCH_CHUNK_SIZE):
+                chunk = image_ids[i : i + self.BATCH_CHUNK_SIZE]
+                rows = (
+                    session.execute(select(ProcessedImage).where(ProcessedImage.image_id.in_(chunk)))
+                    .scalars()
+                    .all()
+                )
+                for row in rows:
+                    metadata = {c.name: getattr(row, c.name) for c in row.__table__.columns}
+                    if row.image_id in by_image:
+                        by_image[row.image_id].append(metadata)
+
+        target_resolutions = [512, 768, 1024, 1536]
+        return {
+            image_id: [
+                target
+                for target in target_resolutions
+                if self._filter_by_resolution(by_image[image_id], target) is not None
+            ]
+            for image_id in image_ids
+        }
+
+    def get_processed_image(
+        self,
+        image_id: int,
+        resolution: int = 0,
+        all_data: bool = False,
+    ) -> dict[str, Any] | list[dict[str, Any]] | None:  # 戻り値の型を調整
+        """指定された image_id に関連する処理済み画像のメタデータを取得します。
+        resolution に基づいてフィルタリングするか、all_data=True で全て取得します。
+
+        Args:
+            image_id (int): 元画像のID。
+            resolution (int): フィルタリングの基準となる解像度 (長辺)。
+                              0 の場合は最も解像度が低いものを返します。
+            all_data (bool): True の場合はフィルタリングせず、関連する全ての
+                             処理済み画像メタデータをリストで返します。
+
+        Returns:
+            Optional[Union[dict[str, Any], list[dict[str, Any]]]]:
+                - all_data=True: 処理済み画像メタデータの辞書のリスト。見つからない場合は空リスト。
+                - all_data=False: 条件に一致した処理済み画像メタデータの辞書。見つからない場合は None。
+
+        Raises:
+            SQLAlchemyError: データベース操作でエラーが発生した場合。
+
+        """
+        with self.session_factory() as session:
+            try:
+                # image_id に紐づく全ての処理済み画像を取得
+                stmt = select(ProcessedImage).where(ProcessedImage.image_id == image_id)
+                results: list[ProcessedImage] = list(session.execute(stmt).scalars().all())
+
+                if not results:
+                    logger.warning(f"処理済み画像が見つかりません: image_id={image_id}")
+                    return [] if all_data else None
+
+                # モデルオブジェクトを辞書のリストに変換
+                metadata_list = [
+                    {c.name: getattr(img, c.name) for c in img.__table__.columns} for img in results
+                ]
+
+                if all_data:
+                    logger.debug(
+                        f"全 {len(metadata_list)} 件の処理済み画像メタデータを取得しました: image_id={image_id}",
+                    )
+                    return metadata_list
+
+                # 解像度に基づいてフィルタリング
+                selected_metadata: dict[str, Any] | None = None
+                if resolution == 0:
+                    # 最も解像度が低いもの (面積で比較)
+                    selected_metadata = min(metadata_list, key=lambda x: x["width"] * x["height"])
+                    logger.debug(
+                        f"最低解像度の処理済み画像を選択しました: image_id={image_id}, id={selected_metadata['id']}",
+                    )
+                else:
+                    # 指定解像度に最も近いものを選択
+                    selected_metadata = self._filter_by_resolution(metadata_list, resolution)
+
+                # all_data=False の場合、ここで選択されたメタデータ (またはNone) を返す
+                if not all_data:
+                    if selected_metadata:
+                        logger.debug(
+                            f"解像度 {resolution} に一致する処理済み画像を選択しました: image_id={image_id}, id={selected_metadata.get('id')}",
+                        )
+                    else:
+                        logger.warning(
+                            f"解像度 {resolution} に一致する処理済み画像が見つかりませんでした: image_id={image_id}",
+                        )
+                    return selected_metadata
+
+            except SQLAlchemyError as e:
+                logger.error(
+                    f"処理済み画像の取得中にエラーが発生しました (ID: {image_id}): {e}",
+                    exc_info=True,
+                )
+                raise
+
+    def _filter_by_resolution(
+        self,
+        metadata_list: list[dict[str, Any]],
+        resolution: int,
+    ) -> dict[str, Any] | None:
+        """解像度に基づいてメタデータをフィルタリングします。
+        指定された解像度に最も近いもの (面積比で許容誤差20%以内) を返します。
+
+        Args:
+            metadata_list (list[dict[str, Any]]): ProcessedImageのメタデータの辞書のリスト。
+            resolution (int): 目標解像度 (長辺)。
+
+        Returns:
+            dict[str, Any] | None: フィルタリングされたメタデータの辞書。見つからない場合はNone。
+
+        """
+        # 型安全性チェック: resolution が文字列の場合は int に変換
+        if isinstance(resolution, str):
+            try:
+                resolution = int(resolution)
+                logger.warning(
+                    f"解像度パラメータが文字列として渡されました: '{resolution}' -> {resolution}",
+                )
+            except ValueError:
+                logger.error(f"解像度パラメータの変換に失敗しました: '{resolution}'")
+                return None
+
+        best_match: dict[str, Any] | None = None
+        min_error_ratio = float("inf")
+
+        target_area = resolution * resolution  # Target area based on square of the long side
+
+        for metadata in metadata_list:
+            width = metadata.get("width", 0)
+            height = metadata.get("height", 0)
+            if not width or not height:
+                continue
+
+            # 1. Check for exact match on the longer side
+            long_side = max(width, height)
+            if long_side == resolution:
+                logger.debug(f"Exact resolution match found: {metadata['id']}")
+                return metadata  # Exact match found, return immediately
+
+            # 2. Calculate area ratio difference if no exact match yet
+            short_side = min(width, height)
+            actual_area = long_side * short_side
+
+            # Avoid division by zero if target_area is 0 (resolution is 0)
+            # Though resolution=0 should be handled before calling this function
+            if target_area == 0:
+                error_ratio = float("inf")  # Or handle as a special case if needed
+            else:
+                error_ratio = abs(target_area - actual_area) / target_area
+
+            # Check if within 20% tolerance and better than the current best match
+            if error_ratio <= 0.2 and error_ratio < min_error_ratio:
+                min_error_ratio = error_ratio
+                best_match = metadata
+
+        if best_match:
+            logger.debug(
+                f"Closest resolution match found (error: {min_error_ratio:.2f}): {best_match['id']}",
+            )
+        else:
+            logger.debug(f"No suitable processed image found for resolution {resolution}")
+
+        return best_match  # Return the best match found within tolerance, or None
+
+    # --- Annotation Read Helpers (single image, per-item formatters) ---
+
+    @staticmethod
+    def _format_tag_annotation(tag: Any) -> dict[str, Any]:
+        """タグアノテーションをdict形式にフォーマットする。
+
+        Args:
+            tag: タグORMオブジェクト。
+
+        Returns:
+            フォーマット済み辞書。
+
+        """
+        return {
+            "id": tag.id,
+            "tag": tag.tag,
+            "tag_id": tag.tag_id,
+            "model_id": tag.model_id,
+            "existing": tag.existing,
+            "is_edited_manually": tag.is_edited_manually,
+            "confidence_score": tag.confidence_score,
+            "created_at": tag.created_at,
+            "updated_at": tag.updated_at,
+        }
+
+    @staticmethod
+    def _format_caption_annotation(caption: Any) -> dict[str, Any]:
+        """キャプションアノテーションをdict形式にフォーマットする。
+
+        Args:
+            caption: キャプションORMオブジェクト。
+
+        Returns:
+            フォーマット済み辞書。
+
+        """
+        return {
+            "id": caption.id,
+            "caption": caption.caption,
+            "model_id": caption.model_id,
+            "existing": caption.existing,
+            "is_edited_manually": caption.is_edited_manually,
+            "created_at": caption.created_at,
+            "updated_at": caption.updated_at,
+        }
+
+    @staticmethod
+    def _format_score_annotation(score: Any) -> dict[str, Any]:
+        """スコアアノテーションをdict形式にフォーマットする。
+
+        Args:
+            score: スコアORMオブジェクト。
+
+        Returns:
+            フォーマット済み辞書。
+
+        """
+        return {
+            "id": score.id,
+            "score": score.score,
+            "model_id": score.model_id,
+            "is_edited_manually": score.is_edited_manually,
+            "created_at": score.created_at,
+            "updated_at": score.updated_at,
+        }
+
+    @staticmethod
+    def _format_rating_annotation(rating: Any) -> dict[str, Any]:
+        """レーティングアノテーションをdict形式にフォーマットする。
+
+        Args:
+            rating: レーティングORMオブジェクト。
+
+        Returns:
+            フォーマット済み辞書。
+
+        """
+        model_name = rating.model.name if rating.model else "Unknown"
+        litellm_model_id = rating.model.litellm_model_id if rating.model else None
+        is_manual = litellm_model_id == MANUAL_EDIT_LITELLM_ID or model_name == MANUAL_EDIT_NAME
+        return {
+            "id": rating.id,
+            "raw_rating_value": rating.raw_rating_value,
+            "normalized_rating": rating.normalized_rating,
+            "model_id": rating.model_id,
+            "model": model_name,
+            "model_name": model_name,
+            "source": "Manual" if is_manual else "AI",
+            "confidence_score": rating.confidence_score,
+            "created_at": rating.created_at,
+            "updated_at": rating.updated_at,
+        }
+
+    @staticmethod
+    def _format_score_label_annotation(sl: Any) -> dict[str, Any]:
+        """スコアラベルアノテーション (ADR 0028) を dict 形式にフォーマットする。
+
+        ADR 0028 で「常に model 名と組で保持」と決定したため、他 per-item helper と
+        異なり ``model`` (model.name) を含める。``sl.model`` relationship が eager
+        load されている前提 (``joinedload(ScoreLabel.model)`` 等)。
+
+        Args:
+            sl: ScoreLabel ORM オブジェクト。
+
+        Returns:
+            フォーマット済み辞書 (model 含む)。
+        """
+        return {
+            "id": sl.id,
+            "label": sl.label,
+            "model_id": sl.model_id,
+            "model": sl.model.name if sl.model else "Unknown",
+            "is_edited_manually": sl.is_edited_manually,
+            "created_at": sl.created_at,
+            "updated_at": sl.updated_at,
+        }
+
+    def get_image_annotations(self, image_id: int) -> dict[str, Any]:
+        """指定された画像IDのアノテーション(タグ、キャプション、スコア、スコアラベル、レーティング)を取得する。
+
+        Eager Loadingを使用して関連データを効率的に取得する。
+
+        Args:
+            image_id: アノテーションを取得する画像のID。
+
+        Returns:
+            アノテーションデータを含む辞書。
+            キー: 'tags', 'captions', 'scores', 'score_labels', 'ratings',
+            'quality_summary' (ADR 0029、derived view)
+            画像が存在しない場合は空のリストを持つ辞書を返す。
+
+        Raises:
+            SQLAlchemyError: データベース操作でエラーが発生した場合。
+
+        """
+        logger.debug(f"Getting annotations for image_id: {image_id}")
+        annotations: dict[str, Any] = {
+            "tags": [],
+            "captions": [],
+            "scores": [],
+            "score_labels": [],
+            "ratings": [],
+            "quality_summary": {},
+        }
+
+        with self.session_factory() as session:
+            try:
+                stmt = (
+                    select(Image)
+                    .where(Image.id == image_id)
+                    .options(
+                        joinedload(Image.tags),
+                        joinedload(Image.captions),
+                        joinedload(Image.scores),
+                        # ADR 0028: score_labels は model 名と組で返すため
+                        # ScoreLabel.model も eager load する
+                        joinedload(Image.score_labels).joinedload(ScoreLabel.model),
+                        joinedload(Image.ratings).joinedload(Rating.model),
+                        joinedload(Image.processed_images),
+                    )
+                )
+                image = session.execute(stmt).unique().scalar_one_or_none()
+
+                if image is None:
+                    logger.warning(f"画像が見つかりません: image_id={image_id}")
+                    return annotations
+
+                if image.tags:
+                    annotations["tags"] = [self._format_tag_annotation(t) for t in image.tags]
+                if image.captions:
+                    annotations["captions"] = [self._format_caption_annotation(c) for c in image.captions]
+                if image.scores:
+                    annotations["scores"] = [self._format_score_annotation(s) for s in image.scores]
+                if image.score_labels:
+                    annotations["score_labels"] = [
+                        self._format_score_label_annotation(sl) for sl in image.score_labels
+                    ]
+                if image.ratings:
+                    annotations["ratings"] = [self._format_rating_annotation(r) for r in image.ratings]
+
+                # ADR 0029: derived view、永続化しない。raw annotation から毎回計算する。
+                annotations["quality_summary"] = compute_quality_summary(
+                    annotations["score_labels"], annotations["scores"]
+                )
+
+                logger.info(
+                    f"取得したアノテーション数: tags={len(annotations['tags'])}, "
+                    f"captions={len(annotations['captions'])}, scores={len(annotations['scores'])}, "
+                    f"score_labels={len(annotations['score_labels'])}, "
+                    f"ratings={len(annotations['ratings'])} for image_id={image_id}",
+                )
+                return annotations
+
+            except SQLAlchemyError as e:
+                logger.error(
+                    f"画像ID {image_id} のアノテーション取得中にエラーが発生しました: {e}",
+                    exc_info=True,
+                )
+                raise
+
+    # --- Filter Helpers ---
+
+    def _parse_datetime_str(self, date_str: str | None) -> datetime.datetime | None:
+        """日付文字列を UTC timezone-aware datetime オブジェクトに変換。
+
+        アプリケーション全体でUTC統一方針に従い、入力文字列をUTCとして解釈します。
+        データベースは TIMESTAMP(timezone=True) でUTC保存されているため、
+        フィルタリング時の比較もUTC基準で行います。
+
+        Args:
+            date_str: ISO 8601形式の日付文字列 (YYYY-MM-DDTHH:MM:SS or YYYY-MM-DD HH:MM:SS)
+
+        Returns:
+            datetime.datetime | None: UTC timezone-aware datetime オブジェクト、無効な場合は None
+
+        """
+        if not date_str:
+            return None
+        try:
+            # ISO 8601形式 (YYYY-MM-DDTHH:MM:SS or YYYY-MM-DD HH:MM:SS) を想定
+            # スペース区切りも考慮
+            date_str = date_str.replace(" ", "T")
+            # マイクロ秒以下を削除 (存在する場合)
+            if "." in date_str:
+                date_str = date_str.split(".")[0]
+
+            # naive datetime としてパースしてからUTCタイムゾーンを設定
+            # 入力文字列はUTC時刻として解釈する（アプリケーション統一方針）
+            parsed_dt = datetime.datetime.fromisoformat(date_str)
+
+            # タイムゾーン情報がない場合はUTCとして扱う
+            if parsed_dt.tzinfo is None:
+                from datetime import UTC
+
+                parsed_dt = parsed_dt.replace(tzinfo=UTC)
+
+            return parsed_dt
+        except ValueError:
+            logger.warning(f"無効な日付形式です: {date_str}。無視されます。")
+            return None
+
+    def _prepare_like_pattern(self, term: str) -> tuple[str, bool]:
+        """検索語からLIKEパターンと完全一致フラグを準備します。"""
+        is_exact = False
+        pattern = term.strip()  # 前後の空白を除去
+
+        if pattern.startswith('"') and pattern.endswith('"') and len(pattern) > 1:
+            # ダブルクォートで囲まれている場合は完全一致
+            is_exact = True
+            pattern = pattern[1:-1]  # クォートを除去
+            # クォート内のワイルドカードはリテラルとして扱う
+            pattern = pattern.replace("%", "\\%").replace("_", "\\_").replace("*", "*")
+        elif "*" in pattern:
+            # アスタリスクがあれば LIKE 検索 (部分一致)
+            # アスタリスクを SQL の % に置換
+            pattern = pattern.replace("%", "\\%").replace("_", "\\_").replace("*", "%")
+            is_exact = False
+        else:
+            # デフォルトは部分一致 (LIKE)
+            is_exact = False
+            # 前後に % を追加
+            pattern = f"%{pattern.replace('%', '\\%').replace('_', '\\_')}%"
+
+        # logger.debug(f"Prepared pattern: '{pattern}', is_exact: {is_exact} for term: '{term}'")
+        return pattern, is_exact
+
+    def _apply_date_filter(
+        self,
+        query: Select[Any],
+        start_dt: datetime.datetime | None,
+        end_dt: datetime.datetime | None,
+    ) -> Select[Any]:
+        """クエリに日付フィルタを適用します (画像またはアノテーションの更新日時)。"""
+        if not start_dt and not end_dt:
+            return query
+
+        # 画像自体の作成/更新日時のみを考慮
+        img_date_conds = []
+        if start_dt:
+            img_date_conds.append(Image.updated_at >= start_dt)
+        if end_dt:
+            img_date_conds.append(Image.updated_at <= end_dt)
+        if img_date_conds:
+            query = query.where(and_(*img_date_conds))
+
+        return query
+
+    def _apply_tag_filter(
+        self,
+        query: Select[Any],
+        tags: list[str] | None,
+        excluded_tags: list[str] | None,
+        use_and: bool,
+        include_untagged: bool,
+    ) -> Select[Any]:
+        """クエリにタグフィルタを適用します。"""
+        if include_untagged:
+            # タグが存在しない画像 (outerjoinしてTag.idがNULL)
+            # 注: この条件は他のタグ/キャプション条件と併用されない前提 (Manager側で制御想定)
+            query = query.outerjoin(Tag, Image.id == Tag.image_id).where(Tag.id.is_(None))
+        elif tags:
+            # use_and (AND検索) の場合、タグごとにJOIN条件を追加する
+            if use_and:
+                logger.debug(f"Applying AND tag filter (EXISTS) for tags: {tags}")
+                for _i, tag_term in enumerate(tags):
+                    pattern, is_exact = self._prepare_like_pattern(tag_term)
+                    # is_exact フラグに基づいて条件を選択
+                    subquery_condition = (Tag.tag == pattern) if is_exact else Tag.tag.like(pattern)
+                    # EXISTS サブクエリを作成
+                    exists_subquery = (
+                        select(Tag.id)  # SELECT句は何でもよい (通常は 1 や PK)
+                        .where(
+                            Tag.image_id == Image.id,  # WHERE句に明示的な相関条件は残す
+                            subquery_condition,
+                        )
+                        .correlate(Image)  # 明示的に相関させる
+                        .exists()
+                    )
+                    # メインクエリに EXISTS 条件を追加
+                    query = query.where(exists_subquery)
+            else:
+                # use_and=False (OR検索) の場合、単一のJOINとOR条件
+                logger.debug(f"Applying OR tag filter for tags: {tags}")
+                tag_criteria = []
+                for t in tags:
+                    pattern, is_exact = self._prepare_like_pattern(t)
+                    if is_exact:
+                        tag_criteria.append(Tag.tag == pattern)
+                    else:
+                        tag_criteria.append(Tag.tag.like(pattern))
+                if tag_criteria:
+                    query = query.join(Tag, Image.id == Tag.image_id).where(or_(*tag_criteria))
+                    # logger.debug(f"Query after OR tag join: {query}") # クエリ確認用
+
+        if excluded_tags and not include_untagged:
+            logger.debug(f"Applying excluded tag filter (NOT EXISTS) for tags: {excluded_tags}")
+            for excluded_tag in excluded_tags:
+                pattern, is_exact = self._prepare_like_pattern(excluded_tag)
+                excluded_condition = (Tag.tag == pattern) if is_exact else Tag.tag.like(pattern)
+                not_exists_subquery = (
+                    select(Tag.id)
+                    .where(
+                        Tag.image_id == Image.id,
+                        excluded_condition,
+                    )
+                    .correlate(Image)
+                    .exists()
+                )
+                query = query.where(not_(not_exists_subquery))
+
+        return query
+
+    def _apply_caption_filter(self, query: Select[Any], caption: str | None) -> Select[Any]:
+        """クエリにキャプションフィルタを適用します (EXISTSを使用)。"""
+        if caption:
+            logger.debug(f"Applying caption filter (EXISTS) for caption: '{caption}'")
+            pattern, is_exact = self._prepare_like_pattern(caption)
+
+            caption_filter = (Caption.caption == pattern) if is_exact else (Caption.caption.like(pattern))
+
+            # EXISTS サブクエリを作成
+            exists_subquery = (
+                select(Caption.id)
+                .where(
+                    Caption.image_id == Image.id,  # メインクエリの Image と相関させる
+                    caption_filter,
+                )
+                .correlate(Image)  # 明示的に相関させる
+                .exists()
+            )
+            # メインクエリに EXISTS 条件を追加
+            query = query.where(exists_subquery)
+        return query
+
+    def _apply_ai_rating_filter(self, query: Select[Any], ai_rating_filter: str) -> Select[Any]:
+        """クエリにAI評価レーティングフィルタを適用します (多数決ロジック)。
+
+        1つの画像に複数のAIモデルによる異なる評価がある場合、
+        50%以上のAI評価が指定されたレーティングと一致する画像のみを返します。
+
+        Args:
+            query (Select): 適用対象のクエリ
+            ai_rating_filter (str): フィルタリングするレーティング値 (PG, PG-13, R, X, XXX, UNRATED)
+
+        Returns:
+            Select: AIレーティングフィルタが適用されたクエリ
+
+        """
+        logger.debug(f"Applying AI rating filter (majority vote) for rating: '{ai_rating_filter}'")
+
+        # MANUAL_EDIT は AI フィルタから除外（AI 判定行のみを対象とする）
+        ai_only = Rating.model_id.in_(select(Model.id).where(Model.name != "MANUAL_EDIT"))
+
+        # UNRATED: AI レーティングが存在しない画像をフィルタ
+        if ai_rating_filter == "UNRATED":
+            has_any_ai_rating = exists(
+                select(Rating.id).where(Rating.image_id == Image.id, ai_only)
+            ).correlate(Image)
+            query = query.where(not_(has_any_ai_rating))
+            logger.debug("AI rating filter applied: UNRATED (no AI ratings)")
+            return query
+
+        # 多数決ロジック: 画像ごとに総AI評価数とマッチング数を計算
+        # マッチング数 >= 総評価数 / 2.0 の画像のみを返す
+
+        # サブクエリ1: 画像ごとの総AI評価数（MANUAL_EDIT 除外）
+        total_ratings_subquery = (
+            select(Rating.image_id, func.count(Rating.id).label("total_count"))
+            .where(ai_only)
+            .group_by(Rating.image_id)
+            .subquery()
+        )
+
+        # サブクエリ2: 画像ごとのマッチング評価数（MANUAL_EDIT 除外）
+        matching_ratings_subquery = (
+            select(Rating.image_id, func.count(Rating.id).label("matching_count"))
+            .where(func.lower(Rating.normalized_rating) == ai_rating_filter.lower(), ai_only)
+            .group_by(Rating.image_id)
+            .subquery()
+        )
+
+        # EXISTS条件: マッチング数 >= 総評価数 / 2.0
+        # COALESCE(matching_count, 0) で、マッチが0件の画像も処理
+        majority_vote_condition = exists(
+            select(1)
+            .select_from(total_ratings_subquery)
+            .outerjoin(
+                matching_ratings_subquery,
+                total_ratings_subquery.c.image_id == matching_ratings_subquery.c.image_id,
+            )
+            .where(
+                total_ratings_subquery.c.image_id == Image.id,
+                func.coalesce(matching_ratings_subquery.c.matching_count, 0)
+                >= (total_ratings_subquery.c.total_count / 2.0),
+            ),
+        ).correlate(Image)
+
+        query = query.where(majority_vote_condition)
+        logger.debug("AI rating filter applied with majority vote logic")
+        return query
+
+    def _apply_unrated_filter(self, query: Select[Any], include_unrated: bool) -> Select[Any]:
+        """クエリに未評価画像フィルタを適用します (Either-based ロジック)。
+
+        include_unrated=False の場合、手動評価またはAI評価のいずれか1つ以上を持つ画像のみを返します。
+        include_unrated=True の場合、フィルタリングを行いません。
+
+        Args:
+            query (Select): 適用対象のクエリ
+            include_unrated (bool): 未評価画像を含めるかどうか
+
+        Returns:
+            Select: 未評価フィルタが適用されたクエリ
+
+        """
+        if not include_unrated:
+            # MANUAL_EDIT も含む Rating テーブルに行が存在する画像のみを返す
+            # (manual rating も Rating テーブルに統一されたため OR は不要)
+            has_any_rating = exists().where(Rating.image_id == Image.id).correlate(Image)
+            query = query.where(has_any_rating)
+            logger.debug("Unrated filter applied: images must have at least one rating")
+
+        return query
+
+    def _apply_nsfw_filter(self, query: Select[Any], include_nsfw: bool, session: Session) -> Select[Any]:
+        """クエリにNSFWフィルタを適用します。"""
+        if not include_nsfw:
+            # NSFWとみなすレーティング値 (小文字にして比較)
+            nsfw_ratings = ["r", "x", "xxx"]
+
+            # AIによるレーティングに基づく除外条件
+            # Rating テーブルを LEFT JOIN する (なければ Rating.id is NULL)
+            # query = query.outerjoin(Rating, Image.id == Rating.image_id)
+            # 条件: Rating が存在し、かつ normalized_rating が NSFW リストに含まれる
+            ai_nsfw_condition = (
+                exists()
+                .where(Rating.image_id == Image.id, func.lower(Rating.normalized_rating).in_(nsfw_ratings))
+                .correlate(Image)
+            )
+
+            # 手動レーティングに基づく除外条件（ratingsテーブルから最新のMANUAL_EDIT ratingを参照）
+            # ADR 0035 段階 4: MANUAL_EDIT model lookup は ModelRepository static helper を直接呼ぶ。
+            manual_edit_model_id = ModelRepository._get_or_create_manual_edit_model(session)
+            manual_nsfw_condition = (
+                exists()
+                .where(
+                    Rating.image_id == Image.id,
+                    Rating.model_id == manual_edit_model_id,
+                    func.lower(Rating.normalized_rating).in_(nsfw_ratings),
+                )
+                .correlate(Image)
+            )
+
+            # タグベースのNSFW判定（"nsfw" / "explicit" タグが付いている画像を除外）
+            tag_nsfw_condition = (
+                exists()
+                .where(Tag.image_id == Image.id, func.lower(Tag.tag).in_(["nsfw", "explicit"]))
+                .correlate(Image)
+            )
+
+            # AIレーティング、手動レーティング、またはタグがNSFWである画像を除外
+            query = query.where(not_(or_(ai_nsfw_condition, manual_nsfw_condition, tag_nsfw_condition)))
+            # レーティング情報がない (NULL) 画像は除外しない
+        return query
+
+    def _apply_score_filter(
+        self,
+        query: Select[Any],
+        score_min: float | None,
+        score_max: float | None,
+    ) -> Select[Any]:
+        """クエリにスコア範囲フィルタを適用します。
+
+        Args:
+            query: 適用対象のクエリ
+            score_min: 最小スコア値（0.0-10.0）
+            score_max: 最大スコア値（0.0-10.0）
+
+        Returns:
+            フィルタ適用済みのクエリ
+
+        """
+        if score_min is None and score_max is None:
+            return query
+
+        # DB値（0.0-10.0）で直接比較
+        db_min = score_min if score_min is not None else 0.0
+        db_max = score_max if score_max is not None else 10.0
+
+        # 指定範囲内のスコアを持つ画像のみを含める
+        score_condition = (
+            exists()
+            .where(
+                Score.image_id == Image.id,
+                Score.score >= db_min,
+                Score.score <= db_max,
+            )
+            .correlate(Image)
+        )
+
+        query = query.where(score_condition)
+        logger.debug(
+            f"Score filter applied: {db_min:.2f} - {db_max:.2f}",
+        )
+
+        return query
+
+    def _apply_manual_filters(
+        self,
+        query: Select[Any],
+        manual_rating_filter: str | None,
+        manual_edit_filter: bool | None,
+        session: Session,
+    ) -> Select[Any]:
+        """クエリに手動評価と手動編集フラグのフィルタを適用します。"""
+        if manual_rating_filter:
+            # ADR 0035 段階 4: MANUAL_EDIT model lookup は ModelRepository static helper を直接呼ぶ。
+            manual_edit_model_id = ModelRepository._get_or_create_manual_edit_model(session)
+
+            if manual_rating_filter == "UNRATED":
+                # 手動レーティングが設定されていない画像をフィルタ
+                has_manual_rating_subq = (
+                    select(Rating.image_id).where(Rating.model_id == manual_edit_model_id).distinct()
+                )
+                query = query.where(Image.id.notin_(has_manual_rating_subq))
+            else:
+                # 特定の手動レーティングを持つ画像をフィルタ
+                manual_rating_subq = (
+                    select(Rating.image_id)
+                    .where(Rating.normalized_rating == manual_rating_filter)
+                    .where(Rating.model_id == manual_edit_model_id)
+                    .distinct()
+                )
+                query = query.where(Image.id.in_(manual_rating_subq))
+
+        if manual_edit_filter is not None:
+            has_manual_edit = or_(
+                exists().where(Tag.image_id == Image.id, Tag.is_edited_manually.is_(True)).correlate(Image),
+                exists()
+                .where(Caption.image_id == Image.id, Caption.is_edited_manually.is_(True))
+                .correlate(Image),
+                exists().where(Score.image_id == Image.id, Score.is_edited_manually).correlate(Image),
+            )
+
+            if manual_edit_filter:
+                query = query.where(has_manual_edit)
+            else:
+                query = query.where(not_(has_manual_edit))
+
+        return query
+
+    # --- Annotation Format for Metadata (batch read helpers) ---
+
+    def _format_tags(self, image: Image, annotations: dict[str, Any]) -> None:
+        """タグアノテーション情報をフォーマットする。
+
+        Args:
+            image: 画像オブジェクト。
+            annotations: フォーマット結果を格納する辞書（直接更新される）。
+
+        """
+        if image.tags:
+            annotations["tags"] = [
+                {
+                    "id": tag.id,
+                    "tag": tag.tag,
+                    "tag_id": tag.tag_id,
+                    "model_id": tag.model_id,
+                    "model_name": tag.model.name if tag.model else "Unknown",
+                    "source": "Manual" if (tag.is_edited_manually or tag.existing) else "AI",
+                    "existing": tag.existing,
+                    "is_edited_manually": tag.is_edited_manually,
+                    "confidence_score": tag.confidence_score,
+                    "created_at": tag.created_at,
+                    "updated_at": tag.updated_at,
+                }
+                for tag in image.tags
+            ]
+            annotations["tags_text"] = ", ".join([tag.tag for tag in image.tags])
+        else:
+            annotations["tags"] = []
+            annotations["tags_text"] = ""
+
+    def _format_captions(self, image: Image, annotations: dict[str, Any]) -> None:
+        """キャプションアノテーション情報をフォーマットする。
+
+        Args:
+            image: 画像オブジェクト。
+            annotations: フォーマット結果を格納する辞書（直接更新される）。
+
+        """
+        if image.captions:
+            annotations["captions"] = [
+                {
+                    "id": caption.id,
+                    "caption": caption.caption,
+                    "model_id": caption.model_id,
+                    "model_name": caption.model.name if caption.model else "Unknown",
+                    "existing": caption.existing,
+                    "is_edited_manually": caption.is_edited_manually,
+                    "created_at": caption.created_at,
+                    "updated_at": caption.updated_at,
+                }
+                for caption in image.captions
+            ]
+            from datetime import datetime
+
+            latest_caption = max(
+                image.captions,
+                key=lambda c: c.created_at if c.created_at else datetime.min,
+            )
+            annotations["caption_text"] = latest_caption.caption
+        else:
+            annotations["captions"] = []
+            annotations["caption_text"] = ""
+
+    def _format_scores(self, image: Image, annotations: dict[str, Any]) -> None:
+        """スコアアノテーション情報をフォーマットする。
+
+        Args:
+            image: 画像オブジェクト。
+            annotations: フォーマット結果を格納する辞書（直接更新される）。
+
+        """
+        if image.scores:
+            annotations["scores"] = [
+                {
+                    "id": score.id,
+                    "score": score.score,
+                    "model_id": score.model_id,
+                    "model_name": score.model.name if score.model else "Unknown",
+                    "is_edited_manually": score.is_edited_manually,
+                    "created_at": score.created_at,
+                    "updated_at": score.updated_at,
+                }
+                for score in image.scores
+            ]
+            latest_score = max(image.scores, key=lambda s: s.created_at)
+            annotations["score_value"] = latest_score.score
+        else:
+            annotations["scores"] = []
+            annotations["score_value"] = 0.0
+
+    def _format_score_labels(self, image: Image, annotations: dict[str, Any]) -> None:
+        """スコアラベル (canonical scorer の categorical 分類) をフォーマットする。
+
+        ADR 0028 に基づき、各 entry は {model, label} ペアで保持し、scalar shorthand
+        は持たない (multi-scorer の集約 / 多数決方式の前提)。
+
+        Args:
+            image: 画像オブジェクト。
+            annotations: フォーマット結果を格納する辞書（直接更新される）。
+
+        """
+        if image.score_labels:
+            annotations["score_labels"] = [
+                self._format_score_label_annotation(sl) for sl in image.score_labels
+            ]
+        else:
+            annotations["score_labels"] = []
+
+    def _format_ratings(self, image: Image, annotations: dict[str, Any]) -> None:
+        """レーティングアノテーション情報をフォーマットする。
+
+        Args:
+            image: 画像オブジェクト。
+            annotations: フォーマット結果を格納する辞書（直接更新される）。
+
+        """
+        if image.ratings:
+            annotations["ratings"] = [self._format_rating_annotation(rating) for rating in image.ratings]
+            latest_rating = max(image.ratings, key=lambda r: r.created_at)
+            annotations["rating_value"] = latest_rating.normalized_rating
+        else:
+            annotations["ratings"] = []
+            annotations["rating_value"] = ""
+
+    def _format_annotations_for_metadata(self, image: Image) -> dict[str, Any]:
+        """画像のアノテーション情報を辞書形式にフォーマット。
+
+        Args:
+            image: 画像オブジェクト。
+
+        Returns:
+            フォーマット済みアノテーション情報辞書。
+
+        """
+        annotations: dict[str, Any] = {}
+
+        self._format_tags(image, annotations)
+        self._format_captions(image, annotations)
+        self._format_scores(image, annotations)
+        self._format_score_labels(image, annotations)
+        self._format_ratings(image, annotations)
+
+        # ADR 0029: derived view。GUI のメタデータ経路 (SelectedImageDetailsWidget) も
+        # quality_summary を受け取れるよう、get_image_annotations と同じく派生計算する。
+        annotations["quality_summary"] = compute_quality_summary(
+            annotations.get("score_labels", []), annotations.get("scores", [])
+        )
+
+        logger.debug(
+            f"Formatted annotations: tags={len(annotations.get('tags', []))}, "
+            f"captions={len(annotations.get('captions', []))}, "
+            f"scores={len(annotations.get('scores', []))}, "
+            f"score_labels={len(annotations.get('score_labels', []))}, "
+            f"ratings={len(annotations.get('ratings', []))}",
+        )
+
+        return annotations
+
+    # --- Metadata Fetchers (used by get_images_by_filter / get_images_metadata_batch) ---
+
+    def _fetch_original_image_metadata(
+        self,
+        session: Session,
+        image_ids: list[int],
+    ) -> list[dict[str, Any]]:
+        """オリジナル画像のメタデータをアノテーション付きで取得する。
+
+        Args:
+            session: SQLAlchemyセッション。
+            image_ids: 画像IDリスト。
+
+        Returns:
+            メタデータ辞書のリスト。
+
+        """
+        orig_stmt = (
+            select(Image)
+            .where(Image.id.in_(image_ids))
+            .options(
+                selectinload(Image.tags).selectinload(Tag.model),
+                selectinload(Image.captions).selectinload(Caption.model),
+                selectinload(Image.scores).selectinload(Score.model),
+                selectinload(Image.score_labels).selectinload(ScoreLabel.model),
+                selectinload(Image.ratings).selectinload(Rating.model),
+            )
+        )
+        orig_results: list[Image] = list(session.execute(orig_stmt).scalars().all())
+
+        result = []
+        for img in orig_results:
+            metadata = {c.name: getattr(img, c.name) for c in img.__table__.columns}
+            metadata.update(self._format_annotations_for_metadata(img))
+            result.append(metadata)
+        return result
+
+    def _fetch_processed_image_metadata(
+        self,
+        session: Session,
+        image_ids: list[int],
+        resolution: int,
+    ) -> list[dict[str, Any]]:
+        """処理済み画像のメタデータをアノテーション付きで取得する。
+
+        Args:
+            session: SQLAlchemyセッション。
+            image_ids: 画像IDリスト。
+            resolution: 対象解像度。
+
+        Returns:
+            メタデータ辞書のリスト。
+
+        """
+        proc_stmt = select(ProcessedImage).where(ProcessedImage.image_id.in_(image_ids))
+        all_proc_images = session.execute(proc_stmt).scalars().all()
+
+        # Original Imageのアノテーション情報を一括取得
+        orig_annotations_stmt = (
+            select(Image)
+            .where(Image.id.in_(image_ids))
+            .options(
+                selectinload(Image.tags).selectinload(Tag.model),
+                selectinload(Image.captions).selectinload(Caption.model),
+                selectinload(Image.scores).selectinload(Score.model),
+                selectinload(Image.score_labels).selectinload(ScoreLabel.model),
+                selectinload(Image.ratings).selectinload(Rating.model),
+            )
+        )
+        orig_images = session.execute(orig_annotations_stmt).scalars().all()
+        annotations_by_image_id = {
+            img.id: self._format_annotations_for_metadata(img) for img in orig_images
+        }
+
+        # image_id ごとにグループ化
+        proc_images_by_id: dict[int, list[dict[str, Any]]] = {}
+        for img in all_proc_images:
+            if img.image_id not in proc_images_by_id:
+                proc_images_by_id[img.image_id] = []
+            proc_metadata = {c.name: getattr(img, c.name) for c in img.__table__.columns}
+            # idをimages.idに統一（GUI全体で「画像ID」として使われるため）
+            # processed_images.idはprocessed_image_idとして保持
+            proc_metadata["processed_image_id"] = proc_metadata["id"]
+            proc_metadata["id"] = img.image_id
+            if img.image_id in annotations_by_image_id:
+                proc_metadata.update(annotations_by_image_id[img.image_id])
+            proc_images_by_id[img.image_id].append(proc_metadata)
+
+        result = []
+        for image_id in image_ids:
+            metadata_list = proc_images_by_id.get(image_id, [])
+            if metadata_list:
+                selected = self._filter_by_resolution(metadata_list, resolution)
+                if selected:
+                    result.append(selected)
+        return result
+
+    def _fetch_filtered_metadata(
+        self,
+        session: Session,
+        image_ids: list[int],
+        resolution: int,
+    ) -> list[dict[str, Any]]:
+        """フィルタリングされたIDリストに基づき、指定解像度のメタデータを取得する。
+
+        Args:
+            session: SQLAlchemyセッション。
+            image_ids: 画像IDリスト。
+            resolution: 対象解像度(0はオリジナル)。
+
+        Returns:
+            メタデータ辞書のリスト。
+
+        """
+        if not image_ids:
+            return []
+
+        if resolution == 0:
+            return self._fetch_original_image_metadata(session, image_ids)
+        return self._fetch_processed_image_metadata(session, image_ids, resolution)
+
+    def _apply_project_filter(
+        self,
+        query: Select[Any],
+        project_name: str | None,
+        project_id: int | None,
+    ) -> Select[Any]:
+        """プロジェクトフィルタを適用する。
+
+        Args:
+            query: 適用対象の SQLAlchemy Select クエリ。
+            project_name: フィルタ対象プロジェクト名。
+            project_id: フィルタ対象プロジェクトID（project_name より優先）。
+
+        Returns:
+            フィルタ適用済みクエリ。
+        """
+        if project_id is not None:
+            query = query.where(Image.project_id == project_id)
+            logger.debug(f"Project filter applied: project_id={project_id}")
+        elif project_name is not None:
+            project_id_subq = select(Project.id).where(Project.name == project_name).scalar_subquery()
+            query = query.where(Image.project_id == project_id_subq)
+            logger.debug(f"Project filter applied: project_name='{project_name}'")
+        return query
+
+    # --- Main Filter Method ---
+
+    def _build_image_filter_query(
+        self,
+        session: Session,
+        tags: list[str] | None,
+        excluded_tags: list[str] | None,
+        caption: str | None,
+        use_and: bool,
+        start_date: str | None,
+        end_date: str | None,
+        include_untagged: bool,
+        include_nsfw: bool,
+        include_unrated: bool,
+        manual_rating_filter: str | None,
+        ai_rating_filter: str | None,
+        manual_edit_filter: bool | None,
+        score_min: float | None = None,
+        score_max: float | None = None,
+        project_name: str | None = None,
+        project_id: int | None = None,
+    ) -> Select[Any]:
+        """画像フィルタ条件を適用したクエリを構築する。
+
+        Args:
+            session: SQLAlchemyセッション。
+            tags: 検索タグリスト。
+            excluded_tags: 除外検索タグリスト。
+            caption: 検索キャプション文字列。
+            use_and: 複数タグのAND/OR指定。
+            start_date: 検索開始日時(ISO 8601)。
+            end_date: 検索終了日時(ISO 8601)。
+            include_untagged: タグなし画像のみ対象とするか。
+            include_nsfw: NSFWコンテンツを含むか。
+            include_unrated: 未評価画像を含むか。
+            manual_rating_filter: 手動レーティングフィルタ。
+            ai_rating_filter: AI評価フィルタ。
+            manual_edit_filter: 手動編集フラグフィルタ。
+            score_min: 最小スコア値（0.0-10.0）。
+            score_max: 最大スコア値（0.0-10.0）。
+            project_name: プロジェクト名フィルタ（Phase C完了後に有効化）。
+            project_id: プロジェクトIDフィルタ（Phase C完了後に有効化）。
+
+        Returns:
+            フィルタ適用済みのSelectクエリ。
+
+        """
+        query = select(Image.id)
+
+        start_dt = self._parse_datetime_str(start_date)
+        end_dt = self._parse_datetime_str(end_date)
+        query = self._apply_date_filter(query, start_dt, end_dt)
+
+        if include_untagged and (tags or caption):
+            logger.warning("検索語句と include_untagged が同時に指定されたため、検索語句は無視されます。")
+
+        query = self._apply_tag_filter(query, tags, excluded_tags, use_and, include_untagged)
+        query = self._apply_caption_filter(query, caption)
+
+        # Rating Filters (Priority-based: manual > AI)
+        if manual_rating_filter:
+            logger.debug("Applying manual rating filter (priority over AI rating filter)")
+            query = self._apply_manual_filters(query, manual_rating_filter, manual_edit_filter, session)
+        elif ai_rating_filter:
+            logger.debug("Applying AI rating filter (no manual rating filter specified)")
+            query = self._apply_ai_rating_filter(query, ai_rating_filter)
+            query = self._apply_manual_filters(query, None, manual_edit_filter, session)
+        else:
+            query = self._apply_manual_filters(query, None, manual_edit_filter, session)
+
+        # Unrated Filter
+        query = self._apply_unrated_filter(query, include_unrated)
+
+        # NSFW Filter
+        nsfw_values_to_exclude = {"r", "x", "xxx"}
+        apply_nsfw_exclusion = not include_nsfw and (
+            (manual_rating_filter is None or manual_rating_filter.lower() not in nsfw_values_to_exclude)
+            and (ai_rating_filter is None or ai_rating_filter.lower() not in nsfw_values_to_exclude)
+        )
+        if apply_nsfw_exclusion:
+            query = self._apply_nsfw_filter(query, include_nsfw=False, session=session)
+        elif include_nsfw:
+            query = self._apply_nsfw_filter(query, include_nsfw=True, session=session)
+
+        # Score Filter
+        query = self._apply_score_filter(query, score_min, score_max)
+
+        # Project Filter (Phase C完了後に有効化)
+        query = self._apply_project_filter(query, project_name, project_id)
+
+        return query.distinct()
+
+    def get_images_by_filter(
+        self,
+        criteria: ImageFilterCriteria | None = None,
+        **kwargs: Any,
+    ) -> tuple[list[dict[str, Any]], int]:
+        """指定された条件に基づいて画像をフィルタリングし、メタデータと件数を返す。
+
+        Args:
+            criteria: ImageFilterCriteria形式のフィルター条件（推奨）
+            **kwargs: レガシー形式のキーワード引数（後方互換性用）
+
+        Returns:
+            条件にマッチした画像メタデータのリストとその総数。
+        """
+        # criteriaが指定されていればそれを使用、なければkwargsから生成
+        filter_criteria = criteria if criteria else ImageFilterCriteria.from_kwargs(**kwargs)
+
+        # 型安全性チェック: resolution が文字列の場合は int に変換
+        if isinstance(filter_criteria.resolution, str):
+            try:
+                filter_criteria.resolution = int(filter_criteria.resolution)
+                logger.warning(
+                    f"解像度パラメータが文字列として渡されました: '{filter_criteria.resolution}' -> "
+                    f"{filter_criteria.resolution}",
+                )
+            except ValueError:
+                logger.error(f"解像度パラメータの変換に失敗しました: '{filter_criteria.resolution}'")
+                return [], 0
+
+        with self.session_factory() as session:
+            try:
+                query = self._build_image_filter_query(
+                    session=session,
+                    tags=filter_criteria.tags,
+                    excluded_tags=filter_criteria.excluded_tags,
+                    caption=filter_criteria.caption,
+                    use_and=filter_criteria.use_and,
+                    start_date=filter_criteria.start_date,
+                    end_date=filter_criteria.end_date,
+                    include_untagged=filter_criteria.include_untagged,
+                    include_nsfw=filter_criteria.include_nsfw,
+                    include_unrated=filter_criteria.include_unrated,
+                    manual_rating_filter=filter_criteria.manual_rating_filter,
+                    ai_rating_filter=filter_criteria.ai_rating_filter,
+                    manual_edit_filter=filter_criteria.manual_edit_filter,
+                    score_min=filter_criteria.score_min,
+                    score_max=filter_criteria.score_max,
+                    project_name=filter_criteria.project_name,
+                    project_id=filter_criteria.project_id,
+                )
+
+                filtered_image_ids: list[int] = list(session.execute(query).scalars().all())
+
+                if not filtered_image_ids:
+                    logger.info("指定された条件に一致する画像が見つかりませんでした。")
+                    return [], 0
+
+                logger.debug(f"フィルタリングで {len(filtered_image_ids)} 件の候補画像IDを取得しました。")
+
+                final_metadata_list = self._fetch_filtered_metadata(
+                    session, filtered_image_ids, filter_criteria.resolution
+                )
+                list_count = len(final_metadata_list)
+                logger.info(f"最終的な検索結果: {list_count} 件")
+
+                return final_metadata_list, list_count
+
+            except SQLAlchemyError as e:
+                logger.error(f"画像フィルタリング検索中にエラーが発生しました: {e}", exc_info=True)
+                raise
+
+    def get_images_count_only(
+        self,
+        criteria: ImageFilterCriteria | None = None,
+        **kwargs: Any,
+    ) -> int:
+        """指定された条件に基づいて画像件数のみを取得する。
+
+        フィルター式は ``get_images_by_filter`` と同一ロジックを使用し、
+        メタデータ取得を行わない軽量な件数集計を実行する。
+
+        Args:
+            criteria: ImageFilterCriteria形式のフィルター条件（推奨）
+            **kwargs: レガシー形式のキーワード引数（後方互換性用）
+
+        Returns:
+            条件に一致した画像件数。
+
+        """
+        filter_criteria = criteria if criteria else ImageFilterCriteria.from_kwargs(**kwargs)
+
+        with self.session_factory() as session:
+            try:
+                filtered_query = self._build_image_filter_query(
+                    session=session,
+                    tags=filter_criteria.tags,
+                    excluded_tags=filter_criteria.excluded_tags,
+                    caption=filter_criteria.caption,
+                    use_and=filter_criteria.use_and,
+                    start_date=filter_criteria.start_date,
+                    end_date=filter_criteria.end_date,
+                    include_untagged=filter_criteria.include_untagged,
+                    include_nsfw=filter_criteria.include_nsfw,
+                    include_unrated=filter_criteria.include_unrated,
+                    manual_rating_filter=filter_criteria.manual_rating_filter,
+                    ai_rating_filter=filter_criteria.ai_rating_filter,
+                    manual_edit_filter=filter_criteria.manual_edit_filter,
+                    score_min=filter_criteria.score_min,
+                    score_max=filter_criteria.score_max,
+                    project_name=filter_criteria.project_name,
+                    project_id=filter_criteria.project_id,
+                )
+
+                count_query = select(func.count()).select_from(filtered_query.subquery())
+                count = session.execute(count_query).scalar_one()
+                logger.debug(f"フィルター件数のみ取得: {count} 件")
+                return count
+
+            except SQLAlchemyError as e:
+                logger.error(f"画像件数取得中にエラーが発生しました: {e}", exc_info=True)
+                raise
+
+    # --- Count ---
+
+    def get_total_image_count(self) -> int:
+        """データベース内のオリジナル画像の総数を取得します。"""
+        with self.session_factory() as session:
+            try:
+                stmt = select(func.count(Image.id))
+                count = session.execute(stmt).scalar_one()
+                return count
+            except SQLAlchemyError as e:
+                logger.error(f"総画像数の取得中にエラーが発生しました: {e}", exc_info=True)
+                raise  # または、目的のエラー処理に応じて0を返します
+
+    # --- By IDs (alternative entry, used by error workflow) ---
+
+    def get_images_by_ids(self, image_ids: list[int]) -> list[dict[str, Any]]:
+        """画像IDリストから画像メタデータを取得
+
+        Args:
+            image_ids: 画像IDリスト
+
+        Returns:
+            list[dict]: 画像メタデータリスト（既存フォーマット互換）
+
+        Raises:
+            SQLAlchemyError: データベース操作でエラーが発生した場合
+
+        """
+        if not image_ids:
+            return []
+
+        with self.session_factory() as session:
+            try:
+                # アノテーション情報を含めて取得
+                stmt = (
+                    select(Image)
+                    .where(Image.id.in_(image_ids))
+                    .options(
+                        joinedload(Image.tags).joinedload(Tag.model),
+                        joinedload(Image.captions).joinedload(Caption.model),
+                        joinedload(Image.scores).joinedload(Score.model),
+                        joinedload(Image.ratings).joinedload(Rating.model),
+                    )
+                )
+                images = session.execute(stmt).unique().scalars().all()
+
+                # 既存の get_images_by_filter と同じフォーマットで返す
+                metadata_list = []
+                for img in images:
+                    metadata = {c.name: getattr(img, c.name) for c in img.__table__.columns}
+                    # アノテーション情報を追加
+                    metadata.update(self._format_annotations_for_metadata(img))
+                    metadata_list.append(metadata)
+
+                logger.debug(f"画像メタデータを取得: {len(metadata_list)}件")
+                return metadata_list
+            except SQLAlchemyError as e:
+                logger.error(f"画像メタデータの取得中にエラーが発生しました: {e}", exc_info=True)
+                raise
+
+    # --- File Path Resolution ---
+
+    def get_image_id_by_filepath(self, filepath: str) -> int | None:
+        """ファイルパスから画像IDを取得
+
+        Args:
+            filepath: 画像ファイルの絶対パスまたは相対パス
+
+        Returns:
+            int | None: 画像ID（見つからない場合は None）
+
+        """
+        with self.session_factory() as session:
+            try:
+                from ..db_core import resolve_stored_path
+
+                input_path = Path(filepath).resolve()
+                filename = input_path.name
+
+                # filenameで候補を検索
+                stmt = select(Image).where(Image.filename == filename)
+                results = session.execute(stmt).scalars().all()
+
+                # 候補が見つかった場合、stored_image_pathを正規化して比較
+                for image in results:
+                    resolved_stored_path = resolve_stored_path(image.stored_image_path)
+                    if resolved_stored_path.resolve() == input_path:
+                        return image.id
+
+                return None
+
+            except Exception as e:
+                logger.error(f"ファイルパスからの画像ID取得エラー: {filepath}, {e}")
+                return None
+
+    @staticmethod
+    def _normalize_input_paths(filepaths: list[str]) -> tuple[dict[str, Path], set[str]]:
+        """入力 path リストを resolve した dict と filename set に変換する helper。
+
+        Args:
+            filepaths: 解決対象の path リスト。
+
+        Returns:
+            (input_path -> resolved Path の dict, filename set)。
+            resolve できなかった path は元 Path object のまま dict に入れ、
+            filename set には含めない (DB 検索対象から除外)。
+        """
+        path_resolved: dict[str, Path] = {}
+        filenames: set[str] = set()
+        for raw in filepaths:
+            try:
+                resolved = Path(raw).resolve()
+            except (OSError, RuntimeError, ValueError):
+                path_resolved[raw] = Path(raw)
+                continue
+            path_resolved[raw] = resolved
+            filenames.add(resolved.name)
+        return path_resolved, filenames
+
+    def _build_candidates_by_filename(
+        self, candidates: list[Image]
+    ) -> dict[str, list[tuple[Path, int, str]]]:
+        """candidates を filename をキーとする dict に集約する helper。
+
+        ADR 0023 Phase 1.5 (Codex P2 r3209511028): row-level resolve guard 経由で
+        corrupted 行は skip し、健全な行のみ集約する。
+
+        Args:
+            candidates: filename IN 句で取得した Image ORM 行のリスト。
+
+        Returns:
+            filename -> [(resolved_abs Path, image_id, phash), ...] の dict。
+            同じ filename で複数 image (別ディレクトリ) があり得るため list 値。
+        """
+        by_filename: dict[str, list[tuple[Path, int, str]]] = {}
+        for img in candidates:
+            if img.filename is None:
+                continue
+            resolved_abs = self._safe_resolve_stored_path(img.id, img.stored_image_path)
+            if resolved_abs is None:
+                continue
+            by_filename.setdefault(img.filename, []).append((resolved_abs, img.id, img.phash))
+        return by_filename
+
+    @staticmethod
+    def _safe_resolve_stored_path(image_id: int, stored_image_path: str) -> Path | None:
+        """`stored_image_path` を絶対 Path に解決する row-level guard 付き helper。
+
+        ADR 0023 Phase 1.5 (Codex P2 r3209511028): 1 行の corrupted path
+        (シンボリックループ / 解決不能 path 等) で batch 全体を落とさないため、
+        row-level で例外を吸収する。失敗時は warning + None を返す。
+
+        Args:
+            image_id: 対象画像 ID (logging 用)。
+            stored_image_path: DB に保存された生 path。
+
+        Returns:
+            解決済みの絶対 Path、または resolve 失敗時 None。
+        """
+        from ..db_core import resolve_stored_path
+
+        try:
+            resolved_stored = resolve_stored_path(stored_image_path)
+            return resolved_stored.resolve()
+        except (OSError, ValueError, RuntimeError) as exc:
+            logger.warning(
+                f"バッチ画像 ID 解決: stored_image_path resolve 失敗を skip: "
+                f"image_id={image_id}, path={stored_image_path!r}, error={exc}"
+            )
+            return None
+
+    def get_image_ids_by_filepaths(self, filepaths: list[str]) -> dict[str, int | None]:
+        """複数のファイルパスから画像 ID をバッチ解決する。
+
+        ADR 0023 Phase 1.5 (Issue #42, Codex P2 r3209342204): N+1 クエリ回避。
+        `get_image_id_by_filepath()` を N 回呼ぶ代わりに、filename を IN 句で
+        一括取得して input path と stored_image_path の resolve 比較を Python 側
+        で行う。GUI スレッドや Worker 内のループ内で大量パスを引く場合に使用。
+
+        Args:
+            filepaths: 解決対象の画像 path リスト (絶対 / 相対パス混在可)。
+
+        Returns:
+            dict[str, int | None]: 入力 path をキーに、対応する image_id (見つから
+                なければ None) を値とする辞書。入力 path はそのまま辞書キーとして
+                使われる (caller が input list との対応を辿りやすくするため)。
+        """
+        if not filepaths:
+            return {}
+
+        path_resolved, filenames = self._normalize_input_paths(filepaths)
+        result: dict[str, int | None] = dict.fromkeys(filepaths)
+
+        if not filenames:
+            return result
+
+        with self.session_factory() as session:
+            try:
+                # filename IN (...) で 1 クエリ取得 (重複 filename もまとめて)
+                stmt = select(Image).where(Image.filename.in_(filenames))
+                candidates = list(session.execute(stmt).scalars().all())
+                by_filename = self._build_candidates_by_filename(candidates)
+
+                # input path ごとに対応する image_id を resolve 比較で確定
+                for raw, resolved_input in path_resolved.items():
+                    matches = by_filename.get(resolved_input.name, [])
+                    for stored_resolved, image_id, _phash in matches:
+                        if stored_resolved == resolved_input:
+                            result[raw] = image_id
+                            break
+
+                logger.debug(
+                    f"バッチ画像 ID 解決: 入力 {len(filepaths)}件 → "
+                    f"解決 {sum(1 for v in result.values() if v is not None)}件"
+                )
+                return result
+            except Exception as e:
+                logger.error(f"バッチ画像 ID 解決エラー: {e}", exc_info=True)
+                return result
+
+    def get_phashes_by_filepaths(self, filepaths: list[str]) -> dict[str, str | None]:
+        """複数のファイルパスから pHash をバッチ解決する。
+
+        `get_image_ids_by_filepaths()` と同じ path resolve 規則で、登録済み画像の
+        pHash を input path 順に引けるようにする。未登録または resolve 不能な path
+        は None を返す。
+        """
+        if not filepaths:
+            return {}
+
+        path_resolved, filenames = self._normalize_input_paths(filepaths)
+        result: dict[str, str | None] = dict.fromkeys(filepaths)
+
+        if not filenames:
+            return result
+
+        with self.session_factory() as session:
+            try:
+                stmt = select(Image).where(Image.filename.in_(filenames))
+                candidates = list(session.execute(stmt).scalars().all())
+                by_filename = self._build_candidates_by_filename(candidates)
+
+                for raw, resolved_input in path_resolved.items():
+                    matches = by_filename.get(resolved_input.name, [])
+                    for stored_resolved, _image_id, phash in matches:
+                        if stored_resolved == resolved_input:
+                            result[raw] = phash
+                            break
+
+                logger.debug(
+                    f"バッチ pHash 解決: 入力 {len(filepaths)}件 → "
+                    f"解決 {sum(1 for v in result.values() if v is not None)}件"
+                )
+                return result
+            except Exception as e:
+                logger.error(f"バッチ pHash 解決エラー: {e}", exc_info=True)
+                return result

--- a/tests/integration/test_safety_refusal_records.py
+++ b/tests/integration/test_safety_refusal_records.py
@@ -381,7 +381,12 @@ def test_get_image_ids_by_filepaths_isolates_row_resolution_failures(
         failures.append(image_id_arg)
         return None  # helper 自体が失敗をキャプチャした体で None 返却
 
-    monkeypatch.setattr(ImageRepository, "_safe_resolve_stored_path", staticmethod(flaky_safe_resolve))
+    # ADR 0035 段階 4: `_safe_resolve_stored_path` は新 `repository.image.ImageRepository`
+    # に移設済み。レガシー facade (`db_repository.ImageRepository`) は delegating wrapper
+    # を持つだけなので、static helper の patch は新クラス側に当てる。
+    from lorairo.database.repository.image import ImageRepository as _NewImageRepository
+
+    monkeypatch.setattr(_NewImageRepository, "_safe_resolve_stored_path", staticmethod(flaky_safe_resolve))
 
     result = repo.get_image_ids_by_filepaths([file_path, "/nonexistent/foo.png"])
 

--- a/tests/unit/database/repository/test_image_repository.py
+++ b/tests/unit/database/repository/test_image_repository.py
@@ -335,6 +335,46 @@ class TestFacadeDelegation:
 
 
 @pytest.mark.unit
+class TestFacadeAttributePropagation:
+    """PR #488 Codex review P2/P3: facade の共有属性が内部 delegating repos に伝播する。
+
+    `repository.session_factory = X` / `repository.BATCH_CHUNK_SIZE = N` を
+    init 後に書き戻すケース (テストやランタイム fixture) で内部 `_image_repo` /
+    `_model_repo` / `_project_repo` / `_error_record_repo` が drift しないことを
+    保証する。
+    """
+
+    def test_session_factory_propagates_to_internal_repos(self, memory_session_factory) -> None:
+        """facade.session_factory 書き換えで内部 repos も同期される。"""
+        facade = LegacyImageRepository(session_factory=memory_session_factory)
+        new_factory = MagicMock(name="replacement")
+        facade.session_factory = new_factory
+        assert facade.session_factory is new_factory
+        assert facade._image_repo.session_factory is new_factory
+        assert facade._model_repo.session_factory is new_factory
+        assert facade._project_repo.session_factory is new_factory
+        assert facade._error_record_repo.session_factory is new_factory
+
+    def test_batch_chunk_size_propagates_to_internal_repos(self, memory_session_factory) -> None:
+        """facade.BATCH_CHUNK_SIZE 書き換えで内部 repos の chunking もそれに従う。"""
+        facade = LegacyImageRepository(session_factory=memory_session_factory)
+        facade.BATCH_CHUNK_SIZE = 7
+        assert facade.BATCH_CHUNK_SIZE == 7
+        assert facade._image_repo.BATCH_CHUNK_SIZE == 7
+        assert facade._model_repo.BATCH_CHUNK_SIZE == 7
+        assert facade._project_repo.BATCH_CHUNK_SIZE == 7
+        assert facade._error_record_repo.BATCH_CHUNK_SIZE == 7
+
+    def test_other_attribute_assignment_does_not_propagate(self, memory_session_factory) -> None:
+        """propagation 対象外の属性 (merged_reader 等) は伝播されない。"""
+        facade = LegacyImageRepository(session_factory=memory_session_factory)
+        facade.merged_reader = "sentinel-value"  # type: ignore[assignment]
+        assert facade.merged_reader == "sentinel-value"
+        # 内部 repos に merged_reader 属性が新規追加されないこと
+        assert not hasattr(facade._image_repo, "merged_reader")
+
+
+@pytest.mark.unit
 class TestImageDatabaseManagerDIContract:
     """ImageDatabaseManager が image_repo を inject 経由で保持することを確認。"""
 

--- a/tests/unit/database/repository/test_image_repository.py
+++ b/tests/unit/database/repository/test_image_repository.py
@@ -1,0 +1,373 @@
+"""ImageRepository 直接の単体テスト (ADR 0035 段階 4, Issue #423)。
+
+`db_repository.py` から抽出した新 `ImageRepository` (`repository/image.py`) の
+責務境界を独立して検証する。既存の `tests/unit/database/test_db_repository_*.py`
+は delegating facade 経由で同じ実装をカバーしているため、本ファイルでは新
+ImageRepository を直接 instantiate して以下を最小限カバーする:
+
+- BaseRepository 継承 / session_factory 共有 / BATCH_CHUNK_SIZE
+- 画像 CRUD (add_original_image, _image_exists, add_processed_image,
+  _find_existing_processed_image_id) の正常系 + 異常系
+- FilenameAlias (get_all_image_filename_index, add_filename_alias)
+- 検索系 (find_duplicate_image_by_phash, find_image_ids_by_phashes,
+  get_annotated_image_ids) の動作 + 空入力ガード
+- Annotation read formatter (`_format_*_annotation`) の static helper 挙動
+- Filter helper (`_apply_*_filter`) の query 変換
+- ImageRepository facade 経由でも同じ新クラスが見えること (delegation 整合性)
+- DI contract: ImageDatabaseManager は injected image_repo を保持し、
+  session_factory フォールバックが既存テストを破壊しないこと
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, Mock
+
+import pytest
+from sqlalchemy import create_engine, select
+from sqlalchemy.orm import sessionmaker
+
+from lorairo.database.db_manager import ImageDatabaseManager
+from lorairo.database.db_repository import ImageRepository as LegacyImageRepository
+from lorairo.database.repository.base import BaseRepository
+from lorairo.database.repository.image import ImageRepository
+from lorairo.database.schema import (
+    Image,
+    ImageFilenameAlias,
+    ProcessedImage,
+)
+from lorairo.services.configuration_service import ConfigurationService
+
+
+@pytest.fixture
+def memory_session_factory():
+    """in-memory SQLite セッションファクトリ（schema 全テーブル）。"""
+    from lorairo.database.schema import Base
+
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    return sessionmaker(engine)
+
+
+@pytest.fixture
+def image_repository(memory_session_factory) -> ImageRepository:
+    """In-memory SQLite に対する ImageRepository インスタンス。"""
+    return ImageRepository(session_factory=memory_session_factory)
+
+
+def _insert_image(
+    repo: ImageRepository,
+    *,
+    uuid: str = "uuid-1",
+    phash: str = "phash-1",
+    filename: str = "sample.png",
+    width: int = 64,
+    height: int = 64,
+) -> int:
+    """テスト用画像を 1 件作成して id を返す。"""
+    info = {
+        "uuid": uuid,
+        "phash": phash,
+        "original_image_path": f"/tmp/{filename}",
+        "stored_image_path": f"/tmp/{filename}",
+        "width": width,
+        "height": height,
+        "format": "PNG",
+        "extension": ".png",
+        "filename": filename,
+    }
+    return repo.add_original_image(info)
+
+
+@pytest.mark.unit
+class TestImageRepositoryStructure:
+    """ADR 0035 段階 4 で確立した抽出構造の sanity check。"""
+
+    def test_inherits_base_repository(self) -> None:
+        """ImageRepository は BaseRepository を継承する。"""
+        assert issubclass(ImageRepository, BaseRepository)
+
+    def test_holds_session_factory(self, memory_session_factory) -> None:
+        """`session_factory` を BaseRepository 経由で保持する。"""
+        repo = ImageRepository(session_factory=memory_session_factory)
+        assert repo.session_factory is memory_session_factory
+
+    def test_inherits_batch_chunk_size(self) -> None:
+        """`BATCH_CHUNK_SIZE` を BaseRepository から継承する。"""
+        assert ImageRepository.BATCH_CHUNK_SIZE == BaseRepository.BATCH_CHUNK_SIZE
+
+
+@pytest.mark.unit
+class TestAddOriginalImage:
+    """`add_original_image` の永続化動作。"""
+
+    def test_creates_image_and_returns_positive_id(
+        self, image_repository: ImageRepository, memory_session_factory
+    ) -> None:
+        """新規画像を保存して正の ID を返し、DB にも書き込まれる。"""
+        image_id = _insert_image(image_repository, uuid="u1", phash="p1")
+        assert isinstance(image_id, int)
+        assert image_id > 0
+
+        with memory_session_factory() as session:
+            row = session.execute(select(Image).where(Image.id == image_id)).scalar_one()
+            assert row.uuid == "u1"
+            assert row.phash == "p1"
+
+    def test_returns_existing_id_on_phash_duplicate(self, image_repository: ImageRepository) -> None:
+        """同じ pHash の画像を再登録すると既存 ID が返る。"""
+        first = _insert_image(image_repository, uuid="u-dup-1", phash="dup-phash")
+        second = _insert_image(image_repository, uuid="u-dup-2", phash="dup-phash")
+        assert second == first
+
+    def test_raises_value_error_when_required_keys_missing(self, image_repository: ImageRepository) -> None:
+        """必須キー不足は ValueError。"""
+        with pytest.raises(ValueError, match="必須情報が不足しています"):
+            image_repository.add_original_image({"uuid": "u-x"})
+
+
+@pytest.mark.unit
+class TestImageExists:
+    """`_image_exists` の存在判定。"""
+
+    def test_returns_true_for_existing_image(self, image_repository: ImageRepository) -> None:
+        image_id = _insert_image(image_repository, uuid="u-exists", phash="p-exists")
+        assert image_repository._image_exists(image_id) is True
+
+    def test_returns_false_for_missing_image(self, image_repository: ImageRepository) -> None:
+        assert image_repository._image_exists(99999) is False
+
+
+@pytest.mark.unit
+class TestFindDuplicateImageByPhash:
+    """`find_duplicate_image_by_phash` の検索動作。"""
+
+    def test_returns_id_on_hit(self, image_repository: ImageRepository) -> None:
+        image_id = _insert_image(image_repository, uuid="u-h", phash="phash-hit")
+        assert image_repository.find_duplicate_image_by_phash("phash-hit") == image_id
+
+    def test_returns_none_on_miss(self, image_repository: ImageRepository) -> None:
+        assert image_repository.find_duplicate_image_by_phash("phash-miss") is None
+
+    def test_returns_none_for_empty_phash(self, image_repository: ImageRepository) -> None:
+        """空文字列入力で early-return None。"""
+        assert image_repository.find_duplicate_image_by_phash("") is None
+
+
+@pytest.mark.unit
+class TestFindImageIdsByPhashes:
+    """`find_image_ids_by_phashes` のバッチ検索。"""
+
+    def test_returns_mapping_for_existing_phashes(self, image_repository: ImageRepository) -> None:
+        a = _insert_image(image_repository, uuid="u-a", phash="phash-a", filename="a.png")
+        b = _insert_image(image_repository, uuid="u-b", phash="phash-b", filename="b.png")
+        result = image_repository.find_image_ids_by_phashes({"phash-a", "phash-b", "phash-c"})
+        assert result == {"phash-a": a, "phash-b": b}
+
+    def test_returns_empty_dict_for_empty_input(self, image_repository: ImageRepository) -> None:
+        assert image_repository.find_image_ids_by_phashes(set()) == {}
+
+
+@pytest.mark.unit
+class TestGetAnnotatedImageIds:
+    """`get_annotated_image_ids` の存在判定。"""
+
+    def test_returns_empty_set_for_empty_input(self, image_repository: ImageRepository) -> None:
+        assert image_repository.get_annotated_image_ids([]) == set()
+
+    def test_returns_empty_set_when_no_annotations(self, image_repository: ImageRepository) -> None:
+        image_id = _insert_image(image_repository, uuid="u-no-anno", phash="p-no-anno")
+        assert image_repository.get_annotated_image_ids([image_id]) == set()
+
+
+@pytest.mark.unit
+class TestFilenameAlias:
+    """`get_all_image_filename_index` / `add_filename_alias` の動作。"""
+
+    def test_index_includes_main_filenames(self, image_repository: ImageRepository) -> None:
+        _insert_image(image_repository, uuid="u-idx", phash="p-idx", filename="hello.png")
+        index = image_repository.get_all_image_filename_index()
+        assert index["hello"] == 1
+
+    def test_add_filename_alias_appears_in_index(
+        self, image_repository: ImageRepository, memory_session_factory
+    ) -> None:
+        image_id = _insert_image(image_repository, uuid="u-al", phash="p-al", filename="x.png")
+        image_repository.add_filename_alias(image_id, "alias-stem")
+        index = image_repository.get_all_image_filename_index()
+        assert index.get("alias-stem") == image_id
+
+        with memory_session_factory() as session:
+            row = session.execute(
+                select(ImageFilenameAlias).where(ImageFilenameAlias.stem == "alias-stem")
+            ).scalar_one()
+            assert row.image_id == image_id
+
+
+@pytest.mark.unit
+class TestAddProcessedImage:
+    """`add_processed_image` の永続化動作。"""
+
+    def test_adds_processed_image(self, image_repository: ImageRepository, memory_session_factory) -> None:
+        image_id = _insert_image(image_repository, uuid="u-proc", phash="p-proc")
+        info = {
+            "image_id": image_id,
+            "stored_image_path": "/tmp/sample_512.png",
+            "width": 512,
+            "height": 512,
+            "has_alpha": False,
+            "filename": "sample_512.png",
+        }
+        processed_id = image_repository.add_processed_image(info)
+        assert isinstance(processed_id, int)
+        assert processed_id is not None and processed_id > 0
+        with memory_session_factory() as session:
+            row = session.execute(
+                select(ProcessedImage).where(ProcessedImage.id == processed_id)
+            ).scalar_one()
+            assert row.image_id == image_id
+
+    def test_raises_value_error_when_image_missing(self, image_repository: ImageRepository) -> None:
+        info = {
+            "image_id": 99999,
+            "stored_image_path": "/tmp/x.png",
+            "width": 256,
+            "height": 256,
+            "has_alpha": False,
+        }
+        with pytest.raises(ValueError, match="関連するオリジナル画像が見つかりません"):
+            image_repository.add_processed_image(info)
+
+
+@pytest.mark.unit
+class TestFormatAnnotationStatics:
+    """`_format_*_annotation` static helper の挙動。"""
+
+    def test_format_tag_annotation_returns_dict(self) -> None:
+        tag = SimpleNamespace(
+            id=1,
+            tag="cat",
+            tag_id=10,
+            model_id=20,
+            existing=False,
+            is_edited_manually=False,
+            confidence_score=0.9,
+            created_at=None,
+            updated_at=None,
+        )
+        result = ImageRepository._format_tag_annotation(tag)
+        assert result["tag"] == "cat"
+        assert result["model_id"] == 20
+
+    def test_format_rating_annotation_marks_manual(self) -> None:
+        """`litellm_model_id` が manual sentinel の場合 source=Manual。"""
+        from lorairo.database.schema import MANUAL_EDIT_LITELLM_ID
+
+        rating = SimpleNamespace(
+            id=1,
+            raw_rating_value="PG",
+            normalized_rating="PG",
+            model_id=99,
+            model=SimpleNamespace(name="something", litellm_model_id=MANUAL_EDIT_LITELLM_ID),
+            confidence_score=None,
+            created_at=None,
+            updated_at=None,
+        )
+        result = ImageRepository._format_rating_annotation(rating)
+        assert result["source"] == "Manual"
+
+
+@pytest.mark.unit
+class TestApplyDateFilter:
+    """`_apply_date_filter` クエリ変換動作。"""
+
+    def test_returns_query_unchanged_when_both_dates_none(self, image_repository: ImageRepository) -> None:
+        base = select(Image.id)
+        out = image_repository._apply_date_filter(base, None, None)
+        assert out is base
+
+
+@pytest.mark.unit
+class TestFacadeDelegation:
+    """ImageRepository delegating facade (db_repository.ImageRepository) の整合性。"""
+
+    def test_facade_holds_new_image_repo_instance(self, memory_session_factory) -> None:
+        """レガシー facade は `_image_repo` 属性に新 ImageRepository を保持する。"""
+        facade = LegacyImageRepository(session_factory=memory_session_factory)
+        assert isinstance(facade._image_repo, ImageRepository)
+
+    def test_facade_add_original_image_delegates(self, memory_session_factory) -> None:
+        """facade.add_original_image() は内部の新 ImageRepository.add_original_image() に委譲する。"""
+        facade = LegacyImageRepository(session_factory=memory_session_factory)
+        info = {
+            "uuid": "delegate-uuid",
+            "phash": "delegate-phash",
+            "original_image_path": "/tmp/d.png",
+            "stored_image_path": "/tmp/d.png",
+            "width": 32,
+            "height": 32,
+            "format": "PNG",
+            "extension": ".png",
+        }
+        # 内部 instance method を mock し、facade 経由でも呼ばれることを確認
+        facade._image_repo.add_original_image = Mock(return_value=42)  # type: ignore[method-assign]
+        result = facade.add_original_image(info)
+        facade._image_repo.add_original_image.assert_called_once_with(info=info)
+        assert result == 42
+
+    def test_facade_static_format_delegates_to_class(self) -> None:
+        """staticmethod (`_format_tag_annotation`) は新クラスの static method を呼ぶ。"""
+        tag = SimpleNamespace(
+            id=1,
+            tag="dog",
+            tag_id=11,
+            model_id=21,
+            existing=False,
+            is_edited_manually=False,
+            confidence_score=0.8,
+            created_at=None,
+            updated_at=None,
+        )
+        # facade.X と新クラス.X が同じ結果を返す (実装が共有されている)
+        from_facade = LegacyImageRepository._format_tag_annotation(tag)
+        from_new = ImageRepository._format_tag_annotation(tag)
+        assert from_facade == from_new
+
+
+@pytest.mark.unit
+class TestImageDatabaseManagerDIContract:
+    """ImageDatabaseManager が image_repo を inject 経由で保持することを確認。"""
+
+    def test_manager_creates_image_repo_when_not_injected(self, memory_session_factory) -> None:
+        """image_repo 未指定でも、repository.session_factory から自動生成される。"""
+        repo = LegacyImageRepository(session_factory=memory_session_factory)
+        cfg = Mock(spec=ConfigurationService)
+        manager = ImageDatabaseManager(repository=repo, config_service=cfg)
+        assert isinstance(manager.image_repo, ImageRepository)
+        assert manager.image_repo.session_factory is memory_session_factory
+
+    def test_manager_uses_injected_image_repo(self, memory_session_factory) -> None:
+        """明示注入された image_repo を保持し、Mock 化で外部依存を切り離せる。"""
+        repo = LegacyImageRepository(session_factory=memory_session_factory)
+        cfg = Mock(spec=ConfigurationService)
+        injected = Mock(spec=ImageRepository)
+        manager = ImageDatabaseManager(
+            repository=repo,
+            config_service=cfg,
+            image_repo=injected,
+        )
+        assert manager.image_repo is injected
+
+    def test_manager_image_repo_independent_of_legacy_facade_repo(self, memory_session_factory) -> None:
+        """Manager.image_repo はレガシー facade の `_image_repo` とは独立 instance である。
+
+        facade の `_image_repo` は facade 用の delegating 経路、Manager の `image_repo`
+        は Manager 直接呼び出し用 (段階 5 で完全移行) のため、別物。
+        """
+        repo = LegacyImageRepository(session_factory=memory_session_factory)
+        cfg = Mock(spec=ConfigurationService)
+        manager = ImageDatabaseManager(repository=repo, config_service=cfg)
+        # 別 instance であることを確認 (両方 ImageRepository だが is で異なる)
+        assert manager.image_repo is not repo._image_repo
+        # 両方とも同じ session_factory を共有している (composition pattern)
+        assert manager.image_repo.session_factory is repo._image_repo.session_factory

--- a/tests/unit/database/test_db_repository_ai_rating_filter.py
+++ b/tests/unit/database/test_db_repository_ai_rating_filter.py
@@ -132,8 +132,10 @@ class TestGetImagesByFilterAIRating:
         """manual_rating_filter が ai_rating_filter より優先されることを確認"""
         repository, _mock_session = mock_session_and_repository
 
-        with patch.object(repository, "_apply_manual_filters") as mock_manual:
-            with patch.object(repository, "_apply_ai_rating_filter") as mock_ai:
+        # ADR 0035 段階 4: get_images_by_filter は新 ImageRepository (`_image_repo`) に
+        # delegate しているため、internal filter helpers はそちらを mock する。
+        with patch.object(repository._image_repo, "_apply_manual_filters") as mock_manual:
+            with patch.object(repository._image_repo, "_apply_ai_rating_filter") as mock_ai:
                 mock_manual.return_value = select(Image.id)
                 mock_ai.return_value = select(Image.id)
 
@@ -149,7 +151,9 @@ class TestGetImagesByFilterAIRating:
         """ai_rating_filter のみが指定された場合、適用されることを確認"""
         repository, _mock_session = mock_session_and_repository
 
-        with patch.object(repository, "_apply_ai_rating_filter") as mock_ai:
+        # ADR 0035 段階 4: get_images_by_filter は新 ImageRepository (`_image_repo`) に
+        # delegate しているため、internal filter helpers はそちらを mock する。
+        with patch.object(repository._image_repo, "_apply_ai_rating_filter") as mock_ai:
             mock_ai.return_value = select(Image.id)
 
             # ai_rating_filter のみを指定
@@ -333,8 +337,14 @@ class TestUnratedFilter:
         base_query = select(Image.id)
         mock_session = Mock(spec=Session)
 
-        # _get_or_create_manual_edit_modelをモック
-        with patch.object(repository, "_get_or_create_manual_edit_model", return_value=1):
+        # ADR 0035 段階 4: 新 ImageRepository (`repository/image.py`) は
+        # MANUAL_EDIT model lookup を `ModelRepository._get_or_create_manual_edit_model`
+        # static helper に直接委譲しているため、import 元 (`lorairo.database.repository.image`)
+        # の参照を mock する。
+        with patch(
+            "lorairo.database.repository.image.ModelRepository._get_or_create_manual_edit_model",
+            return_value=1,
+        ):
             result_query = repository._apply_manual_filters(base_query, "UNRATED", None, mock_session)
 
         # クエリが変更されたことを確認

--- a/tests/unit/database/test_db_repository_annotations.py
+++ b/tests/unit/database/test_db_repository_annotations.py
@@ -308,7 +308,7 @@ class TestFetchFilteredMetadataAnnotations:
         mock_result.scalars.return_value.all.return_value = [mock_image]
         mock_session.execute.return_value = mock_result
 
-        with patch.object(repository, "_format_annotations_for_metadata") as mock_format:
+        with patch.object(repository._image_repo, "_format_annotations_for_metadata") as mock_format:
             mock_format.return_value = {
                 "tags": [{"id": 1, "tag": "test"}],
                 "captions": [],
@@ -369,8 +369,8 @@ class TestFetchFilteredMetadataAnnotations:
         mock_session.execute.side_effect = mock_execute
 
         with (
-            patch.object(repository, "_format_annotations_for_metadata") as mock_format,
-            patch.object(repository, "_filter_by_resolution") as mock_filter,
+            patch.object(repository._image_repo, "_format_annotations_for_metadata") as mock_format,
+            patch.object(repository._image_repo, "_filter_by_resolution") as mock_filter,
         ):
             mock_format.return_value = {
                 "tags": [{"id": 1, "tag": "test"}],

--- a/tests/unit/database/test_db_repository_batch_queries.py
+++ b/tests/unit/database/test_db_repository_batch_queries.py
@@ -44,7 +44,6 @@ class TestGetImagesMetadataBatch:
     def test_chunking_splits_large_input(self, repository):
         """BATCH_CHUNK_SIZE を超える入力がチャンク分割される"""
         repository.BATCH_CHUNK_SIZE = 3
-        repository._image_repo.BATCH_CHUNK_SIZE = 3
         mock_session = MagicMock()
         repository.session_factory.return_value.__enter__ = Mock(return_value=mock_session)
         repository.session_factory.return_value.__exit__ = Mock(return_value=False)
@@ -65,7 +64,6 @@ class TestGetImagesMetadataBatch:
     def test_chunking_exact_boundary(self, repository):
         """入力がちょうどBATCH_CHUNK_SIZEの場合、1チャンクで処理される"""
         repository.BATCH_CHUNK_SIZE = 3
-        repository._image_repo.BATCH_CHUNK_SIZE = 3
         mock_session = MagicMock()
         repository.session_factory.return_value.__enter__ = Mock(return_value=mock_session)
         repository.session_factory.return_value.__exit__ = Mock(return_value=False)
@@ -83,7 +81,6 @@ class TestGetImagesMetadataBatch:
     def test_chunking_boundary_plus_one(self, repository):
         """入力がBATCH_CHUNK_SIZE+1の場合、2チャンクに分割される"""
         repository.BATCH_CHUNK_SIZE = 3
-        repository._image_repo.BATCH_CHUNK_SIZE = 3
         mock_session = MagicMock()
         repository.session_factory.return_value.__enter__ = Mock(return_value=mock_session)
         repository.session_factory.return_value.__exit__ = Mock(return_value=False)
@@ -107,7 +104,6 @@ class TestGetImagesMetadataBatch:
     def test_chunking_single_element(self, repository):
         """要素1つの場合、1チャンクで処理される"""
         repository.BATCH_CHUNK_SIZE = 3
-        repository._image_repo.BATCH_CHUNK_SIZE = 3
         mock_session = MagicMock()
         repository.session_factory.return_value.__enter__ = Mock(return_value=mock_session)
         repository.session_factory.return_value.__exit__ = Mock(return_value=False)
@@ -125,7 +121,6 @@ class TestGetImagesMetadataBatch:
     def test_chunking_exact_multiple(self, repository):
         """入力がBATCH_CHUNK_SIZEの整数倍の場合、余りチャンクが生成されない"""
         repository.BATCH_CHUNK_SIZE = 2
-        repository._image_repo.BATCH_CHUNK_SIZE = 2
         mock_session = MagicMock()
         repository.session_factory.return_value.__enter__ = Mock(return_value=mock_session)
         repository.session_factory.return_value.__exit__ = Mock(return_value=False)
@@ -187,7 +182,6 @@ class TestGetAnnotatedImageIds:
     def test_chunking_merges_results(self, repository):
         """チャンク分割結果がsetにマージされる"""
         repository.BATCH_CHUNK_SIZE = 2
-        repository._image_repo.BATCH_CHUNK_SIZE = 2
         mock_session = MagicMock()
         repository.session_factory.return_value.__enter__ = Mock(return_value=mock_session)
         repository.session_factory.return_value.__exit__ = Mock(return_value=False)
@@ -214,7 +208,6 @@ class TestGetAnnotatedImageIds:
     def test_chunking_exact_boundary(self, repository):
         """入力がちょうどBATCH_CHUNK_SIZEの場合、1チャンクで処理される"""
         repository.BATCH_CHUNK_SIZE = 3
-        repository._image_repo.BATCH_CHUNK_SIZE = 3
         mock_session = MagicMock()
         repository.session_factory.return_value.__enter__ = Mock(return_value=mock_session)
         repository.session_factory.return_value.__exit__ = Mock(return_value=False)
@@ -228,7 +221,6 @@ class TestGetAnnotatedImageIds:
     def test_chunking_boundary_plus_one(self, repository):
         """入力がBATCH_CHUNK_SIZE+1の場合、2チャンクに分割される"""
         repository.BATCH_CHUNK_SIZE = 3
-        repository._image_repo.BATCH_CHUNK_SIZE = 3
         mock_session = MagicMock()
         repository.session_factory.return_value.__enter__ = Mock(return_value=mock_session)
         repository.session_factory.return_value.__exit__ = Mock(return_value=False)
@@ -253,7 +245,6 @@ class TestGetAnnotatedImageIds:
     def test_chunking_single_element(self, repository):
         """要素1つの場合、1チャンクで処理される"""
         repository.BATCH_CHUNK_SIZE = 3
-        repository._image_repo.BATCH_CHUNK_SIZE = 3
         mock_session = MagicMock()
         repository.session_factory.return_value.__enter__ = Mock(return_value=mock_session)
         repository.session_factory.return_value.__exit__ = Mock(return_value=False)
@@ -267,7 +258,6 @@ class TestGetAnnotatedImageIds:
     def test_chunking_no_results_across_chunks(self, repository):
         """全チャンクで結果が空の場合、空setが返る"""
         repository.BATCH_CHUNK_SIZE = 2
-        repository._image_repo.BATCH_CHUNK_SIZE = 2
         mock_session = MagicMock()
         repository.session_factory.return_value.__enter__ = Mock(return_value=mock_session)
         repository.session_factory.return_value.__exit__ = Mock(return_value=False)
@@ -324,7 +314,6 @@ class TestFindImageIdsByPhashes:
     def test_chunking_merges_results(self, repository):
         """チャンク分割結果がdictにマージされる"""
         repository.BATCH_CHUNK_SIZE = 2
-        repository._image_repo.BATCH_CHUNK_SIZE = 2
         mock_session = MagicMock()
         repository.session_factory.return_value.__enter__ = Mock(return_value=mock_session)
         repository.session_factory.return_value.__exit__ = Mock(return_value=False)
@@ -357,7 +346,6 @@ class TestFindImageIdsByPhashes:
     def test_chunking_exact_boundary(self, repository):
         """入力がちょうどBATCH_CHUNK_SIZEの場合、1チャンクで処理される"""
         repository.BATCH_CHUNK_SIZE = 3
-        repository._image_repo.BATCH_CHUNK_SIZE = 3
         mock_session = MagicMock()
         repository.session_factory.return_value.__enter__ = Mock(return_value=mock_session)
         repository.session_factory.return_value.__exit__ = Mock(return_value=False)
@@ -374,7 +362,6 @@ class TestFindImageIdsByPhashes:
     def test_chunking_boundary_plus_one(self, repository):
         """入力がBATCH_CHUNK_SIZE+1の場合、2チャンクに分割される"""
         repository.BATCH_CHUNK_SIZE = 3
-        repository._image_repo.BATCH_CHUNK_SIZE = 3
         mock_session = MagicMock()
         repository.session_factory.return_value.__enter__ = Mock(return_value=mock_session)
         repository.session_factory.return_value.__exit__ = Mock(return_value=False)
@@ -403,7 +390,6 @@ class TestFindImageIdsByPhashes:
     def test_chunking_single_element(self, repository):
         """要素1つの場合、1チャンクで処理される"""
         repository.BATCH_CHUNK_SIZE = 3
-        repository._image_repo.BATCH_CHUNK_SIZE = 3
         mock_session = MagicMock()
         repository.session_factory.return_value.__enter__ = Mock(return_value=mock_session)
         repository.session_factory.return_value.__exit__ = Mock(return_value=False)
@@ -417,7 +403,6 @@ class TestFindImageIdsByPhashes:
     def test_chunking_no_results_across_chunks(self, repository):
         """全チャンクで結果が空の場合、空dictが返る"""
         repository.BATCH_CHUNK_SIZE = 2
-        repository._image_repo.BATCH_CHUNK_SIZE = 2
         mock_session = MagicMock()
         repository.session_factory.return_value.__enter__ = Mock(return_value=mock_session)
         repository.session_factory.return_value.__exit__ = Mock(return_value=False)

--- a/tests/unit/database/test_db_repository_batch_queries.py
+++ b/tests/unit/database/test_db_repository_batch_queries.py
@@ -33,7 +33,9 @@ class TestGetImagesMetadataBatch:
         repository.session_factory.return_value.__exit__ = Mock(return_value=False)
 
         expected = [{"id": 1, "filename": "a.jpg"}, {"id": 2, "filename": "b.jpg"}]
-        with patch.object(repository, "_fetch_filtered_metadata", return_value=expected) as mock_fetch:
+        with patch.object(
+            repository._image_repo, "_fetch_filtered_metadata", return_value=expected
+        ) as mock_fetch:
             result = repository.get_images_metadata_batch([1, 2])
 
         mock_fetch.assert_called_once_with(mock_session, [1, 2], resolution=0)
@@ -42,12 +44,13 @@ class TestGetImagesMetadataBatch:
     def test_chunking_splits_large_input(self, repository):
         """BATCH_CHUNK_SIZE を超える入力がチャンク分割される"""
         repository.BATCH_CHUNK_SIZE = 3
+        repository._image_repo.BATCH_CHUNK_SIZE = 3
         mock_session = MagicMock()
         repository.session_factory.return_value.__enter__ = Mock(return_value=mock_session)
         repository.session_factory.return_value.__exit__ = Mock(return_value=False)
 
         with patch.object(
-            repository,
+            repository._image_repo,
             "_fetch_filtered_metadata",
             side_effect=[
                 [{"id": 1}, {"id": 2}, {"id": 3}],
@@ -62,12 +65,13 @@ class TestGetImagesMetadataBatch:
     def test_chunking_exact_boundary(self, repository):
         """入力がちょうどBATCH_CHUNK_SIZEの場合、1チャンクで処理される"""
         repository.BATCH_CHUNK_SIZE = 3
+        repository._image_repo.BATCH_CHUNK_SIZE = 3
         mock_session = MagicMock()
         repository.session_factory.return_value.__enter__ = Mock(return_value=mock_session)
         repository.session_factory.return_value.__exit__ = Mock(return_value=False)
 
         with patch.object(
-            repository,
+            repository._image_repo,
             "_fetch_filtered_metadata",
             return_value=[{"id": 1}, {"id": 2}, {"id": 3}],
         ) as mock_fetch:
@@ -79,12 +83,13 @@ class TestGetImagesMetadataBatch:
     def test_chunking_boundary_plus_one(self, repository):
         """入力がBATCH_CHUNK_SIZE+1の場合、2チャンクに分割される"""
         repository.BATCH_CHUNK_SIZE = 3
+        repository._image_repo.BATCH_CHUNK_SIZE = 3
         mock_session = MagicMock()
         repository.session_factory.return_value.__enter__ = Mock(return_value=mock_session)
         repository.session_factory.return_value.__exit__ = Mock(return_value=False)
 
         with patch.object(
-            repository,
+            repository._image_repo,
             "_fetch_filtered_metadata",
             side_effect=[
                 [{"id": 1}, {"id": 2}, {"id": 3}],
@@ -102,12 +107,13 @@ class TestGetImagesMetadataBatch:
     def test_chunking_single_element(self, repository):
         """要素1つの場合、1チャンクで処理される"""
         repository.BATCH_CHUNK_SIZE = 3
+        repository._image_repo.BATCH_CHUNK_SIZE = 3
         mock_session = MagicMock()
         repository.session_factory.return_value.__enter__ = Mock(return_value=mock_session)
         repository.session_factory.return_value.__exit__ = Mock(return_value=False)
 
         with patch.object(
-            repository,
+            repository._image_repo,
             "_fetch_filtered_metadata",
             return_value=[{"id": 99}],
         ) as mock_fetch:
@@ -119,12 +125,13 @@ class TestGetImagesMetadataBatch:
     def test_chunking_exact_multiple(self, repository):
         """入力がBATCH_CHUNK_SIZEの整数倍の場合、余りチャンクが生成されない"""
         repository.BATCH_CHUNK_SIZE = 2
+        repository._image_repo.BATCH_CHUNK_SIZE = 2
         mock_session = MagicMock()
         repository.session_factory.return_value.__enter__ = Mock(return_value=mock_session)
         repository.session_factory.return_value.__exit__ = Mock(return_value=False)
 
         with patch.object(
-            repository,
+            repository._image_repo,
             "_fetch_filtered_metadata",
             side_effect=[
                 [{"id": 1}, {"id": 2}],
@@ -143,7 +150,7 @@ class TestGetImagesMetadataBatch:
         repository.session_factory.return_value.__exit__ = Mock(return_value=False)
 
         with patch.object(
-            repository,
+            repository._image_repo,
             "_fetch_filtered_metadata",
             side_effect=SQLAlchemyError("test"),
         ):
@@ -180,6 +187,7 @@ class TestGetAnnotatedImageIds:
     def test_chunking_merges_results(self, repository):
         """チャンク分割結果がsetにマージされる"""
         repository.BATCH_CHUNK_SIZE = 2
+        repository._image_repo.BATCH_CHUNK_SIZE = 2
         mock_session = MagicMock()
         repository.session_factory.return_value.__enter__ = Mock(return_value=mock_session)
         repository.session_factory.return_value.__exit__ = Mock(return_value=False)
@@ -206,6 +214,7 @@ class TestGetAnnotatedImageIds:
     def test_chunking_exact_boundary(self, repository):
         """入力がちょうどBATCH_CHUNK_SIZEの場合、1チャンクで処理される"""
         repository.BATCH_CHUNK_SIZE = 3
+        repository._image_repo.BATCH_CHUNK_SIZE = 3
         mock_session = MagicMock()
         repository.session_factory.return_value.__enter__ = Mock(return_value=mock_session)
         repository.session_factory.return_value.__exit__ = Mock(return_value=False)
@@ -219,6 +228,7 @@ class TestGetAnnotatedImageIds:
     def test_chunking_boundary_plus_one(self, repository):
         """入力がBATCH_CHUNK_SIZE+1の場合、2チャンクに分割される"""
         repository.BATCH_CHUNK_SIZE = 3
+        repository._image_repo.BATCH_CHUNK_SIZE = 3
         mock_session = MagicMock()
         repository.session_factory.return_value.__enter__ = Mock(return_value=mock_session)
         repository.session_factory.return_value.__exit__ = Mock(return_value=False)
@@ -243,6 +253,7 @@ class TestGetAnnotatedImageIds:
     def test_chunking_single_element(self, repository):
         """要素1つの場合、1チャンクで処理される"""
         repository.BATCH_CHUNK_SIZE = 3
+        repository._image_repo.BATCH_CHUNK_SIZE = 3
         mock_session = MagicMock()
         repository.session_factory.return_value.__enter__ = Mock(return_value=mock_session)
         repository.session_factory.return_value.__exit__ = Mock(return_value=False)
@@ -256,6 +267,7 @@ class TestGetAnnotatedImageIds:
     def test_chunking_no_results_across_chunks(self, repository):
         """全チャンクで結果が空の場合、空setが返る"""
         repository.BATCH_CHUNK_SIZE = 2
+        repository._image_repo.BATCH_CHUNK_SIZE = 2
         mock_session = MagicMock()
         repository.session_factory.return_value.__enter__ = Mock(return_value=mock_session)
         repository.session_factory.return_value.__exit__ = Mock(return_value=False)
@@ -312,6 +324,7 @@ class TestFindImageIdsByPhashes:
     def test_chunking_merges_results(self, repository):
         """チャンク分割結果がdictにマージされる"""
         repository.BATCH_CHUNK_SIZE = 2
+        repository._image_repo.BATCH_CHUNK_SIZE = 2
         mock_session = MagicMock()
         repository.session_factory.return_value.__enter__ = Mock(return_value=mock_session)
         repository.session_factory.return_value.__exit__ = Mock(return_value=False)
@@ -344,6 +357,7 @@ class TestFindImageIdsByPhashes:
     def test_chunking_exact_boundary(self, repository):
         """入力がちょうどBATCH_CHUNK_SIZEの場合、1チャンクで処理される"""
         repository.BATCH_CHUNK_SIZE = 3
+        repository._image_repo.BATCH_CHUNK_SIZE = 3
         mock_session = MagicMock()
         repository.session_factory.return_value.__enter__ = Mock(return_value=mock_session)
         repository.session_factory.return_value.__exit__ = Mock(return_value=False)
@@ -360,6 +374,7 @@ class TestFindImageIdsByPhashes:
     def test_chunking_boundary_plus_one(self, repository):
         """入力がBATCH_CHUNK_SIZE+1の場合、2チャンクに分割される"""
         repository.BATCH_CHUNK_SIZE = 3
+        repository._image_repo.BATCH_CHUNK_SIZE = 3
         mock_session = MagicMock()
         repository.session_factory.return_value.__enter__ = Mock(return_value=mock_session)
         repository.session_factory.return_value.__exit__ = Mock(return_value=False)
@@ -388,6 +403,7 @@ class TestFindImageIdsByPhashes:
     def test_chunking_single_element(self, repository):
         """要素1つの場合、1チャンクで処理される"""
         repository.BATCH_CHUNK_SIZE = 3
+        repository._image_repo.BATCH_CHUNK_SIZE = 3
         mock_session = MagicMock()
         repository.session_factory.return_value.__enter__ = Mock(return_value=mock_session)
         repository.session_factory.return_value.__exit__ = Mock(return_value=False)
@@ -401,6 +417,7 @@ class TestFindImageIdsByPhashes:
     def test_chunking_no_results_across_chunks(self, repository):
         """全チャンクで結果が空の場合、空dictが返る"""
         repository.BATCH_CHUNK_SIZE = 2
+        repository._image_repo.BATCH_CHUNK_SIZE = 2
         mock_session = MagicMock()
         repository.session_factory.return_value.__enter__ = Mock(return_value=mock_session)
         repository.session_factory.return_value.__exit__ = Mock(return_value=False)

--- a/tests/unit/database/test_db_repository_error_records.py
+++ b/tests/unit/database/test_db_repository_error_records.py
@@ -204,7 +204,7 @@ class TestGetImagesByIds:
         ]
         repository.session_factory.return_value.__enter__.return_value = mock_session
 
-        with patch.object(repository, "_format_annotations_for_metadata", return_value={}):
+        with patch.object(repository._image_repo, "_format_annotations_for_metadata", return_value={}):
             images = repository.get_images_by_ids([1])
 
         assert len(images) == 1

--- a/tests/unit/database/test_db_repository_score_labels.py
+++ b/tests/unit/database/test_db_repository_score_labels.py
@@ -270,8 +270,6 @@ class TestGetImageAnnotationsScoreLabels:
         mock_session.execute.return_value = mock_result
 
         repository.session_factory = MagicMock(return_value=mock_session)
-
-        repository._image_repo.session_factory = repository.session_factory
         return mock_session
 
     def test_get_image_annotations_includes_score_labels_key_when_empty(
@@ -364,7 +362,6 @@ class TestGetImageAnnotationsQualitySummary:
         mock_result.unique.return_value.scalar_one_or_none.return_value = image
         mock_session.execute.return_value = mock_result
         repository.session_factory = MagicMock(return_value=mock_session)
-        repository._image_repo.session_factory = repository.session_factory
         return mock_session
 
     def test_quality_summary_no_score_when_empty(self, repository: ImageRepository) -> None:

--- a/tests/unit/database/test_db_repository_score_labels.py
+++ b/tests/unit/database/test_db_repository_score_labels.py
@@ -270,6 +270,8 @@ class TestGetImageAnnotationsScoreLabels:
         mock_session.execute.return_value = mock_result
 
         repository.session_factory = MagicMock(return_value=mock_session)
+
+        repository._image_repo.session_factory = repository.session_factory
         return mock_session
 
     def test_get_image_annotations_includes_score_labels_key_when_empty(
@@ -362,6 +364,7 @@ class TestGetImageAnnotationsQualitySummary:
         mock_result.unique.return_value.scalar_one_or_none.return_value = image
         mock_session.execute.return_value = mock_result
         repository.session_factory = MagicMock(return_value=mock_session)
+        repository._image_repo.session_factory = repository.session_factory
         return mock_session
 
     def test_quality_summary_no_score_when_empty(self, repository: ImageRepository) -> None:


### PR DESCRIPTION
## Summary

ADR 0035 Repository Aggregate Split の段階 4 として、`db_repository.py` god class から `Image` / `ProcessedImage` / `FilenameAlias` を新 `repository/image.py` の `ImageRepository` (BaseRepository 継承) に抽出する。

- レガシー `db_repository.ImageRepository`: 3591 → 1864 行 (-1727 行)。本コミットで delegating wrapper のみが残る。
- `ImageDatabaseManager.image_repo` を DI 経由で公開 (model_repo / project_repo / error_record_repo と同じ pattern)。
- Annotation 書き込み (`save_annotations` / `_save_*` / `update_*_batch` / tag 登録 / genai-tag-db-tools 統合) は段階 5 領域として未着手。

## Commits

1. `refactor: extract ImageRepository (#423 段階 4, ADR 0035)` — 新 `repository/image.py` 追加 (~2120 行)。
2. `refactor: convert Image methods to delegating wrappers (#423 段階 4)` — `db_repository.py` の ~50 メソッドを 1 行 delegate に縮減 + テスト patch path 修正。
3. `refactor: inject ImageRepository into ImageDatabaseManager (#423 段階 4)` — `image_repo` optional 引数を `__init__` に追加。
4. `test: cover ImageRepository extraction (#423 段階 4)` — 28 件の単体テスト追加 (Structure / Method classes / FacadeDelegation / DIContract)。

## Scope

**抽出したメソッド** (`repository/image.py`):
- CRUD: `_image_exists`, `add_original_image`, `add_processed_image`, `_find_existing_processed_image_id`
- FilenameAlias: `get_all_image_filename_index`, `add_filename_alias`
- 検索: `find_duplicate_image_by_phash`, `find_image_ids_by_phashes`, `get_annotated_image_ids`
- メタデータ (annotation 読み込み込み): `get_image_metadata`, `get_images_metadata_batch`, `get_batch_available_resolutions`, `get_processed_image`, `_filter_by_resolution`
- Annotation read (single image): `get_image_annotations` + 5 つの `_format_*_annotation` static helper
- Annotation format (batch read): 5 つの `_format_*` + `_format_annotations_for_metadata`
- メタデータ fetch: `_fetch_original/processed/filtered_image_metadata`
- フィルタ helper: `_parse_datetime_str`, `_prepare_like_pattern`, 8 つの `_apply_*_filter`, `_apply_project_filter`
- フィルタ統合: `_build_image_filter_query`, `get_images_by_filter`, `get_images_count_only`
- 件数: `get_total_image_count`
- ID 引き: `get_images_by_ids`
- Path 解決: `get_image_id_by_filepath`, `get_image_ids_by_filepaths`, `get_phashes_by_filepaths`, 関連 helper

**段階 5 領域 (本 PR には含めない)**:
- Annotation 書き込み (`save_annotations`, `_save_*`, `update_*_batch`, `update_manual_rating`, `update_annotation_manual_edit_flag`)
- Tag CRUD (`add_tag_to_images_batch`, `batch_resolve_tag_ids`, `_register_*`, `_retry_tag_search`)
- genai-tag-db-tools 統合 (`_initialize_merged_reader`, `_initialize_tag_register_service`)

## ADR Compliance

- **ADR 0035 §1** (Aggregate boundary): Image / ProcessedImage / FilenameAlias を 1 Repository に集約。Project FK 経由のアサインは段階 2 の `ProjectRepository` 担当。
- **ADR 0035 §3** (Manager 層の composition): `ImageDatabaseManager.image_repo` を optional injection で公開、テスト時 Mock 可能。
- **ADR 0035 §5** (Delegating wrapper): レガシー facade を 1 行 delegate に縮減し、段階 5 完了まで既存呼び出し元との後方互換を維持。
- **ADR 0035 §6** (Staged migration): 段階 4 でも `db_repository.ImageRepository` import path を維持し、外部呼び出し元の即時更新を強制しない。

## PR #476 / PR #477 Lesson Inheritance

- **DI contract (PR #477)**: レガシー facade の wrapper は `self._image_repo.X(...)` で instance-based dispatch を行い、test double / subclass override を尊重する。
- **Static helper boundary**: `_get_or_create_manual_edit_model` は `ModelRepository._get_or_create_manual_edit_model(session)` の static-style で呼ぶ (instance を受けない設計のため妥当)。テスト patch は import path 経由で実施。
- **OSError catch (PR #476)**: `register_original_image` / `detect_duplicate_image` は段階 4 では未抽出 (Manager 層に残る)。既存の OSError catch (commit 284bc5e2) はそのまま保持。

## Test plan

- [x] `pytest tests/unit/database/repository/test_image_repository.py` 28 件成功 (新規追加)
- [x] `pytest tests/unit/database` 476 件成功 (既存テストの patch path 修正含む)
- [x] `pytest tests/integration -m "not gui_show and not calls_real_webapi and not downloads_and_runs_model and not slow"` 227 件成功
- [x] CI-equivalent filter (`pytest -m "not gui_show and not calls_real_webapi and not downloads_and_runs_model and not slow"`) 全 3315 件成功
- [x] `ruff format` / `ruff check` 通過

## Related

- Parent: #418
- Stage 1: PR #477 (ModelRepository)
- Stage 2: PR #479 (ProjectRepository)
- Stage 3: PR #482 (ErrorRecordRepository)
- Next: Stage 5 (AnnotationRepository) — `save_annotations` + tag CRUD + genai-tag-db-tools 統合

CI-EQUIV-TESTED

🤖 Generated with [Claude Code](https://claude.com/claude-code)