### PR TITLE
feat: add provider batch CLI

### DIFF
--- a/src/lorairo/annotations/annotator_adapter.py
+++ b/src/lorairo/annotations/annotator_adapter.py
@@ -23,6 +23,14 @@ from PIL import Image
 
 from lorairo.services.configuration_service import ConfigurationService
 from lorairo.services.model_registry_protocol import ModelInfo
+from lorairo.services.provider_batch_library_compat import (
+    to_library_handle,
+    to_library_submit_request,
+    to_provider_batch_fetch_result,
+    to_provider_batch_models,
+    to_provider_batch_status,
+    to_provider_batch_submission,
+)
 from lorairo.utils.log import logger
 
 if TYPE_CHECKING:
@@ -208,24 +216,40 @@ class AnnotatorLibraryAdapter:
 
     def submit_batch(self, request: BatchSubmitRequest) -> ProviderBatchSubmission:
         """Provider Batch API job を image-annotator-lib の公開 API へ委譲する。"""
-        return cast("ProviderBatchSubmission", self._call_batch_api("submit_batch", request))
+        return to_provider_batch_submission(
+            self._call_batch_api("submit_batch", to_library_submit_request(request)),
+            request.provider,
+        )
 
     def retrieve_batch(self, handle: BatchJobHandle) -> ProviderBatchStatus:
         """Provider Batch API job の状態取得を image-annotator-lib の公開 API へ委譲する。"""
-        return cast("ProviderBatchStatus", self._call_batch_api("retrieve_batch", handle))
+        return to_provider_batch_status(
+            self._call_batch_api("retrieve_batch", to_library_handle(handle)),
+            handle.provider,
+        )
 
     def cancel_batch(self, handle: BatchJobHandle) -> ProviderBatchStatus:
         """Provider Batch API job の cancel を image-annotator-lib の公開 API へ委譲する。"""
-        return cast("ProviderBatchStatus", self._call_batch_api("cancel_batch", handle))
+        return to_provider_batch_status(
+            self._call_batch_api("cancel_batch", to_library_handle(handle)),
+            handle.provider,
+        )
 
     def fetch_batch_results(
         self, handle: BatchJobHandle, destination_dir: Path
     ) -> ProviderBatchFetchResult:
         """Provider Batch API job の normalized result 取得を image-annotator-lib の公開 API へ委譲する。"""
-        return cast(
-            "ProviderBatchFetchResult",
-            self._call_batch_api("fetch_batch_results", handle, destination_dir),
+        library_handle = to_library_handle(handle)
+        return to_provider_batch_fetch_result(
+            self._call_fetch_batch_results(library_handle, destination_dir),
+            handle.provider,
+            destination_dir,
+            fallback_provider_job_id=handle.provider_job_id,
         )
+
+    def list_batch_capable_models(self) -> tuple[Any, ...]:
+        """Provider Batch API 対応モデル情報を image-annotator-lib から取得する。"""
+        return to_provider_batch_models(self._call_batch_api("list_batch_capable_models"))
 
     def _call_batch_api(self, method_name: str, *args: Any) -> Any:
         import image_annotator_lib
@@ -236,6 +260,31 @@ class AnnotatorLibraryAdapter:
 
             raise ProviderBatchError(f"image-annotator-lib batch API method is unavailable: {method_name}")
         return method(*args)
+
+    def _call_fetch_batch_results(self, handle: Any, destination_dir: Path) -> Any:
+        import inspect
+
+        import image_annotator_lib
+
+        method = getattr(image_annotator_lib, "fetch_batch_results", None)
+        if not callable(method):
+            from lorairo.services.provider_batch_service import ProviderBatchError
+
+            raise ProviderBatchError(
+                "image-annotator-lib batch API method is unavailable: fetch_batch_results"
+            )
+
+        try:
+            signature = inspect.signature(method)
+            accepts_destination_dir = len(signature.parameters) >= 2
+        except (TypeError, ValueError):
+            try:
+                return method(handle, destination_dir)
+            except TypeError:
+                return method(handle)
+        if accepts_destination_dir:
+            return method(handle, destination_dir)
+        return method(handle)
 
     def _prepare_api_keys(self) -> dict[str, str]:
         """APIキー辞書を準備

--- a/src/lorairo/cli/commands/batch.py
+++ b/src/lorairo/cli/commands/batch.py
@@ -115,6 +115,13 @@ def _handle_error(error: Exception) -> None:
     raise typer.Exit(code=1) from error
 
 
+def _validate_submit_provider(provider: str) -> str:
+    provider_key = provider.strip().lower()
+    if provider_key == "google":
+        raise ProviderBatchError("Google Provider Batch is disabled / not configured until Phase 3.")
+    return provider_key
+
+
 @app.command("submit")
 def submit(
     project: str = typer.Option(..., "--project", "-p", help="Project name"),
@@ -137,8 +144,9 @@ def submit(
     """Submit images to a Provider Batch job."""
     try:
         container = _active_container(project)
+        provider_key = _validate_submit_provider(provider)
         job_id = container.provider_batch_workflow_service.submit_images(
-            provider=provider,
+            provider=provider_key,
             endpoint=endpoint,
             litellm_model_id=model,
             prompt_profile=prompt_profile,

--- a/src/lorairo/cli/commands/batch.py
+++ b/src/lorairo/cli/commands/batch.py
@@ -1,0 +1,273 @@
+"""Provider Batch job management commands."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from datetime import datetime
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import typer
+from rich.table import Table
+
+from lorairo.cli._console import make_console
+from lorairo.services.provider_batch_service import ProviderBatchError
+from lorairo.services.service_container import get_service_container
+
+if TYPE_CHECKING:
+    from lorairo.database.schema import ProviderBatchJob
+    from lorairo.services.provider_batch_service import ProviderBatchArtifactRef, ProviderBatchFetchResult
+    from lorairo.services.provider_batch_workflow_service import ProviderBatchImportResult
+    from lorairo.services.service_container import ServiceContainer
+
+
+app = typer.Typer(help="Provider Batch job management commands")
+console = make_console()
+
+
+def _active_container(project: str) -> ServiceContainer:
+    container = get_service_container()
+    container.set_active_project(project)
+    return container
+
+
+def _format_datetime(value: datetime | None) -> str:
+    if value is None:
+        return "-"
+    return value.strftime("%Y-%m-%d %H:%M:%S")
+
+
+def _format_count(value: int | None) -> str:
+    return "-" if value is None else str(value)
+
+
+def _job_counts(job: ProviderBatchJob) -> str:
+    return (
+        f"{job.succeeded_count}/{job.request_count} ok; "
+        f"{job.failed_count} failed; {job.canceled_count} canceled; {job.expired_count} expired"
+    )
+
+
+def _imported_state(job: ProviderBatchJob) -> str:
+    return "yes" if job.imported_at is not None or job.status == "imported" else "no"
+
+
+def _job_table(jobs: Sequence[ProviderBatchJob], *, title: str) -> Table:
+    table = Table(title=title)
+    table.add_column("ID", style="cyan", no_wrap=True)
+    table.add_column("Provider", no_wrap=True)
+    table.add_column("Provider Job ID", no_wrap=True)
+    table.add_column("Status", no_wrap=True)
+    table.add_column("Counts", no_wrap=True)
+    table.add_column("Submitted", no_wrap=True)
+    table.add_column("Completed", no_wrap=True)
+    table.add_column("Imported", no_wrap=True)
+
+    for job in jobs:
+        table.add_row(
+            str(job.id),
+            job.provider,
+            job.provider_job_id or "-",
+            job.status,
+            _job_counts(job),
+            _format_datetime(job.submitted_at),
+            _format_datetime(job.completed_at),
+            _imported_state(job),
+        )
+    return table
+
+
+def _job_summary(job: ProviderBatchJob) -> str:
+    return (
+        f"Job {job.id}: provider={job.provider}, provider_job_id={job.provider_job_id or '-'}, "
+        f"status={job.status}, counts={_job_counts(job)}, submitted={_format_datetime(job.submitted_at)}, "
+        f"completed={_format_datetime(job.completed_at)}, imported={_imported_state(job)}"
+    )
+
+
+def _print_job(job: ProviderBatchJob, *, title: str = "Provider Batch Job") -> None:
+    console.print(_job_summary(job))
+    console.print(_job_table([job], title=title))
+
+
+def _print_artifacts(artifacts: Sequence[ProviderBatchArtifactRef]) -> None:
+    if not artifacts:
+        console.print("Artifacts: 0")
+        return
+
+    table = Table(title="Artifacts")
+    table.add_column("Type")
+    table.add_column("Path")
+    table.add_column("Provider File ID")
+    table.add_column("SHA-256")
+    for artifact in artifacts:
+        table.add_row(
+            artifact.artifact_type,
+            str(artifact.local_path),
+            artifact.provider_file_id or "-",
+            artifact.sha256 or "-",
+        )
+    console.print(table)
+
+
+def _handle_error(error: Exception) -> None:
+    console.print(f"[red]Error:[/red] {error}")
+    raise typer.Exit(code=1) from error
+
+
+@app.command("submit")
+def submit(
+    project: str = typer.Option(..., "--project", "-p", help="Project name"),
+    provider: str = typer.Option(..., "--provider", help="Provider name"),
+    model: str = typer.Option(..., "--model", help="LiteLLM model ID"),
+    endpoint: str = typer.Option("responses", "--endpoint", help="Provider batch endpoint"),
+    prompt_profile: str = typer.Option(
+        "default",
+        "--prompt-profile",
+        help="Prompt profile name",
+    ),
+    image_ids: list[int] | None = typer.Option(
+        None,
+        "--image-id",
+        help="Image ID to submit. Repeat for multiple images.",
+    ),
+    description: str | None = typer.Option(None, "--description", help="Job description"),
+    model_id: int | None = typer.Option(None, "--model-id", help="LoRAIro model database ID"),
+) -> None:
+    """Submit images to a Provider Batch job."""
+    try:
+        container = _active_container(project)
+        job_id = container.provider_batch_workflow_service.submit_images(
+            provider=provider,
+            endpoint=endpoint,
+            litellm_model_id=model,
+            prompt_profile=prompt_profile,
+            image_ids=image_ids or [],
+            model_id=model_id,
+            description=description,
+        )
+        console.print(f"Provider batch job submitted: {job_id}")
+    except Exception as e:
+        _handle_error(e)
+
+
+@app.command("list")
+def list_jobs(
+    project: str = typer.Option(..., "--project", "-p", help="Project name"),
+    provider: str | None = typer.Option(None, "--provider", help="Filter by provider"),
+    status: str | None = typer.Option(None, "--status", help="Filter by common job status"),
+    limit: int = typer.Option(100, "--limit", min=1, help="Maximum jobs to show"),
+) -> None:
+    """List Provider Batch jobs."""
+    try:
+        container = _active_container(project)
+        jobs = container.image_repository.list_provider_batch_jobs(
+            provider=provider,
+            status=status,
+            limit=limit,
+        )
+        if not jobs:
+            console.print("No provider batch jobs found.")
+            return
+        for job in jobs:
+            console.print(_job_summary(job))
+        console.print(_job_table(jobs, title="Provider Batch Jobs"))
+    except Exception as e:
+        _handle_error(e)
+
+
+@app.command("status")
+def status(
+    project: str = typer.Option(..., "--project", "-p", help="Project name"),
+    job_id: int = typer.Argument(..., help="Provider Batch job ID"),
+    refresh: bool = typer.Option(
+        True,
+        "--refresh/--no-refresh",
+        help="Refresh from provider before showing status",
+    ),
+) -> None:
+    """Show Provider Batch job status."""
+    try:
+        container = _active_container(project)
+        if refresh:
+            job = container.provider_batch_workflow_service.refresh(job_id)
+        else:
+            db_job = container.image_repository.get_provider_batch_job(job_id)
+            if db_job is None:
+                raise ProviderBatchError(f"Provider batch job が見つかりません: job_id={job_id}")
+            job = db_job
+        _print_job(job)
+    except Exception as e:
+        _handle_error(e)
+
+
+@app.command("cancel")
+def cancel(
+    project: str = typer.Option(..., "--project", "-p", help="Project name"),
+    job_id: int = typer.Argument(..., help="Provider Batch job ID"),
+) -> None:
+    """Cancel a Provider Batch job."""
+    try:
+        container = _active_container(project)
+        job = container.provider_batch_workflow_service.cancel(job_id)
+        console.print(f"Provider batch job canceled: {job.id} ({job.status})")
+    except Exception as e:
+        _handle_error(e)
+
+
+@app.command("fetch")
+def fetch(
+    project: str = typer.Option(..., "--project", "-p", help="Project name"),
+    job_id: int = typer.Argument(..., help="Provider Batch job ID"),
+    destination_dir: Path | None = typer.Option(
+        None,
+        "--destination-dir",
+        help="Directory for downloaded provider result artifacts",
+    ),
+) -> None:
+    """Fetch Provider Batch results and artifacts."""
+    try:
+        container = _active_container(project)
+        result: ProviderBatchFetchResult = container.provider_batch_workflow_service.fetch_results(
+            job_id,
+            destination_dir,
+        )
+        console.print(
+            "Provider batch results fetched: "
+            f"provider_job_id={result.provider_job_id}, "
+            f"items={len(result.items)}, artifacts={len(result.artifacts)}"
+        )
+        _print_artifacts(result.artifacts)
+    except Exception as e:
+        _handle_error(e)
+
+
+@app.command("import")
+def import_results(
+    project: str = typer.Option(..., "--project", "-p", help="Project name"),
+    job_id: int = typer.Argument(..., help="Provider Batch job ID"),
+    destination_dir: Path | None = typer.Option(
+        None,
+        "--destination-dir",
+        help="Directory for downloaded provider result artifacts",
+    ),
+) -> None:
+    """Import Provider Batch results into annotations."""
+    try:
+        container = _active_container(project)
+        result: ProviderBatchImportResult = container.provider_batch_workflow_service.import_results(
+            job_id,
+            destination_dir=destination_dir,
+        )
+        console.print(
+            "Provider batch results imported: "
+            f"imported={_format_count(result.imported_count)}, "
+            f"skipped={_format_count(result.skipped_count)}, "
+            f"errors={_format_count(result.error_count)}, "
+            f"total={_format_count(result.total_count)}, "
+            f"job_imported={result.job_imported}"
+        )
+        if result.missing_custom_ids:
+            console.print(f"Missing custom IDs: {', '.join(result.missing_custom_ids)}")
+    except Exception as e:
+        _handle_error(e)

--- a/src/lorairo/cli/main.py
+++ b/src/lorairo/cli/main.py
@@ -20,7 +20,7 @@ from rich.table import Table
 
 from lorairo.cli._console import make_console
 from lorairo.cli._glyphs import FAIL, OK
-from lorairo.cli.commands import annotate, export, images, models, project
+from lorairo.cli.commands import annotate, batch, export, images, models, project
 from lorairo.services.service_container import get_service_container
 from lorairo.utils.config import DEFAULT_CLI_LOG_PATH, DEFAULT_CONFIG_PATH
 from lorairo.utils.log import initialize_logging
@@ -51,6 +51,7 @@ console = make_console()
 app.add_typer(project.app, name="project", help="Project management commands")
 app.add_typer(images.app, name="images", help="Image management commands")
 app.add_typer(annotate.app, name="annotate", help="Annotation commands")
+app.add_typer(batch.app, name="batch", help="Provider Batch job management commands")
 app.add_typer(export.app, name="export", help="Dataset export commands")
 app.add_typer(models.app, name="models", help="Model registry commands")
 

--- a/src/lorairo/services/provider_batch_library_compat.py
+++ b/src/lorairo/services/provider_batch_library_compat.py
@@ -1,0 +1,289 @@
+"""Compatibility helpers for image-annotator-lib Provider Batch DTOs."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from lorairo.services.provider_batch_service import (
+    BatchJobHandle,
+    BatchSubmitItem,
+    BatchSubmitRequest,
+    ProviderBatchArtifactRef,
+    ProviderBatchError,
+    ProviderBatchFetchResult,
+    ProviderBatchResultItem,
+    ProviderBatchStatus,
+    ProviderBatchSubmission,
+)
+
+
+def to_library_submit_request(request: Any) -> Any:
+    """Convert LoRAIro submit request to the installed library DTO when available."""
+    if not isinstance(request, BatchSubmitRequest):
+        return request
+    try:
+        from image_annotator_lib import BatchSubmitItem as LibraryBatchSubmitItem
+        from image_annotator_lib import BatchSubmitRequest as LibraryBatchSubmitRequest
+    except ImportError:
+        return request
+
+    return LibraryBatchSubmitRequest(
+        **_supported_kwargs(
+            LibraryBatchSubmitRequest,
+            {
+                "provider": request.provider,
+                "endpoint": request.endpoint,
+                "litellm_model_id": request.litellm_model_id,
+                "prompt_profile": request.prompt_profile,
+                "description": request.description,
+                "api_keys": dict(request.api_keys),
+                "items": [
+                    LibraryBatchSubmitItem(
+                        **_supported_kwargs(
+                            LibraryBatchSubmitItem,
+                            {
+                                "custom_id": item.custom_id,
+                                "image_id": item.image_id,
+                                "image_path": item.image_path,
+                                "task_type": item.task_type,
+                                "model_id": item.model_id,
+                                "raw_request": item.raw_request,
+                            },
+                        )
+                    )
+                    for item in request.items
+                ],
+                "model_id": request.model_id,
+                "request_artifact_path": request.request_artifact_path,
+                "raw_provider_payload": request.raw_provider_payload,
+            },
+        )
+    )
+
+
+def to_library_handle(handle: Any) -> Any:
+    """Convert LoRAIro job handle to the installed library DTO when available."""
+    if not isinstance(handle, BatchJobHandle):
+        return handle
+    try:
+        from image_annotator_lib import BatchJobHandle as LibraryBatchJobHandle
+    except ImportError:
+        return handle
+
+    return LibraryBatchJobHandle(
+        provider=handle.provider,
+        provider_job_id=handle.provider_job_id,
+        api_keys=dict(handle.api_keys),
+    )
+
+
+def to_provider_batch_submission(result: Any, provider: str) -> ProviderBatchSubmission:
+    """Normalize object/mapping library submit results to LoRAIro's internal DTO."""
+    if isinstance(result, ProviderBatchSubmission):
+        return result
+    status = _status_value(_value(result, "status"))
+    provider_status = _status_value(_value(result, "provider_status")) or status
+    return ProviderBatchSubmission(
+        provider_job_id=_required_str(result, "provider_job_id"),
+        provider_status=provider_status,
+        status=status,
+        request_count=_optional_int(_value(result, "request_count")),
+        submitted_at=_datetime_or_none(_value(result, "submitted_at"), "submitted_at"),
+        expires_at=_datetime_or_none(_value(result, "expires_at"), "expires_at"),
+        raw_provider_payload=_raw_provider_payload_or_none(result),
+    )
+
+
+def to_provider_batch_status(result: Any, provider: str) -> ProviderBatchStatus:
+    """Normalize object/mapping library status results to LoRAIro's internal DTO."""
+    if isinstance(result, ProviderBatchStatus):
+        return result
+    status = _status_value(_value(result, "status"))
+    provider_status = _status_value(_value(result, "provider_status")) or status
+    return ProviderBatchStatus(
+        provider_job_id=_required_str(result, "provider_job_id"),
+        provider_status=provider_status,
+        status=status,
+        request_count=_optional_int(_value(result, "request_count")),
+        succeeded_count=_optional_int(_value(result, "succeeded_count")),
+        failed_count=_optional_int(_value(result, "failed_count")),
+        canceled_count=_optional_int(_value(result, "canceled_count")),
+        expired_count=_optional_int(_value(result, "expired_count")),
+        submitted_at=_datetime_or_none(_value(result, "submitted_at"), "submitted_at"),
+        completed_at=_datetime_or_none(_value(result, "completed_at"), "completed_at"),
+        canceled_at=_datetime_or_none(_value(result, "canceled_at"), "canceled_at"),
+        expires_at=_datetime_or_none(_value(result, "expires_at"), "expires_at"),
+        raw_provider_payload=_raw_provider_payload_or_none(result),
+    )
+
+
+def to_provider_batch_fetch_result(
+    result: Any,
+    provider: str,
+    destination_dir: Path,
+    fallback_provider_job_id: str | None = None,
+) -> ProviderBatchFetchResult:
+    """Normalize object/mapping library fetch results to LoRAIro's internal DTO."""
+    if isinstance(result, ProviderBatchFetchResult):
+        return result
+    status = _status_value(_value(result, "status"))
+    provider_status = _status_value(_value(result, "provider_status")) or status
+    provider_job_id = _required_str(result, "provider_job_id", fallback=fallback_provider_job_id)
+    return ProviderBatchFetchResult(
+        provider_job_id=provider_job_id,
+        provider_status=provider_status,
+        status=status,
+        request_count=_optional_int(_value(result, "request_count")),
+        succeeded_count=_optional_int(_value(result, "succeeded_count")),
+        failed_count=_optional_int(_value(result, "failed_count")),
+        canceled_count=_optional_int(_value(result, "canceled_count")),
+        expired_count=_optional_int(_value(result, "expired_count")),
+        completed_at=_datetime_or_none(_value(result, "completed_at"), "completed_at"),
+        expires_at=_datetime_or_none(_value(result, "expires_at"), "expires_at"),
+        artifacts=tuple(_to_artifact_ref(artifact) for artifact in _value(result, "artifacts", ()) or ()),
+        items=tuple(_to_result_item(item) for item in _value(result, "items", ()) or ()),
+        raw_provider_payload=_raw_provider_payload_or_none(result),
+    )
+
+
+def to_provider_batch_models(result: Any) -> tuple[Any, ...]:
+    """Return library batch-capable model metadata as an immutable sequence."""
+    if result is None:
+        return ()
+    if isinstance(result, Sequence) and not isinstance(result, (str, bytes)):
+        return tuple(result)
+    if isinstance(result, (str, bytes)):
+        return (result,)
+    return (result,)
+
+
+def _to_result_item(item: Any) -> ProviderBatchResultItem:
+    if isinstance(item, ProviderBatchResultItem):
+        return item
+    error = _value(item, "error")
+    return ProviderBatchResultItem(
+        custom_id=_required_str(item, "custom_id"),
+        status=_required_status(item, "status"),
+        annotation=_value(item, "annotation"),
+        error_type=_optional_str(
+            _coalesce_none(_value(item, "error_type"), _value(error, "code"), _value(error, "type"))
+        ),
+        error_message=_optional_str(
+            _coalesce_none(_value(item, "error_message"), _value(item, "message"), _value(error, "message"))
+        ),
+        raw_response=_raw_response(item),
+    )
+
+
+def _to_artifact_ref(artifact: Any) -> ProviderBatchArtifactRef:
+    if isinstance(artifact, ProviderBatchArtifactRef):
+        return artifact
+    return ProviderBatchArtifactRef(
+        artifact_type=str(_value(artifact, "artifact_type")),
+        local_path=Path(_value(artifact, "local_path")),
+        provider_file_id=_optional_str(_value(artifact, "provider_file_id")),
+        sha256=_optional_str(_value(artifact, "sha256")),
+    )
+
+
+def _raw_response(item: Any) -> Any:
+    raw = _value(item, "raw_response")
+    if raw is not None:
+        return raw
+    error = _value(item, "error")
+    provider_status = _status_value(_value(item, "provider_status"))
+    payload: dict[str, Any] = {}
+    if provider_status:
+        payload["provider_status"] = provider_status
+    if error is not None:
+        payload["error"] = {
+            "phase": _status_value(_value(error, "phase")),
+            "code": _value(error, "code"),
+            "message": _value(error, "message"),
+            "retryable": _value(error, "retryable"),
+        }
+    return payload or None
+
+
+def _value(value: Any, key: str, default: Any = None) -> Any:
+    if isinstance(value, Mapping):
+        return value.get(key, default)
+    return getattr(value, key, default)
+
+
+def _coalesce_none(*values: Any) -> Any:
+    for value in values:
+        if value is not None:
+            return value
+    return None
+
+
+def _required_str(result: Any, key: str, *, fallback: str | None = None) -> str:
+    value = _value(result, key)
+    if value is None and fallback is not None:
+        value = fallback
+    if value is None:
+        raise ProviderBatchError(f"image-annotator-lib batch result is missing required field: {key}")
+    return str(value)
+
+
+def _required_status(result: Any, key: str) -> str:
+    value = _status_value(_value(result, key))
+    if not value:
+        raise ProviderBatchError(f"image-annotator-lib batch result is missing required field: {key}")
+    return value
+
+
+def _datetime_or_none(value: Any, field_name: str) -> datetime | None:
+    if value is None or value == "":
+        return None
+    if isinstance(value, datetime):
+        return value
+    if isinstance(value, str):
+        normalized = value[:-1] + "+00:00" if value.endswith("Z") else value
+        try:
+            return datetime.fromisoformat(normalized)
+        except ValueError as e:
+            raise ProviderBatchError(
+                f"image-annotator-lib batch result has invalid datetime field: {field_name}={value!r}"
+            ) from e
+    raise ProviderBatchError(
+        f"image-annotator-lib batch result has invalid datetime field type: "
+        f"{field_name}={type(value).__name__}"
+    )
+
+
+def _raw_provider_payload_or_none(result: Any) -> Any:
+    return _value(result, "raw_provider_payload")
+
+
+def _supported_kwargs(cls: Any, values: Mapping[str, Any]) -> dict[str, Any]:
+    try:
+        field_names = set(getattr(cls, "__dataclass_fields__", {}))
+    except TypeError:
+        field_names = set()
+    if not field_names:
+        return dict(values)
+    return {key: value for key, value in values.items() if key in field_names}
+
+
+def _status_value(value: Any) -> str:
+    if value is None:
+        return ""
+    enum_value = getattr(value, "value", None)
+    return str(enum_value if enum_value is not None else value)
+
+
+def _optional_str(value: Any) -> str | None:
+    if value is None:
+        return None
+    return str(value)
+
+
+def _optional_int(value: Any) -> int | None:
+    if value is None:
+        return None
+    return int(value)

--- a/src/lorairo/services/provider_batch_workflow_service.py
+++ b/src/lorairo/services/provider_batch_workflow_service.py
@@ -17,6 +17,14 @@ from typing import TYPE_CHECKING, Any
 from lorairo.database.db_repository import ImageRepository
 from lorairo.services.annotation_save_service import AnnotationSaveResult, AnnotationSaveService
 from lorairo.services.configuration_service import ConfigurationService
+from lorairo.services.provider_batch_library_compat import (
+    to_library_handle,
+    to_library_submit_request,
+    to_provider_batch_fetch_result,
+    to_provider_batch_models,
+    to_provider_batch_status,
+    to_provider_batch_submission,
+)
 from lorairo.services.provider_batch_service import (
     BatchJobHandle,
     BatchSubmitItem,
@@ -77,16 +85,34 @@ class ProviderBatchLibraryAdapter:
         self._client = client
 
     def submit_batch(self, request: BatchSubmitRequest) -> Any:
-        return self._call_client("submit_batch", request)
+        return to_provider_batch_submission(
+            self._call_client("submit_batch", to_library_submit_request(request)),
+            self.provider,
+        )
 
     def retrieve_batch(self, handle: BatchJobHandle) -> Any:
-        return self._call_client("retrieve_batch", handle)
+        return to_provider_batch_status(
+            self._call_client("retrieve_batch", to_library_handle(handle)),
+            self.provider,
+        )
 
     def cancel_batch(self, handle: BatchJobHandle) -> Any:
-        return self._call_client("cancel_batch", handle)
+        return to_provider_batch_status(
+            self._call_client("cancel_batch", to_library_handle(handle)),
+            self.provider,
+        )
 
     def fetch_batch_results(self, handle: BatchJobHandle, destination_dir: Path) -> Any:
-        return self._call_client("fetch_batch_results", handle, destination_dir)
+        return to_provider_batch_fetch_result(
+            self._call_client("fetch_batch_results", to_library_handle(handle), destination_dir),
+            self.provider,
+            destination_dir,
+            fallback_provider_job_id=handle.provider_job_id,
+        )
+
+    def list_batch_capable_models(self) -> tuple[Any, ...]:
+        """Return image-annotator-lib Provider Batch model metadata."""
+        return to_provider_batch_models(self._call_client("list_batch_capable_models"))
 
     def _call_client(self, method_name: str, *args: Any) -> Any:
         method = getattr(self._client, method_name, None)

--- a/tests/unit/annotations/test_annotator_adapter_provider_batch.py
+++ b/tests/unit/annotations/test_annotator_adapter_provider_batch.py
@@ -12,9 +12,9 @@ from lorairo.annotations.annotator_adapter import AnnotatorLibraryAdapter
 from lorairo.services.provider_batch_service import (
     BatchJobHandle,
     BatchSubmitRequest,
-    ProviderBatchArtifactRef,
-    ProviderBatchArtifacts,
     ProviderBatchError,
+    ProviderBatchFetchResult,
+    ProviderBatchResultItem,
     ProviderBatchStatus,
     ProviderBatchSubmission,
 )
@@ -35,23 +35,24 @@ class TestAnnotatorAdapterProviderBatch:
     ) -> None:
         calls: list[tuple[str, object]] = []
 
-        def submit_batch(request: BatchSubmitRequest) -> ProviderBatchSubmission:
+        def submit_batch(request: object) -> ProviderBatchSubmission:
             calls.append(("submit", request))
             return ProviderBatchSubmission(provider_job_id="batch_123", provider_status="validating")
 
-        def retrieve_batch(handle: BatchJobHandle) -> ProviderBatchStatus:
+        def retrieve_batch(handle: object) -> ProviderBatchStatus:
             calls.append(("retrieve", handle))
             return ProviderBatchStatus(provider_job_id="batch_123", provider_status="completed")
 
-        def cancel_batch(handle: BatchJobHandle) -> ProviderBatchStatus:
+        def cancel_batch(handle: object) -> ProviderBatchStatus:
             calls.append(("cancel", handle))
             return ProviderBatchStatus(provider_job_id="batch_123", provider_status="cancelled")
 
-        def fetch_batch_results(handle: BatchJobHandle, destination_dir: Path) -> ProviderBatchArtifacts:
-            calls.append(("fetch", destination_dir))
-            return ProviderBatchArtifacts(
+        def fetch_batch_results(handle: object) -> ProviderBatchFetchResult:
+            calls.append(("fetch", handle))
+            return ProviderBatchFetchResult(
                 provider_job_id="batch_123",
-                artifacts=(ProviderBatchArtifactRef("output", destination_dir / "output.jsonl"),),
+                provider_status="completed",
+                items=(ProviderBatchResultItem("img-1", "succeeded", annotation={"tags": ["tag"]}),),
             )
 
         monkeypatch.setattr(image_annotator_lib, "submit_batch", submit_batch, raising=False)
@@ -72,10 +73,98 @@ class TestAnnotatorAdapterProviderBatch:
         assert adapter.submit_batch(request).provider_status == "validating"
         assert adapter.retrieve_batch(handle).provider_status == "completed"
         assert adapter.cancel_batch(handle).provider_status == "cancelled"
-        assert adapter.fetch_batch_results(handle, tmp_path).artifacts[0].local_path == (
-            tmp_path / "output.jsonl"
-        )
+        assert adapter.fetch_batch_results(handle, tmp_path).items[0].annotation == {"tags": ["tag"]}
         assert [name for name, _value in calls] == ["submit", "retrieve", "cancel", "fetch"]
+        assert calls[0][1].provider == "openai"
+        assert calls[3][1].provider_job_id == "batch_123"
+
+    def test_list_batch_capable_models_forwards_to_image_annotator_lib(
+        self,
+        adapter: AnnotatorLibraryAdapter,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setattr(
+            image_annotator_lib,
+            "list_batch_capable_models",
+            lambda: ["anthropic/claude-test"],
+            raising=False,
+        )
+
+        assert adapter.list_batch_capable_models() == ("anthropic/claude-test",)
+
+    def test_fetch_batch_results_forwards_destination_dir_when_library_accepts_it(
+        self,
+        adapter: AnnotatorLibraryAdapter,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        calls: list[tuple[object, Path]] = []
+
+        def fetch_batch_results(handle: object, destination_dir: Path) -> ProviderBatchFetchResult:
+            calls.append((handle, destination_dir))
+            return ProviderBatchFetchResult(
+                provider_job_id="batch_123",
+                provider_status="completed",
+            )
+
+        monkeypatch.setattr(image_annotator_lib, "fetch_batch_results", fetch_batch_results, raising=False)
+
+        handle = BatchJobHandle(provider="openai", provider_job_id="batch_123", api_keys={})
+
+        adapter.fetch_batch_results(handle, tmp_path)
+
+        assert calls[0][1] == tmp_path
+
+    @pytest.mark.parametrize("signature_error", [TypeError, ValueError])
+    def test_fetch_batch_results_falls_back_when_signature_is_unavailable(
+        self,
+        adapter: AnnotatorLibraryAdapter,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+        signature_error: type[Exception],
+    ) -> None:
+        calls: list[object] = []
+
+        def fetch_batch_results(handle: object) -> ProviderBatchFetchResult:
+            calls.append(handle)
+            return ProviderBatchFetchResult(
+                provider_job_id="batch_123",
+                provider_status="completed",
+            )
+
+        monkeypatch.setattr(image_annotator_lib, "fetch_batch_results", fetch_batch_results, raising=False)
+        monkeypatch.setattr("inspect.signature", lambda _method: (_ for _ in ()).throw(signature_error))
+
+        handle = BatchJobHandle(provider="openai", provider_job_id="batch_123", api_keys={})
+
+        adapter.fetch_batch_results(handle, tmp_path)
+
+        assert len(calls) == 1
+
+    def test_fetch_batch_results_tries_destination_dir_when_signature_is_unavailable(
+        self,
+        adapter: AnnotatorLibraryAdapter,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        calls: list[tuple[object, Path]] = []
+
+        def fetch_batch_results(handle: object, destination_dir: Path) -> ProviderBatchFetchResult:
+            calls.append((handle, destination_dir))
+            return ProviderBatchFetchResult(
+                provider_job_id="batch_123",
+                provider_status="completed",
+            )
+
+        monkeypatch.setattr(image_annotator_lib, "fetch_batch_results", fetch_batch_results, raising=False)
+        monkeypatch.setattr("inspect.signature", lambda _method: (_ for _ in ()).throw(ValueError))
+
+        handle = BatchJobHandle(provider="openai", provider_job_id="batch_123", api_keys={})
+
+        adapter.fetch_batch_results(handle, tmp_path)
+
+        assert len(calls) == 1
+        assert calls[0][1] == tmp_path
 
     def test_provider_batch_methods_raise_when_library_api_is_unavailable(
         self,

--- a/tests/unit/cli/test_commands_batch.py
+++ b/tests/unit/cli/test_commands_batch.py
@@ -142,6 +142,34 @@ def test_submit_prints_service_error(mock_get_container: MagicMock) -> None:
 @pytest.mark.unit
 @pytest.mark.cli
 @patch("lorairo.cli.commands.batch.get_service_container")
+def test_submit_rejects_google_until_phase3(mock_get_container: MagicMock) -> None:
+    container, workflow, _repository = _container()
+    mock_get_container.return_value = container
+
+    result = runner.invoke(
+        app,
+        [
+            "batch",
+            "submit",
+            "-p",
+            "demo",
+            "--provider",
+            "google",
+            "--model",
+            "gemini-2.0-flash",
+            "--image-id",
+            "10",
+        ],
+    )
+
+    assert result.exit_code == 1
+    workflow.submit_images.assert_not_called()
+    assert "disabled / not configured" in result.stdout
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+@patch("lorairo.cli.commands.batch.get_service_container")
 def test_list_shows_jobs_with_filters(mock_get_container: MagicMock) -> None:
     container, _workflow, repository = _container()
     repository.list_provider_batch_jobs.return_value = [_job()]

--- a/tests/unit/cli/test_commands_batch.py
+++ b/tests/unit/cli/test_commands_batch.py
@@ -1,0 +1,283 @@
+"""Provider Batch CLI command tests."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+from typer.testing import CliRunner
+
+from lorairo.cli.main import app
+from lorairo.services.annotation_save_service import AnnotationSaveResult
+from lorairo.services.provider_batch_service import (
+    ProviderBatchArtifactRef,
+    ProviderBatchError,
+    ProviderBatchFetchResult,
+)
+from lorairo.services.provider_batch_workflow_service import (
+    ProviderBatchImportResult,
+    ProviderBatchResultApplyResult,
+)
+
+runner = CliRunner()
+
+
+def _job(
+    *,
+    job_id: int = 7,
+    provider: str = "openai",
+    provider_job_id: str | None = "batch_123",
+    status: str = "completed",
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        id=job_id,
+        provider=provider,
+        provider_job_id=provider_job_id,
+        status=status,
+        request_count=3,
+        succeeded_count=2,
+        failed_count=1,
+        canceled_count=0,
+        expired_count=0,
+        submitted_at=datetime(2026, 5, 1, 12, 0, tzinfo=UTC),
+        completed_at=datetime(2026, 5, 1, 12, 30, tzinfo=UTC),
+        imported_at=None,
+    )
+
+
+def _container() -> tuple[MagicMock, MagicMock, MagicMock]:
+    workflow = MagicMock()
+    repository = MagicMock()
+    container = MagicMock()
+    container.provider_batch_workflow_service = workflow
+    container.image_repository = repository
+    return container, workflow, repository
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+def test_batch_help_is_registered() -> None:
+    result = runner.invoke(app, ["batch", "--help"])
+
+    assert result.exit_code == 0
+    assert "Provider Batch" in result.stdout
+    assert "submit" in result.stdout
+    assert "import" in result.stdout
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+@patch("lorairo.cli.commands.batch.get_service_container")
+def test_submit_calls_workflow_service(mock_get_container: MagicMock) -> None:
+    container, workflow, _repository = _container()
+    workflow.submit_images.return_value = 42
+    mock_get_container.return_value = container
+
+    result = runner.invoke(
+        app,
+        [
+            "batch",
+            "submit",
+            "--project",
+            "demo",
+            "--provider",
+            "openai",
+            "--model",
+            "openai/gpt-4.1-mini",
+            "--image-id",
+            "10",
+            "--image-id",
+            "11",
+            "--description",
+            "nightly",
+            "--model-id",
+            "5",
+        ],
+    )
+
+    assert result.exit_code == 0
+    container.set_active_project.assert_called_once_with("demo")
+    workflow.submit_images.assert_called_once_with(
+        provider="openai",
+        endpoint="responses",
+        litellm_model_id="openai/gpt-4.1-mini",
+        prompt_profile="default",
+        image_ids=[10, 11],
+        model_id=5,
+        description="nightly",
+    )
+    assert "submitted: 42" in result.stdout
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+@patch("lorairo.cli.commands.batch.get_service_container")
+def test_submit_prints_service_error(mock_get_container: MagicMock) -> None:
+    container, workflow, _repository = _container()
+    workflow.submit_images.side_effect = ProviderBatchError("no images")
+    mock_get_container.return_value = container
+
+    result = runner.invoke(
+        app,
+        [
+            "batch",
+            "submit",
+            "-p",
+            "demo",
+            "--provider",
+            "openai",
+            "--model",
+            "openai/gpt-4.1-mini",
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert "Error:" in result.stdout
+    assert "no images" in result.stdout
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+@patch("lorairo.cli.commands.batch.get_service_container")
+def test_list_shows_jobs_with_filters(mock_get_container: MagicMock) -> None:
+    container, _workflow, repository = _container()
+    repository.list_provider_batch_jobs.return_value = [_job()]
+    mock_get_container.return_value = container
+
+    result = runner.invoke(
+        app,
+        ["batch", "list", "-p", "demo", "--provider", "openai", "--status", "completed"],
+    )
+
+    assert result.exit_code == 0
+    repository.list_provider_batch_jobs.assert_called_once_with(
+        provider="openai",
+        status="completed",
+        limit=100,
+    )
+    assert "Provider Batch Jobs" in result.stdout
+    assert "batch_123" in result.stdout
+    assert "2/3 ok" in result.stdout
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+@patch("lorairo.cli.commands.batch.get_service_container")
+def test_status_refreshes_by_default(mock_get_container: MagicMock) -> None:
+    container, workflow, repository = _container()
+    workflow.refresh.return_value = _job(status="running")
+    mock_get_container.return_value = container
+
+    result = runner.invoke(app, ["batch", "status", "-p", "demo", "7"])
+
+    assert result.exit_code == 0
+    workflow.refresh.assert_called_once_with(7)
+    repository.get_provider_batch_job.assert_not_called()
+    assert "running" in result.stdout
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+@patch("lorairo.cli.commands.batch.get_service_container")
+def test_status_no_refresh_uses_database_state(mock_get_container: MagicMock) -> None:
+    container, workflow, repository = _container()
+    repository.get_provider_batch_job.return_value = _job(status="completed")
+    mock_get_container.return_value = container
+
+    result = runner.invoke(app, ["batch", "status", "-p", "demo", "7", "--no-refresh"])
+
+    assert result.exit_code == 0
+    workflow.refresh.assert_not_called()
+    repository.get_provider_batch_job.assert_called_once_with(7)
+    assert "completed" in result.stdout
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+@patch("lorairo.cli.commands.batch.get_service_container")
+def test_status_no_refresh_reports_missing_job(mock_get_container: MagicMock) -> None:
+    container, _workflow, repository = _container()
+    repository.get_provider_batch_job.return_value = None
+    mock_get_container.return_value = container
+
+    result = runner.invoke(app, ["batch", "status", "-p", "demo", "99", "--no-refresh"])
+
+    assert result.exit_code == 1
+    assert "job_id=99" in result.stdout
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+@patch("lorairo.cli.commands.batch.get_service_container")
+def test_cancel_calls_workflow_service(mock_get_container: MagicMock) -> None:
+    container, workflow, _repository = _container()
+    workflow.cancel.return_value = _job(status="canceled")
+    mock_get_container.return_value = container
+
+    result = runner.invoke(app, ["batch", "cancel", "-p", "demo", "7"])
+
+    assert result.exit_code == 0
+    workflow.cancel.assert_called_once_with(7)
+    assert "canceled: 7 (canceled)" in result.stdout
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+@patch("lorairo.cli.commands.batch.get_service_container")
+def test_fetch_calls_workflow_service(mock_get_container: MagicMock, tmp_path: Path) -> None:
+    container, workflow, _repository = _container()
+    artifact = ProviderBatchArtifactRef(
+        artifact_type="output",
+        local_path=tmp_path / "batch_123.jsonl",
+        provider_file_id="file_123",
+        sha256="abc",
+    )
+    workflow.fetch_results.return_value = ProviderBatchFetchResult(
+        provider_job_id="batch_123",
+        provider_status="completed",
+        status="completed",
+        artifacts=(artifact,),
+        items=(SimpleNamespace(custom_id="img-1"),),
+    )
+    mock_get_container.return_value = container
+
+    result = runner.invoke(
+        app,
+        ["batch", "fetch", "-p", "demo", "7", "--destination-dir", str(tmp_path)],
+    )
+
+    assert result.exit_code == 0
+    workflow.fetch_results.assert_called_once_with(7, tmp_path)
+    assert "items=1, artifacts=1" in result.stdout
+    assert "file_123" in result.stdout
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+@patch("lorairo.cli.commands.batch.get_service_container")
+def test_import_calls_workflow_service(mock_get_container: MagicMock, tmp_path: Path) -> None:
+    container, workflow, _repository = _container()
+    workflow.import_results.return_value = ProviderBatchImportResult(
+        save_result=AnnotationSaveResult(success_count=2, skip_count=1, error_count=0, total_count=3),
+        apply_result=ProviderBatchResultApplyResult(updated_count=3, missing_count=0, total_count=3),
+        imported_count=2,
+        skipped_count=1,
+        error_count=0,
+        total_count=3,
+        job_imported=False,
+    )
+    mock_get_container.return_value = container
+
+    result = runner.invoke(
+        app,
+        ["batch", "import", "-p", "demo", "7", "--destination-dir", str(tmp_path)],
+    )
+
+    assert result.exit_code == 0
+    workflow.import_results.assert_called_once_with(7, destination_dir=tmp_path)
+    assert "imported=2" in result.stdout
+    assert "skipped=1" in result.stdout
+    assert "errors=0" in result.stdout

--- a/tests/unit/services/test_provider_batch_library_compat.py
+++ b/tests/unit/services/test_provider_batch_library_compat.py
@@ -1,0 +1,350 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import image_annotator_lib
+import pytest
+
+from lorairo.services.provider_batch_library_compat import (
+    to_library_handle,
+    to_library_submit_request,
+    to_provider_batch_fetch_result,
+    to_provider_batch_models,
+    to_provider_batch_status,
+    to_provider_batch_submission,
+)
+from lorairo.services.provider_batch_service import (
+    BatchJobHandle,
+    BatchSubmitItem,
+    BatchSubmitRequest,
+    ProviderBatchError,
+)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "payload",
+    [
+        SimpleNamespace(
+            provider_job_id="batch_123",
+            provider_status="validating",
+            status="submitted",
+            request_count=0,
+            submitted_at="2026-05-26T12:00:00Z",
+            expires_at="2026-05-27T12:00:00+00:00",
+            raw_provider_payload={"request_id": "req_1"},
+        ),
+        {
+            "provider_job_id": "batch_123",
+            "provider_status": "validating",
+            "status": "submitted",
+            "request_count": 0,
+            "submitted_at": "2026-05-26T12:00:00Z",
+            "expires_at": "2026-05-27T12:00:00+00:00",
+            "raw_provider_payload": {"request_id": "req_1"},
+        },
+    ],
+)
+def test_submission_conversion_accepts_object_and_mapping(payload: object) -> None:
+    result = to_provider_batch_submission(payload, "anthropic")
+
+    assert result.provider_job_id == "batch_123"
+    assert result.provider_status == "validating"
+    assert result.request_count == 0
+    assert result.submitted_at == datetime(2026, 5, 26, 12, 0, tzinfo=UTC)
+    assert result.expires_at == datetime(2026, 5, 27, 12, 0, tzinfo=UTC)
+    assert result.raw_provider_payload == {"request_id": "req_1"}
+
+
+@pytest.mark.unit
+def test_submission_conversion_keeps_missing_raw_payload_none() -> None:
+    result = to_provider_batch_submission(
+        {
+            "provider_job_id": "batch_123",
+            "provider_status": "validating",
+            "submitted_at": "",
+            "expires_at": None,
+        },
+        "anthropic",
+    )
+
+    assert result.submitted_at is None
+    assert result.expires_at is None
+    assert result.raw_provider_payload is None
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("payload", [{}, {"provider_job_id": None}])
+def test_submission_conversion_rejects_missing_provider_job_id(payload: dict[str, object]) -> None:
+    with pytest.raises(ProviderBatchError, match="provider_job_id"):
+        to_provider_batch_submission(payload, "anthropic")
+
+
+@pytest.mark.unit
+def test_status_conversion_coerces_datetimes_and_keeps_falsy_counts() -> None:
+    result = to_provider_batch_status(
+        SimpleNamespace(
+            provider_job_id="batch_123",
+            provider_status="ended",
+            status="completed",
+            request_count=0,
+            succeeded_count=0,
+            failed_count=0,
+            canceled_count=0,
+            expired_count=0,
+            submitted_at="2026-05-26T12:00:00Z",
+            completed_at="2026-05-26T13:00:00Z",
+            canceled_at="",
+            expires_at=None,
+        ),
+        "anthropic",
+    )
+
+    assert result.request_count == 0
+    assert result.succeeded_count == 0
+    assert result.failed_count == 0
+    assert result.canceled_count == 0
+    assert result.expired_count == 0
+    assert result.submitted_at == datetime(2026, 5, 26, 12, 0, tzinfo=UTC)
+    assert result.completed_at == datetime(2026, 5, 26, 13, 0, tzinfo=UTC)
+    assert result.canceled_at is None
+    assert result.expires_at is None
+    assert result.raw_provider_payload is None
+
+
+@pytest.mark.unit
+def test_status_conversion_rejects_invalid_datetime() -> None:
+    with pytest.raises(ProviderBatchError, match="invalid datetime"):
+        to_provider_batch_status(
+            {
+                "provider_job_id": "batch_123",
+                "provider_status": "running",
+                "submitted_at": "not-a-date",
+            },
+            "anthropic",
+        )
+
+
+@pytest.mark.unit
+def test_fetch_result_accepts_mapping_payload(tmp_path: Path) -> None:
+    result = to_provider_batch_fetch_result(
+        {
+            "provider_job_id": "batch_123",
+            "provider_status": "ended",
+            "status": "completed",
+            "request_count": 1,
+            "succeeded_count": 0,
+            "failed_count": 1,
+            "completed_at": "2026-05-26T13:00:00Z",
+            "expires_at": "2026-05-27T13:00:00Z",
+            "raw_provider_payload": {"provider_error": {"code": "job_failed"}},
+            "artifacts": [
+                {
+                    "artifact_type": "output",
+                    "local_path": str(tmp_path / "output.jsonl"),
+                    "provider_file_id": "file_123",
+                    "sha256": "abc",
+                }
+            ],
+            "items": [
+                {
+                    "custom_id": "image-1",
+                    "status": "failed",
+                    "error": {
+                        "phase": "result",
+                        "code": "bad_response",
+                        "message": "invalid json",
+                        "retryable": False,
+                    },
+                }
+            ],
+        },
+        "anthropic",
+        tmp_path,
+    )
+
+    assert result.provider_job_id == "batch_123"
+    assert result.provider_status == "ended"
+    assert result.raw_provider_payload == {"provider_error": {"code": "job_failed"}}
+    assert result.completed_at == datetime(2026, 5, 26, 13, 0, tzinfo=UTC)
+    assert result.expires_at == datetime(2026, 5, 27, 13, 0, tzinfo=UTC)
+    assert result.artifacts[0].local_path == tmp_path / "output.jsonl"
+    assert result.artifacts[0].provider_file_id == "file_123"
+    assert result.items[0].custom_id == "image-1"
+    assert result.items[0].error_type == "bad_response"
+    assert result.items[0].raw_response == {
+        "error": {
+            "phase": "result",
+            "code": "bad_response",
+            "message": "invalid json",
+            "retryable": False,
+        }
+    }
+
+
+@pytest.mark.unit
+def test_submit_conversion_preserves_metadata_when_library_dto_supports_it(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    @dataclass(frozen=True)
+    class LibraryBatchSubmitItem:
+        custom_id: str
+        image_id: int
+        image_path: Path
+        task_type: str
+        model_id: int | None
+        raw_request: Any
+
+    @dataclass(frozen=True)
+    class LibraryBatchSubmitRequest:
+        provider: str
+        endpoint: str
+        litellm_model_id: str
+        prompt_profile: str
+        description: str | None
+        api_keys: dict[str, str]
+        items: list[LibraryBatchSubmitItem]
+        model_id: int | None
+        request_artifact_path: Path | None
+        raw_provider_payload: Any
+
+    monkeypatch.setattr(image_annotator_lib, "BatchSubmitItem", LibraryBatchSubmitItem, raising=False)
+    monkeypatch.setattr(image_annotator_lib, "BatchSubmitRequest", LibraryBatchSubmitRequest, raising=False)
+
+    request = BatchSubmitRequest(
+        provider="anthropic",
+        endpoint="messages",
+        litellm_model_id="anthropic/claude-test",
+        prompt_profile="default",
+        api_keys={"anthropic": "test"},
+        items=(
+            BatchSubmitItem(
+                custom_id="image-1",
+                image_id=1,
+                image_path=tmp_path / "image.webp",
+                task_type="caption",
+                model_id=10,
+                raw_request={"temperature": 0.1},
+            ),
+        ),
+        model_id=10,
+        request_artifact_path=tmp_path / "request.jsonl",
+        raw_provider_payload={"metadata": "kept"},
+    )
+
+    converted = to_library_submit_request(request)
+
+    assert converted.model_id == 10
+    assert converted.request_artifact_path == tmp_path / "request.jsonl"
+    assert converted.raw_provider_payload == {"metadata": "kept"}
+    assert converted.items[0].task_type == "caption"
+    assert converted.items[0].model_id == 10
+    assert converted.items[0].raw_request == {"temperature": 0.1}
+
+
+@pytest.mark.unit
+def test_library_conversion_is_idempotent_for_already_converted_dtos() -> None:
+    submit_request = SimpleNamespace(provider="anthropic", items=[])
+    handle = SimpleNamespace(provider="anthropic", provider_job_id="batch_123")
+
+    assert to_library_submit_request(submit_request) is submit_request
+    assert to_library_handle(handle) is handle
+
+    lorairo_handle = BatchJobHandle(provider="anthropic", provider_job_id="batch_123", api_keys={})
+    assert to_library_handle(lorairo_handle).provider_job_id == "batch_123"
+
+
+@pytest.mark.unit
+def test_batch_models_wraps_scalar_model_id() -> None:
+    assert to_provider_batch_models("anthropic/claude-test") == ("anthropic/claude-test",)
+    assert to_provider_batch_models(123) == (123,)
+
+
+@pytest.mark.unit
+def test_fetch_result_rejects_missing_provider_job_id(tmp_path: Path) -> None:
+    with pytest.raises(ProviderBatchError, match="provider_job_id"):
+        to_provider_batch_fetch_result({"provider_status": "completed"}, "anthropic", tmp_path)
+
+
+@pytest.mark.unit
+def test_fetch_result_uses_fallback_provider_job_id_when_payload_omits_it(tmp_path: Path) -> None:
+    result = to_provider_batch_fetch_result(
+        {"provider_status": "completed"},
+        "anthropic",
+        tmp_path,
+        fallback_provider_job_id="batch_123",
+    )
+
+    assert result.provider_job_id == "batch_123"
+
+
+@pytest.mark.unit
+def test_fetch_result_without_raw_payload_keeps_payload_none(tmp_path: Path) -> None:
+    result = to_provider_batch_fetch_result(
+        {"provider_job_id": "batch_123", "provider_status": "completed", "items": []},
+        "anthropic",
+        tmp_path,
+    )
+
+    assert result.raw_provider_payload is None
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "item",
+    [
+        {"status": "failed"},
+        {"custom_id": "image-1"},
+        {"custom_id": "image-1", "status": ""},
+    ],
+)
+def test_fetch_result_rejects_items_missing_required_fields(
+    tmp_path: Path,
+    item: dict[str, object],
+) -> None:
+    with pytest.raises(ProviderBatchError, match="required field"):
+        to_provider_batch_fetch_result(
+            {"provider_job_id": "batch_123", "provider_status": "completed", "items": [item]},
+            "anthropic",
+            tmp_path,
+        )
+
+
+@pytest.mark.unit
+def test_fetch_result_item_error_fallbacks_preserve_diagnostics(tmp_path: Path) -> None:
+    result = to_provider_batch_fetch_result(
+        {
+            "provider_job_id": "batch_123",
+            "provider_status": "completed",
+            "items": [
+                {
+                    "custom_id": "image-1",
+                    "status": "failed",
+                    "message": "top-level message",
+                    "error": {
+                        "type": "invalid_request",
+                        "message": "nested message",
+                        "retryable": False,
+                    },
+                }
+            ],
+        },
+        "anthropic",
+        tmp_path,
+    )
+
+    assert result.items[0].error_type == "invalid_request"
+    assert result.items[0].error_message == "top-level message"
+    assert result.items[0].raw_response == {
+        "error": {
+            "phase": "",
+            "code": None,
+            "message": "nested message",
+            "retryable": False,
+        }
+    }

--- a/tests/unit/services/test_service_container_provider_batch.py
+++ b/tests/unit/services/test_service_container_provider_batch.py
@@ -3,11 +3,18 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Any, cast
 from unittest.mock import Mock
 
 import pytest
 
-from lorairo.services.provider_batch_service import BatchSubmitRequest, ProviderBatchSubmission
+from lorairo.services.provider_batch_service import (
+    BatchJobHandle,
+    BatchSubmitRequest,
+    ProviderBatchFetchResult,
+    ProviderBatchResultItem,
+    ProviderBatchSubmission,
+)
 from lorairo.services.provider_batch_workflow_service import ProviderBatchWorkflowService
 from lorairo.services.service_container import ServiceContainer
 
@@ -15,17 +22,32 @@ from lorairo.services.service_container import ServiceContainer
 class FakeBatchAnnotatorLibrary:
     def __init__(self) -> None:
         self.submitted_request: BatchSubmitRequest | None = None
+        self.fetch_call: tuple[BatchJobHandle, Path] | None = None
 
     def submit_batch(self, request: BatchSubmitRequest) -> ProviderBatchSubmission:
         self.submitted_request = request
         return ProviderBatchSubmission(provider_job_id="batch_container", provider_status="validating")
+
+    def fetch_batch_results(
+        self,
+        handle: BatchJobHandle,
+        destination_dir: Path,
+    ) -> ProviderBatchFetchResult:
+        self.fetch_call = (handle, destination_dir)
+        return ProviderBatchFetchResult(
+            provider_job_id=handle.provider_job_id,
+            provider_status="completed",
+            items=(
+                ProviderBatchResultItem(custom_id="img-1", status="succeeded", annotation={"tag": "ok"}),
+            ),
+        )
 
 
 @pytest.mark.unit
 class TestServiceContainerProviderBatch:
     def test_provider_batch_workflow_service_is_lazy_singleton(self) -> None:
         container = ServiceContainer()
-        container._annotator_library = object()
+        container._annotator_library = cast(Any, object())
 
         assert container._provider_batch_workflow_service is None
 
@@ -40,12 +62,12 @@ class TestServiceContainerProviderBatch:
 
     def test_reset_container_clears_provider_batch_workflow_service(self) -> None:
         container = ServiceContainer()
-        container._annotator_library = object()
+        container._annotator_library = cast(Any, object())
         service = container.provider_batch_workflow_service
 
         container.reset_container()
         container2 = ServiceContainer()
-        container2._annotator_library = object()
+        container2._annotator_library = cast(Any, object())
 
         assert container2._provider_batch_workflow_service is None
         assert container2.provider_batch_workflow_service is not service
@@ -60,7 +82,7 @@ class TestServiceContainerProviderBatch:
         repository.create_provider_batch_job_with_items.return_value = 123
         config = Mock()
         config.get_api_keys.return_value = {"openai": "sk-test"}
-        container._annotator_library = fake_library
+        container._annotator_library = cast(Any, fake_library)
         container._image_repository = repository
         container._config_service = config
 
@@ -76,3 +98,21 @@ class TestServiceContainerProviderBatch:
         assert fake_library.submitted_request is not None
         assert fake_library.submitted_request.provider == "openai"
         assert fake_library.submitted_request.items[0].image_path == Path("/tmp/container-image.webp")
+
+    def test_provider_batch_adapter_fetch_passes_destination_dir(self, tmp_path: Path) -> None:
+        container = ServiceContainer()
+        fake_library = FakeBatchAnnotatorLibrary()
+        container._annotator_library = cast(Any, fake_library)
+
+        service = container.provider_batch_workflow_service
+        adapter = cast(Any, service)._job_service._adapters["openai"]
+        result = adapter.fetch_batch_results(
+            BatchJobHandle(provider="openai", provider_job_id="batch_container", api_keys={}),
+            tmp_path,
+        )
+
+        assert result.items[0].annotation == {"tag": "ok"}
+        assert fake_library.fetch_call is not None
+        handle, destination_dir = fake_library.fetch_call
+        assert handle.provider_job_id == "batch_container"
+        assert destination_dir == tmp_path


### PR DESCRIPTION
## Summary
- add `lorairo batch` commands for submit/list/status/cancel/fetch/import
- show persisted Provider Batch job state and result/import summaries
- reject Google submit as disabled / not configured until Phase 3

Refs #461
Refs #463
Depends on #495

## Tests
- `uv run ruff check src/lorairo/cli/main.py src/lorairo/cli/commands/batch.py tests/unit/cli/test_commands_batch.py`
- `uv run mypy src/lorairo/cli/main.py src/lorairo/cli/commands/batch.py`
- `uv run pytest tests/unit/cli/test_main.py tests/unit/cli/test_commands_batch.py -q`