### PR TITLE
chore: allow shared uv environment commands

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -50,7 +50,9 @@
       "Bash(timeout *)",
       "Bash(npx skills *)",
       "Bash(PYTHONPATH=\"\" VIRTUAL_ENV=\"\" .venv/bin/python *)",
-      "Bash(QT_QPA_PLATFORM=offscreen uv run pytest *)"
+      "Bash(UV_PROJECT_ENVIRONMENT=/workspaces/LoRAIro/.venv uv *)",
+      "Bash(QT_QPA_PLATFORM=offscreen uv run pytest *)",
+      "Bash(QT_QPA_PLATFORM=offscreen UV_PROJECT_ENVIRONMENT=/workspaces/LoRAIro/.venv uv run pytest *)"
     ],
     "additionalDirectories": [
       "/tmp/worktrees/"

--- a/tests/unit/test_hook_pre_commands.py
+++ b/tests/unit/test_hook_pre_commands.py
@@ -53,7 +53,7 @@ def test_blocks_uv_without_shared_environment_in_worktree() -> None:
 
 def test_allows_uv_with_shared_environment_in_worktree() -> None:
     result = _run_hook(
-        "UV_PROJECT_ENVIRONMENT=/workspaces/LoRAIro/.venv uv run pytest",
+        "UV_PROJECT_ENVIRONMENT=/workspaces/LoRAIro/.venv uv run pytest tests/unit/test_hook_pre_commands.py",
         cwd="/tmp/worktrees/issue-123",
     )
 


### PR DESCRIPTION
## Summary
- Allow Claude Bash permissions for shared-venv uv commands from worktrees
- Cover pytest commands that include the shared UV_PROJECT_ENVIRONMENT prefix

## Tests
- UV_PROJECT_ENVIRONMENT=/workspaces/LoRAIro/.venv uv run pytest tests/unit/test_hook_pre_commands.py