### PR TITLE
chore: enforce shared uv venv in worktrees

### DIFF
--- a/.claude/hooks/hook_pre_commands.py
+++ b/.claude/hooks/hook_pre_commands.py
@@ -12,13 +12,17 @@ LoRAIroプロジェクト用コマンド制御・変換システム。
 """
 
 import json
+import os
 import re
+import shlex
 import sys
 from datetime import datetime
 from pathlib import Path
 from typing import Any
 
 LOG_DIR = Path("/workspaces/LoRAIro/.claude/logs")
+WORKTREE_ROOT = Path("/tmp/worktrees")
+SHARED_UV_ENV = "UV_PROJECT_ENVIRONMENT=/workspaces/LoRAIro/.venv"
 
 
 def log_debug(message: str) -> None:
@@ -71,6 +75,89 @@ def check_blocked(command: str, rules: dict[str, Any]) -> str | None:
             suggestion = rule.get("suggestion", "")
             return f"🚫 {reason}\n→ {suggestion}"
     return None
+
+
+def _is_under_worktree(path: str | Path) -> bool:
+    """パスが /tmp/worktrees 配下かどうかを判定する。"""
+    try:
+        return Path(path).expanduser().resolve().is_relative_to(WORKTREE_ROOT)
+    except (OSError, RuntimeError):
+        return str(path).startswith(f"{WORKTREE_ROOT}/")
+
+
+def _command_cd_worktree(command: str) -> bool:
+    """command 内の `cd /tmp/worktrees/...` を検出する。"""
+    try:
+        parts = shlex.split(command)
+    except ValueError:
+        return bool(re.search(r"\bcd\s+/tmp/worktrees(?:/|\b)", command))
+
+    for index, part in enumerate(parts[:-1]):
+        if part == "cd" and _is_under_worktree(parts[index + 1]):
+            return True
+    return False
+
+
+def _runs_in_worktree(command: str, input_data: dict[str, Any]) -> bool:
+    """Bash 実行コンテキストが worktree 配下かどうかを推定する。"""
+    tool_input = input_data.get("tool_input", {})
+    for key in ("cwd", "workdir", "working_dir"):
+        value = tool_input.get(key) or input_data.get(key)
+        if value and _is_under_worktree(value):
+            return True
+
+    return _command_cd_worktree(command) or _is_under_worktree(os.getcwd())
+
+
+def _has_uv_invocation(command: str) -> bool:
+    """uv 実行を検出する。env prefix や cd 後の実行も対象にする。"""
+    return bool(re.search(r"(^|[\s;&|])(?:env\s+)?(?:[A-Za-z_][A-Za-z0-9_]*=\S+\s+)*uv(?:\s|$)", command))
+
+
+def _has_shared_uv_environment(command: str) -> bool:
+    """共有 venv の UV_PROJECT_ENVIRONMENT 指定を検出する。"""
+    pattern = rf"(^|[\s;&|])(?:env\s+)?{re.escape(SHARED_UV_ENV)}(?:\s|$)"
+    return bool(re.search(pattern, command))
+
+
+def _is_bare_uv_command(command: str) -> bool:
+    """`uv` 単体は help 表示のみで venv を作らないため許可する。"""
+    stripped = command.strip()
+    if stripped == "uv":
+        return True
+
+    try:
+        parts = shlex.split(stripped)
+    except ValueError:
+        return False
+
+    if parts == ["uv"]:
+        return True
+
+    for separator in ("&&", ";"):
+        if separator in parts:
+            uv_index = parts.index(separator) + 1
+            return parts[uv_index:] == ["uv"]
+    return False
+
+
+def check_worktree_uv_environment(command: str, input_data: dict[str, Any]) -> str | None:
+    """worktree 内の uv は共有 .venv を明示させ、worktree .venv 作成を防ぐ。"""
+    if not _has_uv_invocation(command):
+        return None
+    if not _runs_in_worktree(command, input_data):
+        return None
+    if _has_shared_uv_environment(command):
+        return None
+    if _is_bare_uv_command(command):
+        return None
+
+    log_debug(f"BLOCKING: uv without shared env in worktree: {command}")
+    return (
+        "🚫 worktree 内で uv を実行する場合は共有 venv を明示してください。\n"
+        f"→ `{SHARED_UV_ENV} uv ...` を使用してください。\n"
+        "→ venv を作らない確認目的だけなら `uv` 単体は許可されています。"
+    )
 
 
 def check_draft_pr_create(command: str) -> str | None:
@@ -140,6 +227,12 @@ def main() -> None:
         draft_pr_msg = check_draft_pr_create(command)
         if draft_pr_msg:
             print(json.dumps({"decision": "block", "reason": draft_pr_msg}, ensure_ascii=False))
+            sys.exit(2)
+
+        # worktree 内 uv 実行制御
+        worktree_uv_msg = check_worktree_uv_environment(command, input_data)
+        if worktree_uv_msg:
+            print(json.dumps({"decision": "block", "reason": worktree_uv_msg}, ensure_ascii=False))
             sys.exit(2)
 
         # grep系コマンド制御

--- a/.claude/hooks/hook_worktree_create.py
+++ b/.claude/hooks/hook_worktree_create.py
@@ -2,14 +2,17 @@
 """
 Claude Code Hooks - WorktreeCreate (PostToolUse Hook)
 
-ワークツリー作成後に uv sync --dev を自動実行する。
-新しいワークツリーで依存関係が即座に使えるようにする。
+ワークツリー作成後に共有 venv を指定して uv sync --dev を自動実行する。
+ワークツリー内に .venv を作らず、新しいワークツリーで依存関係が即座に使えるようにする。
 """
 
 import json
+import os
 import subprocess
 import sys
 from pathlib import Path
+
+SHARED_UV_ENVIRONMENT = "/workspaces/LoRAIro/.venv"
 
 
 def main() -> None:
@@ -28,9 +31,13 @@ def main() -> None:
         if not path.exists():
             sys.exit(0)
 
+        env = os.environ.copy()
+        env["UV_PROJECT_ENVIRONMENT"] = SHARED_UV_ENVIRONMENT
+
         result = subprocess.run(
             ["uv", "sync", "--dev"],
             cwd=path,
+            env=env,
             capture_output=True,
             text=True,
         )

--- a/.claude/rules/git-workflow.md
+++ b/.claude/rules/git-workflow.md
@@ -44,6 +44,9 @@ make worktree-cleanup-merged
 
 ## venv（ワークツリー内）
 
-- ワークツリー内で `uv sync` する場合、venv は `/tmp/worktrees/` のボリューム上に作られるため高速
-- プロジェクトルートの `.venv` とは別管理になる
+- 原則としてワークツリー内に `.venv` を作らない
+- `/tmp/worktrees/` 配下で `uv` を実行する場合は、共有実行環境を明示する:
+  `UV_PROJECT_ENVIRONMENT=/workspaces/LoRAIro/.venv uv ...`
+- `uv` 単体の help/inspection は venv を作らないため例外として許可する
+- ワークツリー固有の `.venv` が必要な特殊事情がある場合は、理由を明示してから実行する
 - 並列で `uv run` を実行する場合の詳細ルールは [parallel-execution.md](parallel-execution.md) を参照

--- a/.claude/rules/parallel-execution.md
+++ b/.claude/rules/parallel-execution.md
@@ -4,11 +4,13 @@
 
 ## 核心ルール
 
-**並列で `uv` を走らせる場合は同一 `.venv` を共有しない。** worktree 分離か、`uv run --active` を使わない（`--active` なしの `uv run` は uv-managed venv で並列セーフ）。
+**並列で `uv` を走らせる場合は同一 `.venv` への同期系操作を競合させない。** worktree 内で実行する通常の `uv` コマンドは `UV_PROJECT_ENVIRONMENT=/workspaces/LoRAIro/.venv` を明示して共有 venv を使う。`uv sync` / `uv lock` などの書き換え系は直列化し、`uv run --active` は使わない。
 
 ## Hook で自動ブロックされる操作
 
 `uv run --active` は `.claude/hooks/rules/hook_pre_commands_rules.json` で機械的にブロックされる。Claude が以下のコマンドを発行すると PreToolUse Hook が exit code 2 で停止する:
+
+また、`/tmp/worktrees/` 配下の `uv` 実行は `UV_PROJECT_ENVIRONMENT=/workspaces/LoRAIro/.venv` を含まない場合にブロックされる。例外は venv を作らない `uv` 単体の help/inspection のみ。
 
 ```bash
 # 禁止（Hook で自動ブロック）
@@ -29,13 +31,14 @@ uv run pytest                  # uv-managed venv、並列セーフ
 
 ### 1. 並列で `uv run` を走らせる場合は worktree 分離
 
-並列タスクごとに独立した worktree を切り、それぞれが独自の `.venv` を持つ構成にする。配置先は `/tmp/worktrees/` 配下（[git-workflow.md](git-workflow.md) 参照）。
+並列タスクごとに独立した worktree を切る。配置先は `/tmp/worktrees/` 配下（[git-workflow.md](git-workflow.md) 参照）。ただし通常は worktree ごとの `.venv` を作らず、共有実行環境を明示する。
 
 ```bash
 # 正しい: 並列ジョブごとに worktree
 git worktree add /tmp/worktrees/job-a -b feat/job-a
 git worktree add /tmp/worktrees/job-b -b feat/job-b
-# それぞれの worktree 内で uv sync && uv run pytest を実行
+# それぞれの worktree 内で共有 venv を明示して実行
+UV_PROJECT_ENVIRONMENT=/workspaces/LoRAIro/.venv uv run pytest
 
 # 禁止: 同一 .venv を並列で叩く
 uv run pytest tests/unit/ &

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -338,7 +338,7 @@ LoRAIro #288 で判明した制約。`.claude/rules/parallel-execution.md` の w
 
 1. **LoRAIro root `.venv` 共有** (current best practice、ADR 0024 amended #291):
 
-   `make test-iam-lib` は `UV_PROJECT_ENVIRONMENT=$(CURDIR)/.venv uv run --no-sync pytest` 経由で LoRAIro root の named volume `.venv` を共有する。`$(CURDIR)` は make 起動時の repo root に動的解決されるため devcontainer (`/workspaces/LoRAIro/`) でも worktree (`/tmp/worktrees/<wt>/`) でも同一 target が動作する。bind mount I/O 問題は発生しない。
+   `make test-iam-lib` は `UV_PROJECT_ENVIRONMENT=$(CURDIR)/.venv uv run --no-sync pytest` 経由で LoRAIro root の named volume `.venv` を共有する。devcontainer 共有 checkout では `$(CURDIR)` が `/workspaces/LoRAIro/` になる。worktree (`/tmp/worktrees/<wt>/`) から agent が `uv` を直接実行する場合は `UV_PROJECT_ENVIRONMENT=/workspaces/LoRAIro/.venv uv ...` を明示し、worktree 内 `.venv` を作らない。
 
    ```bash
    make test-iam-lib    # LoRAIro .venv (named volume、Python 3.13) で iam-lib pytest を実行
@@ -346,9 +346,15 @@ LoRAIro #288 で判明した制約。`.claude/rules/parallel-execution.md` の w
 
    iam-lib の dev deps (`pytest-clarity` / `pytest-mock` / `pytest-xdist`) は LoRAIro `[dependency-groups] dev` に統合済。`make test-iam-lib` は内部で `_ensure-root-venv` (= `uv sync --dev`) を prerequisite として実行し、fresh checkout / new dev deps pull 直後の install 漏れを防ぐ。
 
-2. **Worktree 内で test 実行** (代替、worktree 専用 venv):
+2. **Worktree 内で test 実行**:
 
-   worktree (`/tmp/worktrees/`) は named volume なので worktree 内で `cd local_packages/image-annotator-lib && uv sync` し、独立 venv を作っても I/O 高速。複数 worktree で異なる iam-lib HEAD を test したい場合に有用。
+   原則として worktree 専用 venv は作らない。直接 `uv` を呼ぶ場合は以下の形にする:
+
+   ```bash
+   UV_PROJECT_ENVIRONMENT=/workspaces/LoRAIro/.venv uv run pytest
+   ```
+
+   複数 worktree で異なる Python 環境や依存解決を検証する必要がある場合だけ、理由を明示して worktree 専用 venv を使う。
 
 #### Hook との関係
 
@@ -356,6 +362,7 @@ LoRAIro #288 で判明した制約。`.claude/rules/parallel-execution.md` の w
 
 並列 `uv sync` (Issue #222 教訓) のガードは引き続き以下で担保:
 
+- `.claude/hooks/hook_pre_commands.py` / `.codex/hooks/hook_pre_commands.py` の worktree uv guard (`UV_PROJECT_ENVIRONMENT=/workspaces/LoRAIro/.venv` 必須、`uv` 単体のみ例外)
 - `.claude/hooks/rules/hook_pre_commands_rules.json` の `uv\s+run.*--active` block
 - `.claude/rules/parallel-execution.md` の worktree 分離 rule
 

--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -20,6 +20,17 @@
           }
         ]
       }
+    ],
+    "WorktreeCreate": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/workspaces/LoRAIro/.codex/hooks/hook_worktree_create.py"
+          }
+        ]
+      }
     ]
   }
 }

--- a/.codex/hooks/hook_pre_commands.py
+++ b/.codex/hooks/hook_pre_commands.py
@@ -11,13 +11,17 @@ LoRAIroプロジェクト用コマンド制御・変換システム。
 """
 
 import json
+import os
 import re
+import shlex
 import sys
 from datetime import datetime
 from pathlib import Path
 from typing import Any
 
 LOG_DIR = Path("/workspaces/LoRAIro/.claude/logs")
+WORKTREE_ROOT = Path("/tmp/worktrees")
+SHARED_UV_ENV = "UV_PROJECT_ENVIRONMENT=/workspaces/LoRAIro/.venv"
 
 
 def log_debug(message: str) -> None:
@@ -72,6 +76,89 @@ def check_blocked(command: str, rules: dict[str, Any]) -> str | None:
     return None
 
 
+def _is_under_worktree(path: str | Path) -> bool:
+    """パスが /tmp/worktrees 配下かどうかを判定する。"""
+    try:
+        return Path(path).expanduser().resolve().is_relative_to(WORKTREE_ROOT)
+    except (OSError, RuntimeError):
+        return str(path).startswith(f"{WORKTREE_ROOT}/")
+
+
+def _command_cd_worktree(command: str) -> bool:
+    """command 内の `cd /tmp/worktrees/...` を検出する。"""
+    try:
+        parts = shlex.split(command)
+    except ValueError:
+        return bool(re.search(r"\bcd\s+/tmp/worktrees(?:/|\b)", command))
+
+    for index, part in enumerate(parts[:-1]):
+        if part == "cd" and _is_under_worktree(parts[index + 1]):
+            return True
+    return False
+
+
+def _runs_in_worktree(command: str, input_data: dict[str, Any]) -> bool:
+    """Bash 実行コンテキストが worktree 配下かどうかを推定する。"""
+    tool_input = input_data.get("tool_input", {})
+    for key in ("cwd", "workdir", "working_dir"):
+        value = tool_input.get(key) or input_data.get(key)
+        if value and _is_under_worktree(value):
+            return True
+
+    return _command_cd_worktree(command) or _is_under_worktree(os.getcwd())
+
+
+def _has_uv_invocation(command: str) -> bool:
+    """uv 実行を検出する。env prefix や cd 後の実行も対象にする。"""
+    return bool(re.search(r"(^|[\s;&|])(?:env\s+)?(?:[A-Za-z_][A-Za-z0-9_]*=\S+\s+)*uv(?:\s|$)", command))
+
+
+def _has_shared_uv_environment(command: str) -> bool:
+    """共有 venv の UV_PROJECT_ENVIRONMENT 指定を検出する。"""
+    pattern = rf"(^|[\s;&|])(?:env\s+)?{re.escape(SHARED_UV_ENV)}(?:\s|$)"
+    return bool(re.search(pattern, command))
+
+
+def _is_bare_uv_command(command: str) -> bool:
+    """`uv` 単体は help 表示のみで venv を作らないため許可する。"""
+    stripped = command.strip()
+    if stripped == "uv":
+        return True
+
+    try:
+        parts = shlex.split(stripped)
+    except ValueError:
+        return False
+
+    if parts == ["uv"]:
+        return True
+
+    for separator in ("&&", ";"):
+        if separator in parts:
+            uv_index = parts.index(separator) + 1
+            return parts[uv_index:] == ["uv"]
+    return False
+
+
+def check_worktree_uv_environment(command: str, input_data: dict[str, Any]) -> str | None:
+    """worktree 内の uv は共有 .venv を明示させ、worktree .venv 作成を防ぐ。"""
+    if not _has_uv_invocation(command):
+        return None
+    if not _runs_in_worktree(command, input_data):
+        return None
+    if _has_shared_uv_environment(command):
+        return None
+    if _is_bare_uv_command(command):
+        return None
+
+    log_debug(f"BLOCKING: uv without shared env in worktree: {command}")
+    return (
+        "🚫 worktree 内で uv を実行する場合は共有 venv を明示してください。\n"
+        f"→ `{SHARED_UV_ENV} uv ...` を使用してください。\n"
+        "→ venv を作らない確認目的だけなら `uv` 単体は許可されています。"
+    )
+
+
 def check_grep_command(command: str) -> str | None:
     """grep系コマンドの制御。
 
@@ -119,6 +206,12 @@ def main() -> None:
         rules = load_rules()
         if not rules:
             sys.exit(0)
+
+        # worktree 内 uv 実行制御
+        worktree_uv_msg = check_worktree_uv_environment(command, input_data)
+        if worktree_uv_msg:
+            print(json.dumps({"decision": "block", "reason": worktree_uv_msg}, ensure_ascii=False))
+            sys.exit(2)
 
         # grep系コマンド制御
         grep_msg = check_grep_command(command)

--- a/.codex/hooks/hook_worktree_create.py
+++ b/.codex/hooks/hook_worktree_create.py
@@ -2,14 +2,17 @@
 """
 Claude Code Hooks - WorktreeCreate (PostToolUse Hook)
 
-ワークツリー作成後に uv sync --dev を自動実行する。
-新しいワークツリーで依存関係が即座に使えるようにする。
+ワークツリー作成後に共有 venv を指定して uv sync --dev を自動実行する。
+ワークツリー内に .venv を作らず、新しいワークツリーで依存関係が即座に使えるようにする。
 """
 
 import json
+import os
 import subprocess
 import sys
 from pathlib import Path
+
+SHARED_UV_ENVIRONMENT = "/workspaces/LoRAIro/.venv"
 
 
 def main() -> None:
@@ -28,9 +31,13 @@ def main() -> None:
         if not path.exists():
             sys.exit(0)
 
+        env = os.environ.copy()
+        env["UV_PROJECT_ENVIRONMENT"] = SHARED_UV_ENVIRONMENT
+
         result = subprocess.run(
             ["uv", "sync", "--dev"],
             cwd=path,
+            env=env,
             capture_output=True,
             text=True,
         )

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,6 +45,8 @@
 - For issue resolution or feature implementation, completion means: implement, validate, commit, push, open a ready-for-review PR, run PR maintenance automation through CI/review, and merge when safe, unless the user explicitly asks to stop before publishing or keep the PR as draft.
 - Do not end issue or multi-file feature work after local implementation only. Report the PR URL and final monitored state as the outcome.
 - If PR creation is blocked by auth, network, failing validation, or unclear scope, report the blocker explicitly instead of silently stopping at local changes.
+- When running `uv` from a `/tmp/worktrees/` checkout, use the shared execution environment explicitly:
+  `UV_PROJECT_ENVIRONMENT=/workspaces/LoRAIro/.venv uv ...`. Do not create a worktree-local `.venv` unless there is a specific technical reason. If the shared environment cannot be used, only a bare `uv` help/inspection command is allowed without `UV_PROJECT_ENVIRONMENT`.
 - Agent-created PRs should normally be created ready for review, not draft. When a draft PR exists because the user explicitly asked to keep it draft, mark it ready for review as soon as the user allows review, then immediately start or resume PR maintenance automation: poll CI, watch bot review artifacts/comments, repair actionable findings in the PR worktree, reply in Japanese, merge when safe, and report the final monitored state.
 - After creating an agent PR, explicitly verify `gh pr view "$PR" --json isDraft -q .isDraft`. If it is
   `true`, run `gh pr ready "$PR"` and re-check. Do not set up `gh pr merge --auto` while the PR is still draft.

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,14 @@
 
 .PHONY: help setup test test-iam-lib test-runtime-local test-runtime-webapi test-genai-tag test-all mypy format install install-dev clean run-gui generate-ui skills-update venv-rebuild worktree-cleanup-merged worktree-cleanup-merged-dry-run _ensure-submodules _ensure-root-venv
 
+WORKTREE_ROOT := /tmp/worktrees
+ifeq ($(filter $(WORKTREE_ROOT)/%,$(CURDIR)),)
+LORAIRO_UV_PROJECT_ENVIRONMENT := $(CURDIR)/.venv
+else
+LORAIRO_UV_PROJECT_ENVIRONMENT := /workspaces/LoRAIro/.venv
+export UV_PROJECT_ENVIRONMENT := $(LORAIRO_UV_PROJECT_ENVIRONMENT)
+endif
+
 # Default target
 help:
 	@echo "LoRAIro Project - Available Commands:"
@@ -54,9 +62,9 @@ test: _ensure-submodules
 	@echo "Running LoRAIro main tests (testpaths=[\"tests\"], ADR 0024)..."
 	uv run pytest
 
-# NOTE (ADR 0024 amended #291): `cd <pkg> && UV_PROJECT_ENVIRONMENT=$(CURDIR)/.venv uv run --no-sync pytest`
+# NOTE (ADR 0024 amended #291): `cd <pkg> && UV_PROJECT_ENVIRONMENT=$(LORAIRO_UV_PROJECT_ENVIRONMENT) uv run --no-sync pytest`
 # で LoRAIro root `.venv` を共有 (bind mount I/O 制約回避、ADR 0024 amendment 参照)。
-# `$(CURDIR)` で動的解決するため devcontainer 外 checkout や worktree (`/tmp/worktrees/<wt>`) でも動作。
+# worktree (`/tmp/worktrees/<wt>`) では `/workspaces/LoRAIro/.venv` を強制し、worktree 内 `.venv` を作らない。
 # `_ensure-root-venv` prerequisite で dev deps の install を保証 (fresh checkout / new dev deps pull 直後でも fail しない)。
 # `--no-sync` は LoRAIro `.venv` が iam-lib pyproject に合わせて re-sync されるのを防ぐ。
 # iam-lib dev deps (pytest-clarity / pytest-mock / pytest-xdist) は LoRAIro [dependency-groups] dev に統合済。
@@ -77,7 +85,7 @@ _ensure-root-venv: _ensure-submodules
 test-iam-lib: _ensure-root-venv
 	@echo "Running image-annotator-lib tests (sharing LoRAIro root .venv via UV_PROJECT_ENVIRONMENT)..."
 	cd local_packages/image-annotator-lib && \
-		UV_PROJECT_ENVIRONMENT=$(CURDIR)/.venv \
+		UV_PROJECT_ENVIRONMENT=$(LORAIRO_UV_PROJECT_ENVIRONMENT) \
 		uv run --no-sync pytest \
 		-m "not downloads_and_runs_model and not calls_real_webapi"
 

--- a/scripts/run_runtime_webapi_tests.py
+++ b/scripts/run_runtime_webapi_tests.py
@@ -18,6 +18,8 @@ from lorairo.services.configuration_service import ConfigurationService
 REPO_ROOT = Path(__file__).resolve().parents[1]
 IAM_LIB_DIR = REPO_ROOT / "local_packages" / "image-annotator-lib"
 RUNTIME_TEST_PATH = "tests/runtime_validation/test_real_webapi_runtime.py"
+WORKTREE_ROOT = Path("/tmp/worktrees")
+SHARED_UV_PROJECT_ENVIRONMENT = Path("/workspaces/LoRAIro/.venv")
 
 PROVIDER_CONFIG_KEYS = {
     "openai": "openai_key",
@@ -50,6 +52,18 @@ def load_api_keys(config_service: ConfigurationService | None = None) -> dict[st
     }
 
 
+def resolve_uv_project_environment(repo_root: Path) -> Path:
+    """Use the shared LoRAIro venv for /tmp/worktrees checkouts."""
+    try:
+        if repo_root.resolve().is_relative_to(WORKTREE_ROOT):
+            return SHARED_UV_PROJECT_ENVIRONMENT
+    except (OSError, RuntimeError):
+        if str(repo_root).startswith(f"{WORKTREE_ROOT}/"):
+            return SHARED_UV_PROJECT_ENVIRONMENT
+
+    return repo_root / ".venv"
+
+
 def build_child_env(
     api_keys: Mapping[str, str],
     *,
@@ -66,7 +80,7 @@ def build_child_env(
         if api_key:
             env[env_key] = api_key
 
-    env["UV_PROJECT_ENVIRONMENT"] = str(repo_root / ".venv")
+    env["UV_PROJECT_ENVIRONMENT"] = str(resolve_uv_project_environment(repo_root))
     return env
 
 

--- a/tests/unit/scripts/test_run_runtime_webapi_tests.py
+++ b/tests/unit/scripts/test_run_runtime_webapi_tests.py
@@ -71,6 +71,16 @@ def test_build_child_env_removes_existing_api_env_when_config_missing() -> None:
     assert env["PATH"] == "/usr/bin"
 
 
+def test_build_child_env_uses_shared_venv_for_worktree() -> None:
+    env = runner_script.build_child_env(
+        {"openai": "", "anthropic": "", "google": "", "openrouter": ""},
+        base_env={"PATH": "/usr/bin"},
+        repo_root=Path("/tmp/worktrees/issue-123"),
+    )
+
+    assert env["UV_PROJECT_ENVIRONMENT"] == "/workspaces/LoRAIro/.venv"
+
+
 def test_run_runtime_webapi_tests_invokes_iam_lib_pytest_without_printing_keys(capsys) -> None:
     calls = []
     config = FakeConfigService(

--- a/tests/unit/test_hook_pre_commands.py
+++ b/tests/unit/test_hook_pre_commands.py
@@ -11,10 +11,14 @@ PROJECT_ROOT = Path(__file__).resolve().parents[2]
 HOOK = PROJECT_ROOT / ".claude" / "hooks" / "hook_pre_commands.py"
 
 
-def _run_hook(command: str) -> subprocess.CompletedProcess[str]:
+def _run_hook(command: str, *, cwd: str | None = None) -> subprocess.CompletedProcess[str]:
+    tool_input = {"command": command}
+    if cwd is not None:
+        tool_input["cwd"] = cwd
+
     return subprocess.run(
         [sys.executable, str(HOOK)],
-        input=json.dumps({"tool_input": {"command": command}}),
+        input=json.dumps({"tool_input": tool_input}),
         text=True,
         capture_output=True,
         check=False,
@@ -36,3 +40,46 @@ def test_allows_ready_pr_create_command() -> None:
 
     assert result.returncode == 0
     assert result.stdout == ""
+
+
+def test_blocks_uv_without_shared_environment_in_worktree() -> None:
+    result = _run_hook("uv run pytest", cwd="/tmp/worktrees/issue-123")
+
+    assert result.returncode == 2
+    payload = json.loads(result.stdout)
+    assert payload["decision"] == "block"
+    assert "UV_PROJECT_ENVIRONMENT=/workspaces/LoRAIro/.venv" in payload["reason"]
+
+
+def test_allows_uv_with_shared_environment_in_worktree() -> None:
+    result = _run_hook(
+        "UV_PROJECT_ENVIRONMENT=/workspaces/LoRAIro/.venv uv run pytest",
+        cwd="/tmp/worktrees/issue-123",
+    )
+
+    assert result.returncode == 0
+    assert result.stdout == ""
+
+
+def test_blocks_similar_but_different_uv_environment_in_worktree() -> None:
+    result = _run_hook(
+        "UV_PROJECT_ENVIRONMENT=/workspaces/LoRAIro/.venv2 uv run pytest",
+        cwd="/tmp/worktrees/issue-123",
+    )
+
+    assert result.returncode == 2
+
+
+def test_allows_bare_uv_in_worktree() -> None:
+    result = _run_hook("uv", cwd="/tmp/worktrees/issue-123")
+
+    assert result.returncode == 0
+    assert result.stdout == ""
+
+
+def test_blocks_cd_worktree_uv_without_shared_environment() -> None:
+    result = _run_hook("cd /tmp/worktrees/issue-123 && uv sync --dev")
+
+    assert result.returncode == 2
+    payload = json.loads(result.stdout)
+    assert "worktree" in payload["reason"]


### PR DESCRIPTION
## Summary
- require worktree uv commands to use UV_PROJECT_ENVIRONMENT=/workspaces/LoRAIro/.venv in Claude/Codex pre-command hooks
- run WorktreeCreate uv sync against the shared venv and wire the Codex WorktreeCreate hook
- update Makefile/runtime test env resolution and agent rules to avoid worktree-local .venv creation

## Tests
- UV_PROJECT_ENVIRONMENT=/workspaces/LoRAIro/.venv uv run pytest tests/unit/test_hook_pre_commands.py tests/unit/scripts/test_run_runtime_webapi_tests.py
- UV_PROJECT_ENVIRONMENT=/workspaces/LoRAIro/.venv uv run ruff check .claude/hooks/hook_pre_commands.py .codex/hooks/hook_pre_commands.py .claude/hooks/hook_worktree_create.py .codex/hooks/hook_worktree_create.py scripts/run_runtime_webapi_tests.py tests/unit/test_hook_pre_commands.py tests/unit/scripts/test_run_runtime_webapi_tests.py
- UV_PROJECT_ENVIRONMENT=/workspaces/LoRAIro/.venv uv run python scripts/validate_harness.py