### PR TITLE
chore: clean merged agent worktrees

### DIFF
--- a/.agents/skills/agent-pr-maintainer/SKILL.md
+++ b/.agents/skills/agent-pr-maintainer/SKILL.md
@@ -65,6 +65,8 @@ the code-editing session that applies fixes in the existing worktree.
 - Merge without human intervention only when bot review has completed cleanly and required checks are clean.
 - Treat an empty review/comment set as "review not completed yet", not as clean.
 - Use squash merge.
+- After a PR is merged, immediately clean up the merged `/tmp/worktrees/` checkout so its `.venv` does not
+  remain in `docker_data.vhdx`.
 
 ## Polling Workflow
 
@@ -196,6 +198,16 @@ Then run:
 ```bash
 gh pr merge "$PR" --squash --auto --delete-branch --match-head-commit "$HEAD_SHA"
 ```
+
+After GitHub reports the PR as merged, switch to the shared checkout and remove the merged worktree:
+
+```bash
+cd /workspaces/LoRAIro
+make worktree-cleanup-merged
+```
+
+If only the current PR worktree should be removed, use `git worktree remove "$WORKTREE_PATH"` from outside that
+worktree. Do not leave the merged worktree or its `.venv` behind.
 
 ## State
 

--- a/.claude/rules/git-workflow.md
+++ b/.claude/rules/git-workflow.md
@@ -31,10 +31,15 @@ git worktree add ../fix-issue-123 -b fix/issue-123
 - メインワークスペースの作業状態を汚さない
 
 ### クリーンアップ
-- マージ完了後はワークツリーを削除する
+- マージ完了後は、PR 作業で使ったワークツリーを即削除する
+- 作業中のカレントディレクトリが削除対象の場合は、共有 checkout (`/workspaces/LoRAIro`) に戻ってから削除する
+- 複数の残骸をまとめて掃除する場合は、共有 checkout から `make worktree-cleanup-merged` を実行する
+- `make worktree-cleanup-merged` は `/tmp/worktrees/` 配下に限定し、未コミット変更がなく、merged PR または `origin/main` へ到達済みの worktree だけを削除する
 
 ```bash
 git worktree remove /tmp/worktrees/fix-issue-123
+# または
+make worktree-cleanup-merged
 ```
 
 ## venv（ワークツリー内）

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,6 +48,7 @@
 - Agent-created PRs should normally be created ready for review, not draft. When a draft PR exists because the user explicitly asked to keep it draft, mark it ready for review as soon as the user allows review, then immediately start or resume PR maintenance automation: poll CI, watch bot review artifacts/comments, repair actionable findings in the PR worktree, reply in Japanese, merge when safe, and report the final monitored state.
 - After creating an agent PR, explicitly verify `gh pr view "$PR" --json isDraft -q .isDraft`. If it is
   `true`, run `gh pr ready "$PR"` and re-check. Do not set up `gh pr merge --auto` while the PR is still draft.
+- After an agent-created PR is merged, immediately remove the clean `/tmp/worktrees/` worktree with `git worktree remove <path>` or run `make worktree-cleanup-merged` from the shared checkout. Do not leave merged worktrees or their `.venv` directories behind.
 - Keep agent-specific rules as references to this file and `.claude/rules/git-workflow.md` rather than duplicating conflicting workflow text.
 
 ## Codex Parallel Agent Workflow

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # LoRAIro Project Makefile
 # Development task automation
 
-.PHONY: help setup test test-iam-lib test-runtime-local test-runtime-webapi test-genai-tag test-all mypy format install install-dev clean run-gui generate-ui skills-update venv-rebuild _ensure-submodules _ensure-root-venv
+.PHONY: help setup test test-iam-lib test-runtime-local test-runtime-webapi test-genai-tag test-all mypy format install install-dev clean run-gui generate-ui skills-update venv-rebuild worktree-cleanup-merged worktree-cleanup-merged-dry-run _ensure-submodules _ensure-root-venv
 
 # Default target
 help:
@@ -23,6 +23,8 @@ help:
 	@echo "  format       Format code (ruff format)"
 	@echo "  clean        Clean build artifacts"
 	@echo "  venv-rebuild Rebuild .venv from scratch (recovery from corruption)"
+	@echo "  worktree-cleanup-merged Remove clean merged /tmp/worktrees entries"
+	@echo "  worktree-cleanup-merged-dry-run Show clean merged /tmp/worktrees entries"
 	@echo "  skills-update Update community skills in .github/skills/"
 
 # Development targets
@@ -122,6 +124,14 @@ venv-rebuild: _ensure-submodules
 	rm -rf .venv
 	uv sync --dev
 	@echo ".venv rebuilt successfully."
+
+worktree-cleanup-merged:
+	@echo "Removing clean merged worktrees under /tmp/worktrees..."
+	uv run python scripts/cleanup_merged_worktrees.py
+
+worktree-cleanup-merged-dry-run:
+	@echo "Checking clean merged worktrees under /tmp/worktrees..."
+	uv run python scripts/cleanup_merged_worktrees.py --dry-run
 
 clean:
 	@echo "Cleaning build artifacts and caches..."

--- a/scripts/cleanup_merged_worktrees.py
+++ b/scripts/cleanup_merged_worktrees.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+"""Remove clean, merged agent worktrees under /tmp/worktrees."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+WORKTREE_ROOT = Path("/tmp/worktrees")
+DEFAULT_BASE = "origin/main"
+
+
+@dataclass(frozen=True)
+class Worktree:
+    path: Path
+    head: str | None
+    branch: str | None
+
+
+def run_git(args: list[str], *, cwd: Path, check: bool = True) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", *args],
+        cwd=cwd,
+        check=check,
+        capture_output=True,
+        text=True,
+    )
+
+
+def run_gh(args: list[str], *, cwd: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["gh", *args],
+        cwd=cwd,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+def parse_worktrees(output: str) -> list[Worktree]:
+    worktrees: list[Worktree] = []
+    current: dict[str, str] = {}
+
+    for line in output.splitlines():
+        if not line:
+            if current:
+                worktrees.append(_worktree_from_record(current))
+                current = {}
+            continue
+
+        key, _, value = line.partition(" ")
+        current[key] = value
+
+    if current:
+        worktrees.append(_worktree_from_record(current))
+
+    return worktrees
+
+
+def _worktree_from_record(record: dict[str, str]) -> Worktree:
+    branch_ref = record.get("branch")
+    branch = branch_ref.removeprefix("refs/heads/") if branch_ref else None
+    return Worktree(path=Path(record["worktree"]), head=record.get("HEAD"), branch=branch)
+
+
+def has_local_changes(path: Path) -> bool:
+    result = run_git(["status", "--porcelain"], cwd=path)
+    return bool(result.stdout.strip())
+
+
+def head_is_merged(worktree: Worktree, *, repo: Path, base: str) -> bool:
+    if not worktree.head:
+        return False
+
+    result = run_git(["merge-base", "--is-ancestor", worktree.head, base], cwd=repo, check=False)
+    return result.returncode == 0
+
+
+def pr_is_merged(worktree: Worktree, *, repo: Path) -> bool:
+    if not worktree.branch:
+        return False
+
+    result = run_gh(
+        [
+            "pr",
+            "list",
+            "--head",
+            worktree.branch,
+            "--state",
+            "merged",
+            "--json",
+            "number,mergedAt",
+            "--limit",
+            "1",
+        ],
+        cwd=repo,
+    )
+    if result.returncode != 0:
+        return False
+
+    try:
+        prs = json.loads(result.stdout)
+    except json.JSONDecodeError:
+        return False
+
+    return bool(prs)
+
+
+def removable_reason(worktree: Worktree, *, repo: Path, base: str) -> str | None:
+    if not worktree.path.is_relative_to(WORKTREE_ROOT):
+        return None
+    if not worktree.path.exists():
+        return None
+    if has_local_changes(worktree.path):
+        return None
+    if pr_is_merged(worktree, repo=repo):
+        return "merged PR"
+    if head_is_merged(worktree, repo=repo, base=base):
+        return f"HEAD is ancestor of {base}"
+    return None
+
+
+def remove_worktree(worktree: Worktree, *, repo: Path, force: bool) -> subprocess.CompletedProcess[str]:
+    args = ["worktree", "remove"]
+    if force:
+        args.append("--force")
+    args.append(str(worktree.path))
+    return run_git(args, cwd=repo, check=False)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--base", default=DEFAULT_BASE, help=f"base ref used for ancestry checks (default: {DEFAULT_BASE})"
+    )
+    parser.add_argument(
+        "--dry-run", action="store_true", help="list removable worktrees without deleting them"
+    )
+    parser.add_argument("--force", action="store_true", help="pass --force to git worktree remove")
+    args = parser.parse_args()
+
+    repo = Path(run_git(["rev-parse", "--show-toplevel"], cwd=Path.cwd()).stdout.strip())
+    worktree_list = run_git(["worktree", "list", "--porcelain"], cwd=repo).stdout
+    worktrees = parse_worktrees(worktree_list)
+
+    matched = 0
+    removed = 0
+    for worktree in worktrees:
+        reason = removable_reason(worktree, repo=repo, base=args.base)
+        if reason is None:
+            continue
+
+        matched += 1
+        branch = worktree.branch or "(detached)"
+        if args.dry_run:
+            print(f"would remove {worktree.path} [{branch}]: {reason}")
+            continue
+
+        result = remove_worktree(worktree, repo=repo, force=args.force)
+        if result.returncode == 0:
+            removed += 1
+            print(f"removed {worktree.path} [{branch}]: {reason}")
+        else:
+            print(
+                f"failed to remove {worktree.path} [{branch}]: {result.stderr.strip()}",
+                file=sys.stderr,
+            )
+
+    if matched == 0:
+        print("no clean merged worktrees found under /tmp/worktrees")
+        return 0
+    elif args.dry_run:
+        print(f"found {matched} removable worktree(s)")
+        return 0
+
+    print(f"removed {removed} merged worktree(s)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add a cleanup script for clean merged worktrees under /tmp/worktrees
- expose Makefile targets for cleanup and dry-run checks
- update agent workflow docs so merged PR worktrees are removed immediately

## Validation
- python3 -m py_compile scripts/cleanup_merged_worktrees.py
- /workspaces/LoRAIro/.venv/bin/ruff check scripts/cleanup_merged_worktrees.py
- /workspaces/LoRAIro/.venv/bin/ruff format --check scripts/cleanup_merged_worktrees.py
- python3 scripts/cleanup_merged_worktrees.py --dry-run

Note: uv run ruff check scripts/cleanup_merged_worktrees.py was attempted in the fresh worktree, but uv could not generate editable metadata because submodules were not initialized there.