### PR TITLE
fix: allow Codex uv env from shell policy

### DIFF
--- a/.claude/hooks/hook_pre_commands.py
+++ b/.claude/hooks/hook_pre_commands.py
@@ -22,7 +22,9 @@ from typing import Any
 
 LOG_DIR = Path("/workspaces/LoRAIro/.claude/logs")
 WORKTREE_ROOT = Path("/tmp/worktrees")
-SHARED_UV_ENV = "UV_PROJECT_ENVIRONMENT=/workspaces/LoRAIro/.venv"
+SHARED_UV_ENV_NAME = "UV_PROJECT_ENVIRONMENT"
+SHARED_UV_ENV_VALUE = "/workspaces/LoRAIro/.venv"
+SHARED_UV_ENV = f"{SHARED_UV_ENV_NAME}={SHARED_UV_ENV_VALUE}"
 
 
 def log_debug(message: str) -> None:
@@ -117,7 +119,7 @@ def _has_uv_invocation(command: str) -> bool:
 def _has_shared_uv_environment(command: str) -> bool:
     """共有 venv の UV_PROJECT_ENVIRONMENT 指定を検出する。"""
     pattern = rf"(^|[\s;&|])(?:env\s+)?{re.escape(SHARED_UV_ENV)}(?:\s|$)"
-    return bool(re.search(pattern, command))
+    return bool(re.search(pattern, command)) or os.environ.get(SHARED_UV_ENV_NAME) == SHARED_UV_ENV_VALUE
 
 
 def _is_bare_uv_command(command: str) -> bool:

--- a/.claude/rules/git-workflow.md
+++ b/.claude/rules/git-workflow.md
@@ -45,8 +45,10 @@ make worktree-cleanup-merged
 ## venv（ワークツリー内）
 
 - 原則としてワークツリー内に `.venv` を作らない
-- `/tmp/worktrees/` 配下で `uv` を実行する場合は、共有実行環境を明示する:
-  `UV_PROJECT_ENVIRONMENT=/workspaces/LoRAIro/.venv uv ...`
+- `/tmp/worktrees/` 配下で `uv` を実行する場合は、共有実行環境 `/workspaces/LoRAIro/.venv` を使う。
+- Codex では `.codex/config.toml` の `[shell_environment_policy.set]` に
+  `UV_PROJECT_ENVIRONMENT = "/workspaces/LoRAIro/.venv"` を設定し、`uv run ruff ...` のように env prefix なしで実行する。
+- その環境設定がない shell では `UV_PROJECT_ENVIRONMENT=/workspaces/LoRAIro/.venv uv ...` を明示する。
 - `uv` 単体の help/inspection は venv を作らないため例外として許可する
 - ワークツリー固有の `.venv` が必要な特殊事情がある場合は、理由を明示してから実行する
 - 並列で `uv run` を実行する場合の詳細ルールは [parallel-execution.md](parallel-execution.md) を参照

--- a/.codex/hooks/hook_pre_commands.py
+++ b/.codex/hooks/hook_pre_commands.py
@@ -21,7 +21,9 @@ from typing import Any
 
 LOG_DIR = Path("/workspaces/LoRAIro/.claude/logs")
 WORKTREE_ROOT = Path("/tmp/worktrees")
-SHARED_UV_ENV = "UV_PROJECT_ENVIRONMENT=/workspaces/LoRAIro/.venv"
+SHARED_UV_ENV_NAME = "UV_PROJECT_ENVIRONMENT"
+SHARED_UV_ENV_VALUE = "/workspaces/LoRAIro/.venv"
+SHARED_UV_ENV = f"{SHARED_UV_ENV_NAME}={SHARED_UV_ENV_VALUE}"
 
 
 def log_debug(message: str) -> None:
@@ -116,7 +118,7 @@ def _has_uv_invocation(command: str) -> bool:
 def _has_shared_uv_environment(command: str) -> bool:
     """共有 venv の UV_PROJECT_ENVIRONMENT 指定を検出する。"""
     pattern = rf"(^|[\s;&|])(?:env\s+)?{re.escape(SHARED_UV_ENV)}(?:\s|$)"
-    return bool(re.search(pattern, command))
+    return bool(re.search(pattern, command)) or os.environ.get(SHARED_UV_ENV_NAME) == SHARED_UV_ENV_VALUE
 
 
 def _is_bare_uv_command(command: str) -> bool:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,8 +45,10 @@
 - For issue resolution or feature implementation, completion means: implement, validate, commit, push, open a ready-for-review PR, run PR maintenance automation through CI/review, and merge when safe, unless the user explicitly asks to stop before publishing or keep the PR as draft.
 - Do not end issue or multi-file feature work after local implementation only. Report the PR URL and final monitored state as the outcome.
 - If PR creation is blocked by auth, network, failing validation, or unclear scope, report the blocker explicitly instead of silently stopping at local changes.
-- When running `uv` from a `/tmp/worktrees/` checkout, use the shared execution environment explicitly:
-  `UV_PROJECT_ENVIRONMENT=/workspaces/LoRAIro/.venv uv ...`. Do not create a worktree-local `.venv` unless there is a specific technical reason. If the shared environment cannot be used, only a bare `uv` help/inspection command is allowed without `UV_PROJECT_ENVIRONMENT`.
+- When running `uv` from a `/tmp/worktrees/` checkout, use the shared execution environment `/workspaces/LoRAIro/.venv`.
+  Codex sessions should set this once in `.codex/config.toml` under `[shell_environment_policy.set]` as
+  `UV_PROJECT_ENVIRONMENT = "/workspaces/LoRAIro/.venv"` and then run normal commands like `uv run ruff ...`.
+  In shells where that environment is not configured, use `UV_PROJECT_ENVIRONMENT=/workspaces/LoRAIro/.venv uv ...` explicitly. Do not create a worktree-local `.venv` unless there is a specific technical reason. If the shared environment cannot be used, only a bare `uv` help/inspection command is allowed without `UV_PROJECT_ENVIRONMENT`.
 - Agent-created PRs should normally be created ready for review, not draft. When a draft PR exists because the user explicitly asked to keep it draft, mark it ready for review as soon as the user allows review, then immediately start or resume PR maintenance automation: poll CI, watch bot review artifacts/comments, repair actionable findings in the PR worktree, reply in Japanese, merge when safe, and report the final monitored state.
 - After creating an agent PR, explicitly verify `gh pr view "$PR" --json isDraft -q .isDraft`. If it is
   `true`, run `gh pr ready "$PR"` and re-check. Do not set up `gh pr merge --auto` while the PR is still draft.

--- a/tests/unit/test_hook_pre_commands.py
+++ b/tests/unit/test_hook_pre_commands.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -11,10 +12,20 @@ PROJECT_ROOT = Path(__file__).resolve().parents[2]
 HOOK = PROJECT_ROOT / ".claude" / "hooks" / "hook_pre_commands.py"
 
 
-def _run_hook(command: str, *, cwd: str | None = None) -> subprocess.CompletedProcess[str]:
+def _run_hook(
+    command: str,
+    *,
+    cwd: str | None = None,
+    env: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess[str]:
     tool_input = {"command": command}
     if cwd is not None:
         tool_input["cwd"] = cwd
+
+    subprocess_env = os.environ.copy()
+    subprocess_env.pop("UV_PROJECT_ENVIRONMENT", None)
+    if env is not None:
+        subprocess_env.update(env)
 
     return subprocess.run(
         [sys.executable, str(HOOK)],
@@ -22,6 +33,7 @@ def _run_hook(command: str, *, cwd: str | None = None) -> subprocess.CompletedPr
         text=True,
         capture_output=True,
         check=False,
+        env=subprocess_env,
     )
 
 
@@ -55,6 +67,17 @@ def test_allows_uv_with_shared_environment_in_worktree() -> None:
     result = _run_hook(
         "UV_PROJECT_ENVIRONMENT=/workspaces/LoRAIro/.venv uv run pytest tests/unit/test_hook_pre_commands.py",
         cwd="/tmp/worktrees/issue-123",
+    )
+
+    assert result.returncode == 0
+    assert result.stdout == ""
+
+
+def test_allows_uv_with_shared_environment_from_process_env_in_worktree() -> None:
+    result = _run_hook(
+        "uv run pytest tests/unit/test_hook_pre_commands.py",
+        cwd="/tmp/worktrees/issue-123",
+        env={"UV_PROJECT_ENVIRONMENT": "/workspaces/LoRAIro/.venv"},
     )
 
     assert result.returncode == 0


### PR DESCRIPTION
## Summary
- Allow the worktree uv guard to accept UV_PROJECT_ENVIRONMENT from the process environment, not only inline command prefixes
- Document Codex shell policy usage so commands can be run as `uv run ruff ...` without `UV_PROJECT_ENVIRONMENT=...` in the command string
- Add focused hook coverage for environment-provided shared uv configuration

## Verification
- `UV_PROJECT_ENVIRONMENT=/workspaces/LoRAIro/.venv uv run pytest tests/unit/test_hook_pre_commands.py -q`
- `UV_PROJECT_ENVIRONMENT=/workspaces/LoRAIro/.venv uv run ruff check .codex/hooks/hook_pre_commands.py .claude/hooks/hook_pre_commands.py tests/unit/test_hook_pre_commands.py`
- `git diff --check`