### PR TITLE
feat: bridge provider batch result import

### DIFF
--- a/src/lorairo/annotations/annotator_adapter.py
+++ b/src/lorairo/annotations/annotator_adapter.py
@@ -33,7 +33,7 @@ if TYPE_CHECKING:
     from lorairo.services.provider_batch_service import (
         BatchJobHandle,
         BatchSubmitRequest,
-        ProviderBatchArtifacts,
+        ProviderBatchFetchResult,
         ProviderBatchStatus,
         ProviderBatchSubmission,
     )
@@ -218,10 +218,12 @@ class AnnotatorLibraryAdapter:
         """Provider Batch API job の cancel を image-annotator-lib の公開 API へ委譲する。"""
         return cast("ProviderBatchStatus", self._call_batch_api("cancel_batch", handle))
 
-    def fetch_batch_results(self, handle: BatchJobHandle, destination_dir: Path) -> ProviderBatchArtifacts:
-        """Provider Batch API job の artifact 取得を image-annotator-lib の公開 API へ委譲する。"""
+    def fetch_batch_results(
+        self, handle: BatchJobHandle, destination_dir: Path
+    ) -> ProviderBatchFetchResult:
+        """Provider Batch API job の normalized result 取得を image-annotator-lib の公開 API へ委譲する。"""
         return cast(
-            "ProviderBatchArtifacts",
+            "ProviderBatchFetchResult",
             self._call_batch_api("fetch_batch_results", handle, destination_dir),
         )
 

--- a/src/lorairo/database/db_repository.py
+++ b/src/lorairo/database/db_repository.py
@@ -1472,6 +1472,7 @@ class ImageRepository:
                 stmt = (
                     select(ProviderBatchJob)
                     .options(
+                        selectinload(ProviderBatchJob.model),
                         selectinload(ProviderBatchJob.items),
                         selectinload(ProviderBatchJob.artifacts),
                     )

--- a/src/lorairo/services/__init__.py
+++ b/src/lorairo/services/__init__.py
@@ -19,14 +19,16 @@ from .provider_batch_service import (
     ProviderBatchArtifactRef,
     ProviderBatchArtifacts,
     ProviderBatchError,
+    ProviderBatchFetchResult,
     ProviderBatchJobService,
+    ProviderBatchResultItem,
     ProviderBatchStatus,
     ProviderBatchSubmission,
 )
 from .provider_batch_workflow_service import (
     ProviderBatchLibraryAdapter,
+    ProviderBatchImportResult,
     ProviderBatchResultApplyResult,
-    ProviderBatchResultItem,
     ProviderBatchWorkflowService,
 )
 from .service_container import ServiceContainer, get_service_container
@@ -46,6 +48,8 @@ __all__ = [
     "ProviderBatchArtifactRef",
     "ProviderBatchArtifacts",
     "ProviderBatchError",
+    "ProviderBatchFetchResult",
+    "ProviderBatchImportResult",
     "ProviderBatchJobService",
     "ProviderBatchLibraryAdapter",
     "ProviderBatchResultApplyResult",

--- a/src/lorairo/services/annotation_save_service.py
+++ b/src/lorairo/services/annotation_save_service.py
@@ -6,6 +6,7 @@ CLI・GUI・API の3経路で共有する Qt-free サービス。
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
@@ -34,6 +35,11 @@ class AnnotationSaveResult:
     error_count: int
     total_count: int
     error_details: list[str] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class _ModelRef:
+    id: int
 
 
 class AnnotationSaveService:
@@ -498,6 +504,75 @@ class AnnotationSaveService:
         total_count = len(results)
         logger.info(f"DB保存完了: {success_count}/{total_count}件成功")
 
+        return AnnotationSaveResult(
+            success_count=success_count,
+            skip_count=skip_count,
+            error_count=error_count,
+            total_count=total_count,
+            error_details=error_details,
+        )
+
+    def save_provider_batch_results_by_image_id(
+        self,
+        results_by_image_id: Mapping[int, Any],
+        *,
+        model_id: int | None,
+        model_name: str,
+    ) -> AnnotationSaveResult:
+        """Provider Batch の normalized result を image_id keyed で保存する。
+
+        Provider Batch import は ``custom_id`` → ``provider_batch_items.image_id`` を
+        SSoT とするため、pHash や file stem fallback は使わない。
+        """
+        if not results_by_image_id:
+            return AnnotationSaveResult(
+                success_count=0,
+                skip_count=0,
+                error_count=0,
+                total_count=0,
+            )
+        if model_id is None:
+            raise ValueError("Provider Batch result 保存には model_id が必要です")
+
+        wrapped_results = {
+            int(image_id): {model_name: unified_result}
+            for image_id, unified_result in results_by_image_id.items()
+        }
+        _model_names, all_raw_tags = self._collect_names_and_tags(wrapped_results)
+        models_cache: dict[str, Any] = {model_name: _ModelRef(model_id)}
+        tag_id_cache = self._resolve_tag_ids(all_raw_tags)
+
+        success_count = 0
+        skip_count = 0
+        error_count = 0
+        error_details: list[str] = []
+
+        for image_id, image_annotations in wrapped_results.items():
+            try:
+                annotations_dict = self._build_annotations_dict(
+                    image_annotations,
+                    models_cache,
+                    image_id=image_id,
+                )
+                if not annotations_dict or not any(annotations_dict.values()):
+                    logger.debug(f"画像ID {image_id} に保存するアノテーションがありません")
+                    skip_count += 1
+                    continue
+                self._repository.save_annotations(
+                    image_id,
+                    annotations_dict,
+                    skip_existence_check=True,
+                    tag_id_cache=tag_id_cache if tag_id_cache else None,
+                )
+                success_count += 1
+            except Exception as e:
+                error_msg = f"image_id={image_id}: {e}"
+                error_details.append(error_msg)
+                error_count += 1
+                logger.error(f"Provider Batch result 保存失敗 image_id={image_id}: {e}", exc_info=True)
+
+        total_count = len(wrapped_results)
+        logger.info(f"Provider Batch result DB保存完了: {success_count}/{total_count}件成功")
         return AnnotationSaveResult(
             success_count=success_count,
             skip_count=skip_count,

--- a/src/lorairo/services/provider_batch_service.py
+++ b/src/lorairo/services/provider_batch_service.py
@@ -141,6 +141,37 @@ class ProviderBatchArtifacts:
     raw_provider_payload: ProviderBatchRawPayload = None
 
 
+@dataclass(frozen=True)
+class ProviderBatchResultItem:
+    """Provider-neutral normalized batch result item."""
+
+    custom_id: str
+    status: str
+    annotation: Any | None = None
+    error_type: str | None = None
+    error_message: str | None = None
+    raw_response: ProviderBatchRawPayload = None
+
+
+@dataclass(frozen=True)
+class ProviderBatchFetchResult:
+    """Provider adapter の normalized fetch/import 結果。"""
+
+    provider_job_id: str
+    provider_status: str
+    status: str | None = None
+    request_count: int | None = None
+    succeeded_count: int | None = None
+    failed_count: int | None = None
+    canceled_count: int | None = None
+    expired_count: int | None = None
+    completed_at: datetime | None = None
+    expires_at: datetime | None = None
+    artifacts: tuple[ProviderBatchArtifactRef, ...] = field(default_factory=tuple)
+    items: tuple[ProviderBatchResultItem, ...] = field(default_factory=tuple)
+    raw_provider_payload: ProviderBatchRawPayload = None
+
+
 class ProviderBatchAdapter(Protocol):
     """image-annotator-lib batch API client interface."""
 
@@ -158,8 +189,10 @@ class ProviderBatchAdapter(Protocol):
         """Provider batch job を cancel する。"""
         ...
 
-    def fetch_batch_results(self, handle: BatchJobHandle, destination_dir: Path) -> ProviderBatchArtifacts:
-        """Provider batch job の output/error artifacts を download する。"""
+    def fetch_batch_results(
+        self, handle: BatchJobHandle, destination_dir: Path
+    ) -> ProviderBatchFetchResult:
+        """Provider batch job の normalized result と artifacts を取得する。"""
         ...
 
 
@@ -399,26 +432,67 @@ class ProviderBatchJobService:
         destination_dir: Path,
         api_keys: Mapping[str, str] | None = None,
     ) -> ProviderBatchArtifacts:
-        """Provider result artifacts を download し、artifact records を保存する。"""
+        """Provider result artifacts を download し、artifact records を保存する。
+
+        互換 wrapper。正規化済み result item を扱う新規経路は ``fetch_results()`` を使う。
+        """
+        fetch_result = self.fetch_results(job_id, destination_dir, api_keys=api_keys)
+        return ProviderBatchArtifacts(
+            provider_job_id=fetch_result.provider_job_id,
+            artifacts=fetch_result.artifacts,
+            raw_provider_payload=fetch_result.raw_provider_payload,
+        )
+
+    def fetch_results(
+        self,
+        job_id: int,
+        destination_dir: Path,
+        api_keys: Mapping[str, str] | None = None,
+    ) -> ProviderBatchFetchResult:
+        """Provider result を取得し、job/artifact metadata を保存する。"""
         job = self._require_job(job_id)
         if job.provider_job_id is None:
             raise ProviderBatchError(f"provider_job_id が未設定です: job_id={job_id}")
 
+        fetch_result = self._fetch_from_adapter(job, destination_dir, api_keys)
+        self._validate_provider_job_id(job, fetch_result.provider_job_id)
+
+        updates = self._register_fetch_artifacts(job_id, fetch_result.artifacts)
+        updates.update(self._build_fetch_job_updates(job, fetch_result))
+        if fetch_result.raw_provider_payload is not None:
+            updates["raw_provider_payload"] = self._serialize_payload(fetch_result.raw_provider_payload)
+        if updates:
+            self._repository.update_provider_batch_job(job_id, updates)
+
+        return fetch_result
+
+    def _fetch_from_adapter(
+        self,
+        job: ProviderBatchJob,
+        destination_dir: Path,
+        api_keys: Mapping[str, str] | None,
+    ) -> ProviderBatchFetchResult:
         adapter = self._get_adapter(job.provider)
         if hasattr(adapter, "fetch_batch_results"):
-            artifacts = adapter.fetch_batch_results(self._build_handle(job, api_keys), destination_dir)
+            raw_result = adapter.fetch_batch_results(self._build_handle(job, api_keys), destination_dir)
         else:
-            artifacts = adapter.download_results(  # type: ignore[attr-defined]
-                job.provider_job_id, destination_dir
+            raw_result = adapter.download_results(  # type: ignore[attr-defined]
+                job.provider_job_id,
+                destination_dir,
             )
-        self._validate_provider_job_id(job, artifacts.provider_job_id)
+        return self._coerce_fetch_result(raw_result, job.provider_job_id or "")
 
+    def _register_fetch_artifacts(
+        self,
+        job_id: int,
+        artifacts: tuple[ProviderBatchArtifactRef, ...],
+    ) -> dict[str, Any]:
         updates: dict[str, Any] = {}
         existing_artifact_keys = {
             (registered.artifact_type, registered.local_path)
             for registered in self._repository.list_provider_batch_artifacts(job_id)
         }
-        for artifact in artifacts.artifacts:
+        for artifact in artifacts:
             local_path = str(artifact.local_path)
             artifact_key = (artifact.artifact_type, local_path)
             if artifact_key not in existing_artifact_keys:
@@ -438,13 +512,31 @@ class ProviderBatchJobService:
                 updates["output_artifact_path"] = local_path
             elif artifact.artifact_type == "error":
                 updates["error_artifact_path"] = local_path
+        return updates
 
-        if artifacts.raw_provider_payload is not None:
-            updates["raw_provider_payload"] = self._serialize_payload(artifacts.raw_provider_payload)
-        if updates:
-            self._repository.update_provider_batch_job(job_id, updates)
-
-        return artifacts
+    def _build_fetch_job_updates(
+        self,
+        job: ProviderBatchJob,
+        fetch_result: ProviderBatchFetchResult,
+    ) -> dict[str, Any]:
+        updates: dict[str, Any] = {}
+        provider_status = fetch_result.status or fetch_result.provider_status
+        if provider_status:
+            next_status = self.normalize_status(job.provider, provider_status)
+            self.validate_transition(job.status, next_status)
+            updates["status"] = next_status
+            updates["provider_status"] = fetch_result.provider_status
+        optional_fields = {
+            "request_count": fetch_result.request_count,
+            "succeeded_count": fetch_result.succeeded_count,
+            "failed_count": fetch_result.failed_count,
+            "canceled_count": fetch_result.canceled_count,
+            "expired_count": fetch_result.expired_count,
+            "completed_at": fetch_result.completed_at,
+            "expires_at": fetch_result.expires_at,
+        }
+        updates.update({key: value for key, value in optional_fields.items() if value is not None})
+        return updates
 
     @classmethod
     def normalize_status(cls, provider: str, provider_status: str) -> str:
@@ -507,6 +599,102 @@ class ProviderBatchJobService:
         if refreshed is None:
             raise ProviderBatchError(f"更新後の provider batch job が見つかりません: job_id={job.id}")
         return refreshed
+
+    @classmethod
+    def _coerce_fetch_result(
+        cls,
+        result: ProviderBatchFetchResult | ProviderBatchArtifacts | Mapping[str, Any] | Any,
+        fallback_provider_job_id: str,
+    ) -> ProviderBatchFetchResult:
+        if isinstance(result, ProviderBatchFetchResult):
+            return result
+        if isinstance(result, ProviderBatchArtifacts):
+            return ProviderBatchFetchResult(
+                provider_job_id=result.provider_job_id,
+                provider_status="completed",
+                artifacts=result.artifacts,
+                raw_provider_payload=result.raw_provider_payload,
+            )
+        if isinstance(result, Mapping):
+            provider_job_id = cls._optional_str(result.get("provider_job_id")) or fallback_provider_job_id
+            provider_status = cls._optional_str(result.get("provider_status") or result.get("status"))
+            if provider_status is None:
+                provider_status = "completed"
+            return ProviderBatchFetchResult(
+                provider_job_id=provider_job_id,
+                provider_status=provider_status,
+                status=cls._optional_str(result.get("status")),
+                request_count=cls._optional_int(result.get("request_count")),
+                succeeded_count=cls._optional_int(result.get("succeeded_count")),
+                failed_count=cls._optional_int(result.get("failed_count")),
+                canceled_count=cls._optional_int(result.get("canceled_count")),
+                expired_count=cls._optional_int(result.get("expired_count")),
+                completed_at=result.get("completed_at"),
+                expires_at=result.get("expires_at"),
+                artifacts=tuple(result.get("artifacts") or ()),
+                items=tuple(cls._coerce_result_item(item) for item in result.get("items") or ()),
+                raw_provider_payload=result.get("raw_provider_payload"),
+            )
+
+        provider_job_id = (
+            cls._optional_str(getattr(result, "provider_job_id", None)) or fallback_provider_job_id
+        )
+        provider_status = cls._optional_str(
+            getattr(result, "provider_status", None) or getattr(result, "status", None)
+        )
+        if provider_status is None:
+            provider_status = "completed"
+        return ProviderBatchFetchResult(
+            provider_job_id=provider_job_id,
+            provider_status=provider_status,
+            status=cls._optional_str(getattr(result, "status", None)),
+            request_count=cls._optional_int(getattr(result, "request_count", None)),
+            succeeded_count=cls._optional_int(getattr(result, "succeeded_count", None)),
+            failed_count=cls._optional_int(getattr(result, "failed_count", None)),
+            canceled_count=cls._optional_int(getattr(result, "canceled_count", None)),
+            expired_count=cls._optional_int(getattr(result, "expired_count", None)),
+            completed_at=getattr(result, "completed_at", None),
+            expires_at=getattr(result, "expires_at", None),
+            artifacts=tuple(getattr(result, "artifacts", ()) or ()),
+            items=tuple(cls._coerce_result_item(item) for item in getattr(result, "items", ()) or ()),
+            raw_provider_payload=getattr(result, "raw_provider_payload", None),
+        )
+
+    @classmethod
+    def _coerce_result_item(
+        cls, item: ProviderBatchResultItem | Mapping[str, Any] | Any
+    ) -> ProviderBatchResultItem:
+        if isinstance(item, ProviderBatchResultItem):
+            return item
+        if isinstance(item, Mapping):
+            error = item.get("error")
+            return ProviderBatchResultItem(
+                custom_id=str(item["custom_id"]),
+                status=str(item["status"]),
+                annotation=item.get("annotation"),
+                error_type=cls._optional_str(
+                    item.get("error_type") or cls._extract_error_field(error, "type")
+                ),
+                error_message=cls._optional_str(
+                    item.get("error_message")
+                    or item.get("message")
+                    or cls._extract_error_field(error, "message")
+                ),
+                raw_response=item.get("raw_response"),
+            )
+        error = getattr(item, "error", None)
+        return ProviderBatchResultItem(
+            custom_id=str(item.custom_id),
+            status=str(item.status),
+            annotation=getattr(item, "annotation", None),
+            error_type=cls._optional_str(
+                getattr(item, "error_type", None) or cls._extract_error_field(error, "type")
+            ),
+            error_message=cls._optional_str(
+                getattr(item, "error_message", None) or cls._extract_error_field(error, "message")
+            ),
+            raw_response=getattr(item, "raw_response", None),
+        )
 
     def _require_job(self, job_id: int) -> ProviderBatchJob:
         job = self._repository.get_provider_batch_job(job_id)
@@ -573,6 +761,26 @@ class ProviderBatchJobService:
     @staticmethod
     def _normalize_provider_name(provider: str) -> str:
         return provider.strip().lower()
+
+    @staticmethod
+    def _optional_str(value: Any) -> str | None:
+        if value is None:
+            return None
+        return str(value)
+
+    @staticmethod
+    def _optional_int(value: Any) -> int | None:
+        if value is None:
+            return None
+        return int(value)
+
+    @staticmethod
+    def _extract_error_field(error: Any, field_name: str) -> Any:
+        if error is None:
+            return None
+        if isinstance(error, Mapping):
+            return error.get(field_name) or error.get(f"error_{field_name}")
+        return getattr(error, field_name, None) or getattr(error, f"error_{field_name}", None)
 
     @staticmethod
     def _serialize_payload(payload: ProviderBatchRawPayload) -> str | None:

--- a/src/lorairo/services/provider_batch_service.py
+++ b/src/lorairo/services/provider_batch_service.py
@@ -618,9 +618,7 @@ class ProviderBatchJobService:
             )
         if isinstance(result, Mapping):
             provider_job_id = cls._optional_str(result.get("provider_job_id")) or fallback_provider_job_id
-            provider_status = cls._optional_str(result.get("provider_status") or result.get("status"))
-            if provider_status is None:
-                provider_status = "completed"
+            provider_status = cls._optional_str(result.get("provider_status") or result.get("status")) or ""
             return ProviderBatchFetchResult(
                 provider_job_id=provider_job_id,
                 provider_status=provider_status,
@@ -642,11 +640,10 @@ class ProviderBatchJobService:
         provider_job_id = (
             cls._optional_str(getattr(result, "provider_job_id", None)) or fallback_provider_job_id
         )
-        provider_status = cls._optional_str(
-            getattr(result, "provider_status", None) or getattr(result, "status", None)
+        provider_status = (
+            cls._optional_str(getattr(result, "provider_status", None) or getattr(result, "status", None))
+            or ""
         )
-        if provider_status is None:
-            provider_status = "completed"
         return ProviderBatchFetchResult(
             provider_job_id=provider_job_id,
             provider_status=provider_status,

--- a/src/lorairo/services/provider_batch_service.py
+++ b/src/lorairo/services/provider_batch_service.py
@@ -612,7 +612,7 @@ class ProviderBatchJobService:
         if isinstance(result, ProviderBatchArtifacts):
             return ProviderBatchFetchResult(
                 provider_job_id=result.provider_job_id,
-                provider_status="completed",
+                provider_status="",
                 artifacts=result.artifacts,
                 raw_provider_payload=result.raw_provider_payload,
             )
@@ -630,9 +630,11 @@ class ProviderBatchJobService:
                 failed_count=cls._optional_int(result.get("failed_count")),
                 canceled_count=cls._optional_int(result.get("canceled_count")),
                 expired_count=cls._optional_int(result.get("expired_count")),
-                completed_at=result.get("completed_at"),
-                expires_at=result.get("expires_at"),
-                artifacts=tuple(result.get("artifacts") or ()),
+                completed_at=cls._optional_datetime(result.get("completed_at")),
+                expires_at=cls._optional_datetime(result.get("expires_at")),
+                artifacts=tuple(
+                    cls._coerce_artifact_ref(artifact) for artifact in result.get("artifacts") or ()
+                ),
                 items=tuple(cls._coerce_result_item(item) for item in result.get("items") or ()),
                 raw_provider_payload=result.get("raw_provider_payload"),
             )
@@ -654,11 +656,34 @@ class ProviderBatchJobService:
             failed_count=cls._optional_int(getattr(result, "failed_count", None)),
             canceled_count=cls._optional_int(getattr(result, "canceled_count", None)),
             expired_count=cls._optional_int(getattr(result, "expired_count", None)),
-            completed_at=getattr(result, "completed_at", None),
-            expires_at=getattr(result, "expires_at", None),
-            artifacts=tuple(getattr(result, "artifacts", ()) or ()),
+            completed_at=cls._optional_datetime(getattr(result, "completed_at", None)),
+            expires_at=cls._optional_datetime(getattr(result, "expires_at", None)),
+            artifacts=tuple(
+                cls._coerce_artifact_ref(artifact) for artifact in getattr(result, "artifacts", ()) or ()
+            ),
             items=tuple(cls._coerce_result_item(item) for item in getattr(result, "items", ()) or ()),
             raw_provider_payload=getattr(result, "raw_provider_payload", None),
+        )
+
+    @classmethod
+    def _coerce_artifact_ref(
+        cls,
+        artifact: ProviderBatchArtifactRef | Mapping[str, Any] | Any,
+    ) -> ProviderBatchArtifactRef:
+        if isinstance(artifact, ProviderBatchArtifactRef):
+            return artifact
+        if isinstance(artifact, Mapping):
+            return ProviderBatchArtifactRef(
+                artifact_type=str(artifact["artifact_type"]),
+                local_path=Path(artifact["local_path"]),
+                provider_file_id=cls._optional_str(artifact.get("provider_file_id")),
+                sha256=cls._optional_str(artifact.get("sha256")),
+            )
+        return ProviderBatchArtifactRef(
+            artifact_type=str(artifact.artifact_type),
+            local_path=Path(artifact.local_path),
+            provider_file_id=cls._optional_str(getattr(artifact, "provider_file_id", None)),
+            sha256=cls._optional_str(getattr(artifact, "sha256", None)),
         )
 
     @classmethod
@@ -774,6 +799,16 @@ class ProviderBatchJobService:
         if value is None:
             return None
         return int(value)
+
+    @staticmethod
+    def _optional_datetime(value: Any) -> datetime | None:
+        if value is None:
+            return None
+        if isinstance(value, datetime):
+            return value
+        if isinstance(value, str):
+            return datetime.fromisoformat(value.replace("Z", "+00:00"))
+        raise ProviderBatchError(f"datetime に変換できない値です: {value!r}")
 
     @staticmethod
     def _extract_error_field(error: Any, field_name: str) -> Any:

--- a/src/lorairo/services/provider_batch_service.py
+++ b/src/lorairo/services/provider_batch_service.py
@@ -523,8 +523,9 @@ class ProviderBatchJobService:
         provider_status = fetch_result.status or fetch_result.provider_status
         if provider_status:
             next_status = self.normalize_status(job.provider, provider_status)
-            self.validate_transition(job.status, next_status)
-            updates["status"] = next_status
+            if not (job.status == "imported" and next_status == "completed"):
+                self.validate_transition(job.status, next_status)
+                updates["status"] = next_status
             updates["provider_status"] = fetch_result.provider_status
         optional_fields = {
             "request_count": fetch_result.request_count,

--- a/src/lorairo/services/provider_batch_workflow_service.py
+++ b/src/lorairo/services/provider_batch_workflow_service.py
@@ -22,6 +22,7 @@ from lorairo.services.provider_batch_service import (
     BatchSubmitItem,
     BatchSubmitRequest,
     ProviderBatchAdapter,
+    ProviderBatchArtifactRef,
     ProviderBatchArtifacts,
     ProviderBatchError,
     ProviderBatchFetchResult,
@@ -407,7 +408,7 @@ class ProviderBatchWorkflowService:
         if isinstance(result, ProviderBatchArtifacts):
             return ProviderBatchFetchResult(
                 provider_job_id=result.provider_job_id,
-                provider_status="completed",
+                provider_status="",
                 artifacts=result.artifacts,
                 raw_provider_payload=result.raw_provider_payload,
             )
@@ -416,7 +417,16 @@ class ProviderBatchWorkflowService:
                 provider_job_id=str(result.get("provider_job_id") or fallback_provider_job_id),
                 provider_status=str(result.get("provider_status") or result.get("status") or "completed"),
                 status=cls._optional_str(result.get("status")),
-                artifacts=tuple(result.get("artifacts") or ()),
+                request_count=cls._optional_int(result.get("request_count")),
+                succeeded_count=cls._optional_int(result.get("succeeded_count")),
+                failed_count=cls._optional_int(result.get("failed_count")),
+                canceled_count=cls._optional_int(result.get("canceled_count")),
+                expired_count=cls._optional_int(result.get("expired_count")),
+                completed_at=cls._optional_datetime(result.get("completed_at")),
+                expires_at=cls._optional_datetime(result.get("expires_at")),
+                artifacts=tuple(
+                    cls._coerce_artifact_ref(artifact) for artifact in result.get("artifacts") or ()
+                ),
                 items=tuple(cls._coerce_result_item(item) for item in result.get("items") or ()),
                 raw_provider_payload=result.get("raw_provider_payload"),
             )
@@ -427,9 +437,39 @@ class ProviderBatchWorkflowService:
                 getattr(result, "provider_status", None) or getattr(result, "status", None) or "completed"
             ),
             status=cls._optional_str(getattr(result, "status", None)),
-            artifacts=tuple(getattr(result, "artifacts", ()) or ()),
+            request_count=cls._optional_int(getattr(result, "request_count", None)),
+            succeeded_count=cls._optional_int(getattr(result, "succeeded_count", None)),
+            failed_count=cls._optional_int(getattr(result, "failed_count", None)),
+            canceled_count=cls._optional_int(getattr(result, "canceled_count", None)),
+            expired_count=cls._optional_int(getattr(result, "expired_count", None)),
+            completed_at=cls._optional_datetime(getattr(result, "completed_at", None)),
+            expires_at=cls._optional_datetime(getattr(result, "expires_at", None)),
+            artifacts=tuple(
+                cls._coerce_artifact_ref(artifact) for artifact in getattr(result, "artifacts", ()) or ()
+            ),
             items=tuple(cls._coerce_result_item(item) for item in getattr(result, "items", ()) or ()),
             raw_provider_payload=getattr(result, "raw_provider_payload", None),
+        )
+
+    @classmethod
+    def _coerce_artifact_ref(
+        cls,
+        artifact: ProviderBatchArtifactRef | Mapping[str, Any] | Any,
+    ) -> ProviderBatchArtifactRef:
+        if isinstance(artifact, ProviderBatchArtifactRef):
+            return artifact
+        if isinstance(artifact, Mapping):
+            return ProviderBatchArtifactRef(
+                artifact_type=str(artifact["artifact_type"]),
+                local_path=Path(artifact["local_path"]),
+                provider_file_id=cls._optional_str(artifact.get("provider_file_id")),
+                sha256=cls._optional_str(artifact.get("sha256")),
+            )
+        return ProviderBatchArtifactRef(
+            artifact_type=str(artifact.artifact_type),
+            local_path=Path(artifact.local_path),
+            provider_file_id=cls._optional_str(getattr(artifact, "provider_file_id", None)),
+            sha256=cls._optional_str(getattr(artifact, "sha256", None)),
         )
 
     @staticmethod
@@ -490,6 +530,22 @@ class ProviderBatchWorkflowService:
         if value is None:
             return None
         return str(value)
+
+    @staticmethod
+    def _optional_int(value: Any) -> int | None:
+        if value is None:
+            return None
+        return int(value)
+
+    @staticmethod
+    def _optional_datetime(value: Any) -> datetime | None:
+        if value is None:
+            return None
+        if isinstance(value, datetime):
+            return value
+        if isinstance(value, str):
+            return datetime.fromisoformat(value.replace("Z", "+00:00"))
+        raise ProviderBatchError(f"datetime に変換できない値です: {value!r}")
 
     @staticmethod
     def _serialize_payload(payload: ProviderBatchRawPayload) -> str | None:

--- a/src/lorairo/services/provider_batch_workflow_service.py
+++ b/src/lorairo/services/provider_batch_workflow_service.py
@@ -33,7 +33,7 @@ from lorairo.services.provider_batch_service import (
 from lorairo.utils.log import logger
 
 if TYPE_CHECKING:
-    from lorairo.database.schema import ProviderBatchJob
+    from lorairo.database.schema import ProviderBatchItem, ProviderBatchJob
 
 
 @dataclass(frozen=True)
@@ -58,6 +58,15 @@ class ProviderBatchImportResult:
     total_count: int
     missing_custom_ids: tuple[str, ...] = field(default_factory=tuple)
     job_imported: bool = False
+
+
+@dataclass(frozen=True)
+class _PreparedProviderBatchImport:
+    results_by_model_id: Mapping[int, Mapping[int, Any]]
+    imported_custom_ids: tuple[str, ...]
+    missing_custom_ids: tuple[str, ...]
+    already_imported_count: int
+    non_importable_count: int
 
 
 class ProviderBatchLibraryAdapter:
@@ -269,43 +278,34 @@ class ProviderBatchWorkflowService:
         )
 
         refreshed_job = self._require_job(job_id)
-        items_by_custom_id = {item.custom_id: item for item in refreshed_job.items}
-        results_by_image_id: dict[int, Any] = {}
-        imported_custom_ids: list[str] = []
-        missing_custom_ids: list[str] = list(apply_result.missing_custom_ids)
+        prepared = self._prepare_import_results(refreshed_job, normalized_fetch, apply_result)
 
-        for raw_item in normalized_fetch.items:
-            item = self._coerce_result_item(raw_item)
-            db_item = items_by_custom_id.get(item.custom_id)
-            if db_item is None or db_item.image_id is None:
-                missing_custom_ids.append(item.custom_id)
-                continue
-            if item.status not in {"succeeded", "completed", "imported"} or item.annotation is None:
-                continue
-            results_by_image_id[db_item.image_id] = item.annotation
-            imported_custom_ids.append(item.custom_id)
-
-        model_id = refreshed_job.model_id or self._first_item_model_id(refreshed_job)
-        if results_by_image_id and model_id is None:
-            raise ProviderBatchError(f"Provider batch import に model_id が必要です: job_id={job_id}")
-        self._validate_importable_job_state(refreshed_job, results_by_image_id)
-        model_name = self._model_name_for_job(refreshed_job, model_id)
-        save_result = self._annotation_save_service.save_provider_batch_results_by_image_id(
-            results_by_image_id,
-            model_id=model_id,
-            model_name=model_name,
+        importable_count = sum(
+            len(results_by_image_id) for results_by_image_id in prepared.results_by_model_id.values()
         )
+        self._validate_importable_job_state(refreshed_job, importable_count)
+        save_result = self._save_results_by_model(refreshed_job, prepared.results_by_model_id)
 
-        unique_missing_custom_ids = tuple(sorted(set(missing_custom_ids)))
+        unique_missing_custom_ids = tuple(sorted(set(prepared.missing_custom_ids)))
+        settled_count = save_result.success_count + prepared.already_imported_count
+        import_clean = (
+            save_result.error_count == 0
+            and save_result.skip_count == 0
+            and not unique_missing_custom_ids
+            and prepared.non_importable_count == 0
+        )
         job_imported = (
-            save_result.success_count > 0 and save_result.error_count == 0 and not unique_missing_custom_ids
+            bool(normalized_fetch.items) and settled_count == len(normalized_fetch.items) and import_clean
         )
         mark_imported_items = (
-            save_result.success_count == len(imported_custom_ids) and save_result.error_count == 0
+            save_result.success_count == len(prepared.imported_custom_ids)
+            and save_result.error_count == 0
+            and save_result.skip_count == 0
         )
         if mark_imported_items:
-            self._mark_items_imported(job_id, imported_custom_ids)
+            self._mark_items_imported(job_id, prepared.imported_custom_ids)
         if job_imported:
+            ProviderBatchJobService.validate_transition(refreshed_job.status, "imported")
             self._repository.update_provider_batch_job(
                 job_id,
                 {"status": "imported", "imported_at": datetime.now(UTC)},
@@ -315,7 +315,10 @@ class ProviderBatchWorkflowService:
             save_result=save_result,
             apply_result=apply_result,
             imported_count=save_result.success_count,
-            skipped_count=save_result.skip_count + len(unique_missing_custom_ids),
+            skipped_count=save_result.skip_count
+            + len(unique_missing_custom_ids)
+            + prepared.non_importable_count
+            + prepared.already_imported_count,
             error_count=save_result.error_count,
             total_count=len(normalized_fetch.items),
             missing_custom_ids=unique_missing_custom_ids,
@@ -323,11 +326,86 @@ class ProviderBatchWorkflowService:
         )
 
     @staticmethod
-    def _validate_importable_job_state(
-        job: ProviderBatchJob, results_by_image_id: Mapping[int, Any]
-    ) -> None:
-        if results_by_image_id:
+    def _validate_importable_job_state(job: ProviderBatchJob, importable_count: int) -> None:
+        if importable_count:
             ProviderBatchJobService.validate_transition(job.status, "imported")
+
+    def _prepare_import_results(
+        self,
+        job: ProviderBatchJob,
+        fetch_result: ProviderBatchFetchResult,
+        apply_result: ProviderBatchResultApplyResult,
+    ) -> _PreparedProviderBatchImport:
+        items_by_custom_id = {item.custom_id: item for item in job.items}
+        results_by_model_id: dict[int, dict[int, Any]] = {}
+        imported_custom_ids: list[str] = []
+        missing_custom_ids: list[str] = list(apply_result.missing_custom_ids)
+        already_imported_count = 0
+        non_importable_count = 0
+
+        for raw_item in fetch_result.items:
+            item = self._coerce_result_item(raw_item)
+            db_item = items_by_custom_id.get(item.custom_id)
+            if db_item is None or db_item.image_id is None:
+                missing_custom_ids.append(item.custom_id)
+                continue
+            if db_item.status == "imported":
+                already_imported_count += 1
+                continue
+            if item.status not in {"succeeded", "completed", "imported"} or item.annotation is None:
+                non_importable_count += 1
+                continue
+            model_id = self._model_id_for_item(job, db_item)
+            if model_id is None:
+                raise ProviderBatchError(f"Provider batch import に model_id が必要です: job_id={job.id}")
+            results_by_model_id.setdefault(model_id, {})[db_item.image_id] = item.annotation
+            imported_custom_ids.append(item.custom_id)
+
+        return _PreparedProviderBatchImport(
+            results_by_model_id=results_by_model_id,
+            imported_custom_ids=tuple(imported_custom_ids),
+            missing_custom_ids=tuple(missing_custom_ids),
+            already_imported_count=already_imported_count,
+            non_importable_count=non_importable_count,
+        )
+
+    def _save_results_by_model(
+        self,
+        job: ProviderBatchJob,
+        results_by_model_id: Mapping[int, Mapping[int, Any]],
+    ) -> AnnotationSaveResult:
+        if not results_by_model_id:
+            return AnnotationSaveResult(success_count=0, skip_count=0, error_count=0, total_count=0)
+
+        success_count = 0
+        skip_count = 0
+        error_count = 0
+        total_count = 0
+        error_details: list[str] = []
+        for model_id, results_by_image_id in results_by_model_id.items():
+            model_name = self._model_name_for_job(job, model_id)
+            result = self._annotation_save_service.save_provider_batch_results_by_image_id(
+                results_by_image_id,
+                model_id=model_id,
+                model_name=model_name,
+            )
+            success_count += result.success_count
+            skip_count += result.skip_count
+            error_count += result.error_count
+            total_count += result.total_count
+            error_details.extend(result.error_details)
+
+        return AnnotationSaveResult(
+            success_count=success_count,
+            skip_count=skip_count,
+            error_count=error_count,
+            total_count=total_count,
+            error_details=error_details,
+        )
+
+    @staticmethod
+    def _model_id_for_item(job: ProviderBatchJob, item: ProviderBatchItem) -> int | None:
+        return item.model_id if item.model_id is not None else job.model_id
 
     def _mark_items_imported(self, job_id: int, custom_ids: Sequence[str]) -> None:
         updates_by_custom_id = {custom_id: {"status": "imported"} for custom_id in custom_ids}
@@ -350,11 +428,18 @@ class ProviderBatchWorkflowService:
                 f"job_id={job_id}, expected={job.provider_job_id}, actual={provider_job_id}"
             )
 
+        current_items_by_custom_id = {item.custom_id: item for item in job.items}
         updates_by_custom_id: dict[str, dict[str, Any]] = {}
         for raw_item in items:
             item = self._coerce_result_item(raw_item)
+            current_item = current_items_by_custom_id.get(item.custom_id)
+            next_status = (
+                "imported"
+                if current_item is not None and current_item.status == "imported"
+                else item.status
+            )
             updates_by_custom_id[item.custom_id] = {
-                "status": item.status,
+                "status": next_status,
                 "error_type": item.error_type,
                 "error_message": item.error_message,
                 "raw_response": self._serialize_payload(item.raw_response),
@@ -490,16 +575,13 @@ class ProviderBatchWorkflowService:
         )
 
     @staticmethod
-    def _first_item_model_id(job: ProviderBatchJob) -> int | None:
-        for item in job.items:
-            if item.model_id is not None:
-                return item.model_id
-        return None
-
-    @staticmethod
     def _model_name_for_job(job: ProviderBatchJob, model_id: int | None) -> str:
         model = job.model
-        litellm_model_id = getattr(model, "litellm_model_id", None) if model is not None else None
+        litellm_model_id = (
+            getattr(model, "litellm_model_id", None)
+            if model is not None and job.model_id == model_id
+            else None
+        )
         if litellm_model_id:
             return str(litellm_model_id)
         if model_id is not None:

--- a/src/lorairo/services/provider_batch_workflow_service.py
+++ b/src/lorairo/services/provider_batch_workflow_service.py
@@ -300,10 +300,12 @@ class ProviderBatchWorkflowService:
         job_imported = (
             save_result.success_count > 0 and save_result.error_count == 0 and not unique_missing_custom_ids
         )
+        mark_imported_items = (
+            save_result.success_count == len(imported_custom_ids) and save_result.error_count == 0
+        )
+        if mark_imported_items:
+            self._mark_items_imported(job_id, imported_custom_ids)
         if job_imported:
-            updates_by_custom_id = {custom_id: {"status": "imported"} for custom_id in imported_custom_ids}
-            if updates_by_custom_id:
-                self._repository.update_provider_batch_items_by_custom_id(job_id, updates_by_custom_id)
             self._repository.update_provider_batch_job(
                 job_id,
                 {"status": "imported", "imported_at": datetime.now(UTC)},
@@ -326,6 +328,11 @@ class ProviderBatchWorkflowService:
     ) -> None:
         if results_by_image_id:
             ProviderBatchJobService.validate_transition(job.status, "imported")
+
+    def _mark_items_imported(self, job_id: int, custom_ids: Sequence[str]) -> None:
+        updates_by_custom_id = {custom_id: {"status": "imported"} for custom_id in custom_ids}
+        if updates_by_custom_id:
+            self._repository.update_provider_batch_items_by_custom_id(job_id, updates_by_custom_id)
 
     def apply_result_items(
         self,
@@ -421,9 +428,10 @@ class ProviderBatchWorkflowService:
                 raw_provider_payload=result.raw_provider_payload,
             )
         if isinstance(result, Mapping):
+            provider_status = cls._optional_str(result.get("provider_status") or result.get("status")) or ""
             return ProviderBatchFetchResult(
                 provider_job_id=str(result.get("provider_job_id") or fallback_provider_job_id),
-                provider_status=str(result.get("provider_status") or result.get("status") or "completed"),
+                provider_status=provider_status,
                 status=cls._optional_str(result.get("status")),
                 request_count=cls._optional_int(result.get("request_count")),
                 succeeded_count=cls._optional_int(result.get("succeeded_count")),
@@ -441,9 +449,10 @@ class ProviderBatchWorkflowService:
         return ProviderBatchFetchResult(
             provider_job_id=cls._optional_str(getattr(result, "provider_job_id", None))
             or fallback_provider_job_id,
-            provider_status=str(
-                getattr(result, "provider_status", None) or getattr(result, "status", None) or "completed"
-            ),
+            provider_status=cls._optional_str(
+                getattr(result, "provider_status", None) or getattr(result, "status", None)
+            )
+            or "",
             status=cls._optional_str(getattr(result, "status", None)),
             request_count=cls._optional_int(getattr(result, "request_count", None)),
             succeeded_count=cls._optional_int(getattr(result, "succeeded_count", None)),

--- a/src/lorairo/services/provider_batch_workflow_service.py
+++ b/src/lorairo/services/provider_batch_workflow_service.py
@@ -288,6 +288,7 @@ class ProviderBatchWorkflowService:
         model_id = refreshed_job.model_id or self._first_item_model_id(refreshed_job)
         if results_by_image_id and model_id is None:
             raise ProviderBatchError(f"Provider batch import に model_id が必要です: job_id={job_id}")
+        self._validate_importable_job_state(refreshed_job, results_by_image_id)
         model_name = self._model_name_for_job(refreshed_job, model_id)
         save_result = self._annotation_save_service.save_provider_batch_results_by_image_id(
             results_by_image_id,
@@ -318,6 +319,13 @@ class ProviderBatchWorkflowService:
             missing_custom_ids=unique_missing_custom_ids,
             job_imported=job_imported,
         )
+
+    @staticmethod
+    def _validate_importable_job_state(
+        job: ProviderBatchJob, results_by_image_id: Mapping[int, Any]
+    ) -> None:
+        if results_by_image_id:
+            ProviderBatchJobService.validate_transition(job.status, "imported")
 
     def apply_result_items(
         self,

--- a/src/lorairo/services/provider_batch_workflow_service.py
+++ b/src/lorairo/services/provider_batch_workflow_service.py
@@ -296,7 +296,7 @@ class ProviderBatchWorkflowService:
 
         unique_missing_custom_ids = tuple(sorted(set(missing_custom_ids)))
         job_imported = (
-            bool(normalized_fetch.items) and save_result.error_count == 0 and not unique_missing_custom_ids
+            save_result.success_count > 0 and save_result.error_count == 0 and not unique_missing_custom_ids
         )
         if job_imported:
             updates_by_custom_id = {custom_id: {"status": "imported"} for custom_id in imported_custom_ids}
@@ -370,11 +370,14 @@ class ProviderBatchWorkflowService:
         if not provider_status:
             return
         next_status = ProviderBatchJobService.normalize_status(job.provider, provider_status)
-        ProviderBatchJobService.validate_transition(job.status, next_status)
+        should_preserve_imported = job.status == "imported" and next_status == "completed"
+        if not should_preserve_imported:
+            ProviderBatchJobService.validate_transition(job.status, next_status)
         updates: dict[str, Any] = {
-            "status": next_status,
             "provider_status": fetch_result.provider_status,
         }
+        if not should_preserve_imported:
+            updates["status"] = next_status
         optional_fields = {
             "request_count": fetch_result.request_count,
             "succeeded_count": fetch_result.succeeded_count,
@@ -418,7 +421,8 @@ class ProviderBatchWorkflowService:
                 raw_provider_payload=result.get("raw_provider_payload"),
             )
         return ProviderBatchFetchResult(
-            provider_job_id=str(getattr(result, "provider_job_id", fallback_provider_job_id)),
+            provider_job_id=cls._optional_str(getattr(result, "provider_job_id", None))
+            or fallback_provider_job_id,
             provider_status=str(
                 getattr(result, "provider_status", None) or getattr(result, "status", None) or "completed"
             ),

--- a/src/lorairo/services/provider_batch_workflow_service.py
+++ b/src/lorairo/services/provider_batch_workflow_service.py
@@ -10,10 +10,12 @@ from __future__ import annotations
 import json
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from lorairo.database.db_repository import ImageRepository
+from lorairo.services.annotation_save_service import AnnotationSaveResult, AnnotationSaveService
 from lorairo.services.configuration_service import ConfigurationService
 from lorairo.services.provider_batch_service import (
     BatchJobHandle,
@@ -22,24 +24,15 @@ from lorairo.services.provider_batch_service import (
     ProviderBatchAdapter,
     ProviderBatchArtifacts,
     ProviderBatchError,
+    ProviderBatchFetchResult,
     ProviderBatchJobService,
     ProviderBatchRawPayload,
+    ProviderBatchResultItem,
 )
 from lorairo.utils.log import logger
 
 if TYPE_CHECKING:
     from lorairo.database.schema import ProviderBatchJob
-
-
-@dataclass(frozen=True)
-class ProviderBatchResultItem:
-    """Provider-neutral batch result item state for LoRAIro persistence."""
-
-    custom_id: str
-    status: str
-    error_type: str | None = None
-    error_message: str | None = None
-    raw_response: ProviderBatchRawPayload = None
 
 
 @dataclass(frozen=True)
@@ -50,6 +43,20 @@ class ProviderBatchResultApplyResult:
     missing_count: int
     total_count: int
     missing_custom_ids: tuple[str, ...] = field(default_factory=tuple)
+
+
+@dataclass(frozen=True)
+class ProviderBatchImportResult:
+    """Summary of importing normalized provider batch results into annotations."""
+
+    save_result: AnnotationSaveResult
+    apply_result: ProviderBatchResultApplyResult
+    imported_count: int
+    skipped_count: int
+    error_count: int
+    total_count: int
+    missing_custom_ids: tuple[str, ...] = field(default_factory=tuple)
+    job_imported: bool = False
 
 
 class ProviderBatchLibraryAdapter:
@@ -87,10 +94,12 @@ class ProviderBatchWorkflowService:
         config_service: ConfigurationService,
         job_service: ProviderBatchJobService | None = None,
         adapters: Mapping[str, ProviderBatchAdapter] | None = None,
+        annotation_save_service: AnnotationSaveService | None = None,
     ) -> None:
         self._repository = repository
         self._config_service = config_service
         self._job_service = job_service or ProviderBatchJobService(repository, adapters)
+        self._annotation_save_service = annotation_save_service or AnnotationSaveService(repository)
 
     def register_adapter(self, adapter: ProviderBatchAdapter) -> None:
         """Register a provider adapter with the underlying job service."""
@@ -200,15 +209,113 @@ class ProviderBatchWorkflowService:
         destination_dir: str | Path | None = None,
     ) -> ProviderBatchArtifacts:
         """Download provider artifacts into the configured batch results directory by default."""
+        fetch_result = self.fetch_results(job_id, destination_dir)
+        return ProviderBatchArtifacts(
+            provider_job_id=fetch_result.provider_job_id,
+            artifacts=fetch_result.artifacts,
+            raw_provider_payload=fetch_result.raw_provider_payload,
+        )
+
+    def fetch_results(
+        self,
+        job_id: int,
+        destination_dir: str | Path | None = None,
+    ) -> ProviderBatchFetchResult:
+        """Fetch normalized provider results and apply per-item result state."""
         resolved_destination = (
             Path(destination_dir)
             if destination_dir is not None
             else self._config_service.get_batch_results_directory()
         )
-        return self._job_service.download_results(
+        fetch_result = self._job_service.fetch_results(
             job_id,
             resolved_destination,
             api_keys=self._config_service.get_api_keys(),
+        )
+        if fetch_result.items:
+            self.apply_result_items(job_id, fetch_result.provider_job_id, fetch_result.items)
+        return fetch_result
+
+    def import_results(
+        self,
+        job_id: int,
+        fetch_result: ProviderBatchFetchResult | Mapping[str, Any] | Any | None = None,
+        destination_dir: str | Path | None = None,
+    ) -> ProviderBatchImportResult:
+        """Import normalized provider batch results using custom_id as the mapping SSoT."""
+        job = self._require_job(job_id)
+        if job.status == "imported" or job.imported_at is not None:
+            raise ProviderBatchError(f"Provider batch job は import 済みです: job_id={job_id}")
+        if job.provider_job_id is None:
+            raise ProviderBatchError(f"provider_job_id が未設定です: job_id={job_id}")
+
+        normalized_fetch = (
+            self._coerce_fetch_result(fetch_result, job.provider_job_id)
+            if fetch_result is not None
+            else self.fetch_results(job_id, destination_dir)
+        )
+        if normalized_fetch.provider_job_id != job.provider_job_id:
+            raise ProviderBatchError(
+                "Provider batch import job ID mismatch: "
+                f"job_id={job_id}, expected={job.provider_job_id}, actual={normalized_fetch.provider_job_id}"
+            )
+        self._apply_fetch_job_state(job, normalized_fetch)
+
+        apply_result = (
+            self.apply_result_items(job_id, normalized_fetch.provider_job_id, normalized_fetch.items)
+            if normalized_fetch.items
+            else ProviderBatchResultApplyResult(updated_count=0, missing_count=0, total_count=0)
+        )
+
+        refreshed_job = self._require_job(job_id)
+        items_by_custom_id = {item.custom_id: item for item in refreshed_job.items}
+        results_by_image_id: dict[int, Any] = {}
+        imported_custom_ids: list[str] = []
+        missing_custom_ids: list[str] = list(apply_result.missing_custom_ids)
+
+        for raw_item in normalized_fetch.items:
+            item = self._coerce_result_item(raw_item)
+            db_item = items_by_custom_id.get(item.custom_id)
+            if db_item is None or db_item.image_id is None:
+                missing_custom_ids.append(item.custom_id)
+                continue
+            if item.status not in {"succeeded", "completed", "imported"} or item.annotation is None:
+                continue
+            results_by_image_id[db_item.image_id] = item.annotation
+            imported_custom_ids.append(item.custom_id)
+
+        model_id = refreshed_job.model_id or self._first_item_model_id(refreshed_job)
+        if results_by_image_id and model_id is None:
+            raise ProviderBatchError(f"Provider batch import に model_id が必要です: job_id={job_id}")
+        model_name = self._model_name_for_job(refreshed_job, model_id)
+        save_result = self._annotation_save_service.save_provider_batch_results_by_image_id(
+            results_by_image_id,
+            model_id=model_id,
+            model_name=model_name,
+        )
+
+        unique_missing_custom_ids = tuple(sorted(set(missing_custom_ids)))
+        job_imported = (
+            bool(normalized_fetch.items) and save_result.error_count == 0 and not unique_missing_custom_ids
+        )
+        if job_imported:
+            updates_by_custom_id = {custom_id: {"status": "imported"} for custom_id in imported_custom_ids}
+            if updates_by_custom_id:
+                self._repository.update_provider_batch_items_by_custom_id(job_id, updates_by_custom_id)
+            self._repository.update_provider_batch_job(
+                job_id,
+                {"status": "imported", "imported_at": datetime.now(UTC)},
+            )
+
+        return ProviderBatchImportResult(
+            save_result=save_result,
+            apply_result=apply_result,
+            imported_count=save_result.success_count,
+            skipped_count=save_result.skip_count + len(unique_missing_custom_ids),
+            error_count=save_result.error_count,
+            total_count=len(normalized_fetch.items),
+            missing_custom_ids=unique_missing_custom_ids,
+            job_imported=job_imported,
         )
 
     def apply_result_items(
@@ -254,6 +361,90 @@ class ProviderBatchWorkflowService:
             missing_custom_ids=tuple(missing_custom_ids),
         )
 
+    def _apply_fetch_job_state(
+        self,
+        job: ProviderBatchJob,
+        fetch_result: ProviderBatchFetchResult,
+    ) -> None:
+        provider_status = fetch_result.status or fetch_result.provider_status
+        if not provider_status:
+            return
+        next_status = ProviderBatchJobService.normalize_status(job.provider, provider_status)
+        ProviderBatchJobService.validate_transition(job.status, next_status)
+        updates: dict[str, Any] = {
+            "status": next_status,
+            "provider_status": fetch_result.provider_status,
+        }
+        optional_fields = {
+            "request_count": fetch_result.request_count,
+            "succeeded_count": fetch_result.succeeded_count,
+            "failed_count": fetch_result.failed_count,
+            "canceled_count": fetch_result.canceled_count,
+            "expired_count": fetch_result.expired_count,
+            "completed_at": fetch_result.completed_at,
+            "expires_at": fetch_result.expires_at,
+        }
+        updates.update({key: value for key, value in optional_fields.items() if value is not None})
+        self._repository.update_provider_batch_job(job.id, updates)
+
+    def _require_job(self, job_id: int) -> ProviderBatchJob:
+        job = self._repository.get_provider_batch_job(job_id)
+        if job is None:
+            raise ProviderBatchError(f"Provider batch job が見つかりません: job_id={job_id}")
+        return job
+
+    @classmethod
+    def _coerce_fetch_result(
+        cls,
+        result: ProviderBatchFetchResult | ProviderBatchArtifacts | Mapping[str, Any] | Any,
+        fallback_provider_job_id: str,
+    ) -> ProviderBatchFetchResult:
+        if isinstance(result, ProviderBatchFetchResult):
+            return result
+        if isinstance(result, ProviderBatchArtifacts):
+            return ProviderBatchFetchResult(
+                provider_job_id=result.provider_job_id,
+                provider_status="completed",
+                artifacts=result.artifacts,
+                raw_provider_payload=result.raw_provider_payload,
+            )
+        if isinstance(result, Mapping):
+            return ProviderBatchFetchResult(
+                provider_job_id=str(result.get("provider_job_id") or fallback_provider_job_id),
+                provider_status=str(result.get("provider_status") or result.get("status") or "completed"),
+                status=cls._optional_str(result.get("status")),
+                artifacts=tuple(result.get("artifacts") or ()),
+                items=tuple(cls._coerce_result_item(item) for item in result.get("items") or ()),
+                raw_provider_payload=result.get("raw_provider_payload"),
+            )
+        return ProviderBatchFetchResult(
+            provider_job_id=str(getattr(result, "provider_job_id", fallback_provider_job_id)),
+            provider_status=str(
+                getattr(result, "provider_status", None) or getattr(result, "status", None) or "completed"
+            ),
+            status=cls._optional_str(getattr(result, "status", None)),
+            artifacts=tuple(getattr(result, "artifacts", ()) or ()),
+            items=tuple(cls._coerce_result_item(item) for item in getattr(result, "items", ()) or ()),
+            raw_provider_payload=getattr(result, "raw_provider_payload", None),
+        )
+
+    @staticmethod
+    def _first_item_model_id(job: ProviderBatchJob) -> int | None:
+        for item in job.items:
+            if item.model_id is not None:
+                return item.model_id
+        return None
+
+    @staticmethod
+    def _model_name_for_job(job: ProviderBatchJob, model_id: int | None) -> str:
+        model = job.model
+        litellm_model_id = getattr(model, "litellm_model_id", None) if model is not None else None
+        if litellm_model_id:
+            return str(litellm_model_id)
+        if model_id is not None:
+            return f"__provider_batch_model_{model_id}__"
+        return "__provider_batch_model_unknown__"
+
     @classmethod
     def _coerce_result_item(
         cls, item: ProviderBatchResultItem | Mapping[str, Any] | Any
@@ -261,18 +452,32 @@ class ProviderBatchWorkflowService:
         if isinstance(item, ProviderBatchResultItem):
             return item
         if isinstance(item, Mapping):
+            error = item.get("error")
             return ProviderBatchResultItem(
                 custom_id=str(item["custom_id"]),
                 status=str(item["status"]),
-                error_type=cls._optional_str(item.get("error_type")),
-                error_message=cls._optional_str(item.get("error_message")),
+                annotation=item.get("annotation"),
+                error_type=cls._optional_str(
+                    item.get("error_type") or cls._extract_error_field(error, "type")
+                ),
+                error_message=cls._optional_str(
+                    item.get("error_message")
+                    or item.get("message")
+                    or cls._extract_error_field(error, "message")
+                ),
                 raw_response=item.get("raw_response"),
             )
+        error = getattr(item, "error", None)
         return ProviderBatchResultItem(
             custom_id=str(item.custom_id),
             status=str(item.status),
-            error_type=cls._optional_str(getattr(item, "error_type", None)),
-            error_message=cls._optional_str(getattr(item, "error_message", None)),
+            annotation=getattr(item, "annotation", None),
+            error_type=cls._optional_str(
+                getattr(item, "error_type", None) or cls._extract_error_field(error, "type")
+            ),
+            error_message=cls._optional_str(
+                getattr(item, "error_message", None) or cls._extract_error_field(error, "message")
+            ),
             raw_response=getattr(item, "raw_response", None),
         )
 
@@ -289,3 +494,11 @@ class ProviderBatchWorkflowService:
         if isinstance(payload, str):
             return payload
         return json.dumps(payload, ensure_ascii=False, sort_keys=True)
+
+    @staticmethod
+    def _extract_error_field(error: Any, field_name: str) -> Any:
+        if error is None:
+            return None
+        if isinstance(error, Mapping):
+            return error.get(field_name) or error.get(f"error_{field_name}")
+        return getattr(error, field_name, None) or getattr(error, f"error_{field_name}", None)

--- a/src/lorairo/services/service_container.py
+++ b/src/lorairo/services/service_container.py
@@ -303,6 +303,7 @@ class ServiceContainer:
                 self.image_repository,
                 self.config_service,
                 adapters=adapters,
+                annotation_save_service=self.annotation_save_service,
             )
             logger.debug("ProviderBatchWorkflowService初期化完了")
         return self._provider_batch_workflow_service

--- a/tests/unit/services/test_annotation_save_service.py
+++ b/tests/unit/services/test_annotation_save_service.py
@@ -92,6 +92,67 @@ def test_save_annotation_results_with_known_phashes_saves_all(
 
 
 @pytest.mark.unit
+def test_save_provider_batch_results_by_image_id_saves_without_phash_lookup(
+    service: AnnotationSaveService,
+    mock_repository: MagicMock,
+) -> None:
+    """Provider Batch import は image_id keyed result を直接保存する。"""
+    mock_repository.batch_resolve_tag_ids.return_value = {}
+
+    result = service.save_provider_batch_results_by_image_id(
+        {7: _make_success_result(tags=["tag1"], captions=["caption"])},
+        model_id=10,
+        model_name="openai/gpt-test",
+    )
+
+    assert result.success_count == 1
+    assert result.skip_count == 0
+    assert result.error_count == 0
+    mock_repository.find_image_ids_by_phashes.assert_not_called()
+    mock_repository.get_models_by_litellm_ids.assert_not_called()
+    mock_repository.save_annotations.assert_called_once()
+    image_id_arg = mock_repository.save_annotations.call_args[0][0]
+    annotations_arg = mock_repository.save_annotations.call_args[0][1]
+    assert image_id_arg == 7
+    assert annotations_arg["tags"][0]["model_id"] == 10
+    assert annotations_arg["tags"][0]["tag"] == "tag1"
+    assert annotations_arg["captions"][0]["caption"] == "caption"
+
+
+@pytest.mark.unit
+def test_save_provider_batch_results_by_image_id_records_refusal(
+    service: AnnotationSaveService,
+    mock_repository: MagicMock,
+) -> None:
+    """Provider Batch 経由の refusal も image_id 付き error_records に残す。"""
+    refusal_result = MagicMock()
+    refusal_result.error = "SafetyRefusalError: policy refused"
+    refusal_result.tags = []
+    refusal_result.captions = []
+    refusal_result.scores = None
+    refusal_result.score_labels = None
+    refusal_result.ratings = None
+
+    result = service.save_provider_batch_results_by_image_id(
+        {7: refusal_result},
+        model_id=10,
+        model_name="openai/gpt-test",
+    )
+
+    assert result.success_count == 0
+    assert result.skip_count == 1
+    assert result.error_count == 0
+    mock_repository.save_error_record.assert_called_once_with(
+        operation_type="annotation",
+        error_type="SafetyRefusalError",
+        error_message="policy refused",
+        image_id=7,
+        model_name="openai/gpt-test",
+    )
+    mock_repository.save_annotations.assert_not_called()
+
+
+@pytest.mark.unit
 def test_save_annotation_results_with_unknown_phash_skips_silently(
     service: AnnotationSaveService,
     mock_repository: MagicMock,

--- a/tests/unit/services/test_provider_batch_service.py
+++ b/tests/unit/services/test_provider_batch_service.py
@@ -506,6 +506,28 @@ class TestProviderBatchJobService:
 
         assert test_repository.list_provider_batch_artifacts(job_id) == []
 
+    def test_download_results_allows_completed_provider_status_after_import(
+        self,
+        test_repository: ImageRepository,
+    ) -> None:
+        adapter = FakeProviderBatchAdapter()
+        adapter.fetch_result = ProviderBatchFetchResult(
+            provider_job_id="batch_123",
+            provider_status="completed",
+            artifacts=(ProviderBatchArtifactRef("output", Path("/tmp/output.jsonl")),),
+        )
+        service = ProviderBatchJobService(test_repository, {"openai": adapter})
+        job_id = service.submit_batch(make_submit_request())
+        test_repository.update_provider_batch_job(job_id, {"status": "imported"})
+
+        service.download_results(job_id, Path("/tmp"))
+
+        job = test_repository.get_provider_batch_job(job_id)
+        assert job is not None
+        assert job.status == "imported"
+        assert job.provider_status == "completed"
+        assert job.output_artifact_path == "/tmp/output.jsonl"
+
     def test_missing_adapter_raises(self, test_repository: ImageRepository) -> None:
         service = ProviderBatchJobService(test_repository)
 

--- a/tests/unit/services/test_provider_batch_service.py
+++ b/tests/unit/services/test_provider_batch_service.py
@@ -528,6 +528,56 @@ class TestProviderBatchJobService:
         assert job.provider_status == "completed"
         assert job.output_artifact_path == "/tmp/output.jsonl"
 
+    def test_download_results_does_not_rewrite_terminal_status_for_legacy_artifacts(
+        self,
+        test_repository: ImageRepository,
+    ) -> None:
+        adapter = FakeProviderBatchAdapter()
+        adapter.fetch_result = ProviderBatchArtifacts(
+            provider_job_id="batch_123",
+            artifacts=(ProviderBatchArtifactRef("error", Path("/tmp/error.jsonl")),),
+        )
+        service = ProviderBatchJobService(test_repository, {"openai": adapter})
+        job_id = service.submit_batch(make_submit_request())
+        test_repository.update_provider_batch_job(job_id, {"status": "failed"})
+
+        service.download_results(job_id, Path("/tmp"))
+
+        job = test_repository.get_provider_batch_job(job_id)
+        assert job is not None
+        assert job.status == "failed"
+        assert job.error_artifact_path == "/tmp/error.jsonl"
+
+    def test_fetch_results_coerces_mapping_artifacts_and_timestamps(
+        self,
+        test_repository: ImageRepository,
+    ) -> None:
+        adapter = FakeProviderBatchAdapter()
+        adapter.fetch_result = {
+            "provider_job_id": "batch_123",
+            "provider_status": "completed",
+            "completed_at": "2026-05-25T02:00:00+00:00",
+            "artifacts": [
+                {
+                    "artifact_type": "output",
+                    "local_path": "/tmp/output.jsonl",
+                    "provider_file_id": "file_out",
+                    "sha256": "abc",
+                }
+            ],
+        }
+        service = ProviderBatchJobService(test_repository, {"openai": adapter})
+        job_id = service.submit_batch(make_submit_request())
+
+        fetch_result = service.fetch_results(job_id, Path("/tmp"))
+
+        assert fetch_result.artifacts[0].local_path == Path("/tmp/output.jsonl")
+        job = test_repository.get_provider_batch_job(job_id)
+        assert job is not None
+        assert job.completed_at is not None
+        assert job.completed_at.isoformat() == "2026-05-25T02:00:00"
+        assert job.output_artifact_path == "/tmp/output.jsonl"
+
     def test_missing_adapter_raises(self, test_repository: ImageRepository) -> None:
         service = ProviderBatchJobService(test_repository)
 

--- a/tests/unit/services/test_provider_batch_service.py
+++ b/tests/unit/services/test_provider_batch_service.py
@@ -578,6 +578,26 @@ class TestProviderBatchJobService:
         assert job.completed_at.isoformat() == "2026-05-25T02:00:00"
         assert job.output_artifact_path == "/tmp/output.jsonl"
 
+    def test_fetch_results_does_not_complete_mapping_without_provider_status(
+        self,
+        test_repository: ImageRepository,
+    ) -> None:
+        adapter = FakeProviderBatchAdapter()
+        adapter.fetch_result = {
+            "provider_job_id": "batch_123",
+            "artifacts": [{"artifact_type": "output", "local_path": "/tmp/output.jsonl"}],
+        }
+        service = ProviderBatchJobService(test_repository, {"openai": adapter})
+        job_id = service.submit_batch(make_submit_request())
+
+        service.fetch_results(job_id, Path("/tmp"))
+
+        job = test_repository.get_provider_batch_job(job_id)
+        assert job is not None
+        assert job.status == "validating"
+        assert job.provider_status == "validating"
+        assert job.output_artifact_path == "/tmp/output.jsonl"
+
     def test_missing_adapter_raises(self, test_repository: ImageRepository) -> None:
         service = ProviderBatchJobService(test_repository)
 

--- a/tests/unit/services/test_provider_batch_service.py
+++ b/tests/unit/services/test_provider_batch_service.py
@@ -20,7 +20,9 @@ from lorairo.services.provider_batch_service import (
     ProviderBatchArtifactRef,
     ProviderBatchArtifacts,
     ProviderBatchError,
+    ProviderBatchFetchResult,
     ProviderBatchJobService,
+    ProviderBatchResultItem,
     ProviderBatchStatus,
     ProviderBatchSubmission,
 )
@@ -66,6 +68,7 @@ class FakeProviderBatchAdapter:
             ),
             raw_provider_payload={"output_file_id": "file_out"},
         )
+        self.fetch_result: ProviderBatchFetchResult | ProviderBatchArtifacts = self.artifacts
 
     def submit_batch(self, request: BatchSubmitRequest) -> ProviderBatchSubmission:
         self.submitted_request = request
@@ -79,10 +82,12 @@ class FakeProviderBatchAdapter:
         self.cancel_handle = handle
         return self.cancel_status
 
-    def fetch_batch_results(self, handle: BatchJobHandle, destination_dir: Path) -> ProviderBatchArtifacts:
+    def fetch_batch_results(
+        self, handle: BatchJobHandle, destination_dir: Path
+    ) -> ProviderBatchFetchResult | ProviderBatchArtifacts:
         self.fetch_handle = handle
         self.fetch_destination = destination_dir
-        return self.artifacts
+        return self.fetch_result
 
 
 class LegacyProviderBatchAdapter(FakeProviderBatchAdapter):
@@ -436,6 +441,41 @@ class TestProviderBatchJobService:
         assert job.error_artifact_path == "/tmp/error.jsonl"
         assert job.raw_provider_payload == '{"output_file_id": "file_out"}'
 
+    def test_fetch_results_registers_artifacts_items_and_updates_job_status(
+        self,
+        test_repository: ImageRepository,
+    ) -> None:
+        adapter = FakeProviderBatchAdapter()
+        adapter.fetch_result = ProviderBatchFetchResult(
+            provider_job_id="batch_123",
+            provider_status="completed",
+            request_count=2,
+            succeeded_count=1,
+            failed_count=1,
+            completed_at=datetime(2026, 5, 25, 2, tzinfo=UTC),
+            artifacts=(ProviderBatchArtifactRef("output", Path("/tmp/output.jsonl"), "file_out"),),
+            items=(
+                ProviderBatchResultItem("img-1", "succeeded", annotation={"tags": ["safe"]}),
+                ProviderBatchResultItem("img-2", "failed", error_type="PARSE", error_message="bad"),
+            ),
+            raw_provider_payload={"status": "completed"},
+        )
+        service = ProviderBatchJobService(test_repository, {"openai": adapter})
+        job_id = service.submit_batch(make_submit_request())
+
+        fetch_result = service.fetch_results(job_id, Path("/tmp/batch_results"))
+
+        assert fetch_result.items[0].annotation == {"tags": ["safe"]}
+        assert len(test_repository.list_provider_batch_artifacts(job_id)) == 1
+        job = test_repository.get_provider_batch_job(job_id)
+        assert job is not None
+        assert job.status == "completed"
+        assert job.provider_status == "completed"
+        assert job.succeeded_count == 1
+        assert job.failed_count == 1
+        assert job.output_artifact_path == "/tmp/output.jsonl"
+        assert job.raw_provider_payload == '{"status": "completed"}'
+
     def test_download_results_is_idempotent_for_existing_artifacts(
         self,
         test_repository: ImageRepository,
@@ -457,6 +497,7 @@ class TestProviderBatchJobService:
     ) -> None:
         adapter = FakeProviderBatchAdapter()
         adapter.artifacts = replace(adapter.artifacts, provider_job_id="batch_other")
+        adapter.fetch_result = adapter.artifacts
         service = ProviderBatchJobService(test_repository, {"openai": adapter})
         job_id = service.submit_batch(make_submit_request())
 

--- a/tests/unit/services/test_provider_batch_workflow_service.py
+++ b/tests/unit/services/test_provider_batch_workflow_service.py
@@ -438,11 +438,7 @@ class TestProviderBatchWorkflowService:
             ),
         )
 
-        annotation_save.save_provider_batch_results_by_image_id.assert_called_once_with(
-            {},
-            model_id=10,
-            model_name="__provider_batch_model_10__",
-        )
+        annotation_save.save_provider_batch_results_by_image_id.assert_not_called()
         assert result.missing_custom_ids == ("img-404",)
         assert result.job_imported is False
         job = test_repository.get_provider_batch_job(job_id)
@@ -500,6 +496,211 @@ class TestProviderBatchWorkflowService:
         assert job is not None
         assert job.status == "completed"
         assert job.imported_at is None
+
+    def test_fetch_results_preserves_imported_item_status(
+        self,
+        test_repository: ImageRepository,
+        batch_config: Mock,
+        db_session_factory: sessionmaker,
+    ) -> None:
+        adapter = FakeProviderBatchAdapter()
+        service = ProviderBatchWorkflowService(test_repository, batch_config, adapters={"openai": adapter})
+        _insert_image(db_session_factory, 1, "/tmp/images/one.webp")
+        job_id = service.submit_images(
+            provider="openai",
+            endpoint="responses",
+            litellm_model_id="openai/gpt-test",
+            prompt_profile="default",
+            image_ids=[1],
+            model_id=10,
+        )
+        test_repository.update_provider_batch_job(job_id, {"status": "completed"})
+        test_repository.update_provider_batch_items_by_custom_id(job_id, {"img-1": {"status": "imported"}})
+        adapter.fetch_result = ProviderBatchFetchResult(
+            provider_job_id="batch_123",
+            provider_status="completed",
+            items=(ProviderBatchResultItem("img-1", "succeeded", annotation={"tags": ["tag"]}),),
+        )
+
+        service.fetch_results(job_id)
+
+        assert test_repository.list_provider_batch_items(job_id)[0].status == "imported"
+
+    def test_import_results_preserves_imported_item_status_on_retry_error(
+        self,
+        test_repository: ImageRepository,
+        batch_config: Mock,
+        db_session_factory: sessionmaker,
+    ) -> None:
+        adapter = FakeProviderBatchAdapter()
+        annotation_save = Mock()
+        annotation_save.save_provider_batch_results_by_image_id.return_value = AnnotationSaveResult(
+            success_count=0,
+            skip_count=0,
+            error_count=1,
+            total_count=1,
+            error_details=["image_id=2: write failed"],
+        )
+        service = ProviderBatchWorkflowService(
+            test_repository,
+            batch_config,
+            adapters={"openai": adapter},
+            annotation_save_service=annotation_save,
+        )
+        _insert_image(db_session_factory, 1, "/tmp/images/one.webp")
+        _insert_image(db_session_factory, 2, "/tmp/images/two.webp")
+        job_id = service.submit_images(
+            provider="openai",
+            endpoint="responses",
+            litellm_model_id="openai/gpt-test",
+            prompt_profile="default",
+            image_ids=[1, 2],
+            model_id=10,
+        )
+        test_repository.update_provider_batch_items_by_custom_id(job_id, {"img-1": {"status": "imported"}})
+
+        result = service.import_results(
+            job_id,
+            ProviderBatchFetchResult(
+                provider_job_id="batch_123",
+                provider_status="completed",
+                items=(
+                    ProviderBatchResultItem("img-1", "succeeded", annotation={"tags": ["old"]}),
+                    ProviderBatchResultItem("img-2", "succeeded", annotation={"tags": ["new"]}),
+                ),
+            ),
+        )
+
+        assert result.error_count == 1
+        assert result.skipped_count == 1
+        items = {item.custom_id: item for item in test_repository.list_provider_batch_items(job_id)}
+        assert items["img-1"].status == "imported"
+        assert items["img-2"].status == "succeeded"
+        annotation_save.save_provider_batch_results_by_image_id.assert_called_once_with(
+            {2: {"tags": ["new"]}},
+            model_id=10,
+            model_name="__provider_batch_model_10__",
+        )
+
+    def test_import_results_preserves_per_item_model_ids(
+        self,
+        test_repository: ImageRepository,
+        batch_config: Mock,
+        db_session_factory: sessionmaker,
+    ) -> None:
+        adapter = FakeProviderBatchAdapter()
+        annotation_save = Mock()
+        annotation_save.save_provider_batch_results_by_image_id.return_value = AnnotationSaveResult(
+            success_count=1,
+            skip_count=0,
+            error_count=0,
+            total_count=1,
+        )
+        service = ProviderBatchWorkflowService(
+            test_repository,
+            batch_config,
+            adapters={"openai": adapter},
+            annotation_save_service=annotation_save,
+        )
+        model_id_1 = test_repository.insert_model(
+            name="gpt-test-a",
+            provider="openai",
+            model_types=["multimodal"],
+            litellm_model_id="openai/gpt-test-a",
+        )
+        model_id_2 = test_repository.insert_model(
+            name="gpt-test-b",
+            provider="openai",
+            model_types=["multimodal"],
+            litellm_model_id="openai/gpt-test-b",
+        )
+        _insert_image(db_session_factory, 1, "/tmp/images/one.webp")
+        _insert_image(db_session_factory, 2, "/tmp/images/two.webp")
+        job_id = service.submit_images(
+            provider="openai",
+            endpoint="responses",
+            litellm_model_id="openai/gpt-test-a",
+            prompt_profile="default",
+            image_ids=[1, 2],
+            model_id=model_id_1,
+        )
+        test_repository.update_provider_batch_items_by_custom_id(
+            job_id,
+            {"img-2": {"model_id": model_id_2}},
+        )
+
+        result = service.import_results(
+            job_id,
+            ProviderBatchFetchResult(
+                provider_job_id="batch_123",
+                provider_status="completed",
+                items=(
+                    ProviderBatchResultItem("img-1", "succeeded", annotation={"tags": ["one"]}),
+                    ProviderBatchResultItem("img-2", "succeeded", annotation={"tags": ["two"]}),
+                ),
+            ),
+        )
+
+        assert result.imported_count == 2
+        annotation_save.save_provider_batch_results_by_image_id.assert_any_call(
+            {1: {"tags": ["one"]}},
+            model_id=model_id_1,
+            model_name="openai/gpt-test-a",
+        )
+        annotation_save.save_provider_batch_results_by_image_id.assert_any_call(
+            {2: {"tags": ["two"]}},
+            model_id=model_id_2,
+            model_name=f"__provider_batch_model_{model_id_2}__",
+        )
+
+    def test_import_results_counts_non_importable_items_as_skipped(
+        self,
+        test_repository: ImageRepository,
+        batch_config: Mock,
+        db_session_factory: sessionmaker,
+    ) -> None:
+        adapter = FakeProviderBatchAdapter()
+        annotation_save = Mock()
+        annotation_save.save_provider_batch_results_by_image_id.return_value = AnnotationSaveResult(
+            success_count=1,
+            skip_count=0,
+            error_count=0,
+            total_count=1,
+        )
+        service = ProviderBatchWorkflowService(
+            test_repository,
+            batch_config,
+            adapters={"openai": adapter},
+            annotation_save_service=annotation_save,
+        )
+        _insert_image(db_session_factory, 1, "/tmp/images/one.webp")
+        _insert_image(db_session_factory, 2, "/tmp/images/two.webp")
+        job_id = service.submit_images(
+            provider="openai",
+            endpoint="responses",
+            litellm_model_id="openai/gpt-test",
+            prompt_profile="default",
+            image_ids=[1, 2],
+            model_id=10,
+        )
+
+        result = service.import_results(
+            job_id,
+            ProviderBatchFetchResult(
+                provider_job_id="batch_123",
+                provider_status="completed",
+                items=(
+                    ProviderBatchResultItem("img-1", "failed", annotation=None),
+                    ProviderBatchResultItem("img-2", "succeeded", annotation={"tags": ["tag"]}),
+                ),
+            ),
+        )
+
+        assert result.imported_count == 1
+        assert result.skipped_count == 1
+        assert result.error_count == 0
+        assert result.total_count == 2
+        assert result.job_imported is False
 
     def test_import_results_uses_fallback_job_id_when_object_result_omits_provider_job_id(
         self,

--- a/tests/unit/services/test_provider_batch_workflow_service.py
+++ b/tests/unit/services/test_provider_batch_workflow_service.py
@@ -490,6 +490,63 @@ class TestProviderBatchWorkflowService:
         assert result.job_imported is True
         annotation_save.save_provider_batch_results_by_image_id.assert_called_once()
 
+    def test_import_results_preserves_mapping_fetch_counts_and_timestamps(
+        self,
+        test_repository: ImageRepository,
+        batch_config: Mock,
+        db_session_factory: sessionmaker,
+    ) -> None:
+        adapter = FakeProviderBatchAdapter()
+        annotation_save = Mock()
+        annotation_save.save_provider_batch_results_by_image_id.return_value = AnnotationSaveResult(
+            success_count=1,
+            skip_count=0,
+            error_count=0,
+            total_count=1,
+        )
+        service = ProviderBatchWorkflowService(
+            test_repository,
+            batch_config,
+            adapters={"openai": adapter},
+            annotation_save_service=annotation_save,
+        )
+        _insert_image(db_session_factory, 1, "/tmp/images/one.webp")
+        job_id = service.submit_images(
+            provider="openai",
+            endpoint="responses",
+            litellm_model_id="openai/gpt-test",
+            prompt_profile="default",
+            image_ids=[1],
+            model_id=10,
+        )
+
+        service.import_results(
+            job_id,
+            {
+                "provider_job_id": "batch_123",
+                "provider_status": "completed",
+                "request_count": "1",
+                "succeeded_count": "1",
+                "failed_count": "0",
+                "completed_at": "2026-05-25T02:00:00+00:00",
+                "items": [
+                    {
+                        "custom_id": "img-1",
+                        "status": "succeeded",
+                        "annotation": {"tags": ["tag"]},
+                    }
+                ],
+            },
+        )
+
+        job = test_repository.get_provider_batch_job(job_id)
+        assert job is not None
+        assert job.request_count == 1
+        assert job.succeeded_count == 1
+        assert job.failed_count == 0
+        assert job.completed_at is not None
+        assert job.completed_at.isoformat() == "2026-05-25T02:00:00"
+
     def test_import_results_does_not_mark_imported_when_no_annotations_were_saved(
         self,
         test_repository: ImageRepository,

--- a/tests/unit/services/test_provider_batch_workflow_service.py
+++ b/tests/unit/services/test_provider_batch_workflow_service.py
@@ -11,17 +11,19 @@ from sqlalchemy.orm import sessionmaker
 
 from lorairo.database.db_repository import ImageRepository
 from lorairo.database.schema import Image
+from lorairo.services.annotation_save_service import AnnotationSaveResult
 from lorairo.services.provider_batch_service import (
     BatchJobHandle,
     BatchSubmitRequest,
     ProviderBatchArtifactRef,
     ProviderBatchArtifacts,
     ProviderBatchError,
+    ProviderBatchFetchResult,
+    ProviderBatchResultItem,
     ProviderBatchStatus,
     ProviderBatchSubmission,
 )
 from lorairo.services.provider_batch_workflow_service import (
-    ProviderBatchResultItem,
     ProviderBatchWorkflowService,
 )
 
@@ -54,6 +56,7 @@ class FakeProviderBatchAdapter:
                 ProviderBatchArtifactRef("error", Path("/tmp/error.jsonl")),
             ),
         )
+        self.fetch_result: ProviderBatchFetchResult | ProviderBatchArtifacts = self.artifacts
 
     def submit_batch(self, request: BatchSubmitRequest) -> ProviderBatchSubmission:
         self.submitted_request = request
@@ -67,10 +70,12 @@ class FakeProviderBatchAdapter:
         self.cancel_handle = handle
         return self.cancel_status
 
-    def fetch_batch_results(self, handle: BatchJobHandle, destination_dir: Path) -> ProviderBatchArtifacts:
+    def fetch_batch_results(
+        self, handle: BatchJobHandle, destination_dir: Path
+    ) -> ProviderBatchFetchResult | ProviderBatchArtifacts:
         self.fetch_handle = handle
         self.fetch_destination = destination_dir
-        return self.artifacts
+        return self.fetch_result
 
 
 @pytest.fixture
@@ -208,6 +213,35 @@ class TestProviderBatchWorkflowService:
             api_keys={"openai": "sk-test"},
         )
 
+    def test_fetch_results_applies_normalized_item_state(
+        self,
+        workflow: tuple[ProviderBatchWorkflowService, FakeProviderBatchAdapter],
+        test_repository: ImageRepository,
+        db_session_factory: sessionmaker,
+        batch_config: Mock,
+    ) -> None:
+        service, adapter = workflow
+        _insert_image(db_session_factory, 1, "/tmp/images/one.webp")
+        job_id = service.submit_images(
+            provider="openai",
+            endpoint="responses",
+            litellm_model_id="openai/gpt-test",
+            prompt_profile="default",
+            image_ids=[1],
+        )
+        adapter.fetch_result = ProviderBatchFetchResult(
+            provider_job_id="batch_123",
+            provider_status="completed",
+            items=(ProviderBatchResultItem("img-1", "succeeded", annotation={"tags": ["tag"]}),),
+        )
+
+        fetch_result = service.fetch_results(job_id)
+
+        assert fetch_result.items[0].annotation == {"tags": ["tag"]}
+        assert adapter.fetch_destination == batch_config.get_batch_results_directory.return_value
+        item = test_repository.list_provider_batch_items(job_id)[0]
+        assert item.status == "succeeded"
+
     def test_refresh_uses_configured_api_keys(
         self,
         workflow: tuple[ProviderBatchWorkflowService, FakeProviderBatchAdapter],
@@ -314,3 +348,171 @@ class TestProviderBatchWorkflowService:
                 "batch_other",
                 [ProviderBatchResultItem("img-1", "succeeded")],
             )
+
+    def test_import_results_uses_custom_id_mapping_and_marks_imported(
+        self,
+        test_repository: ImageRepository,
+        batch_config: Mock,
+        db_session_factory: sessionmaker,
+    ) -> None:
+        adapter = FakeProviderBatchAdapter()
+        annotation_save = Mock()
+        annotation_save.save_provider_batch_results_by_image_id.return_value = AnnotationSaveResult(
+            success_count=1,
+            skip_count=0,
+            error_count=0,
+            total_count=1,
+        )
+        service = ProviderBatchWorkflowService(
+            test_repository,
+            batch_config,
+            adapters={"openai": adapter},
+            annotation_save_service=annotation_save,
+        )
+        _insert_image(db_session_factory, 1, "/tmp/images/one.webp")
+        job_id = service.submit_images(
+            provider="openai",
+            endpoint="responses",
+            litellm_model_id="openai/gpt-test",
+            prompt_profile="default",
+            image_ids=[1],
+            model_id=10,
+        )
+        fetch_result = ProviderBatchFetchResult(
+            provider_job_id="batch_123",
+            provider_status="completed",
+            items=(ProviderBatchResultItem("img-1", "succeeded", annotation={"tags": ["tag"]}),),
+        )
+
+        result = service.import_results(job_id, fetch_result)
+
+        annotation_save.save_provider_batch_results_by_image_id.assert_called_once_with(
+            {1: {"tags": ["tag"]}},
+            model_id=10,
+            model_name="__provider_batch_model_10__",
+        )
+        assert result.imported_count == 1
+        assert result.job_imported is True
+        job = test_repository.get_provider_batch_job(job_id)
+        assert job is not None
+        assert job.status == "imported"
+        assert job.imported_at is not None
+        assert test_repository.list_provider_batch_items(job_id)[0].status == "imported"
+
+    def test_import_results_does_not_fallback_to_file_stem_for_missing_custom_id(
+        self,
+        test_repository: ImageRepository,
+        batch_config: Mock,
+        db_session_factory: sessionmaker,
+    ) -> None:
+        adapter = FakeProviderBatchAdapter()
+        annotation_save = Mock()
+        annotation_save.save_provider_batch_results_by_image_id.return_value = AnnotationSaveResult(
+            success_count=0,
+            skip_count=0,
+            error_count=0,
+            total_count=0,
+        )
+        service = ProviderBatchWorkflowService(
+            test_repository,
+            batch_config,
+            adapters={"openai": adapter},
+            annotation_save_service=annotation_save,
+        )
+        _insert_image(db_session_factory, 1, "/tmp/images/img-404.webp")
+        job_id = service.submit_images(
+            provider="openai",
+            endpoint="responses",
+            litellm_model_id="openai/gpt-test",
+            prompt_profile="default",
+            image_ids=[1],
+            model_id=10,
+        )
+
+        result = service.import_results(
+            job_id,
+            ProviderBatchFetchResult(
+                provider_job_id="batch_123",
+                provider_status="completed",
+                items=(ProviderBatchResultItem("img-404", "succeeded", annotation={"tags": ["tag"]}),),
+            ),
+        )
+
+        annotation_save.save_provider_batch_results_by_image_id.assert_called_once_with(
+            {},
+            model_id=10,
+            model_name="__provider_batch_model_10__",
+        )
+        assert result.missing_custom_ids == ("img-404",)
+        assert result.job_imported is False
+        job = test_repository.get_provider_batch_job(job_id)
+        assert job is not None
+        assert job.status == "completed"
+        assert job.imported_at is None
+
+    def test_import_results_rejects_already_imported_job(
+        self,
+        workflow: tuple[ProviderBatchWorkflowService, FakeProviderBatchAdapter],
+        test_repository: ImageRepository,
+        db_session_factory: sessionmaker,
+    ) -> None:
+        service, _adapter = workflow
+        _insert_image(db_session_factory, 1, "/tmp/images/one.webp")
+        job_id = service.submit_images(
+            provider="openai",
+            endpoint="responses",
+            litellm_model_id="openai/gpt-test",
+            prompt_profile="default",
+            image_ids=[1],
+        )
+        test_repository.update_provider_batch_job(job_id, {"status": "imported"})
+
+        with pytest.raises(ProviderBatchError, match="import 済み"):
+            service.import_results(job_id, ProviderBatchFetchResult("batch_123", "completed"))
+
+    def test_import_results_save_errors_leave_job_retryable(
+        self,
+        test_repository: ImageRepository,
+        batch_config: Mock,
+        db_session_factory: sessionmaker,
+    ) -> None:
+        adapter = FakeProviderBatchAdapter()
+        annotation_save = Mock()
+        annotation_save.save_provider_batch_results_by_image_id.return_value = AnnotationSaveResult(
+            success_count=0,
+            skip_count=0,
+            error_count=1,
+            total_count=1,
+            error_details=["image_id=1: write failed"],
+        )
+        service = ProviderBatchWorkflowService(
+            test_repository,
+            batch_config,
+            adapters={"openai": adapter},
+            annotation_save_service=annotation_save,
+        )
+        _insert_image(db_session_factory, 1, "/tmp/images/one.webp")
+        job_id = service.submit_images(
+            provider="openai",
+            endpoint="responses",
+            litellm_model_id="openai/gpt-test",
+            prompt_profile="default",
+            image_ids=[1],
+            model_id=10,
+        )
+
+        result = service.import_results(
+            job_id,
+            ProviderBatchFetchResult(
+                provider_job_id="batch_123",
+                provider_status="completed",
+                items=(ProviderBatchResultItem("img-1", "succeeded", annotation={"tags": ["tag"]}),),
+            ),
+        )
+
+        assert result.error_count == 1
+        assert result.job_imported is False
+        job = test_repository.get_provider_batch_job(job_id)
+        assert job is not None
+        assert job.status == "completed"
+        assert job.imported_at is None

--- a/tests/unit/services/test_provider_batch_workflow_service.py
+++ b/tests/unit/services/test_provider_batch_workflow_service.py
@@ -450,6 +450,57 @@ class TestProviderBatchWorkflowService:
         assert job.status == "completed"
         assert job.imported_at is None
 
+    def test_import_results_marks_saved_items_imported_when_job_has_missing_ids(
+        self,
+        test_repository: ImageRepository,
+        batch_config: Mock,
+        db_session_factory: sessionmaker,
+    ) -> None:
+        adapter = FakeProviderBatchAdapter()
+        annotation_save = Mock()
+        annotation_save.save_provider_batch_results_by_image_id.return_value = AnnotationSaveResult(
+            success_count=1,
+            skip_count=0,
+            error_count=0,
+            total_count=1,
+        )
+        service = ProviderBatchWorkflowService(
+            test_repository,
+            batch_config,
+            adapters={"openai": adapter},
+            annotation_save_service=annotation_save,
+        )
+        _insert_image(db_session_factory, 1, "/tmp/images/one.webp")
+        job_id = service.submit_images(
+            provider="openai",
+            endpoint="responses",
+            litellm_model_id="openai/gpt-test",
+            prompt_profile="default",
+            image_ids=[1],
+            model_id=10,
+        )
+
+        result = service.import_results(
+            job_id,
+            ProviderBatchFetchResult(
+                provider_job_id="batch_123",
+                provider_status="completed",
+                items=(
+                    ProviderBatchResultItem("img-1", "succeeded", annotation={"tags": ["tag"]}),
+                    ProviderBatchResultItem("img-404", "succeeded", annotation={"tags": ["missing"]}),
+                ),
+            ),
+        )
+
+        assert result.job_imported is False
+        assert result.missing_custom_ids == ("img-404",)
+        item = test_repository.list_provider_batch_items(job_id)[0]
+        assert item.status == "imported"
+        job = test_repository.get_provider_batch_job(job_id)
+        assert job is not None
+        assert job.status == "completed"
+        assert job.imported_at is None
+
     def test_import_results_uses_fallback_job_id_when_object_result_omits_provider_job_id(
         self,
         test_repository: ImageRepository,
@@ -631,6 +682,51 @@ class TestProviderBatchWorkflowService:
         job = test_repository.get_provider_batch_job(job_id)
         assert job is not None
         assert job.status == "running"
+        assert job.imported_at is None
+
+    def test_import_results_rejects_importable_mapping_without_provider_status(
+        self,
+        test_repository: ImageRepository,
+        batch_config: Mock,
+        db_session_factory: sessionmaker,
+    ) -> None:
+        adapter = FakeProviderBatchAdapter()
+        annotation_save = Mock()
+        service = ProviderBatchWorkflowService(
+            test_repository,
+            batch_config,
+            adapters={"openai": adapter},
+            annotation_save_service=annotation_save,
+        )
+        _insert_image(db_session_factory, 1, "/tmp/images/one.webp")
+        job_id = service.submit_images(
+            provider="openai",
+            endpoint="responses",
+            litellm_model_id="openai/gpt-test",
+            prompt_profile="default",
+            image_ids=[1],
+            model_id=10,
+        )
+
+        with pytest.raises(ProviderBatchError, match="validating -> imported"):
+            service.import_results(
+                job_id,
+                {
+                    "provider_job_id": "batch_123",
+                    "items": [
+                        {
+                            "custom_id": "img-1",
+                            "status": "succeeded",
+                            "annotation": {"tags": ["tag"]},
+                        }
+                    ],
+                },
+            )
+
+        annotation_save.save_provider_batch_results_by_image_id.assert_not_called()
+        job = test_repository.get_provider_batch_job(job_id)
+        assert job is not None
+        assert job.status == "validating"
         assert job.imported_at is None
 
     def test_import_results_rejects_already_imported_job(

--- a/tests/unit/services/test_provider_batch_workflow_service.py
+++ b/tests/unit/services/test_provider_batch_workflow_service.py
@@ -450,6 +450,92 @@ class TestProviderBatchWorkflowService:
         assert job.status == "completed"
         assert job.imported_at is None
 
+    def test_import_results_uses_fallback_job_id_when_object_result_omits_provider_job_id(
+        self,
+        test_repository: ImageRepository,
+        batch_config: Mock,
+        db_session_factory: sessionmaker,
+    ) -> None:
+        adapter = FakeProviderBatchAdapter()
+        annotation_save = Mock()
+        annotation_save.save_provider_batch_results_by_image_id.return_value = AnnotationSaveResult(
+            success_count=1,
+            skip_count=0,
+            error_count=0,
+            total_count=1,
+        )
+        service = ProviderBatchWorkflowService(
+            test_repository,
+            batch_config,
+            adapters={"openai": adapter},
+            annotation_save_service=annotation_save,
+        )
+        _insert_image(db_session_factory, 1, "/tmp/images/one.webp")
+        job_id = service.submit_images(
+            provider="openai",
+            endpoint="responses",
+            litellm_model_id="openai/gpt-test",
+            prompt_profile="default",
+            image_ids=[1],
+            model_id=10,
+        )
+        object_result = SimpleNamespace(
+            provider_job_id=None,
+            provider_status="completed",
+            items=(ProviderBatchResultItem("img-1", "succeeded", annotation={"tags": ["tag"]}),),
+        )
+
+        result = service.import_results(job_id, object_result)
+
+        assert result.job_imported is True
+        annotation_save.save_provider_batch_results_by_image_id.assert_called_once()
+
+    def test_import_results_does_not_mark_imported_when_no_annotations_were_saved(
+        self,
+        test_repository: ImageRepository,
+        batch_config: Mock,
+        db_session_factory: sessionmaker,
+    ) -> None:
+        adapter = FakeProviderBatchAdapter()
+        annotation_save = Mock()
+        annotation_save.save_provider_batch_results_by_image_id.return_value = AnnotationSaveResult(
+            success_count=0,
+            skip_count=0,
+            error_count=0,
+            total_count=0,
+        )
+        service = ProviderBatchWorkflowService(
+            test_repository,
+            batch_config,
+            adapters={"openai": adapter},
+            annotation_save_service=annotation_save,
+        )
+        _insert_image(db_session_factory, 1, "/tmp/images/one.webp")
+        job_id = service.submit_images(
+            provider="openai",
+            endpoint="responses",
+            litellm_model_id="openai/gpt-test",
+            prompt_profile="default",
+            image_ids=[1],
+            model_id=10,
+        )
+
+        result = service.import_results(
+            job_id,
+            ProviderBatchFetchResult(
+                provider_job_id="batch_123",
+                provider_status="completed",
+                items=(ProviderBatchResultItem("img-1", "failed", error_message="provider failed"),),
+            ),
+        )
+
+        assert result.imported_count == 0
+        assert result.job_imported is False
+        job = test_repository.get_provider_batch_job(job_id)
+        assert job is not None
+        assert job.status == "completed"
+        assert job.imported_at is None
+
     def test_import_results_rejects_already_imported_job(
         self,
         workflow: tuple[ProviderBatchWorkflowService, FakeProviderBatchAdapter],

--- a/tests/unit/services/test_provider_batch_workflow_service.py
+++ b/tests/unit/services/test_provider_batch_workflow_service.py
@@ -593,6 +593,46 @@ class TestProviderBatchWorkflowService:
         assert job.status == "completed"
         assert job.imported_at is None
 
+    def test_import_results_rejects_importable_items_before_completed(
+        self,
+        test_repository: ImageRepository,
+        batch_config: Mock,
+        db_session_factory: sessionmaker,
+    ) -> None:
+        adapter = FakeProviderBatchAdapter()
+        annotation_save = Mock()
+        service = ProviderBatchWorkflowService(
+            test_repository,
+            batch_config,
+            adapters={"openai": adapter},
+            annotation_save_service=annotation_save,
+        )
+        _insert_image(db_session_factory, 1, "/tmp/images/one.webp")
+        job_id = service.submit_images(
+            provider="openai",
+            endpoint="responses",
+            litellm_model_id="openai/gpt-test",
+            prompt_profile="default",
+            image_ids=[1],
+            model_id=10,
+        )
+
+        with pytest.raises(ProviderBatchError, match="running -> imported"):
+            service.import_results(
+                job_id,
+                ProviderBatchFetchResult(
+                    provider_job_id="batch_123",
+                    provider_status="running",
+                    items=(ProviderBatchResultItem("img-1", "succeeded", annotation={"tags": ["tag"]}),),
+                ),
+            )
+
+        annotation_save.save_provider_batch_results_by_image_id.assert_not_called()
+        job = test_repository.get_provider_batch_job(job_id)
+        assert job is not None
+        assert job.status == "running"
+        assert job.imported_at is None
+
     def test_import_results_rejects_already_imported_job(
         self,
         workflow: tuple[ProviderBatchWorkflowService, FakeProviderBatchAdapter],


### PR DESCRIPTION
## Summary
- add normalized ProviderBatchFetchResult / ProviderBatchResultItem DTOs and fetch_results bridge
- import normalized provider batch annotations by custom_id -> provider_batch_items.image_id mapping
- prevent double import with imported_at/status updates while keeping legacy artifact download wrapper

Closes #462

## Tests
- uv run ruff check src/lorairo/services/provider_batch_service.py src/lorairo/services/provider_batch_workflow_service.py src/lorairo/services/annotation_save_service.py src/lorairo/services/service_container.py src/lorairo/database/db_repository.py src/lorairo/annotations/annotator_adapter.py tests/unit/services/test_provider_batch_service.py tests/unit/services/test_provider_batch_workflow_service.py tests/unit/services/test_annotation_save_service.py
- uv run mypy src/lorairo/services/provider_batch_service.py src/lorairo/services/provider_batch_workflow_service.py src/lorairo/services/annotation_save_service.py src/lorairo/database/db_repository.py src/lorairo/services/service_container.py src/lorairo/annotations/annotator_adapter.py
- uv run pytest tests/unit/services/test_provider_batch_service.py tests/unit/services/test_provider_batch_workflow_service.py tests/unit/services/test_service_container_provider_batch.py tests/unit/services/test_annotation_save_service.py tests/unit/database/test_db_repository_provider_batch.py tests/unit/annotations/test_annotator_adapter_provider_batch.py