### PR TITLE
feat: wire LoRAIro provider batch rating preflight route

### DIFF
--- a/src/lorairo/cli/commands/batch.py
+++ b/src/lorairo/cli/commands/batch.py
@@ -17,9 +17,15 @@ app = typer.Typer(help="Provider Batch API job commands")
 console = make_console()
 
 _SUPPORTED_SUBMIT_PROVIDERS = {"openai", "anthropic"}
-_DEFAULT_ENDPOINTS = {
-    "openai": "/v1/chat/completions",
-    "anthropic": "/v1/messages",
+_SUPPORTED_TASK_TYPES = {"annotation", "rating_preflight"}
+_TASK_TYPE_ENDPOINTS = {
+    "annotation": {
+        "openai": "/v1/chat/completions",
+        "anthropic": "/v1/messages",
+    },
+    "rating_preflight": {
+        "openai": "/v1/moderations",
+    },
 }
 
 
@@ -80,6 +86,23 @@ def _validate_submit_provider(provider: str) -> None:
             "Supported providers: openai, anthropic."
         )
         raise typer.Exit(code=1)
+
+
+def _model_has_model_type(model: Any, model_type: str) -> bool:
+    model_types = getattr(model, "model_types", ())
+    return any(getattr(item, "name", None) == model_type for item in model_types)
+
+
+def _resolve_submit_endpoint(provider: str, task_type: str, endpoint: str | None) -> str:
+    if endpoint is None:
+        provider_endpoints = _TASK_TYPE_ENDPOINTS.get(task_type, _TASK_TYPE_ENDPOINTS["annotation"])
+        if provider not in provider_endpoints:
+            console.print(
+                f"[red]Error:[/red] Task type '{task_type}' is not supported for provider '{provider}'."
+            )
+            raise typer.Exit(code=1)
+        return provider_endpoints[provider]
+    return endpoint
 
 
 def _job_value(job: Any, name: str, default: Any = None) -> Any:
@@ -170,6 +193,9 @@ def submit(
     endpoint: str | None = typer.Option(None, "--endpoint", help="Provider endpoint override"),
     prompt_profile: str = typer.Option("default", "--prompt-profile", help="Prompt profile name"),
     description: str | None = typer.Option(None, "--description", help="Provider job description"),
+    task_type: str = typer.Option(
+        "annotation", "--task-type", help="Task type: annotation or rating_preflight"
+    ),
 ) -> None:
     """Submit registered images to a Provider Batch API job."""
     try:
@@ -179,7 +205,19 @@ def submit(
         db_model = _resolve_model(model_repo, model)
         resolved_provider = _infer_provider(db_model, provider)
         _validate_submit_provider(resolved_provider)
-        resolved_endpoint = endpoint or _DEFAULT_ENDPOINTS[resolved_provider]
+        normalized_task_type = task_type.strip().lower()
+        if normalized_task_type not in _SUPPORTED_TASK_TYPES:
+            console.print(f"[red]Error:[/red] Unsupported task type '{task_type}'.")
+            raise typer.Exit(code=1)
+        if normalized_task_type == "rating_preflight":
+            if resolved_provider != "openai":
+                console.print("[red]Error:[/red] rating_preflight submit is only supported for openai.")
+                raise typer.Exit(code=1)
+            if not _model_has_model_type(db_model, "ratings"):
+                console.print("[red]Error:[/red] rating_preflight submit requires a ratings model.")
+                raise typer.Exit(code=1)
+
+        resolved_endpoint = _resolve_submit_endpoint(resolved_provider, normalized_task_type, endpoint)
 
         job_id = container.provider_batch_workflow_service.submit_images(
             provider=resolved_provider,
@@ -189,6 +227,7 @@ def submit(
             image_ids=image_ids,
             model_id=db_model.id,
             description=description,
+            task_type=normalized_task_type,
         )
         job = provider_batch_repo.get_provider_batch_job(job_id)
         console.print(f"[green]Provider Batch job submitted:[/green] {job_id}")

--- a/src/lorairo/gui/widgets/provider_batch_job_widget.py
+++ b/src/lorairo/gui/widgets/provider_batch_job_widget.py
@@ -30,6 +30,17 @@ _DEFAULT_ENDPOINTS = {
     "openai": "/v1/chat/completions",
     "anthropic": "/v1/messages",
 }
+_TASK_TYPES = ("annotation", "rating_preflight")
+_TASK_TYPE_ENDPOINTS = {
+    "annotation": {
+        "openai": "/v1/chat/completions",
+        "anthropic": "/v1/messages",
+    },
+    "rating_preflight": {
+        "openai": "/v1/moderations",
+    },
+}
+_MODEL_TYPE_RATINGS = "ratings"
 _ITEM_STATUSES = ("all", "failed", "expired", "canceled")
 
 
@@ -86,6 +97,12 @@ class ProviderBatchJobWidget(QWidget):
         self.comboBoxModel.setObjectName("comboBoxProviderBatchModel")
         self.comboBoxModel.setMinimumWidth(320)
         submit_layout.addRow("Model", self.comboBoxModel)
+
+        self.comboBoxTaskType = QComboBox()
+        self.comboBoxTaskType.setObjectName("comboBoxProviderBatchTaskType")
+        self.comboBoxTaskType.addItems(_TASK_TYPES)
+        self.comboBoxTaskType.setCurrentText("annotation")
+        submit_layout.addRow("Task", self.comboBoxTaskType)
 
         self.lineEditImageIds = QLineEdit()
         self.lineEditImageIds.setObjectName("lineEditProviderBatchImageIds")
@@ -184,6 +201,7 @@ class ProviderBatchJobWidget(QWidget):
         self.buttonUseSelected.clicked.connect(self.use_selected_images)
         self.buttonRefreshModels.clicked.connect(self.refresh_models)
         self.buttonSubmit.clicked.connect(self.submit_job)
+        self.comboBoxTaskType.currentTextChanged.connect(self.refresh_models)
         self.buttonRefreshJobs.clicked.connect(self.refresh_jobs)
         self.buttonRefreshStatus.clicked.connect(self.refresh_selected_job_status)
         self.buttonCancel.clicked.connect(self.cancel_selected_job)
@@ -199,6 +217,7 @@ class ProviderBatchJobWidget(QWidget):
         if self._model_repository is None:
             return
 
+        task_type = self._selected_task_type()
         try:
             models = self._load_batch_capable_models()
         except Exception as e:
@@ -209,6 +228,9 @@ class ProviderBatchJobWidget(QWidget):
             provider = self._direct_provider_for_model(model)
             if provider is None:
                 continue
+            if not self._model_supports_task_type(model, provider, task_type):
+                continue
+            endpoint = self._endpoint_for_task(provider, task_type)
             label = f"{provider}: {model.litellm_model_id}"
             self.comboBoxModel.addItem(
                 label,
@@ -216,10 +238,38 @@ class ProviderBatchJobWidget(QWidget):
                     "model_id": model.id,
                     "provider": provider,
                     "litellm_model_id": model.litellm_model_id,
-                    "endpoint": _DEFAULT_ENDPOINTS[provider],
+                    "endpoint": endpoint,
+                    "task_type": task_type,
                 },
             )
         self.labelStatus.setText(f"{self.comboBoxModel.count()} batch-capable model(s)")
+
+    def _selected_task_type(self) -> str:
+        task_type = self.comboBoxTaskType.currentText()
+        if task_type in _TASK_TYPES:
+            return task_type
+        return "annotation"
+
+    def _endpoint_for_task(self, provider: str, task_type: str) -> str:
+        provider_tasks = _TASK_TYPE_ENDPOINTS.get(task_type)
+        if provider_tasks is None:
+            provider_tasks = _TASK_TYPE_ENDPOINTS["annotation"]
+        endpoint = provider_tasks.get(provider)
+        if endpoint is None:
+            raise ValueError(f"Provider '{provider}' は task_type '{task_type}' をサポートしていません。")
+        return endpoint
+
+    @staticmethod
+    def _model_has_model_type(model: Any, model_type: str) -> bool:
+        model_types = getattr(model, "model_types", ())
+        return any(getattr(item, "name", None) == model_type for item in model_types)
+
+    def _model_supports_task_type(self, model: Any, provider: str, task_type: str) -> bool:
+        if task_type == "annotation":
+            return True
+        if task_type == "rating_preflight":
+            return provider == "openai" and self._model_has_model_type(model, _MODEL_TYPE_RATINGS)
+        return False
 
     def _load_batch_capable_models(self) -> list[Any]:
         source = self._model_source
@@ -299,6 +349,7 @@ class ProviderBatchJobWidget(QWidget):
             image_ids = self._parse_image_ids()
             if not image_ids:
                 raise ValueError("image IDs are required")
+            task_type = self._selected_task_type()
             job_id = self._workflow_service.submit_images(
                 provider=model_data["provider"],
                 endpoint=model_data["endpoint"],
@@ -307,6 +358,7 @@ class ProviderBatchJobWidget(QWidget):
                 image_ids=image_ids,
                 model_id=model_data["model_id"],
                 description=self.lineEditDescription.text().strip() or None,
+                task_type=task_type,
             )
             self.refresh_jobs()
             self.select_job(job_id)

--- a/src/lorairo/services/model_sync_service.py
+++ b/src/lorairo/services/model_sync_service.py
@@ -216,6 +216,30 @@ class ModelSyncService:
 
         return db_model_types
 
+    @staticmethod
+    def _ensure_openai_moderation_model(
+        models_metadata: list[ModelMetadata],
+        *,
+        litellm_model_id: str = "omni-moderation-latest",
+        provider: str = "openai",
+    ) -> None:
+        if any(item["litellm_model_id"] == litellm_model_id for item in models_metadata):
+            return
+
+        models_metadata.append(
+            {
+                "name": litellm_model_id,
+                "provider": provider,
+                "class_name": None,
+                "litellm_model_id": litellm_model_id,
+                "model_type": "rating",
+                "model_types": ["ratings"],
+                "estimated_size_gb": None,
+                "requires_api_key": True,
+                "discontinued_at": None,
+            }
+        )
+
     def sync_available_models(self) -> ModelSyncResult:
         """利用可能モデルの自動同期
 
@@ -290,6 +314,9 @@ class ModelSyncService:
                     "discontinued_at": info.discontinued_at,
                 }
                 models_metadata.append(metadata)
+
+            if models_metadata and any(model.get("provider") == "openai" for model in models_metadata):
+                self._ensure_openai_moderation_model(models_metadata)
 
             logger.debug(
                 f"image-annotator-libから {len(models_metadata)}件のアノテーションモデルを取得しました"

--- a/src/lorairo/services/provider_batch_library_compat.py
+++ b/src/lorairo/services/provider_batch_library_compat.py
@@ -264,10 +264,17 @@ def _raw_provider_payload_or_none(result: Any) -> Any:
 
 
 def _supported_kwargs(cls: Any, values: Mapping[str, Any]) -> dict[str, Any]:
-    try:
-        field_names = set(getattr(cls, "__dataclass_fields__", {}))
-    except TypeError:
-        field_names = set()
+    field_names: set[str] = set()
+    dataclass_fields = getattr(cls, "__dataclass_fields__", {})
+    if dataclass_fields:
+        field_names.update(dataclass_fields.keys())
+
+    model_fields = getattr(cls, "model_fields", None)
+    if isinstance(model_fields, dict):
+        field_names.update(model_fields.keys())
+    elif model_fields is not None:
+        field_names.update(str(field_name) for field_name in model_fields.keys())
+
     if not field_names:
         return dict(values)
     return {key: value for key, value in values.items() if key in field_names}

--- a/tests/unit/cli/test_commands_batch.py
+++ b/tests/unit/cli/test_commands_batch.py
@@ -110,9 +110,53 @@ def test_batch_submit_calls_workflow_service(mock_get_container: MagicMock) -> N
         image_ids=[1, 2],
         model_id=7,
         description="nightly",
+        task_type="annotation",
     )
     assert "Provider Batch job submitted" in result.stdout
     assert "batch_42" in result.stdout
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+@patch("lorairo.cli.commands.batch.get_service_container")
+def test_batch_submit_rating_preflight_calls_workflow_service(mock_get_container: MagicMock) -> None:
+    container = _container()
+    container.db_manager.model_repo.get_model_by_litellm_id.return_value = _model(
+        id=11,
+        litellm_model_id="openai/omni-moderation-latest",
+        model_types=(SimpleNamespace(name="ratings"),),
+    )
+    mock_get_container.return_value = container
+
+    result = runner.invoke(
+        app,
+        [
+            "batch",
+            "submit",
+            "--project",
+            "demo",
+            "--model",
+            "openai/omni-moderation-latest",
+            "--task-type",
+            "rating_preflight",
+            "--image-id",
+            "1",
+        ],
+    )
+
+    assert result.exit_code == 0
+    container.set_active_project.assert_called_once_with("demo")
+    container.provider_batch_workflow_service.submit_images.assert_called_once_with(
+        provider="openai",
+        endpoint="/v1/moderations",
+        litellm_model_id="openai/omni-moderation-latest",
+        prompt_profile="default",
+        image_ids=[1],
+        model_id=11,
+        description=None,
+        task_type="rating_preflight",
+    )
+    assert "Provider Batch job submitted" in result.stdout
 
 
 @pytest.mark.unit

--- a/tests/unit/gui/widgets/test_provider_batch_job_widget.py
+++ b/tests/unit/gui/widgets/test_provider_batch_job_widget.py
@@ -17,6 +17,7 @@ def _model(**overrides):
         "id": 7,
         "provider": "openai",
         "litellm_model_id": "openai/gpt-4.1-mini",
+        "model_types": (),
     }
     values.update(overrides)
     return SimpleNamespace(**values)
@@ -173,8 +174,80 @@ def test_submit_job_calls_workflow(widget, dependencies):
         image_ids=[1, 2],
         model_id=7,
         description="nightly",
+        task_type="annotation",
     )
     assert "Submitted Provider Batch job 42" in widget.labelStatus.text()
+
+
+@pytest.mark.unit
+@pytest.mark.gui
+def test_set_dependencies_filters_for_rating_preflight_task(widget):
+    workflow = MagicMock()
+    repository = MagicMock()
+    model_repository = MagicMock()
+    model_source = MagicMock()
+    model_source.list_batch_capable_models.return_value = (
+        "openai/gpt-4.1-mini",
+        "openai/omni-moderation-latest",
+        "anthropic/claude-3-5-sonnet",
+    )
+    model_repository.get_model_by_litellm_id.side_effect = lambda litellm_id: {
+        "openai/gpt-4.1-mini": _model(),
+        "openai/omni-moderation-latest": _model(
+            id=11,
+            provider="openai",
+            litellm_model_id="openai/omni-moderation-latest",
+            model_types=(SimpleNamespace(name="ratings"),),
+        ),
+        "anthropic/claude-3-5-sonnet": _model(
+            id=9,
+            provider="anthropic",
+            litellm_model_id="anthropic/claude-3-5-sonnet",
+        ),
+    }.get(litellm_id)
+    repository.list_provider_batch_jobs.return_value = []
+
+    widget.set_dependencies(workflow, repository, model_source, model_repository)
+    widget.comboBoxTaskType.setCurrentText("rating_preflight")
+
+    assert widget.comboBoxModel.count() == 1
+    assert widget.comboBoxModel.itemText(0) == "openai: openai/omni-moderation-latest"
+
+
+@pytest.mark.unit
+@pytest.mark.gui
+def test_submit_job_rating_preflight_uses_moderations_endpoint(widget):
+    workflow = MagicMock()
+    repository = MagicMock()
+    model_repository = MagicMock()
+    model_source = MagicMock()
+    workflow.submit_images.return_value = 42
+    model_source.list_batch_capable_models.return_value = ("openai/omni-moderation-latest",)
+    model_repository.get_model_by_litellm_id.return_value = _model(
+        id=11,
+        provider="openai",
+        litellm_model_id="openai/omni-moderation-latest",
+        model_types=(SimpleNamespace(name="ratings"),),
+    )
+    repository.list_provider_batch_jobs.return_value = []
+
+    widget.set_dependencies(workflow, repository, model_source, model_repository)
+    widget.comboBoxTaskType.setCurrentText("rating_preflight")
+    widget.lineEditImageIds.setText("1, 2")
+    widget.lineEditDescription.setText("nightly")
+
+    widget.submit_job()
+
+    workflow.submit_images.assert_called_once_with(
+        provider="openai",
+        endpoint="/v1/moderations",
+        litellm_model_id="openai/omni-moderation-latest",
+        prompt_profile="default",
+        image_ids=[1, 2],
+        model_id=11,
+        description="nightly",
+        task_type="rating_preflight",
+    )
 
 
 @pytest.mark.unit

--- a/tests/unit/test_model_sync_service.py
+++ b/tests/unit/test_model_sync_service.py
@@ -238,6 +238,14 @@ class TestModelSyncServiceWithRealDB:
         assert gpt4o_model["provider"] == "openai"
         assert gpt4o_model["class_name"] is None  # Phase 2: AnnotatorInfo に class_name なし
 
+        moderation_model = next(
+            (m for m in metadata_list if m["litellm_model_id"] == "omni-moderation-latest"), None
+        )
+        assert moderation_model is not None
+        assert moderation_model["model_type"] == "rating"
+        assert moderation_model["model_types"] == ["ratings"]
+        assert moderation_model["provider"] == "openai"
+
     def test_pydanticai_direct_model_provider_falls_back_to_unknown(
         self, test_model_repository, mock_config_service
     ):


### PR DESCRIPTION
## Summary
Provider batch wiring for LoRAIro issue #505 (ashigaru3 T3): added OpenAI rating preflight support in GUI + CLI submission paths and model sync compatibility.

- Added task-type-aware routing for provider-batch submit: `annotation` and `rating_preflight`.
- Added GUI task selector and filtered model candidates by provider/task capabilities.
- Wired OpenAI batch endpoint default for rating preflight to `/v1/moderations` and passes `task_type=rating_preflight` through submit.
- Added OpenAI ratings model sync fallback to append `omni-moderation-latest` (`model_type=rating`, `model_types=["ratings"]`) only when OpenAI model metadata exists.

## Spec notes
- OpenAI-side JSONL parser is **not** added in LoRAIro; parsing remains in iam-lib side adapter.
- `omni-moderation-latest` is complemented only when OpenAI provider metadata exists.

## QC / Validation
- Gitshied Gunshi再QC (subtask_507_gunshi_qc_t3_provider_batch_wiring_redo1) result: **pass**.
- Targeted 3 tests passed: `50 passed, 0 failed, 0 skipped, 0 blocked`.
- `git diff --check` is clean (no whitespace issues).

## References
- Refs: LoRAIro#505
