### PR TITLE
feat: map rating model type

### DIFF
--- a/docs/decisions/0031-ai-rating-mapping.md
+++ b/docs/decisions/0031-ai-rating-mapping.md
@@ -162,6 +162,8 @@ LoRAIro#471 では、OpenAI Moderations Batch を annotation API 送信前の ra
    - `provider_batch_items.task_type = "rating_preflight"`
    - `provider_batch_jobs.model_id` / `provider_batch_items.model_id` には
      `omni-moderation-latest` 等の moderation model ledger entry を設定する
+   - moderation model ledger entry は `model_type="rating"` / DB `model_types=["ratings"]`
+     として登録し、`scores` / `tags` には分類しない
    - `provider_batch_items.image_id` で対象画像と対応付ける
    - `provider_batch_items.raw_response` は OpenAI moderation response の保存に使ってよい
    - canonical rating は既存 `ratings` table に保存する
@@ -174,6 +176,16 @@ LoRAIro#471 では、OpenAI Moderations Batch を annotation API 送信前の ra
    OpenAI Batch output/error JSONL の取得・parse、Moderations response の category score 抽出、
    `RatingPrediction` への畳み込みは image-annotator-lib の責務である。LoRAIro 側で
    OpenAI-specific artifact parser を追加しない。
+
+8. **rating 専用モデルには `model_type="rating"` を使う。**
+
+   `TaskCapability.RATINGS` は出力 capability、`model_type="rating"` は主用途分類である。
+   `AnimeRatingAnnotator` や OpenAI Moderations preflight のように rating だけを返すモデルは
+   `model_type="scorer"` に寄せず、LoRAIro DB では `model_types=["ratings"]` に写像する。
+   一方で WDTagger / CamieTagger のように tags と rating を両方返すモデルは、従来どおり
+   `model_type="tagger"` + `capabilities=["tags", "ratings"]` とし、DB では
+   `["tags", "ratings"]` に分類する。スコアも返す rating-capable scorer も同様に
+   `["scores", "ratings"]` を維持する。
 
 参考:
 

--- a/src/lorairo/cli/commands/models.py
+++ b/src/lorairo/cli/commands/models.py
@@ -42,6 +42,7 @@ class ModelCategoryFilter(StrEnum):
     scorer = "scorer"
     captioner = "captioner"
     vision = "vision"
+    rating = "rating"
 
 
 class RouteFilter(StrEnum):
@@ -105,7 +106,7 @@ def list_models(
         ModelCategoryFilter.all,
         "--category",
         case_sensitive=False,
-        help="Filter by model category (all / tagger / scorer / captioner / vision)",
+        help="Filter by model category (all / tagger / scorer / captioner / vision / rating)",
     ),
     route: RouteFilter | None = typer.Option(
         None,

--- a/src/lorairo/services/model_sync_service.py
+++ b/src/lorairo/services/model_sync_service.py
@@ -30,7 +30,7 @@ class ModelMetadata(TypedDict):
     provider: str | None
     class_name: str | None
     litellm_model_id: str  # registry key SSoT (NOT NULL)
-    model_type: str  # AnnotatorInfo.model_type ("tagger"/"scorer"/"captioner"/"vision")
+    model_type: str  # AnnotatorInfo.model_type ("tagger"/"scorer"/"captioner"/"vision"/"rating")
     model_types: list[str]  # LoRAIro DB の model_types (マッピング後)
     estimated_size_gb: float | None
     requires_api_key: bool
@@ -145,7 +145,7 @@ class ModelSyncService:
     """ライブラリとLoRAIro DB間のモデル同期サービス
 
     image-annotator-lib が管理するアノテーション専用モデル (vision/scorer/tagger/
-    captioner) を LoRAIro DB に同期する。upscaler 等の LoRAIro 独自機能は対象外。
+    captioner/rating) を LoRAIro DB に同期する。upscaler 等の LoRAIro 独自機能は対象外。
     """
 
     def __init__(
@@ -190,6 +190,7 @@ class ModelSyncService:
             - "captioner" → ["caption"]
             - "scorer" → ["scores"]
             - "tagger" → ["tags"]
+            - "rating" → ["ratings"]
             - TaskCapability.RATINGS を持つモデルは上記に加えて "ratings" を付与
             - その他 → ["caption"] (警告ログ付き)
         """
@@ -204,6 +205,8 @@ class ModelSyncService:
             db_model_types = ["scores"]
         elif model_type == "tagger":
             db_model_types = ["tags"]
+        elif model_type == "rating":
+            db_model_types = ["ratings"]
         else:
             logger.warning(f"Unknown library model_type: {model_type}, defaulting to ['caption']")
             db_model_types = ["caption"]
@@ -438,5 +441,5 @@ class ModelSyncService:
         Returns:
             bool: image-annotator-lib の `AnnotatorInfo.model_type` Literal 値かどうか
         """
-        valid_types = {"vision", "scorer", "tagger", "captioner"}
+        valid_types = {"vision", "scorer", "tagger", "captioner", "rating"}
         return model_type in valid_types

--- a/tests/unit/cli/test_commands_models.py
+++ b/tests/unit/cli/test_commands_models.py
@@ -235,6 +235,39 @@ def test_models_list_filter_category_tagger(mock_get_container) -> None:
 @pytest.mark.unit
 @pytest.mark.cli
 @patch("lorairo.cli.commands.models.get_service_container")
+def test_models_list_filter_category_rating(mock_get_container) -> None:
+    """--category rating は rating 専用モデルのみ表示する。"""
+    mock_container = MagicMock()
+    mock_container.annotator_library.list_annotator_info.return_value = [
+        _FakeAnnotatorInfo(
+            name="anime_rating_mobilenetv3_sce_dist",
+            model_type="rating",
+            is_local=True,
+            is_api=False,
+            device="cuda",
+        ),
+        _FakeAnnotatorInfo(
+            name="wd-v1-4-tagger",
+            model_type="tagger",
+            is_local=True,
+            is_api=False,
+            device="cuda",
+        ),
+    ]
+    mock_container.annotator_library.is_model_deprecated.return_value = False
+    mock_get_container.return_value = mock_container
+
+    result = runner.invoke(app, ["models", "list", "--category", "rating"])
+
+    assert result.exit_code == 0
+    assert "anime_rating_mobilenetv3_sce_dist" in result.stdout
+    assert "wd-v1-4-tagger" not in result.stdout
+    assert "1 model(s)" in result.stdout
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+@patch("lorairo.cli.commands.models.get_service_container")
 def test_models_list_filter_combines_type_and_category(mock_get_container) -> None:
     """--type local --category scorer はローカル scorer のみ表示する。"""
     mock_container = MagicMock()

--- a/tests/unit/test_model_sync_service.py
+++ b/tests/unit/test_model_sync_service.py
@@ -105,7 +105,7 @@ class TestMockAnnotatorLibrary:
         assert "wd-v1-4-swinv2-tagger" in names
 
     def test_mock_model_types_use_post_issue_19_literals(self):
-        """モックモデルの model_type は Issue #19 の Literal 値 (vision/scorer/tagger/captioner)"""
+        """モックモデルの model_type は Issue #19 以降の Literal 値を使う。"""
         mock_lib = MockAnnotatorLibrary()
         infos = mock_lib.list_annotator_info()
 
@@ -182,6 +182,11 @@ class TestModelTypeMapping:
             capabilities={TaskCapability.TAGS, TaskCapability.RATINGS},
         )
         assert service_with_mock._map_library_model_type_to_db(info) == ["tags", "ratings"]
+
+    def test_rating_maps_to_ratings_only(self, service_with_mock):
+        """rating 専用モデルは scores/tags を付けず ratings のみに分類される。"""
+        info = _info("anime-rating", "rating", is_api=False, capabilities={TaskCapability.RATINGS})
+        assert service_with_mock._map_library_model_type_to_db(info) == ["ratings"]
 
     def test_unknown_type_falls_back_to_caption(self, service_with_mock):
         """未知のタイプは ['caption'] にフォールバック (警告ログ付き、Issue #243)。"""
@@ -509,6 +514,7 @@ class TestModelSyncServiceWithRealDB:
         assert model_sync_service.validate_annotation_model_type("scorer") is True
         assert model_sync_service.validate_annotation_model_type("tagger") is True
         assert model_sync_service.validate_annotation_model_type("captioner") is True
+        assert model_sync_service.validate_annotation_model_type("rating") is True
         # 旧値 "score" は invalid (Issue #19 で "scorer" に統一)
         assert model_sync_service.validate_annotation_model_type("score") is False
         assert model_sync_service.validate_annotation_model_type("upscaler") is False


### PR DESCRIPTION
## Summary
- Map `AnnotatorInfo.model_type="rating"` to LoRAIro DB `model_types=["ratings"]`.
- Update ADR 0031 to state rating-only models, including moderation preflight, use `model_type="rating"`.
- Update image-annotator-lib submodule to NEXTAltair/image-annotator-lib#118 commit `151ecc4`.

## Tests
- `UV_PROJECT_ENVIRONMENT=/workspaces/LoRAIro/.venv uv run pytest tests/unit/test_model_sync_service.py -q`
- `UV_PROJECT_ENVIRONMENT=/workspaces/LoRAIro/.venv uv run pytest local_packages/image-annotator-lib/tests/unit/fast/test_list_annotator_info.py local_packages/image-annotator-lib/tests/unit/test_capability_utils.py -q`
- `UV_PROJECT_ENVIRONMENT=/workspaces/LoRAIro/.venv uv run ruff check ...`
- `UV_PROJECT_ENVIRONMENT=/workspaces/LoRAIro/.venv uv run python scripts/validate_docs.py`

Depends on NEXTAltair/image-annotator-lib#118.