### PR TITLE
feat: add LoRAIro rating eligibility prefilter for WebAPI annotation

### DIFF
--- a/docs/lessons-learned.md
+++ b/docs/lessons-learned.md
@@ -28,6 +28,7 @@ LoRAIro 開発で得られた教訓。バグパターン・設計ミス・解決
 - **セッション管理の落とし穴**: バッチ処理中のセッションをWorker間で共有するとデッドロックが発生する。Worker毎に独立したセッションを使用する。
 - **バッチタグ追加のアトミック性**: タグ追加をループで個別コミットすると、エラー時に中間状態が残る。`Session.add_all()` + 一括コミットでアトミック性を保証する（ADR 0012参照）。
 - **書き込み・読み込みの対称性**: カラムと子テーブルに同一意味のデータを並存させる二重管理は禁止。書き込み API と読み込み API が同一テーブルを参照することを PR レビューで必ず確認する。Issue #118 (NSFW 判定) と Issue #119 (manual_rating フィルタ) は同パターンで発生した（ADR 0015参照）。
+- **`ratings.normalized_rating` は送信判定の唯一参照値**: `ratings.raw_rating_value` は保存元トレース用の補助情報で、`X` / `XXX` フィルタは `normalized_rating` のみで行う。`PG`/`PG-13`/`R`/`UNRATED`/`None` は rating eligibility 通過。
 - **User DB 初期化順序**: Base DBが存在しない環境でもUser DBは単独で動作する必要がある。`init_user_db()` は Base DB の有無に依存しない設計にする。
 - **プロジェクト概念のスキーマ正規化** (ADR 0017): ファイル名から推論する暗黙構造は破綻する。`lorairo_data/<name>_<timestamp>/` ディレクトリ構造だけでプロジェクトを識別していたため、Issue #166 で `repository.get_images_by_filter()` 引数なし全件取得 (21k 件) バグが発生。`projects` テーブル + `Image.project_id` FK 化で `WHERE project_id = ?` インデックス検索に置換し根本解決。DB を第一級エンティティとして設計することで、LIKE 句マッチや全件スキャンを構造的に排除できる。
 

--- a/src/lorairo/database/repository/image.py
+++ b/src/lorairo/database/repository/image.py
@@ -2077,6 +2077,47 @@ class ImageRepository(BaseRepository):
                 logger.error(f"バッチ画像 ID 解決エラー: {e}", exc_info=True)
                 return result
 
+    def get_latest_normalized_ratings_by_image_ids(self, image_ids: list[int]) -> dict[int, str | None]:
+        """画像 ID 一覧から最新 `normalized_rating` を 1 件ずつ取得する。
+
+        `ratings` は複数モデル経由で複数行持つ前提を許容し、`created_at` が
+        新しいものを採用する。`UNRATED` / `None` も値として保持し、
+        prefilter 側で「送信可」として扱う。
+
+        Args:
+            image_ids: 対象画像 ID 一覧。
+
+        Returns:
+            `{image_id: normalized_rating}` の辞書。rating 未登録の image_id は辞書に含まれない。
+        """
+        if not image_ids:
+            return {}
+
+        requested_ids = list({image_id for image_id in image_ids if image_id is not None})
+        if not requested_ids:
+            return {}
+
+        with self.session_factory() as session:
+            try:
+                stmt = (
+                    select(Rating.image_id, Rating.normalized_rating)
+                    .where(Rating.image_id.in_(requested_ids))
+                    .order_by(Rating.image_id.asc(), Rating.created_at.desc(), Rating.id.desc())
+                )
+                results = session.execute(stmt).all()
+                latest_ratings: dict[int, str | None] = {}
+                for image_id, normalized_rating in results:
+                    if image_id not in latest_ratings:
+                        latest_ratings[image_id] = normalized_rating.upper() if normalized_rating else None
+
+                logger.debug(
+                    f"最新 rating 取得: 対象 {len(requested_ids)}件 → 解決 {len(latest_ratings)}件"
+                )
+                return latest_ratings
+            except Exception as e:
+                logger.error(f"最新 normalized_rating 取得エラー: {e}", exc_info=True)
+                return {}
+
     def get_phashes_by_filepaths(self, filepaths: list[str]) -> dict[str, str | None]:
         """複数のファイルパスから pHash をバッチ解決する。
 

--- a/src/lorairo/gui/workers/annotation_worker.py
+++ b/src/lorairo/gui/workers/annotation_worker.py
@@ -559,6 +559,7 @@ class AnnotationWorker(LoRAIroWorkerBase["AnnotationExecutionResult"]):
         N+1 クエリを発行しないよう、Worker 内で実行する設計に変更。filter は
         WebAPI モデル選択時のみ適用し、registry lookup 失敗時は filter skip して
         annotation を続行する (graceful degradation)。
+        WebAPI モデル選択時は refusal + rating prefilter を順次適用する。
 
         副作用: `self.image_paths` を filter 結果で in-place 置換する。
         """
@@ -586,7 +587,8 @@ class AnnotationWorker(LoRAIroWorkerBase["AnnotationExecutionResult"]):
         )
         original_count = len(self.image_paths)
         try:
-            self.image_paths = save_service.filter_refused_image_paths(self.image_paths)
+            filtered_image_paths = save_service.filter_refused_image_paths(self.image_paths)
+            self.image_paths = save_service.filter_excluded_by_rating(filtered_image_paths)
         except Exception as exc:
             logger.warning(
                 f"refusal filter 実行失敗; filter skip して annotation 続行: {exc}",
@@ -597,8 +599,8 @@ class AnnotationWorker(LoRAIroWorkerBase["AnnotationExecutionResult"]):
         excluded = original_count - len(self.image_paths)
         if excluded > 0:
             logger.info(
-                f"refusal filter 適用: {original_count}件 → {len(self.image_paths)}件 "
-                f"(refusal 除外: {excluded}件)"
+                f"prefilter 適用: {original_count}件 → {len(self.image_paths)}件 "
+                f"(refusal + rating 除外: {excluded}件)"
             )
 
     def _save_results_to_database(

--- a/src/lorairo/services/annotation_save_service.py
+++ b/src/lorairo/services/annotation_save_service.py
@@ -611,6 +611,7 @@ class AnnotationSaveService:
         "SafetyRefusalError",
         "ContentPolicyRefusalError",
     )
+    _RATING_EXCLUSION_VALUES: frozenset[str] = frozenset({"X", "XXX"})
 
     def filter_refused_image_paths(self, image_paths: list[str]) -> list[str]:
         """過去に safety/content refusal を返した画像 path を除外する。
@@ -669,4 +670,57 @@ class AnnotationSaveService:
                 f"WebAPI annotation 送信前 filter: 対象 {len(filtered)}件 "
                 f"(refusal 除外: {excluded_count}件)"
             )
+        return filtered
+
+    def filter_excluded_by_rating(self, image_paths: list[str]) -> list[str]:
+        """`ratings.normalized_rating` が X / XXX の画像を除外する prefilter を行う。
+
+        本 method は rating 事前フィルタの SSoT として、`ratings.normalized_rating`
+        を唯一の判定源として扱う。
+        - X / XXX: 送信除外
+        - PG / PG-13 / R / UNRATED / None: 送信許可
+        - 未登録 path: filter 対象外として通過
+
+        Args:
+            image_paths: アノテーション対象候補の画像 path リスト。
+
+        Returns:
+            X / XXX 除外後の image_path リスト (順序維持)。
+        """
+        if not image_paths:
+            return []
+
+        path_to_image_id = self._image_repo.get_image_ids_by_filepaths(image_paths)
+        image_ids = [image_id for image_id in set(path_to_image_id.values()) if image_id is not None]
+        if not image_ids:
+            logger.debug("rating prefilter: 画像ID未解決のため除外なし")
+            return list(image_paths)
+
+        try:
+            latest_rating_map = self._image_repo.get_latest_normalized_ratings_by_image_ids(image_ids)
+        except Exception as e:
+            logger.warning(f"rating prefilter 取得失敗: {e}", exc_info=True)
+            return list(image_paths)
+
+        excluded_image_ids = {
+            image_id
+            for image_id, normalized in latest_rating_map.items()
+            if normalized in self._RATING_EXCLUSION_VALUES
+        }
+        if not excluded_image_ids:
+            logger.debug(f"rating prefilter: 除外対象なし (対象件数={len(image_paths)}件)")
+            return list(image_paths)
+
+        filtered = []
+        excluded_count = 0
+        for path in image_paths:
+            image_id = path_to_image_id.get(path)
+            if image_id is not None and image_id in excluded_image_ids:
+                excluded_count += 1
+                continue
+            filtered.append(path)
+
+        if excluded_count > 0:
+            logger.info(f"rating prefilter: 対象 {len(filtered)}件 (rating 除外: {excluded_count}件)")
+
         return filtered

--- a/tests/integration/test_rating_preflight_send_decision.py
+++ b/tests/integration/test_rating_preflight_send_decision.py
@@ -1,0 +1,124 @@
+"""rating preflight 送信判定（WebAPI/Annotation 事前判定）統合テスト。"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+
+from lorairo.database.repository.annotation_record import AnnotationRepository
+from lorairo.database.repository.image import ImageRepository
+from lorairo.database.schema import Model, Rating
+from lorairo.services.annotation_save_service import AnnotationSaveService
+
+
+@pytest.fixture
+def annotation_service(db_session_factory) -> AnnotationSaveService:
+    """AnnotationSaveService with 本物の ImageRepository を使った fixture。"""
+    annotation_repo = AnnotationRepository(db_session_factory)
+    image_repo = ImageRepository(db_session_factory)
+    return AnnotationSaveService(annotation_repo=annotation_repo, image_repo=image_repo)
+
+
+@pytest.fixture
+def sample_image(tmp_path: Path, db_session_factory) -> tuple[ImageRepository, int, str]:
+    """テスト用画像 1 件を登録して返す。"""
+    repository = ImageRepository(db_session_factory)
+    image_id = repository.add_original_image(
+        {
+            "uuid": str(uuid4()),
+            "phash": "rating-preflight-phash-001",
+            "original_image_path": str(tmp_path / "sample.png"),
+            "stored_image_path": str(tmp_path / "sample.png"),
+            "filename": "sample.png",
+            "width": 64,
+            "height": 64,
+            "format": "PNG",
+            "extension": ".png",
+            "has_alpha": False,
+        }
+    )
+    return repository, image_id, str(tmp_path / "sample.png")
+
+
+def _insert_model_and_ratings(
+    db_session_factory, image_id: int, model_name: str, rows: list[tuple[str, datetime]]
+) -> int:
+    """image_id に対して normalized_rating 履歴を時系列順で投入し、model_id を返す。"""
+    with db_session_factory() as session:
+        model = session.query(Model).filter_by(litellm_model_id=model_name).first()
+        if model is None:
+            model = Model(
+                name=model_name,
+                litellm_model_id=model_name,
+                provider="openai",
+            )
+            session.add(model)
+            session.flush()
+
+        for raw_rating, created_at in rows:
+            session.add(
+                Rating(
+                    image_id=image_id,
+                    model_id=model.id,
+                    raw_rating_value=raw_rating,
+                    normalized_rating=raw_rating,
+                    confidence_score=0.75,
+                    created_at=created_at,
+                    updated_at=created_at,
+                )
+            )
+        session.commit()
+        return model.id
+
+
+@pytest.mark.integration
+def test_filter_excluded_by_rating_uses_latest_rating_row(
+    annotation_service: AnnotationSaveService, sample_image: tuple[ImageRepository, int, str]
+) -> None:
+    """複数履歴がある場合は最新 created_at の rating を採用して判定する。"""
+    repository, image_id, image_path = sample_image
+    now = datetime(2026, 5, 27, 12, 0, 0, tzinfo=timezone.utc)
+    _insert_model_and_ratings(
+        repository.session_factory,
+        image_id,
+        "openai/gpt-4o-mini",
+        [
+            ("PG", now),
+            ("XXX", now + timedelta(minutes=5)),
+        ],
+    )
+
+    assert annotation_service.filter_excluded_by_rating([image_path]) == []
+
+
+@pytest.mark.integration
+def test_filter_excluded_by_rating_allows_safe_rating_values(
+    annotation_service: AnnotationSaveService, sample_image: tuple[ImageRepository, int, str]
+) -> None:
+    """PG / PG-13 / R / UNRATED / None は送信可である。"""
+    repository, image_id, image_path = sample_image
+    now = datetime(2026, 5, 27, 12, 0, 0, tzinfo=timezone.utc)
+    _insert_model_and_ratings(
+        repository.session_factory,
+        image_id,
+        "openai/gpt-4o-mini",
+        [
+            ("R", now),
+            ("UNRATED", now + timedelta(minutes=3)),
+        ],
+    )
+
+    assert annotation_service.filter_excluded_by_rating([image_path]) == [image_path]
+
+
+@pytest.mark.integration
+def test_filter_excluded_by_rating_unknown_path_passes_through(
+    annotation_service: AnnotationSaveService,
+) -> None:
+    """DB 未登録 path は prefilter で通過する。"""
+    assert annotation_service.filter_excluded_by_rating(["/not/registerd/sample.png"]) == [
+        "/not/registerd/sample.png"
+    ]

--- a/tests/unit/gui/workers/test_annotation_worker.py
+++ b/tests/unit/gui/workers/test_annotation_worker.py
@@ -771,6 +771,7 @@ class TestApplyRefusalPrefilter:
         # AnnotationSaveService.filter_refused_image_paths をパッチ
         mock_save_service = Mock()
         mock_save_service.filter_refused_image_paths = Mock(return_value=["/path/img1.jpg"])
+        mock_save_service.filter_excluded_by_rating = Mock(return_value=["/path/img1.jpg"])
         monkeypatch.setattr(aw_mod, "AnnotationSaveService", lambda **kwargs: mock_save_service)
 
         worker = self._make_worker(
@@ -786,7 +787,40 @@ class TestApplyRefusalPrefilter:
         mock_save_service.filter_refused_image_paths.assert_called_once_with(
             ["/path/img1.jpg", "/path/img2.jpg"]
         )
+        mock_save_service.filter_excluded_by_rating.assert_called_once_with(["/path/img1.jpg"])
         # image_paths が filter 結果で置換された
+        assert worker.image_paths == ["/path/img1.jpg"]
+
+    def test_filter_applied_for_webapi_then_rating_filter(self, mock_annotation_logic, monkeypatch):
+        """WebAPI 選択時は refusal / rating の両 filter が順次適用される。"""
+        from lorairo.gui.workers import annotation_worker as aw_mod
+
+        registry = self._registry_with_models([("openai/gpt-4o", True)])
+        mock_db = Mock()
+        mock_db.repository = Mock()
+
+        mock_save_service = Mock()
+        mock_save_service.filter_refused_image_paths = Mock(
+            return_value=["/path/img1.jpg", "/path/img2.jpg"]
+        )
+        mock_save_service.filter_excluded_by_rating = Mock(return_value=["/path/img1.jpg"])
+        monkeypatch.setattr(aw_mod, "AnnotationSaveService", lambda **kwargs: mock_save_service)
+
+        worker = self._make_worker(
+            mock_annotation_logic,
+            ["/path/img1.jpg", "/path/img2.jpg", "/path/img3.jpg"],
+            ["openai/gpt-4o"],
+            mock_db,
+            registry,
+        )
+        worker._apply_refusal_prefilter()
+
+        mock_save_service.filter_refused_image_paths.assert_called_once_with(
+            ["/path/img1.jpg", "/path/img2.jpg", "/path/img3.jpg"]
+        )
+        mock_save_service.filter_excluded_by_rating.assert_called_once_with(
+            ["/path/img1.jpg", "/path/img2.jpg"]
+        )
         assert worker.image_paths == ["/path/img1.jpg"]
 
     def test_filter_skipped_for_local_only_selection(self, mock_annotation_logic, monkeypatch):
@@ -799,6 +833,7 @@ class TestApplyRefusalPrefilter:
 
         mock_save_service = Mock()
         mock_save_service.filter_refused_image_paths = Mock()
+        mock_save_service.filter_excluded_by_rating = Mock()
         monkeypatch.setattr(aw_mod, "AnnotationSaveService", lambda **kwargs: mock_save_service)
 
         worker = self._make_worker(
@@ -812,6 +847,7 @@ class TestApplyRefusalPrefilter:
 
         # filter は呼ばれない (skipped)
         mock_save_service.filter_refused_image_paths.assert_not_called()
+        mock_save_service.filter_excluded_by_rating.assert_not_called()
         # image_paths は変更されない
         assert worker.image_paths == ["/path/img1.jpg", "/path/img2.jpg"]
 
@@ -877,6 +913,9 @@ class TestApplyRefusalPrefilter:
         # filter が image_paths をそのまま返す (refusal 0 件)
         mock_save_service = Mock()
         mock_save_service.filter_refused_image_paths = Mock(
+            return_value=["/path/img1.jpg", "/path/img2.jpg"]
+        )
+        mock_save_service.filter_excluded_by_rating = Mock(
             return_value=["/path/img1.jpg", "/path/img2.jpg"]
         )
         monkeypatch.setattr(aw_mod, "AnnotationSaveService", lambda **kwargs: mock_save_service)

--- a/tests/unit/services/test_annotation_save_service_rating_filter.py
+++ b/tests/unit/services/test_annotation_save_service_rating_filter.py
@@ -1,0 +1,95 @@
+"""`filter_excluded_by_rating` の Unit テスト。"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from lorairo.services.annotation_save_service import AnnotationSaveService
+
+
+@pytest.fixture
+def mock_repository() -> MagicMock:
+    """Repository mock (ImageRepository + 依存を stub）。"""
+    repo = MagicMock()
+    return repo
+
+
+@pytest.fixture
+def service(mock_repository: MagicMock) -> AnnotationSaveService:
+    """テスト対象サービス。"""
+    return AnnotationSaveService(
+        annotation_repo=mock_repository,
+        image_repo=mock_repository,
+        model_repo=mock_repository,
+        error_record_repo=mock_repository,
+    )
+
+
+@pytest.mark.unit
+def test_filter_excluded_by_rating_excludes_x_and_xxx(
+    service: AnnotationSaveService, mock_repository: MagicMock
+) -> None:
+    """X / XXX は除外される。"""
+    mock_repository.get_image_ids_by_filepaths.return_value = {
+        "/img/a.png": 1,
+        "/img/b.png": 2,
+        "/img/c.png": 3,
+        "/img/d.png": 4,
+    }
+    mock_repository.get_latest_normalized_ratings_by_image_ids.return_value = {
+        1: "PG",
+        2: "X",
+        3: "XXX",
+        4: None,
+    }
+
+    assert service.filter_excluded_by_rating(["/img/a.png", "/img/b.png", "/img/c.png", "/img/d.png"]) == [
+        "/img/a.png",
+        "/img/d.png",
+    ]
+    mock_repository.get_latest_normalized_ratings_by_image_ids.assert_called_once()
+
+
+@pytest.mark.unit
+def test_filter_excluded_by_rating_allows_safe_levels(
+    service: AnnotationSaveService, mock_repository: MagicMock
+) -> None:
+    """PG / PG-13 / R / UNRATED / None は通過する。"""
+    mock_repository.get_image_ids_by_filepaths.return_value = {
+        "/img/a.png": 10,
+        "/img/b.png": 11,
+        "/img/c.png": 12,
+        "/img/d.png": 13,
+        "/img/e.png": 14,
+    }
+    mock_repository.get_latest_normalized_ratings_by_image_ids.return_value = {
+        10: "PG",
+        11: "PG-13",
+        12: "R",
+        13: "UNRATED",
+        14: None,
+    }
+
+    assert service.filter_excluded_by_rating(
+        ["/img/a.png", "/img/b.png", "/img/c.png", "/img/d.png", "/img/e.png"]
+    ) == ["/img/a.png", "/img/b.png", "/img/c.png", "/img/d.png", "/img/e.png"]
+
+
+@pytest.mark.unit
+def test_filter_excluded_by_rating_keeps_unknown_paths(
+    service: AnnotationSaveService, mock_repository: MagicMock
+) -> None:
+    """DB 未登録 path はそのまま通過する。"""
+    mock_repository.get_image_ids_by_filepaths.return_value = {
+        "/img/missing.png": None,
+    }
+    mock_repository.get_latest_normalized_ratings_by_image_ids.return_value = {}
+
+    assert service.filter_excluded_by_rating(["/img/missing.png"]) == ["/img/missing.png"]
+    mock_repository.get_latest_normalized_ratings_by_image_ids.assert_not_called()
+
+
+@pytest.mark.unit
+def test_filter_excluded_by_rating_empty_input_returns_empty(service: AnnotationSaveService) -> None:
+    """空入力は空で返る。"""
+    assert service.filter_excluded_by_rating([]) == []


### PR DESCRIPTION
## 概要

LoRAIro #506 の rating eligibility filter を実装し、Refusal filter の後に `ratings.normalized_rating` ベースの除外を加え、WebAPI 送信前の判定を実施します。

## 変更内容

### 実装
- `src/lorairo/services/annotation_save_service.py`
  - `filter_excluded_by_rating()` を追加。
  - `ratings.normalized_rating` を唯一の判定源として採用。
  - 除外: `X`, `XXX`
  - 通過: `PG`, `PG-13`, `R`, `UNRATED`, `None`
- `src/lorairo/gui/workers/annotation_worker.py`
  - WebAPI 選択時に refusal filter 後 `filter_excluded_by_rating()` を順次適用。
- `src/lorairo/database/repository/image.py`
  - `get_latest_normalized_ratings_by_image_ids()` を追加（同 image_id の最新 rating を採用）。
- `tests/unit/services/test_annotation_save_service_rating_filter.py`
  - X / XXX 除外、safe rating 通過、unknown path 通過、空入力対応。
- `tests/unit/gui/workers/test_annotation_worker.py`
  - refusal->rating の順適用確認テストを追加。
- `tests/integration/test_rating_preflight_send_decision.py`
  - 最新 rating 採用（`UNRATED` 通過 / `XXX` 除外）確認。
- `docs/lessons-learned.md`
  - `ratings.raw_rating_value` はトレース補助、送信判定は `ratings.normalized_rating` のみを扱うことを明文化。

## 品質ゲート

- Targeted pytest: **35 passed / 0 skipped**
  - `UV_PROJECT_ENVIRONMENT=/workspaces/LoRAIro/.venv /workspaces/LoRAIro/.venv/bin/pytest -m "not gui_show and not calls_real_webapi and not downloads_and_runs_model and not slow" tests/unit/services/test_annotation_save_service.py tests/unit/services/test_annotation_save_service_rating_filter.py tests/unit/gui/workers/test_annotation_worker.py::TestApplyRefusalPrefilter tests/integration/test_rating_preflight_send_decision.py`

- Karo skip-free gate: **3432 passed / 0 skipped / 3 deselected**
  - `cd /tmp/worktrees/issue-507-t4 && UV_PROJECT_ENVIRONMENT=/workspaces/LoRAIro/.venv /workspaces/LoRAIro/.venv/bin/pytest -m "not gui_show and not calls_real_webapi and not downloads_and_runs_model and not slow" --timeout=60 -k "not test_tag_duplicate_handling_with_real_db and not test_dataset_registration_flow_with_duplicates" -rs`

## 判定結果

- `ratings.normalized_rating` は SSoT で、`X/XXX` を除外、`PG/PG-13/R/UNRATED` を送信対象として扱う。
- Refusal filter 後に rating filter が適用されるため、拒否判定済み画像は既存ロジックに影響を受けた後、最終的な除外を通る。

## 補足

- Karo 側で skip-free gate は再現済みであり、`3432 passed / 0 skipped / 3 deselected` を確認済み。
- 第4チーム側のローカル再実行では Typer/Click の互換性エラー (`TypeError: type 'Choice' is not subscriptable`) が発生したため、ローカル再実行の再現は未完了。
- ただし targeted pytest およびロジック要件は本 PR 内テストで検証済み。

## Issue

- closes #506
