### PR TITLE
feat: add provider batch job GUI

### DIFF
--- a/src/lorairo/annotations/annotator_adapter.py
+++ b/src/lorairo/annotations/annotator_adapter.py
@@ -23,6 +23,14 @@ from PIL import Image
 
 from lorairo.services.configuration_service import ConfigurationService
 from lorairo.services.model_registry_protocol import ModelInfo
+from lorairo.services.provider_batch_library_compat import (
+    to_library_handle,
+    to_library_submit_request,
+    to_provider_batch_fetch_result,
+    to_provider_batch_models,
+    to_provider_batch_status,
+    to_provider_batch_submission,
+)
 from lorairo.utils.log import logger
 
 if TYPE_CHECKING:
@@ -208,24 +216,40 @@ class AnnotatorLibraryAdapter:
 
     def submit_batch(self, request: BatchSubmitRequest) -> ProviderBatchSubmission:
         """Provider Batch API job を image-annotator-lib の公開 API へ委譲する。"""
-        return cast("ProviderBatchSubmission", self._call_batch_api("submit_batch", request))
+        return to_provider_batch_submission(
+            self._call_batch_api("submit_batch", to_library_submit_request(request)),
+            request.provider,
+        )
 
     def retrieve_batch(self, handle: BatchJobHandle) -> ProviderBatchStatus:
         """Provider Batch API job の状態取得を image-annotator-lib の公開 API へ委譲する。"""
-        return cast("ProviderBatchStatus", self._call_batch_api("retrieve_batch", handle))
+        return to_provider_batch_status(
+            self._call_batch_api("retrieve_batch", to_library_handle(handle)),
+            handle.provider,
+        )
 
     def cancel_batch(self, handle: BatchJobHandle) -> ProviderBatchStatus:
         """Provider Batch API job の cancel を image-annotator-lib の公開 API へ委譲する。"""
-        return cast("ProviderBatchStatus", self._call_batch_api("cancel_batch", handle))
+        return to_provider_batch_status(
+            self._call_batch_api("cancel_batch", to_library_handle(handle)),
+            handle.provider,
+        )
 
     def fetch_batch_results(
         self, handle: BatchJobHandle, destination_dir: Path
     ) -> ProviderBatchFetchResult:
         """Provider Batch API job の normalized result 取得を image-annotator-lib の公開 API へ委譲する。"""
-        return cast(
-            "ProviderBatchFetchResult",
-            self._call_batch_api("fetch_batch_results", handle, destination_dir),
+        library_handle = to_library_handle(handle)
+        return to_provider_batch_fetch_result(
+            self._call_fetch_batch_results(library_handle, destination_dir),
+            handle.provider,
+            destination_dir,
+            fallback_provider_job_id=handle.provider_job_id,
         )
+
+    def list_batch_capable_models(self) -> tuple[Any, ...]:
+        """Provider Batch API 対応モデル情報を image-annotator-lib から取得する。"""
+        return to_provider_batch_models(self._call_batch_api("list_batch_capable_models"))
 
     def _call_batch_api(self, method_name: str, *args: Any) -> Any:
         import image_annotator_lib
@@ -236,6 +260,31 @@ class AnnotatorLibraryAdapter:
 
             raise ProviderBatchError(f"image-annotator-lib batch API method is unavailable: {method_name}")
         return method(*args)
+
+    def _call_fetch_batch_results(self, handle: Any, destination_dir: Path) -> Any:
+        import inspect
+
+        import image_annotator_lib
+
+        method = getattr(image_annotator_lib, "fetch_batch_results", None)
+        if not callable(method):
+            from lorairo.services.provider_batch_service import ProviderBatchError
+
+            raise ProviderBatchError(
+                "image-annotator-lib batch API method is unavailable: fetch_batch_results"
+            )
+
+        try:
+            signature = inspect.signature(method)
+            accepts_destination_dir = len(signature.parameters) >= 2
+        except (TypeError, ValueError):
+            try:
+                return method(handle, destination_dir)
+            except TypeError:
+                return method(handle)
+        if accepts_destination_dir:
+            return method(handle, destination_dir)
+        return method(handle)
 
     def _prepare_api_keys(self) -> dict[str, str]:
         """APIキー辞書を準備

--- a/src/lorairo/gui/widgets/provider_batch_job_widget.py
+++ b/src/lorairo/gui/widgets/provider_batch_job_widget.py
@@ -1,0 +1,511 @@
+"""Provider Batch job management widget."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any, ClassVar
+
+from PySide6.QtCore import Qt, Signal, Slot
+from PySide6.QtWidgets import (
+    QCheckBox,
+    QComboBox,
+    QFormLayout,
+    QGroupBox,
+    QHBoxLayout,
+    QLabel,
+    QLineEdit,
+    QMessageBox,
+    QPushButton,
+    QSplitter,
+    QTableWidget,
+    QTableWidgetItem,
+    QVBoxLayout,
+    QWidget,
+)
+
+from ...services.provider_batch_service import ProviderBatchError
+from ...services.service_container import ServiceContainer
+from ...utils.log import logger
+from ..state.dataset_state import DatasetStateManager
+
+
+@dataclass(frozen=True)
+class _ModelCandidate:
+    provider: str
+    litellm_model_id: str
+    display_name: str
+    model_id: int | None = None
+
+
+class ProviderBatchJobWidget(QWidget):
+    """Minimal Provider Batch queue management UI."""
+
+    job_selected = Signal(int)
+    jobs_refreshed = Signal()
+    job_action_completed = Signal(str, int)
+    submit_completed = Signal(int)
+
+    _JOB_HEADERS: ClassVar[list[str]] = [
+        "ID",
+        "Provider",
+        "Model",
+        "Status",
+        "Requested",
+        "Succeeded",
+        "Failed",
+        "Canceled",
+        "Submitted",
+        "Completed",
+        "Imported",
+    ]
+    _ITEM_HEADERS: ClassVar[list[str]] = [
+        "Custom ID",
+        "Image ID",
+        "Model ID",
+        "Status",
+        "Error Type",
+        "Error Message",
+    ]
+    _DIRECT_BATCH_PROVIDERS: ClassVar[set[str]] = {"openai", "anthropic"}
+
+    def __init__(
+        self,
+        service_container: ServiceContainer,
+        dataset_state_manager: DatasetStateManager | None = None,
+        parent: QWidget | None = None,
+    ) -> None:
+        super().__init__(parent)
+        self._service_container = service_container
+        self._dataset_state_manager = dataset_state_manager
+        self._workflow_service = service_container.provider_batch_workflow_service
+        self._repository = service_container.db_manager.repository
+        self._model_candidates: list[_ModelCandidate] = []
+        self._selected_job_id: int | None = None
+
+        self._setup_ui()
+        self._connect_signals()
+        self.refresh_models()
+        self.refresh_jobs()
+
+    def set_dataset_state_manager(self, dataset_state_manager: DatasetStateManager | None) -> None:
+        """Set the shared dataset state used by the selected-images submit option."""
+        self._dataset_state_manager = dataset_state_manager
+
+    def _setup_ui(self) -> None:
+        self.setObjectName("providerBatchJobWidget")
+        layout = QVBoxLayout(self)
+
+        submit_group = QGroupBox("Provider Batch Submit")
+        submit_layout = QFormLayout(submit_group)
+
+        self.providerComboBox = QComboBox()
+        self.providerComboBox.setObjectName("providerBatchProviderComboBox")
+        submit_layout.addRow("Provider", self.providerComboBox)
+
+        self.modelComboBox = QComboBox()
+        self.modelComboBox.setObjectName("providerBatchModelComboBox")
+        submit_layout.addRow("Model", self.modelComboBox)
+
+        self.endpointLineEdit = QLineEdit("responses")
+        self.endpointLineEdit.setObjectName("providerBatchEndpointLineEdit")
+        submit_layout.addRow("Endpoint", self.endpointLineEdit)
+
+        self.promptProfileLineEdit = QLineEdit("default")
+        self.promptProfileLineEdit.setObjectName("providerBatchPromptProfileLineEdit")
+        submit_layout.addRow("Prompt profile", self.promptProfileLineEdit)
+
+        self.useSelectedImagesCheckBox = QCheckBox("Use current selection")
+        self.useSelectedImagesCheckBox.setObjectName("providerBatchUseSelectedImagesCheckBox")
+        self.useSelectedImagesCheckBox.setChecked(True)
+        submit_layout.addRow("Images", self.useSelectedImagesCheckBox)
+
+        self.imageIdsLineEdit = QLineEdit()
+        self.imageIdsLineEdit.setObjectName("providerBatchImageIdsLineEdit")
+        self.imageIdsLineEdit.setPlaceholderText("Manual IDs, e.g. 12, 13, 21")
+        submit_layout.addRow("Manual image IDs", self.imageIdsLineEdit)
+
+        self.descriptionLineEdit = QLineEdit()
+        self.descriptionLineEdit.setObjectName("providerBatchDescriptionLineEdit")
+        submit_layout.addRow("Description", self.descriptionLineEdit)
+
+        submit_buttons = QHBoxLayout()
+        self.refreshModelsButton = QPushButton("Refresh models")
+        self.refreshModelsButton.setObjectName("providerBatchRefreshModelsButton")
+        self.submitButton = QPushButton("Submit")
+        self.submitButton.setObjectName("providerBatchSubmitButton")
+        submit_buttons.addWidget(self.refreshModelsButton)
+        submit_buttons.addStretch(1)
+        submit_buttons.addWidget(self.submitButton)
+        submit_layout.addRow(submit_buttons)
+        layout.addWidget(submit_group)
+
+        toolbar = QHBoxLayout()
+        self.refreshButton = QPushButton("Refresh")
+        self.refreshButton.setObjectName("providerBatchRefreshButton")
+        self.cancelButton = QPushButton("Cancel")
+        self.cancelButton.setObjectName("providerBatchCancelButton")
+        self.fetchButton = QPushButton("Fetch")
+        self.fetchButton.setObjectName("providerBatchFetchButton")
+        self.importButton = QPushButton("Import")
+        self.importButton.setObjectName("providerBatchImportButton")
+        toolbar.addWidget(self.refreshButton)
+        toolbar.addStretch(1)
+        toolbar.addWidget(self.cancelButton)
+        toolbar.addWidget(self.fetchButton)
+        toolbar.addWidget(self.importButton)
+        layout.addLayout(toolbar)
+
+        splitter = QSplitter(Qt.Orientation.Vertical)
+        self.jobTableWidget = QTableWidget(0, len(self._JOB_HEADERS))
+        self.jobTableWidget.setObjectName("providerBatchJobTableWidget")
+        self.jobTableWidget.setHorizontalHeaderLabels(self._JOB_HEADERS)
+        self.jobTableWidget.setSelectionBehavior(QTableWidget.SelectionBehavior.SelectRows)
+        self.jobTableWidget.setSelectionMode(QTableWidget.SelectionMode.SingleSelection)
+        self.jobTableWidget.setEditTriggers(QTableWidget.EditTrigger.NoEditTriggers)
+        self.jobTableWidget.horizontalHeader().setStretchLastSection(True)
+
+        self.itemTableWidget = QTableWidget(0, len(self._ITEM_HEADERS))
+        self.itemTableWidget.setObjectName("providerBatchItemTableWidget")
+        self.itemTableWidget.setHorizontalHeaderLabels(self._ITEM_HEADERS)
+        self.itemTableWidget.setSelectionBehavior(QTableWidget.SelectionBehavior.SelectRows)
+        self.itemTableWidget.setEditTriggers(QTableWidget.EditTrigger.NoEditTriggers)
+        self.itemTableWidget.horizontalHeader().setStretchLastSection(True)
+
+        splitter.addWidget(self.jobTableWidget)
+        splitter.addWidget(self.itemTableWidget)
+        splitter.setSizes([360, 220])
+        layout.addWidget(splitter, 1)
+
+        self.statusLabel = QLabel()
+        self.statusLabel.setObjectName("providerBatchStatusLabel")
+        layout.addWidget(self.statusLabel)
+        self._set_action_buttons_enabled(False)
+
+    def _connect_signals(self) -> None:
+        self.refreshModelsButton.clicked.connect(self.refresh_models)
+        self.providerComboBox.currentTextChanged.connect(self._populate_model_combo)
+        self.submitButton.clicked.connect(self._on_submit_clicked)
+        self.refreshButton.clicked.connect(self.refresh_jobs)
+        self.cancelButton.clicked.connect(self._on_cancel_clicked)
+        self.fetchButton.clicked.connect(self._on_fetch_clicked)
+        self.importButton.clicked.connect(self._on_import_clicked)
+        self.jobTableWidget.itemSelectionChanged.connect(self._on_job_selection_changed)
+
+    @Slot()
+    def refresh_models(self) -> None:
+        """Refresh batch-capable model choices from image-annotator-lib and local model rows."""
+        try:
+            raw_models = self._service_container.annotator_library.list_batch_capable_models()
+            self._model_candidates = self._build_model_candidates(raw_models)
+            providers = sorted({candidate.provider for candidate in self._model_candidates})
+
+            self.providerComboBox.blockSignals(True)
+            self.providerComboBox.clear()
+            self.providerComboBox.addItems(providers)
+            self.providerComboBox.blockSignals(False)
+            self._populate_model_combo()
+            self.statusLabel.setText(f"Batch-capable models: {len(self._model_candidates)}")
+        except Exception as e:
+            logger.error(f"Provider Batch model list refresh failed: {e}", exc_info=True)
+            self._model_candidates = []
+            self.providerComboBox.clear()
+            self.modelComboBox.clear()
+            self.statusLabel.setText(f"Model refresh failed: {e}")
+
+    def _build_model_candidates(self, raw_models: Any) -> list[_ModelCandidate]:
+        library_candidates = [
+            candidate
+            for raw_model in raw_models or []
+            if (candidate := self._candidate_from_raw_model(raw_model)) is not None
+        ]
+        if not library_candidates:
+            return []
+
+        litellm_ids = {candidate.litellm_model_id for candidate in library_candidates}
+        local_models: dict[str, Any] = {}
+        get_models = getattr(self._repository, "get_models_by_litellm_ids", None)
+        if get_models is not None:
+            local_models = get_models(litellm_ids) or {}
+
+        if not local_models:
+            return library_candidates
+
+        candidates: list[_ModelCandidate] = []
+        by_id = {candidate.litellm_model_id: candidate for candidate in library_candidates}
+        for litellm_model_id, model in local_models.items():
+            provider = str(getattr(model, "provider", "") or "").lower()
+            if provider not in self._DIRECT_BATCH_PROVIDERS:
+                continue
+            if getattr(model, "discontinued_at", None) is not None:
+                continue
+            library_candidate = by_id.get(str(litellm_model_id))
+            if library_candidate is None:
+                continue
+            candidates.append(
+                _ModelCandidate(
+                    provider=provider,
+                    litellm_model_id=library_candidate.litellm_model_id,
+                    display_name=str(getattr(model, "name", "") or library_candidate.display_name),
+                    model_id=getattr(model, "id", None),
+                )
+            )
+        return candidates
+
+    def _candidate_from_raw_model(self, raw_model: Any) -> _ModelCandidate | None:
+        provider = self._raw_value(raw_model, "provider")
+        litellm_model_id = self._raw_value(raw_model, "litellm_model_id") or self._raw_value(
+            raw_model, "model_id"
+        )
+        if provider is None or litellm_model_id is None:
+            return None
+        name = self._raw_value(raw_model, "name") or litellm_model_id
+        provider_key = provider.lower()
+        if provider_key not in self._DIRECT_BATCH_PROVIDERS:
+            return None
+        if self._raw_value(raw_model, "discontinued_at") is not None:
+            return None
+        return _ModelCandidate(
+            provider=provider_key,
+            litellm_model_id=litellm_model_id,
+            display_name=name,
+        )
+
+    @staticmethod
+    def _raw_value(raw_model: Any, key: str) -> str | None:
+        if isinstance(raw_model, dict):
+            value = raw_model.get(key)
+        else:
+            value = getattr(raw_model, key, None)
+        if value is None:
+            return None
+        return str(value)
+
+    @Slot()
+    def _populate_model_combo(self) -> None:
+        provider = self.providerComboBox.currentText()
+        self.modelComboBox.clear()
+        for candidate in self._model_candidates:
+            if candidate.provider != provider:
+                continue
+            self.modelComboBox.addItem(
+                f"{candidate.display_name} ({candidate.litellm_model_id})",
+                candidate,
+            )
+        self.submitButton.setEnabled(self.modelComboBox.count() > 0)
+
+    @Slot()
+    def refresh_jobs(self) -> None:
+        """Reload provider batch jobs from the repository."""
+        try:
+            jobs = self._repository.list_provider_batch_jobs(limit=100)
+            model_labels = self._model_labels_by_id()
+            self.jobTableWidget.setRowCount(0)
+            for row, job in enumerate(jobs):
+                self.jobTableWidget.insertRow(row)
+                values = [
+                    getattr(job, "id", ""),
+                    getattr(job, "provider", ""),
+                    self._format_model_label(job, model_labels),
+                    getattr(job, "status", ""),
+                    getattr(job, "request_count", 0),
+                    getattr(job, "succeeded_count", 0),
+                    getattr(job, "failed_count", 0),
+                    getattr(job, "canceled_count", 0),
+                    self._format_datetime(getattr(job, "submitted_at", None)),
+                    self._format_datetime(getattr(job, "completed_at", None)),
+                    self._format_datetime(getattr(job, "imported_at", None)),
+                ]
+                for column, value in enumerate(values):
+                    item = QTableWidgetItem(str(value) if value is not None else "")
+                    if column == 0:
+                        item.setData(Qt.ItemDataRole.UserRole, getattr(job, "id", None))
+                    self.jobTableWidget.setItem(row, column, item)
+            self._selected_job_id = None
+            self.itemTableWidget.setRowCount(0)
+            self._set_action_buttons_enabled(False)
+            self.statusLabel.setText(f"Provider Batch jobs: {len(jobs)}")
+            self.jobs_refreshed.emit()
+        except Exception as e:
+            logger.error(f"Provider Batch job refresh failed: {e}", exc_info=True)
+            self.statusLabel.setText(f"Job refresh failed: {e}")
+
+    def _model_labels_by_id(self) -> dict[int, str]:
+        get_model_objects = getattr(self._repository, "get_model_objects", None)
+        if get_model_objects is None:
+            return {}
+        try:
+            return {
+                int(model.id): str(getattr(model, "litellm_model_id", None) or model.name)
+                for model in get_model_objects()
+                if getattr(model, "id", None) is not None
+            }
+        except Exception as e:
+            logger.debug(f"Provider Batch model label lookup skipped: {e}")
+            return {}
+
+    def _format_model_label(self, job: Any, model_labels: dict[int, str]) -> str:
+        model_id = getattr(job, "model_id", None)
+        if isinstance(model_id, int):
+            return model_labels.get(model_id, self._format_model_id(job))
+        return self._format_model_id(job)
+
+    @staticmethod
+    def _format_model_id(job: Any) -> str:
+        model_id = getattr(job, "model_id", None)
+        return "" if model_id is None else f"model:{model_id}"
+
+    @staticmethod
+    def _format_datetime(value: Any) -> str:
+        if value is None:
+            return ""
+        if isinstance(value, datetime):
+            return value.strftime("%Y-%m-%d %H:%M")
+        return str(value)
+
+    @Slot()
+    def _on_job_selection_changed(self) -> None:
+        selected_items = self.jobTableWidget.selectedItems()
+        if not selected_items:
+            self._selected_job_id = None
+            self.itemTableWidget.setRowCount(0)
+            self._set_action_buttons_enabled(False)
+            return
+        row = selected_items[0].row()
+        id_item = self.jobTableWidget.item(row, 0)
+        job_id = id_item.data(Qt.ItemDataRole.UserRole) if id_item is not None else None
+        self._selected_job_id = int(job_id) if job_id is not None else None
+        self._set_action_buttons_enabled(self._selected_job_id is not None)
+        if self._selected_job_id is not None:
+            self.job_selected.emit(self._selected_job_id)
+            self._refresh_items(self._selected_job_id)
+
+    def _refresh_items(self, job_id: int) -> None:
+        try:
+            items = self._repository.list_provider_batch_items(job_id, limit=1000)
+            self.itemTableWidget.setRowCount(0)
+            for row, item_row in enumerate(items):
+                self.itemTableWidget.insertRow(row)
+                values = [
+                    getattr(item_row, "custom_id", ""),
+                    getattr(item_row, "image_id", ""),
+                    getattr(item_row, "model_id", ""),
+                    getattr(item_row, "status", ""),
+                    getattr(item_row, "error_type", ""),
+                    getattr(item_row, "error_message", ""),
+                ]
+                for column, value in enumerate(values):
+                    self.itemTableWidget.setItem(
+                        row,
+                        column,
+                        QTableWidgetItem(str(value) if value is not None else ""),
+                    )
+        except Exception as e:
+            logger.error(f"Provider Batch item refresh failed: job_id={job_id}: {e}", exc_info=True)
+            self.statusLabel.setText(f"Item refresh failed: {e}")
+
+    def _set_action_buttons_enabled(self, enabled: bool) -> None:
+        self.cancelButton.setEnabled(enabled)
+        self.fetchButton.setEnabled(enabled)
+        self.importButton.setEnabled(enabled)
+
+    @Slot()
+    def _on_cancel_clicked(self) -> None:
+        self._run_job_action("cancel", self._workflow_service.cancel)
+
+    @Slot()
+    def _on_fetch_clicked(self) -> None:
+        self._run_job_action("fetch", self._workflow_service.fetch_results)
+
+    @Slot()
+    def _on_import_clicked(self) -> None:
+        self._run_job_action("import", self._workflow_service.import_results)
+
+    def _run_job_action(self, action_name: str, action: Any) -> None:
+        if self._selected_job_id is None:
+            QMessageBox.information(self, "Provider Batch", "Select a job first.")
+            return
+        job_id = self._selected_job_id
+        try:
+            action(job_id)
+            self.statusLabel.setText(f"{action_name} completed: job {job_id}")
+            self.refresh_jobs()
+            self._select_job(job_id)
+            self.job_action_completed.emit(action_name, job_id)
+        except Exception as e:
+            logger.error(f"Provider Batch {action_name} failed: job_id={job_id}: {e}", exc_info=True)
+            QMessageBox.warning(self, "Provider Batch", f"{action_name} failed:\n{e}")
+            self.statusLabel.setText(f"{action_name} failed: {e}")
+
+    def _select_job(self, job_id: int) -> None:
+        for row in range(self.jobTableWidget.rowCount()):
+            item = self.jobTableWidget.item(row, 0)
+            if item is not None and item.data(Qt.ItemDataRole.UserRole) == job_id:
+                self.jobTableWidget.selectRow(row)
+                return
+
+    @Slot()
+    def _on_submit_clicked(self) -> None:
+        try:
+            image_ids = self._collect_submit_image_ids()
+            candidate = self.modelComboBox.currentData()
+            if not isinstance(candidate, _ModelCandidate):
+                raise ValueError("Provider Batch model is not selected.")
+            endpoint = self.endpointLineEdit.text().strip() or "responses"
+            prompt_profile = self.promptProfileLineEdit.text().strip() or "default"
+            description = self.descriptionLineEdit.text().strip() or None
+            job_id = self._workflow_service.submit_images(
+                provider=candidate.provider,
+                endpoint=endpoint,
+                litellm_model_id=candidate.litellm_model_id,
+                prompt_profile=prompt_profile,
+                image_ids=image_ids,
+                model_id=candidate.model_id,
+                description=description,
+            )
+            self.statusLabel.setText(f"Submitted Provider Batch job: {job_id}")
+            self.refresh_jobs()
+            self._select_job(job_id)
+            self.submit_completed.emit(job_id)
+        except (ProviderBatchError, ValueError) as e:
+            QMessageBox.warning(self, "Provider Batch", str(e))
+            self.statusLabel.setText(str(e))
+        except Exception as e:
+            logger.error(f"Provider Batch submit failed: {e}", exc_info=True)
+            QMessageBox.warning(self, "Provider Batch", f"Submit failed:\n{e}")
+            self.statusLabel.setText(f"Submit failed: {e}")
+
+    def _collect_submit_image_ids(self) -> list[int]:
+        image_ids: list[int] = []
+        if self.useSelectedImagesCheckBox.isChecked() and self._dataset_state_manager is not None:
+            image_ids.extend(self._dataset_state_manager.selected_image_ids)
+        manual_ids = self._parse_manual_image_ids(self.imageIdsLineEdit.text())
+        image_ids.extend(manual_ids)
+        deduped = list(dict.fromkeys(image_ids))
+        if not deduped:
+            raise ValueError("Provider Batch submit requires at least one image ID.")
+        return deduped
+
+    @staticmethod
+    def _parse_manual_image_ids(raw_ids: str) -> list[int]:
+        if not raw_ids.strip():
+            return []
+        tokens = raw_ids.replace("\n", ",").replace(" ", ",").split(",")
+        image_ids: list[int] = []
+        invalid_tokens: list[str] = []
+        for token in tokens:
+            stripped = token.strip()
+            if not stripped:
+                continue
+            try:
+                image_id = int(stripped)
+            except ValueError:
+                invalid_tokens.append(stripped)
+                continue
+            if image_id <= 0:
+                invalid_tokens.append(stripped)
+                continue
+            image_ids.append(image_id)
+        if invalid_tokens:
+            raise ValueError(f"Invalid image IDs: {', '.join(invalid_tokens)}")
+        return image_ids

--- a/src/lorairo/gui/widgets/provider_batch_job_widget.py
+++ b/src/lorairo/gui/widgets/provider_batch_job_widget.py
@@ -82,6 +82,7 @@ class ProviderBatchJobWidget(QWidget):
         self._repository = service_container.db_manager.repository
         self._model_candidates: list[_ModelCandidate] = []
         self._selected_job_id: int | None = None
+        self._selected_job_provider_status = ""
 
         self._setup_ui()
         self._connect_signals()
@@ -143,6 +144,11 @@ class ProviderBatchJobWidget(QWidget):
         toolbar = QHBoxLayout()
         self.refreshButton = QPushButton("Refresh")
         self.refreshButton.setObjectName("providerBatchRefreshButton")
+        self.itemStatusFilterComboBox = QComboBox()
+        self.itemStatusFilterComboBox.setObjectName("providerBatchItemStatusFilterComboBox")
+        self.itemStatusFilterComboBox.addItem("All items", None)
+        for status in ("failed", "expired", "canceled"):
+            self.itemStatusFilterComboBox.addItem(status, status)
         self.cancelButton = QPushButton("Cancel")
         self.cancelButton.setObjectName("providerBatchCancelButton")
         self.fetchButton = QPushButton("Fetch")
@@ -150,6 +156,7 @@ class ProviderBatchJobWidget(QWidget):
         self.importButton = QPushButton("Import")
         self.importButton.setObjectName("providerBatchImportButton")
         toolbar.addWidget(self.refreshButton)
+        toolbar.addWidget(self.itemStatusFilterComboBox)
         toolbar.addStretch(1)
         toolbar.addWidget(self.cancelButton)
         toolbar.addWidget(self.fetchButton)
@@ -180,13 +187,17 @@ class ProviderBatchJobWidget(QWidget):
         self.statusLabel = QLabel()
         self.statusLabel.setObjectName("providerBatchStatusLabel")
         layout.addWidget(self.statusLabel)
+        self.rawProviderStatusLabel = QLabel()
+        self.rawProviderStatusLabel.setObjectName("providerBatchRawProviderStatusLabel")
+        layout.addWidget(self.rawProviderStatusLabel)
         self._set_action_buttons_enabled(False)
 
     def _connect_signals(self) -> None:
         self.refreshModelsButton.clicked.connect(self.refresh_models)
         self.providerComboBox.currentTextChanged.connect(self._populate_model_combo)
         self.submitButton.clicked.connect(self._on_submit_clicked)
-        self.refreshButton.clicked.connect(self.refresh_jobs)
+        self.refreshButton.clicked.connect(self._on_refresh_clicked)
+        self.itemStatusFilterComboBox.currentIndexChanged.connect(self._on_item_status_filter_changed)
         self.cancelButton.clicked.connect(self._on_cancel_clicked)
         self.fetchButton.clicked.connect(self._on_fetch_clicked)
         self.importButton.clicked.connect(self._on_import_clicked)
@@ -229,7 +240,7 @@ class ProviderBatchJobWidget(QWidget):
             local_models = get_models(litellm_ids) or {}
 
         if not local_models:
-            return library_candidates
+            return []
 
         candidates: list[_ModelCandidate] = []
         by_id = {candidate.litellm_model_id: candidate for candidate in library_candidates}
@@ -239,6 +250,9 @@ class ProviderBatchJobWidget(QWidget):
                 continue
             if getattr(model, "discontinued_at", None) is not None:
                 continue
+            model_id = getattr(model, "id", None)
+            if not isinstance(model_id, int):
+                continue
             library_candidate = by_id.get(str(litellm_model_id))
             if library_candidate is None:
                 continue
@@ -247,7 +261,7 @@ class ProviderBatchJobWidget(QWidget):
                     provider=provider,
                     litellm_model_id=library_candidate.litellm_model_id,
                     display_name=str(getattr(model, "name", "") or library_candidate.display_name),
-                    model_id=getattr(model, "id", None),
+                    model_id=model_id,
                 )
             )
         return candidates
@@ -320,10 +334,17 @@ class ProviderBatchJobWidget(QWidget):
                     item = QTableWidgetItem(str(value) if value is not None else "")
                     if column == 0:
                         item.setData(Qt.ItemDataRole.UserRole, getattr(job, "id", None))
+                    if column == 3:
+                        item.setData(
+                            Qt.ItemDataRole.UserRole,
+                            str(getattr(job, "provider_status", "") or ""),
+                        )
                     self.jobTableWidget.setItem(row, column, item)
             self._selected_job_id = None
+            self._selected_job_provider_status = ""
             self.itemTableWidget.setRowCount(0)
             self._set_action_buttons_enabled(False)
+            self._update_raw_provider_status_label()
             self.statusLabel.setText(f"Provider Batch jobs: {len(jobs)}")
             self.jobs_refreshed.emit()
         except Exception as e:
@@ -368,13 +389,20 @@ class ProviderBatchJobWidget(QWidget):
         selected_items = self.jobTableWidget.selectedItems()
         if not selected_items:
             self._selected_job_id = None
+            self._selected_job_provider_status = ""
             self.itemTableWidget.setRowCount(0)
             self._set_action_buttons_enabled(False)
+            self._update_raw_provider_status_label()
             return
         row = selected_items[0].row()
         id_item = self.jobTableWidget.item(row, 0)
         job_id = id_item.data(Qt.ItemDataRole.UserRole) if id_item is not None else None
         self._selected_job_id = int(job_id) if job_id is not None else None
+        status_item = self.jobTableWidget.item(row, 3)
+        self._selected_job_provider_status = (
+            status_item.data(Qt.ItemDataRole.UserRole) if status_item else ""
+        )
+        self._update_raw_provider_status_label()
         self._set_action_buttons_enabled(self._selected_job_id is not None)
         if self._selected_job_id is not None:
             self.job_selected.emit(self._selected_job_id)
@@ -382,7 +410,12 @@ class ProviderBatchJobWidget(QWidget):
 
     def _refresh_items(self, job_id: int) -> None:
         try:
-            items = self._repository.list_provider_batch_items(job_id, limit=1000)
+            status_filter = self.itemStatusFilterComboBox.currentData()
+            items = self._repository.list_provider_batch_items(
+                job_id,
+                status=status_filter if isinstance(status_filter, str) else None,
+                limit=1000,
+            )
             self.itemTableWidget.setRowCount(0)
             for row, item_row in enumerate(items):
                 self.itemTableWidget.insertRow(row)
@@ -403,6 +436,22 @@ class ProviderBatchJobWidget(QWidget):
         except Exception as e:
             logger.error(f"Provider Batch item refresh failed: job_id={job_id}: {e}", exc_info=True)
             self.statusLabel.setText(f"Item refresh failed: {e}")
+
+    @Slot()
+    def _on_refresh_clicked(self) -> None:
+        if self._selected_job_id is None:
+            self.refresh_jobs()
+            return
+        self._run_job_action("refresh", self._workflow_service.refresh)
+
+    @Slot()
+    def _on_item_status_filter_changed(self, _index: int = 0) -> None:
+        if self._selected_job_id is not None:
+            self._refresh_items(self._selected_job_id)
+
+    def _update_raw_provider_status_label(self) -> None:
+        value = self._selected_job_provider_status or "-"
+        self.rawProviderStatusLabel.setText(f"Provider status: {value}")
 
     def _set_action_buttons_enabled(self, enabled: bool) -> None:
         self.cancelButton.setEnabled(enabled)

--- a/src/lorairo/gui/window/main_window.py
+++ b/src/lorairo/gui/window/main_window.py
@@ -42,6 +42,7 @@ from ..widgets.error_log_viewer_dialog import ErrorLogViewerDialog
 from ..widgets.error_notification_widget import ErrorNotificationWidget
 from ..widgets.filter_search_panel import FilterSearchPanel
 from ..widgets.image_preview import ImagePreviewWidget
+from ..widgets.provider_batch_job_widget import ProviderBatchJobWidget
 from ..widgets.quick_tag_dialog import QuickTagDialog
 from ..widgets.selected_image_details_widget import SelectedImageDetailsWidget
 from ..widgets.tag_management_dialog import TagManagementDialog
@@ -88,6 +89,7 @@ class MainWindow(QMainWindow, Ui_MainWindow):
     thumbnail_selector: ThumbnailSelectorWidget | None
     image_preview_widget: ImagePreviewWidget | None
     selected_image_details_widget: SelectedImageDetailsWidget | None
+    provider_batch_job_widget: ProviderBatchJobWidget | None
 
     # Tab widget (programmatically created)
     tabWidgetMainMode: QTabWidget
@@ -373,6 +375,9 @@ class MainWindow(QMainWindow, Ui_MainWindow):
         # BatchTagAddWidget再配置（Phase 2.5統合、Day 2）
         WidgetSetupService.setup_batch_tag_tab_widgets(self)
 
+        # Provider Batch job management tab (Issue #483)
+        self._setup_provider_batch_tab()
+
         # QTabWidget初期化（タブ切り替え用）
         self._setup_tab_widget()
 
@@ -426,6 +431,25 @@ class MainWindow(QMainWindow, Ui_MainWindow):
         # 初期表示は画像詳細タブ（インデックス0）
         self.tab_widget_right_panel.setCurrentIndex(0)
         logger.info("tabWidgetRightPanel initialized with 1 tab: 画像詳細")
+
+    def _setup_provider_batch_tab(self) -> None:
+        """Add the Provider Batch job management tab without editing generated UI."""
+        self.provider_batch_job_widget = None
+        if not hasattr(self, "tabWidgetMainMode") or not self.tabWidgetMainMode:
+            logger.warning("tabWidgetMainMode not found - provider batch tab skipped")
+            return
+
+        try:
+            self.provider_batch_job_widget = ProviderBatchJobWidget(
+                service_container=self.service_container,
+                dataset_state_manager=self.dataset_state_manager,
+                parent=self,
+            )
+            self.tabWidgetMainMode.addTab(self.provider_batch_job_widget, "Provider Batch")
+            logger.info("Provider Batch job management tab added")
+        except Exception as e:
+            logger.error(f"Provider Batch tab setup failed: {e}", exc_info=True)
+            self.provider_batch_job_widget = None
 
     def _show_error_log_dialog(self) -> None:
         """エラーログダイアログを表示（オンデマンド）"""
@@ -1614,6 +1638,10 @@ class MainWindow(QMainWindow, Ui_MainWindow):
         elif index == 1:  # バッチタグ
             logger.info("Switched to Batch Tag tab")
             self._refresh_batch_tag_staging()
+        elif self.tabWidgetMainMode.widget(index) is getattr(self, "provider_batch_job_widget", None):
+            logger.info("Switched to Provider Batch tab")
+            if self.provider_batch_job_widget is not None:
+                self.provider_batch_job_widget.refresh_jobs()
         else:
             logger.warning(f"Unknown tab index: {index}")
 

--- a/src/lorairo/services/provider_batch_library_compat.py
+++ b/src/lorairo/services/provider_batch_library_compat.py
@@ -1,0 +1,289 @@
+"""Compatibility helpers for image-annotator-lib Provider Batch DTOs."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from lorairo.services.provider_batch_service import (
+    BatchJobHandle,
+    BatchSubmitItem,
+    BatchSubmitRequest,
+    ProviderBatchArtifactRef,
+    ProviderBatchError,
+    ProviderBatchFetchResult,
+    ProviderBatchResultItem,
+    ProviderBatchStatus,
+    ProviderBatchSubmission,
+)
+
+
+def to_library_submit_request(request: Any) -> Any:
+    """Convert LoRAIro submit request to the installed library DTO when available."""
+    if not isinstance(request, BatchSubmitRequest):
+        return request
+    try:
+        from image_annotator_lib import BatchSubmitItem as LibraryBatchSubmitItem
+        from image_annotator_lib import BatchSubmitRequest as LibraryBatchSubmitRequest
+    except ImportError:
+        return request
+
+    return LibraryBatchSubmitRequest(
+        **_supported_kwargs(
+            LibraryBatchSubmitRequest,
+            {
+                "provider": request.provider,
+                "endpoint": request.endpoint,
+                "litellm_model_id": request.litellm_model_id,
+                "prompt_profile": request.prompt_profile,
+                "description": request.description,
+                "api_keys": dict(request.api_keys),
+                "items": [
+                    LibraryBatchSubmitItem(
+                        **_supported_kwargs(
+                            LibraryBatchSubmitItem,
+                            {
+                                "custom_id": item.custom_id,
+                                "image_id": item.image_id,
+                                "image_path": item.image_path,
+                                "task_type": item.task_type,
+                                "model_id": item.model_id,
+                                "raw_request": item.raw_request,
+                            },
+                        )
+                    )
+                    for item in request.items
+                ],
+                "model_id": request.model_id,
+                "request_artifact_path": request.request_artifact_path,
+                "raw_provider_payload": request.raw_provider_payload,
+            },
+        )
+    )
+
+
+def to_library_handle(handle: Any) -> Any:
+    """Convert LoRAIro job handle to the installed library DTO when available."""
+    if not isinstance(handle, BatchJobHandle):
+        return handle
+    try:
+        from image_annotator_lib import BatchJobHandle as LibraryBatchJobHandle
+    except ImportError:
+        return handle
+
+    return LibraryBatchJobHandle(
+        provider=handle.provider,
+        provider_job_id=handle.provider_job_id,
+        api_keys=dict(handle.api_keys),
+    )
+
+
+def to_provider_batch_submission(result: Any, provider: str) -> ProviderBatchSubmission:
+    """Normalize object/mapping library submit results to LoRAIro's internal DTO."""
+    if isinstance(result, ProviderBatchSubmission):
+        return result
+    status = _status_value(_value(result, "status"))
+    provider_status = _status_value(_value(result, "provider_status")) or status
+    return ProviderBatchSubmission(
+        provider_job_id=_required_str(result, "provider_job_id"),
+        provider_status=provider_status,
+        status=status,
+        request_count=_optional_int(_value(result, "request_count")),
+        submitted_at=_datetime_or_none(_value(result, "submitted_at"), "submitted_at"),
+        expires_at=_datetime_or_none(_value(result, "expires_at"), "expires_at"),
+        raw_provider_payload=_raw_provider_payload_or_none(result),
+    )
+
+
+def to_provider_batch_status(result: Any, provider: str) -> ProviderBatchStatus:
+    """Normalize object/mapping library status results to LoRAIro's internal DTO."""
+    if isinstance(result, ProviderBatchStatus):
+        return result
+    status = _status_value(_value(result, "status"))
+    provider_status = _status_value(_value(result, "provider_status")) or status
+    return ProviderBatchStatus(
+        provider_job_id=_required_str(result, "provider_job_id"),
+        provider_status=provider_status,
+        status=status,
+        request_count=_optional_int(_value(result, "request_count")),
+        succeeded_count=_optional_int(_value(result, "succeeded_count")),
+        failed_count=_optional_int(_value(result, "failed_count")),
+        canceled_count=_optional_int(_value(result, "canceled_count")),
+        expired_count=_optional_int(_value(result, "expired_count")),
+        submitted_at=_datetime_or_none(_value(result, "submitted_at"), "submitted_at"),
+        completed_at=_datetime_or_none(_value(result, "completed_at"), "completed_at"),
+        canceled_at=_datetime_or_none(_value(result, "canceled_at"), "canceled_at"),
+        expires_at=_datetime_or_none(_value(result, "expires_at"), "expires_at"),
+        raw_provider_payload=_raw_provider_payload_or_none(result),
+    )
+
+
+def to_provider_batch_fetch_result(
+    result: Any,
+    provider: str,
+    destination_dir: Path,
+    fallback_provider_job_id: str | None = None,
+) -> ProviderBatchFetchResult:
+    """Normalize object/mapping library fetch results to LoRAIro's internal DTO."""
+    if isinstance(result, ProviderBatchFetchResult):
+        return result
+    status = _status_value(_value(result, "status"))
+    provider_status = _status_value(_value(result, "provider_status")) or status
+    provider_job_id = _required_str(result, "provider_job_id", fallback=fallback_provider_job_id)
+    return ProviderBatchFetchResult(
+        provider_job_id=provider_job_id,
+        provider_status=provider_status,
+        status=status,
+        request_count=_optional_int(_value(result, "request_count")),
+        succeeded_count=_optional_int(_value(result, "succeeded_count")),
+        failed_count=_optional_int(_value(result, "failed_count")),
+        canceled_count=_optional_int(_value(result, "canceled_count")),
+        expired_count=_optional_int(_value(result, "expired_count")),
+        completed_at=_datetime_or_none(_value(result, "completed_at"), "completed_at"),
+        expires_at=_datetime_or_none(_value(result, "expires_at"), "expires_at"),
+        artifacts=tuple(_to_artifact_ref(artifact) for artifact in _value(result, "artifacts", ()) or ()),
+        items=tuple(_to_result_item(item) for item in _value(result, "items", ()) or ()),
+        raw_provider_payload=_raw_provider_payload_or_none(result),
+    )
+
+
+def to_provider_batch_models(result: Any) -> tuple[Any, ...]:
+    """Return library batch-capable model metadata as an immutable sequence."""
+    if result is None:
+        return ()
+    if isinstance(result, Sequence) and not isinstance(result, (str, bytes)):
+        return tuple(result)
+    if isinstance(result, (str, bytes)):
+        return (result,)
+    return (result,)
+
+
+def _to_result_item(item: Any) -> ProviderBatchResultItem:
+    if isinstance(item, ProviderBatchResultItem):
+        return item
+    error = _value(item, "error")
+    return ProviderBatchResultItem(
+        custom_id=_required_str(item, "custom_id"),
+        status=_required_status(item, "status"),
+        annotation=_value(item, "annotation"),
+        error_type=_optional_str(
+            _coalesce_none(_value(item, "error_type"), _value(error, "code"), _value(error, "type"))
+        ),
+        error_message=_optional_str(
+            _coalesce_none(_value(item, "error_message"), _value(item, "message"), _value(error, "message"))
+        ),
+        raw_response=_raw_response(item),
+    )
+
+
+def _to_artifact_ref(artifact: Any) -> ProviderBatchArtifactRef:
+    if isinstance(artifact, ProviderBatchArtifactRef):
+        return artifact
+    return ProviderBatchArtifactRef(
+        artifact_type=str(_value(artifact, "artifact_type")),
+        local_path=Path(_value(artifact, "local_path")),
+        provider_file_id=_optional_str(_value(artifact, "provider_file_id")),
+        sha256=_optional_str(_value(artifact, "sha256")),
+    )
+
+
+def _raw_response(item: Any) -> Any:
+    raw = _value(item, "raw_response")
+    if raw is not None:
+        return raw
+    error = _value(item, "error")
+    provider_status = _status_value(_value(item, "provider_status"))
+    payload: dict[str, Any] = {}
+    if provider_status:
+        payload["provider_status"] = provider_status
+    if error is not None:
+        payload["error"] = {
+            "phase": _status_value(_value(error, "phase")),
+            "code": _value(error, "code"),
+            "message": _value(error, "message"),
+            "retryable": _value(error, "retryable"),
+        }
+    return payload or None
+
+
+def _value(value: Any, key: str, default: Any = None) -> Any:
+    if isinstance(value, Mapping):
+        return value.get(key, default)
+    return getattr(value, key, default)
+
+
+def _coalesce_none(*values: Any) -> Any:
+    for value in values:
+        if value is not None:
+            return value
+    return None
+
+
+def _required_str(result: Any, key: str, *, fallback: str | None = None) -> str:
+    value = _value(result, key)
+    if value is None and fallback is not None:
+        value = fallback
+    if value is None:
+        raise ProviderBatchError(f"image-annotator-lib batch result is missing required field: {key}")
+    return str(value)
+
+
+def _required_status(result: Any, key: str) -> str:
+    value = _status_value(_value(result, key))
+    if not value:
+        raise ProviderBatchError(f"image-annotator-lib batch result is missing required field: {key}")
+    return value
+
+
+def _datetime_or_none(value: Any, field_name: str) -> datetime | None:
+    if value is None or value == "":
+        return None
+    if isinstance(value, datetime):
+        return value
+    if isinstance(value, str):
+        normalized = value[:-1] + "+00:00" if value.endswith("Z") else value
+        try:
+            return datetime.fromisoformat(normalized)
+        except ValueError as e:
+            raise ProviderBatchError(
+                f"image-annotator-lib batch result has invalid datetime field: {field_name}={value!r}"
+            ) from e
+    raise ProviderBatchError(
+        f"image-annotator-lib batch result has invalid datetime field type: "
+        f"{field_name}={type(value).__name__}"
+    )
+
+
+def _raw_provider_payload_or_none(result: Any) -> Any:
+    return _value(result, "raw_provider_payload")
+
+
+def _supported_kwargs(cls: Any, values: Mapping[str, Any]) -> dict[str, Any]:
+    try:
+        field_names = set(getattr(cls, "__dataclass_fields__", {}))
+    except TypeError:
+        field_names = set()
+    if not field_names:
+        return dict(values)
+    return {key: value for key, value in values.items() if key in field_names}
+
+
+def _status_value(value: Any) -> str:
+    if value is None:
+        return ""
+    enum_value = getattr(value, "value", None)
+    return str(enum_value if enum_value is not None else value)
+
+
+def _optional_str(value: Any) -> str | None:
+    if value is None:
+        return None
+    return str(value)
+
+
+def _optional_int(value: Any) -> int | None:
+    if value is None:
+        return None
+    return int(value)

--- a/src/lorairo/services/provider_batch_workflow_service.py
+++ b/src/lorairo/services/provider_batch_workflow_service.py
@@ -17,6 +17,14 @@ from typing import TYPE_CHECKING, Any
 from lorairo.database.db_repository import ImageRepository
 from lorairo.services.annotation_save_service import AnnotationSaveResult, AnnotationSaveService
 from lorairo.services.configuration_service import ConfigurationService
+from lorairo.services.provider_batch_library_compat import (
+    to_library_handle,
+    to_library_submit_request,
+    to_provider_batch_fetch_result,
+    to_provider_batch_models,
+    to_provider_batch_status,
+    to_provider_batch_submission,
+)
 from lorairo.services.provider_batch_service import (
     BatchJobHandle,
     BatchSubmitItem,
@@ -77,16 +85,34 @@ class ProviderBatchLibraryAdapter:
         self._client = client
 
     def submit_batch(self, request: BatchSubmitRequest) -> Any:
-        return self._call_client("submit_batch", request)
+        return to_provider_batch_submission(
+            self._call_client("submit_batch", to_library_submit_request(request)),
+            self.provider,
+        )
 
     def retrieve_batch(self, handle: BatchJobHandle) -> Any:
-        return self._call_client("retrieve_batch", handle)
+        return to_provider_batch_status(
+            self._call_client("retrieve_batch", to_library_handle(handle)),
+            self.provider,
+        )
 
     def cancel_batch(self, handle: BatchJobHandle) -> Any:
-        return self._call_client("cancel_batch", handle)
+        return to_provider_batch_status(
+            self._call_client("cancel_batch", to_library_handle(handle)),
+            self.provider,
+        )
 
     def fetch_batch_results(self, handle: BatchJobHandle, destination_dir: Path) -> Any:
-        return self._call_client("fetch_batch_results", handle, destination_dir)
+        return to_provider_batch_fetch_result(
+            self._call_client("fetch_batch_results", to_library_handle(handle), destination_dir),
+            self.provider,
+            destination_dir,
+            fallback_provider_job_id=handle.provider_job_id,
+        )
+
+    def list_batch_capable_models(self) -> tuple[Any, ...]:
+        """Return image-annotator-lib Provider Batch model metadata."""
+        return to_provider_batch_models(self._call_client("list_batch_capable_models"))
 
     def _call_client(self, method_name: str, *args: Any) -> Any:
         method = getattr(self._client, method_name, None)

--- a/tests/unit/annotations/test_annotator_adapter_provider_batch.py
+++ b/tests/unit/annotations/test_annotator_adapter_provider_batch.py
@@ -12,9 +12,9 @@ from lorairo.annotations.annotator_adapter import AnnotatorLibraryAdapter
 from lorairo.services.provider_batch_service import (
     BatchJobHandle,
     BatchSubmitRequest,
-    ProviderBatchArtifactRef,
-    ProviderBatchArtifacts,
     ProviderBatchError,
+    ProviderBatchFetchResult,
+    ProviderBatchResultItem,
     ProviderBatchStatus,
     ProviderBatchSubmission,
 )
@@ -35,23 +35,24 @@ class TestAnnotatorAdapterProviderBatch:
     ) -> None:
         calls: list[tuple[str, object]] = []
 
-        def submit_batch(request: BatchSubmitRequest) -> ProviderBatchSubmission:
+        def submit_batch(request: object) -> ProviderBatchSubmission:
             calls.append(("submit", request))
             return ProviderBatchSubmission(provider_job_id="batch_123", provider_status="validating")
 
-        def retrieve_batch(handle: BatchJobHandle) -> ProviderBatchStatus:
+        def retrieve_batch(handle: object) -> ProviderBatchStatus:
             calls.append(("retrieve", handle))
             return ProviderBatchStatus(provider_job_id="batch_123", provider_status="completed")
 
-        def cancel_batch(handle: BatchJobHandle) -> ProviderBatchStatus:
+        def cancel_batch(handle: object) -> ProviderBatchStatus:
             calls.append(("cancel", handle))
             return ProviderBatchStatus(provider_job_id="batch_123", provider_status="cancelled")
 
-        def fetch_batch_results(handle: BatchJobHandle, destination_dir: Path) -> ProviderBatchArtifacts:
-            calls.append(("fetch", destination_dir))
-            return ProviderBatchArtifacts(
+        def fetch_batch_results(handle: object) -> ProviderBatchFetchResult:
+            calls.append(("fetch", handle))
+            return ProviderBatchFetchResult(
                 provider_job_id="batch_123",
-                artifacts=(ProviderBatchArtifactRef("output", destination_dir / "output.jsonl"),),
+                provider_status="completed",
+                items=(ProviderBatchResultItem("img-1", "succeeded", annotation={"tags": ["tag"]}),),
             )
 
         monkeypatch.setattr(image_annotator_lib, "submit_batch", submit_batch, raising=False)
@@ -72,10 +73,98 @@ class TestAnnotatorAdapterProviderBatch:
         assert adapter.submit_batch(request).provider_status == "validating"
         assert adapter.retrieve_batch(handle).provider_status == "completed"
         assert adapter.cancel_batch(handle).provider_status == "cancelled"
-        assert adapter.fetch_batch_results(handle, tmp_path).artifacts[0].local_path == (
-            tmp_path / "output.jsonl"
-        )
+        assert adapter.fetch_batch_results(handle, tmp_path).items[0].annotation == {"tags": ["tag"]}
         assert [name for name, _value in calls] == ["submit", "retrieve", "cancel", "fetch"]
+        assert calls[0][1].provider == "openai"
+        assert calls[3][1].provider_job_id == "batch_123"
+
+    def test_list_batch_capable_models_forwards_to_image_annotator_lib(
+        self,
+        adapter: AnnotatorLibraryAdapter,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setattr(
+            image_annotator_lib,
+            "list_batch_capable_models",
+            lambda: ["anthropic/claude-test"],
+            raising=False,
+        )
+
+        assert adapter.list_batch_capable_models() == ("anthropic/claude-test",)
+
+    def test_fetch_batch_results_forwards_destination_dir_when_library_accepts_it(
+        self,
+        adapter: AnnotatorLibraryAdapter,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        calls: list[tuple[object, Path]] = []
+
+        def fetch_batch_results(handle: object, destination_dir: Path) -> ProviderBatchFetchResult:
+            calls.append((handle, destination_dir))
+            return ProviderBatchFetchResult(
+                provider_job_id="batch_123",
+                provider_status="completed",
+            )
+
+        monkeypatch.setattr(image_annotator_lib, "fetch_batch_results", fetch_batch_results, raising=False)
+
+        handle = BatchJobHandle(provider="openai", provider_job_id="batch_123", api_keys={})
+
+        adapter.fetch_batch_results(handle, tmp_path)
+
+        assert calls[0][1] == tmp_path
+
+    @pytest.mark.parametrize("signature_error", [TypeError, ValueError])
+    def test_fetch_batch_results_falls_back_when_signature_is_unavailable(
+        self,
+        adapter: AnnotatorLibraryAdapter,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+        signature_error: type[Exception],
+    ) -> None:
+        calls: list[object] = []
+
+        def fetch_batch_results(handle: object) -> ProviderBatchFetchResult:
+            calls.append(handle)
+            return ProviderBatchFetchResult(
+                provider_job_id="batch_123",
+                provider_status="completed",
+            )
+
+        monkeypatch.setattr(image_annotator_lib, "fetch_batch_results", fetch_batch_results, raising=False)
+        monkeypatch.setattr("inspect.signature", lambda _method: (_ for _ in ()).throw(signature_error))
+
+        handle = BatchJobHandle(provider="openai", provider_job_id="batch_123", api_keys={})
+
+        adapter.fetch_batch_results(handle, tmp_path)
+
+        assert len(calls) == 1
+
+    def test_fetch_batch_results_tries_destination_dir_when_signature_is_unavailable(
+        self,
+        adapter: AnnotatorLibraryAdapter,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        calls: list[tuple[object, Path]] = []
+
+        def fetch_batch_results(handle: object, destination_dir: Path) -> ProviderBatchFetchResult:
+            calls.append((handle, destination_dir))
+            return ProviderBatchFetchResult(
+                provider_job_id="batch_123",
+                provider_status="completed",
+            )
+
+        monkeypatch.setattr(image_annotator_lib, "fetch_batch_results", fetch_batch_results, raising=False)
+        monkeypatch.setattr("inspect.signature", lambda _method: (_ for _ in ()).throw(ValueError))
+
+        handle = BatchJobHandle(provider="openai", provider_job_id="batch_123", api_keys={})
+
+        adapter.fetch_batch_results(handle, tmp_path)
+
+        assert len(calls) == 1
+        assert calls[0][1] == tmp_path
 
     def test_provider_batch_methods_raise_when_library_api_is_unavailable(
         self,

--- a/tests/unit/gui/widgets/test_provider_batch_job_widget.py
+++ b/tests/unit/gui/widgets/test_provider_batch_job_widget.py
@@ -14,6 +14,7 @@ def _job(job_id: int = 1, status: str = "running") -> SimpleNamespace:
     return SimpleNamespace(
         id=job_id,
         provider="openai",
+        provider_status="in_progress",
         model_id=10,
         status=status,
         request_count=2,
@@ -56,6 +57,7 @@ def _container() -> SimpleNamespace:
 
     workflow_service = Mock()
     workflow_service.submit_images.return_value = 42
+    workflow_service.refresh.return_value = _job()
 
     annotator_library = Mock()
     annotator_library.list_batch_capable_models.return_value = [
@@ -87,6 +89,7 @@ def test_populates_job_and_item_tables(qtbot):
     assert widget.itemTableWidget.item(0, 0).text() == "image-1"
     assert widget.itemTableWidget.item(0, 3).text() == "failed"
     assert widget.itemTableWidget.item(0, 5).text() == "try later"
+    assert widget.rawProviderStatusLabel.text() == "Provider status: in_progress"
 
 
 def test_action_buttons_call_workflow_service(qtbot):
@@ -94,6 +97,9 @@ def test_action_buttons_call_workflow_service(qtbot):
     widget = ProviderBatchJobWidget(container)  # type: ignore[arg-type]
     qtbot.addWidget(widget)
     widget.jobTableWidget.selectRow(0)
+
+    widget.refreshButton.click()
+    container.provider_batch_workflow_service.refresh.assert_called_once_with(1)
 
     widget.cancelButton.click()
     container.provider_batch_workflow_service.cancel.assert_called_once_with(1)
@@ -145,3 +151,81 @@ def test_submit_validation_requires_image_ids(qtbot, monkeypatch):
 
     container.provider_batch_workflow_service.submit_images.assert_not_called()
     assert warnings == ["Provider Batch submit requires at least one image ID."]
+
+
+def test_item_status_filter_limits_detail_query(qtbot):
+    container = _container()
+    widget = ProviderBatchJobWidget(container)  # type: ignore[arg-type]
+    qtbot.addWidget(widget)
+    widget.jobTableWidget.selectRow(0)
+    container.db_manager.repository.list_provider_batch_items.reset_mock()
+
+    widget.itemStatusFilterComboBox.setCurrentText("failed")
+
+    container.db_manager.repository.list_provider_batch_items.assert_called_once_with(
+        1,
+        status="failed",
+        limit=1000,
+    )
+
+
+def test_model_candidates_require_local_direct_provider_model(qtbot):
+    container = _container()
+    repository = container.db_manager.repository
+    repository.get_models_by_litellm_ids.return_value = {
+        "gpt-4.1-mini": SimpleNamespace(
+            id=10,
+            name="GPT 4.1 mini",
+            provider="openai",
+            litellm_model_id="gpt-4.1-mini",
+            discontinued_at=None,
+        ),
+        "claude-3-5-haiku": SimpleNamespace(
+            id=11,
+            name="Claude 3.5 Haiku",
+            provider="anthropic",
+            litellm_model_id="claude-3-5-haiku",
+            discontinued_at=None,
+        ),
+        "openrouter/auto": SimpleNamespace(
+            id=12,
+            name="OpenRouter",
+            provider="openrouter",
+            litellm_model_id="openrouter/auto",
+            discontinued_at=None,
+        ),
+        "gpt-old": SimpleNamespace(
+            id=13,
+            name="Old GPT",
+            provider="openai",
+            litellm_model_id="gpt-old",
+            discontinued_at=datetime(2026, 5, 1, tzinfo=UTC),
+        ),
+    }
+    container.annotator_library.list_batch_capable_models.return_value = [
+        {"provider": "openai", "name": "GPT 4.1 mini", "litellm_model_id": "gpt-4.1-mini"},
+        {"provider": "anthropic", "name": "Claude", "litellm_model_id": "claude-3-5-haiku"},
+        {"provider": "openrouter", "name": "OpenRouter", "litellm_model_id": "openrouter/auto"},
+        {"provider": "openai", "name": "Old GPT", "litellm_model_id": "gpt-old"},
+        {"provider": "google", "name": "Gemini", "litellm_model_id": "gemini-2.0-flash"},
+    ]
+
+    widget = ProviderBatchJobWidget(container)  # type: ignore[arg-type]
+    qtbot.addWidget(widget)
+
+    providers = {
+        widget.providerComboBox.itemText(index) for index in range(widget.providerComboBox.count())
+    }
+    assert providers == {"anthropic", "openai"}
+    assert {candidate.model_id for candidate in widget._model_candidates} == {10, 11}
+
+
+def test_model_candidates_skip_library_models_without_local_rows(qtbot):
+    container = _container()
+    container.db_manager.repository.get_models_by_litellm_ids.return_value = {}
+
+    widget = ProviderBatchJobWidget(container)  # type: ignore[arg-type]
+    qtbot.addWidget(widget)
+
+    assert widget.providerComboBox.count() == 0
+    assert widget.submitButton.isEnabled() is False

--- a/tests/unit/gui/widgets/test_provider_batch_job_widget.py
+++ b/tests/unit/gui/widgets/test_provider_batch_job_widget.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+from PySide6.QtWidgets import QMessageBox
+
+from lorairo.gui.state.dataset_state import DatasetStateManager
+from lorairo.gui.widgets.provider_batch_job_widget import ProviderBatchJobWidget
+
+
+def _job(job_id: int = 1, status: str = "running") -> SimpleNamespace:
+    return SimpleNamespace(
+        id=job_id,
+        provider="openai",
+        model_id=10,
+        status=status,
+        request_count=2,
+        succeeded_count=1,
+        failed_count=1,
+        canceled_count=0,
+        submitted_at=datetime(2026, 5, 26, 1, 2, tzinfo=UTC),
+        completed_at=None,
+        imported_at=None,
+    )
+
+
+def _item(custom_id: str = "image-1") -> SimpleNamespace:
+    return SimpleNamespace(
+        custom_id=custom_id,
+        image_id=1,
+        model_id=10,
+        status="failed",
+        error_type="rate_limit",
+        error_message="try later",
+    )
+
+
+def _container() -> SimpleNamespace:
+    repository = Mock()
+    repository.list_provider_batch_jobs.return_value = [_job()]
+    repository.list_provider_batch_items.return_value = [_item()]
+    repository.get_models_by_litellm_ids.return_value = {
+        "gpt-4.1-mini": SimpleNamespace(
+            id=10,
+            name="GPT 4.1 mini",
+            provider="openai",
+            litellm_model_id="gpt-4.1-mini",
+            discontinued_at=None,
+        )
+    }
+    repository.get_model_objects.return_value = [
+        SimpleNamespace(id=10, name="GPT 4.1 mini", litellm_model_id="gpt-4.1-mini")
+    ]
+
+    workflow_service = Mock()
+    workflow_service.submit_images.return_value = 42
+
+    annotator_library = Mock()
+    annotator_library.list_batch_capable_models.return_value = [
+        {"provider": "openai", "name": "GPT 4.1 mini", "litellm_model_id": "gpt-4.1-mini"},
+        {"provider": "google", "name": "Gemini", "litellm_model_id": "gemini-2.0-flash"},
+        {"provider": "local", "name": "Local", "litellm_model_id": "local/test"},
+    ]
+
+    return SimpleNamespace(
+        provider_batch_workflow_service=workflow_service,
+        db_manager=SimpleNamespace(repository=repository),
+        annotator_library=annotator_library,
+    )
+
+
+def test_populates_job_and_item_tables(qtbot):
+    container = _container()
+    widget = ProviderBatchJobWidget(container)  # type: ignore[arg-type]
+    qtbot.addWidget(widget)
+
+    assert widget.jobTableWidget.rowCount() == 1
+    assert widget.jobTableWidget.item(0, 0).text() == "1"
+    assert widget.jobTableWidget.item(0, 2).text() == "gpt-4.1-mini"
+    assert widget.jobTableWidget.item(0, 4).text() == "2"
+
+    widget.jobTableWidget.selectRow(0)
+
+    assert widget.itemTableWidget.rowCount() == 1
+    assert widget.itemTableWidget.item(0, 0).text() == "image-1"
+    assert widget.itemTableWidget.item(0, 3).text() == "failed"
+    assert widget.itemTableWidget.item(0, 5).text() == "try later"
+
+
+def test_action_buttons_call_workflow_service(qtbot):
+    container = _container()
+    widget = ProviderBatchJobWidget(container)  # type: ignore[arg-type]
+    qtbot.addWidget(widget)
+    widget.jobTableWidget.selectRow(0)
+
+    widget.cancelButton.click()
+    container.provider_batch_workflow_service.cancel.assert_called_once_with(1)
+
+    widget.fetchButton.click()
+    container.provider_batch_workflow_service.fetch_results.assert_called_once_with(1)
+
+    widget.importButton.click()
+    container.provider_batch_workflow_service.import_results.assert_called_once_with(1)
+
+
+def test_submit_uses_selected_and_manual_image_ids(qtbot):
+    container = _container()
+    dataset_state = DatasetStateManager()
+    dataset_state.set_selected_images([7, 8])
+    widget = ProviderBatchJobWidget(container, dataset_state)  # type: ignore[arg-type]
+    qtbot.addWidget(widget)
+    widget.imageIdsLineEdit.setText("8, 9")
+    widget.descriptionLineEdit.setText("nightly batch")
+
+    with qtbot.waitSignal(widget.submit_completed, timeout=1000) as blocker:
+        widget.submitButton.click()
+
+    assert blocker.args == [42]
+    container.provider_batch_workflow_service.submit_images.assert_called_once_with(
+        provider="openai",
+        endpoint="responses",
+        litellm_model_id="gpt-4.1-mini",
+        prompt_profile="default",
+        image_ids=[7, 8, 9],
+        model_id=10,
+        description="nightly batch",
+    )
+
+
+def test_submit_validation_requires_image_ids(qtbot, monkeypatch):
+    container = _container()
+    widget = ProviderBatchJobWidget(container)  # type: ignore[arg-type]
+    qtbot.addWidget(widget)
+    widget.useSelectedImagesCheckBox.setChecked(False)
+    warnings: list[str] = []
+    monkeypatch.setattr(
+        QMessageBox,
+        "warning",
+        lambda _parent, _title, message: warnings.append(message) or QMessageBox.StandardButton.Ok,
+    )
+
+    widget.submitButton.click()
+
+    container.provider_batch_workflow_service.submit_images.assert_not_called()
+    assert warnings == ["Provider Batch submit requires at least one image ID."]

--- a/tests/unit/services/test_provider_batch_library_compat.py
+++ b/tests/unit/services/test_provider_batch_library_compat.py
@@ -1,0 +1,350 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import image_annotator_lib
+import pytest
+
+from lorairo.services.provider_batch_library_compat import (
+    to_library_handle,
+    to_library_submit_request,
+    to_provider_batch_fetch_result,
+    to_provider_batch_models,
+    to_provider_batch_status,
+    to_provider_batch_submission,
+)
+from lorairo.services.provider_batch_service import (
+    BatchJobHandle,
+    BatchSubmitItem,
+    BatchSubmitRequest,
+    ProviderBatchError,
+)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "payload",
+    [
+        SimpleNamespace(
+            provider_job_id="batch_123",
+            provider_status="validating",
+            status="submitted",
+            request_count=0,
+            submitted_at="2026-05-26T12:00:00Z",
+            expires_at="2026-05-27T12:00:00+00:00",
+            raw_provider_payload={"request_id": "req_1"},
+        ),
+        {
+            "provider_job_id": "batch_123",
+            "provider_status": "validating",
+            "status": "submitted",
+            "request_count": 0,
+            "submitted_at": "2026-05-26T12:00:00Z",
+            "expires_at": "2026-05-27T12:00:00+00:00",
+            "raw_provider_payload": {"request_id": "req_1"},
+        },
+    ],
+)
+def test_submission_conversion_accepts_object_and_mapping(payload: object) -> None:
+    result = to_provider_batch_submission(payload, "anthropic")
+
+    assert result.provider_job_id == "batch_123"
+    assert result.provider_status == "validating"
+    assert result.request_count == 0
+    assert result.submitted_at == datetime(2026, 5, 26, 12, 0, tzinfo=UTC)
+    assert result.expires_at == datetime(2026, 5, 27, 12, 0, tzinfo=UTC)
+    assert result.raw_provider_payload == {"request_id": "req_1"}
+
+
+@pytest.mark.unit
+def test_submission_conversion_keeps_missing_raw_payload_none() -> None:
+    result = to_provider_batch_submission(
+        {
+            "provider_job_id": "batch_123",
+            "provider_status": "validating",
+            "submitted_at": "",
+            "expires_at": None,
+        },
+        "anthropic",
+    )
+
+    assert result.submitted_at is None
+    assert result.expires_at is None
+    assert result.raw_provider_payload is None
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("payload", [{}, {"provider_job_id": None}])
+def test_submission_conversion_rejects_missing_provider_job_id(payload: dict[str, object]) -> None:
+    with pytest.raises(ProviderBatchError, match="provider_job_id"):
+        to_provider_batch_submission(payload, "anthropic")
+
+
+@pytest.mark.unit
+def test_status_conversion_coerces_datetimes_and_keeps_falsy_counts() -> None:
+    result = to_provider_batch_status(
+        SimpleNamespace(
+            provider_job_id="batch_123",
+            provider_status="ended",
+            status="completed",
+            request_count=0,
+            succeeded_count=0,
+            failed_count=0,
+            canceled_count=0,
+            expired_count=0,
+            submitted_at="2026-05-26T12:00:00Z",
+            completed_at="2026-05-26T13:00:00Z",
+            canceled_at="",
+            expires_at=None,
+        ),
+        "anthropic",
+    )
+
+    assert result.request_count == 0
+    assert result.succeeded_count == 0
+    assert result.failed_count == 0
+    assert result.canceled_count == 0
+    assert result.expired_count == 0
+    assert result.submitted_at == datetime(2026, 5, 26, 12, 0, tzinfo=UTC)
+    assert result.completed_at == datetime(2026, 5, 26, 13, 0, tzinfo=UTC)
+    assert result.canceled_at is None
+    assert result.expires_at is None
+    assert result.raw_provider_payload is None
+
+
+@pytest.mark.unit
+def test_status_conversion_rejects_invalid_datetime() -> None:
+    with pytest.raises(ProviderBatchError, match="invalid datetime"):
+        to_provider_batch_status(
+            {
+                "provider_job_id": "batch_123",
+                "provider_status": "running",
+                "submitted_at": "not-a-date",
+            },
+            "anthropic",
+        )
+
+
+@pytest.mark.unit
+def test_fetch_result_accepts_mapping_payload(tmp_path: Path) -> None:
+    result = to_provider_batch_fetch_result(
+        {
+            "provider_job_id": "batch_123",
+            "provider_status": "ended",
+            "status": "completed",
+            "request_count": 1,
+            "succeeded_count": 0,
+            "failed_count": 1,
+            "completed_at": "2026-05-26T13:00:00Z",
+            "expires_at": "2026-05-27T13:00:00Z",
+            "raw_provider_payload": {"provider_error": {"code": "job_failed"}},
+            "artifacts": [
+                {
+                    "artifact_type": "output",
+                    "local_path": str(tmp_path / "output.jsonl"),
+                    "provider_file_id": "file_123",
+                    "sha256": "abc",
+                }
+            ],
+            "items": [
+                {
+                    "custom_id": "image-1",
+                    "status": "failed",
+                    "error": {
+                        "phase": "result",
+                        "code": "bad_response",
+                        "message": "invalid json",
+                        "retryable": False,
+                    },
+                }
+            ],
+        },
+        "anthropic",
+        tmp_path,
+    )
+
+    assert result.provider_job_id == "batch_123"
+    assert result.provider_status == "ended"
+    assert result.raw_provider_payload == {"provider_error": {"code": "job_failed"}}
+    assert result.completed_at == datetime(2026, 5, 26, 13, 0, tzinfo=UTC)
+    assert result.expires_at == datetime(2026, 5, 27, 13, 0, tzinfo=UTC)
+    assert result.artifacts[0].local_path == tmp_path / "output.jsonl"
+    assert result.artifacts[0].provider_file_id == "file_123"
+    assert result.items[0].custom_id == "image-1"
+    assert result.items[0].error_type == "bad_response"
+    assert result.items[0].raw_response == {
+        "error": {
+            "phase": "result",
+            "code": "bad_response",
+            "message": "invalid json",
+            "retryable": False,
+        }
+    }
+
+
+@pytest.mark.unit
+def test_submit_conversion_preserves_metadata_when_library_dto_supports_it(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    @dataclass(frozen=True)
+    class LibraryBatchSubmitItem:
+        custom_id: str
+        image_id: int
+        image_path: Path
+        task_type: str
+        model_id: int | None
+        raw_request: Any
+
+    @dataclass(frozen=True)
+    class LibraryBatchSubmitRequest:
+        provider: str
+        endpoint: str
+        litellm_model_id: str
+        prompt_profile: str
+        description: str | None
+        api_keys: dict[str, str]
+        items: list[LibraryBatchSubmitItem]
+        model_id: int | None
+        request_artifact_path: Path | None
+        raw_provider_payload: Any
+
+    monkeypatch.setattr(image_annotator_lib, "BatchSubmitItem", LibraryBatchSubmitItem, raising=False)
+    monkeypatch.setattr(image_annotator_lib, "BatchSubmitRequest", LibraryBatchSubmitRequest, raising=False)
+
+    request = BatchSubmitRequest(
+        provider="anthropic",
+        endpoint="messages",
+        litellm_model_id="anthropic/claude-test",
+        prompt_profile="default",
+        api_keys={"anthropic": "test"},
+        items=(
+            BatchSubmitItem(
+                custom_id="image-1",
+                image_id=1,
+                image_path=tmp_path / "image.webp",
+                task_type="caption",
+                model_id=10,
+                raw_request={"temperature": 0.1},
+            ),
+        ),
+        model_id=10,
+        request_artifact_path=tmp_path / "request.jsonl",
+        raw_provider_payload={"metadata": "kept"},
+    )
+
+    converted = to_library_submit_request(request)
+
+    assert converted.model_id == 10
+    assert converted.request_artifact_path == tmp_path / "request.jsonl"
+    assert converted.raw_provider_payload == {"metadata": "kept"}
+    assert converted.items[0].task_type == "caption"
+    assert converted.items[0].model_id == 10
+    assert converted.items[0].raw_request == {"temperature": 0.1}
+
+
+@pytest.mark.unit
+def test_library_conversion_is_idempotent_for_already_converted_dtos() -> None:
+    submit_request = SimpleNamespace(provider="anthropic", items=[])
+    handle = SimpleNamespace(provider="anthropic", provider_job_id="batch_123")
+
+    assert to_library_submit_request(submit_request) is submit_request
+    assert to_library_handle(handle) is handle
+
+    lorairo_handle = BatchJobHandle(provider="anthropic", provider_job_id="batch_123", api_keys={})
+    assert to_library_handle(lorairo_handle).provider_job_id == "batch_123"
+
+
+@pytest.mark.unit
+def test_batch_models_wraps_scalar_model_id() -> None:
+    assert to_provider_batch_models("anthropic/claude-test") == ("anthropic/claude-test",)
+    assert to_provider_batch_models(123) == (123,)
+
+
+@pytest.mark.unit
+def test_fetch_result_rejects_missing_provider_job_id(tmp_path: Path) -> None:
+    with pytest.raises(ProviderBatchError, match="provider_job_id"):
+        to_provider_batch_fetch_result({"provider_status": "completed"}, "anthropic", tmp_path)
+
+
+@pytest.mark.unit
+def test_fetch_result_uses_fallback_provider_job_id_when_payload_omits_it(tmp_path: Path) -> None:
+    result = to_provider_batch_fetch_result(
+        {"provider_status": "completed"},
+        "anthropic",
+        tmp_path,
+        fallback_provider_job_id="batch_123",
+    )
+
+    assert result.provider_job_id == "batch_123"
+
+
+@pytest.mark.unit
+def test_fetch_result_without_raw_payload_keeps_payload_none(tmp_path: Path) -> None:
+    result = to_provider_batch_fetch_result(
+        {"provider_job_id": "batch_123", "provider_status": "completed", "items": []},
+        "anthropic",
+        tmp_path,
+    )
+
+    assert result.raw_provider_payload is None
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "item",
+    [
+        {"status": "failed"},
+        {"custom_id": "image-1"},
+        {"custom_id": "image-1", "status": ""},
+    ],
+)
+def test_fetch_result_rejects_items_missing_required_fields(
+    tmp_path: Path,
+    item: dict[str, object],
+) -> None:
+    with pytest.raises(ProviderBatchError, match="required field"):
+        to_provider_batch_fetch_result(
+            {"provider_job_id": "batch_123", "provider_status": "completed", "items": [item]},
+            "anthropic",
+            tmp_path,
+        )
+
+
+@pytest.mark.unit
+def test_fetch_result_item_error_fallbacks_preserve_diagnostics(tmp_path: Path) -> None:
+    result = to_provider_batch_fetch_result(
+        {
+            "provider_job_id": "batch_123",
+            "provider_status": "completed",
+            "items": [
+                {
+                    "custom_id": "image-1",
+                    "status": "failed",
+                    "message": "top-level message",
+                    "error": {
+                        "type": "invalid_request",
+                        "message": "nested message",
+                        "retryable": False,
+                    },
+                }
+            ],
+        },
+        "anthropic",
+        tmp_path,
+    )
+
+    assert result.items[0].error_type == "invalid_request"
+    assert result.items[0].error_message == "top-level message"
+    assert result.items[0].raw_response == {
+        "error": {
+            "phase": "",
+            "code": None,
+            "message": "nested message",
+            "retryable": False,
+        }
+    }

--- a/tests/unit/services/test_service_container_provider_batch.py
+++ b/tests/unit/services/test_service_container_provider_batch.py
@@ -3,11 +3,18 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Any, cast
 from unittest.mock import Mock
 
 import pytest
 
-from lorairo.services.provider_batch_service import BatchSubmitRequest, ProviderBatchSubmission
+from lorairo.services.provider_batch_service import (
+    BatchJobHandle,
+    BatchSubmitRequest,
+    ProviderBatchFetchResult,
+    ProviderBatchResultItem,
+    ProviderBatchSubmission,
+)
 from lorairo.services.provider_batch_workflow_service import ProviderBatchWorkflowService
 from lorairo.services.service_container import ServiceContainer
 
@@ -15,17 +22,32 @@ from lorairo.services.service_container import ServiceContainer
 class FakeBatchAnnotatorLibrary:
     def __init__(self) -> None:
         self.submitted_request: BatchSubmitRequest | None = None
+        self.fetch_call: tuple[BatchJobHandle, Path] | None = None
 
     def submit_batch(self, request: BatchSubmitRequest) -> ProviderBatchSubmission:
         self.submitted_request = request
         return ProviderBatchSubmission(provider_job_id="batch_container", provider_status="validating")
+
+    def fetch_batch_results(
+        self,
+        handle: BatchJobHandle,
+        destination_dir: Path,
+    ) -> ProviderBatchFetchResult:
+        self.fetch_call = (handle, destination_dir)
+        return ProviderBatchFetchResult(
+            provider_job_id=handle.provider_job_id,
+            provider_status="completed",
+            items=(
+                ProviderBatchResultItem(custom_id="img-1", status="succeeded", annotation={"tag": "ok"}),
+            ),
+        )
 
 
 @pytest.mark.unit
 class TestServiceContainerProviderBatch:
     def test_provider_batch_workflow_service_is_lazy_singleton(self) -> None:
         container = ServiceContainer()
-        container._annotator_library = object()
+        container._annotator_library = cast(Any, object())
 
         assert container._provider_batch_workflow_service is None
 
@@ -40,12 +62,12 @@ class TestServiceContainerProviderBatch:
 
     def test_reset_container_clears_provider_batch_workflow_service(self) -> None:
         container = ServiceContainer()
-        container._annotator_library = object()
+        container._annotator_library = cast(Any, object())
         service = container.provider_batch_workflow_service
 
         container.reset_container()
         container2 = ServiceContainer()
-        container2._annotator_library = object()
+        container2._annotator_library = cast(Any, object())
 
         assert container2._provider_batch_workflow_service is None
         assert container2.provider_batch_workflow_service is not service
@@ -60,7 +82,7 @@ class TestServiceContainerProviderBatch:
         repository.create_provider_batch_job_with_items.return_value = 123
         config = Mock()
         config.get_api_keys.return_value = {"openai": "sk-test"}
-        container._annotator_library = fake_library
+        container._annotator_library = cast(Any, fake_library)
         container._image_repository = repository
         container._config_service = config
 
@@ -76,3 +98,21 @@ class TestServiceContainerProviderBatch:
         assert fake_library.submitted_request is not None
         assert fake_library.submitted_request.provider == "openai"
         assert fake_library.submitted_request.items[0].image_path == Path("/tmp/container-image.webp")
+
+    def test_provider_batch_adapter_fetch_passes_destination_dir(self, tmp_path: Path) -> None:
+        container = ServiceContainer()
+        fake_library = FakeBatchAnnotatorLibrary()
+        container._annotator_library = cast(Any, fake_library)
+
+        service = container.provider_batch_workflow_service
+        adapter = cast(Any, service)._job_service._adapters["openai"]
+        result = adapter.fetch_batch_results(
+            BatchJobHandle(provider="openai", provider_job_id="batch_container", api_keys={}),
+            tmp_path,
+        )
+
+        assert result.items[0].annotation == {"tag": "ok"}
+        assert fake_library.fetch_call is not None
+        handle, destination_dir = fake_library.fetch_call
+        assert handle.provider_job_id == "batch_container"
+        assert destination_dir == tmp_path


### PR DESCRIPTION
## Summary
- add a Provider Batch tab for job submit/list/detail actions
- support selected/manual image IDs, direct provider model eligibility, status refresh, cancel, fetch, and import
- add failed/expired/canceled item filtering and raw provider status display

Refs #461
Refs #483
Depends on #495

## Tests
- `uv run ruff check src/lorairo/gui/widgets/provider_batch_job_widget.py src/lorairo/gui/window/main_window.py tests/unit/gui/widgets/test_provider_batch_job_widget.py`
- `uv run mypy src/lorairo/gui/widgets/provider_batch_job_widget.py src/lorairo/gui/window/main_window.py`
- `uv run pytest tests/unit/gui/widgets/test_provider_batch_job_widget.py -q`