### PR TITLE
fix: avoid project directory creation during db import

### DIFF
--- a/src/lorairo/database/db_core.py
+++ b/src/lorairo/database/db_core.py
@@ -119,13 +119,21 @@ def _resolve_auto_project_dir(create: bool) -> Path:
     return _next_project_dir_path(base_dir_name, project_name).resolve()
 
 
+_default_db_dir_materialized: bool = False
+
+
 def ensure_default_db_dir() -> Path:
     """Ensure and return the default DB directory for explicit default DB use."""
+    global _default_db_dir_materialized
     configured_dir = _resolve_configured_db_dir()
     if configured_dir is not None:
         configured_dir.mkdir(parents=True, exist_ok=True)
         return configured_dir
-    return _resolve_auto_project_dir(create=True)
+    if _default_db_dir_materialized:
+        return DB_DIR
+    materialized_dir = _resolve_auto_project_dir(create=True)
+    _default_db_dir_materialized = True
+    return materialized_dir
 
 
 DB_DIR = _resolve_configured_db_dir() or _resolve_auto_project_dir(create=False)

--- a/src/lorairo/database/db_core.py
+++ b/src/lorairo/database/db_core.py
@@ -80,13 +80,57 @@ def sanitize_project_name(name: str) -> str:
 
 
 # Get database directory from config, or create new project directory
-database_dir = dir_config.get("database_dir")
-if database_dir:
-    DB_DIR = Path(database_dir)
-else:
+def _next_project_dir_path(base_dir_name: str, project_name: str) -> Path:
+    """Return the next auto project directory path without creating it."""
+    from datetime import datetime
+
+    base_dir = Path(base_dir_name)
+    today = datetime.now().strftime("%Y%m%d")
+    safe_name = sanitize_project_name(project_name)
+    pattern = f"{safe_name}_{today}_"
+
+    existing: list[str] = []
+    if base_dir.exists():
+        existing = [d.name for d in base_dir.iterdir() if d.is_dir() and d.name.startswith(pattern)]
+
+    numbers = []
+    for name in existing:
+        parts = name.split("_")
+        if len(parts) >= 3 and parts[-1].isdigit():
+            numbers.append(int(parts[-1]))
+    next_num = max(numbers, default=0) + 1
+    return base_dir / f"{safe_name}_{today}_{next_num:03d}"
+
+
+def _resolve_configured_db_dir() -> Path | None:
+    """Return configured database_dir, or None when auto project creation is configured."""
+    database_dir = dir_config.get("database_dir")
+    if database_dir:
+        return Path(database_dir).resolve()
+    return None
+
+
+def _resolve_auto_project_dir(create: bool) -> Path:
+    """Resolve the default auto project directory, creating it only when requested."""
     base_dir_name = dir_config.get("database_base_dir", "lorairo_data")
     project_name = dir_config.get("database_project_name", "main_dataset")
-    DB_DIR = get_project_dir(base_dir_name, project_name)
+    if create:
+        return get_project_dir(base_dir_name, project_name).resolve()
+    return _next_project_dir_path(base_dir_name, project_name).resolve()
+
+
+def ensure_default_db_dir() -> Path:
+    """Ensure and return the default DB directory for explicit default DB use."""
+    configured_dir = _resolve_configured_db_dir()
+    if configured_dir is not None:
+        configured_dir.mkdir(parents=True, exist_ok=True)
+        return configured_dir
+    if DB_DIR.exists():
+        return DB_DIR
+    return _resolve_auto_project_dir(create=True)
+
+
+DB_DIR = _resolve_configured_db_dir() or _resolve_auto_project_dir(create=False)
 IMG_DB_FILENAME = db_config.get(
     "image_db_filename", "image_database.db"
 )  # Keep default if not in db_config
@@ -95,9 +139,6 @@ IMG_DB_FILENAME = db_config.get(
 
 # 相対パスを絶対パスに解決（stored_image_path のパス二重結合を防止）
 DB_DIR = DB_DIR.resolve()
-
-# Ensure DB_DIR exists
-DB_DIR.mkdir(parents=True, exist_ok=True)
 
 IMG_DB_FILENAME_VAR: str = IMG_DB_FILENAME  # 一時保存（後で使用）
 
@@ -215,9 +256,12 @@ def ensure_tag_db_initialized() -> None:
     """タグDBを遅延初期化する。初回呼び出し時のみ HF Hub に接続する。"""
     import os
 
-    global _tag_db_initialized, USER_TAG_DB_PATH
+    global _tag_db_initialized, DB_DIR, IMG_DB_PATH, DATABASE_URL, USER_TAG_DB_PATH
     if _tag_db_initialized:
         return
+    DB_DIR = ensure_default_db_dir()
+    IMG_DB_PATH = DB_DIR / IMG_DB_FILENAME
+    DATABASE_URL = f"sqlite:///{IMG_DB_PATH.resolve()}?check_same_thread=False"
     token = os.environ.get("HF_TOKEN") or os.environ.get("HUGGINGFACE_TOKEN")
     try:
         from genai_tag_db_tools import initialize_databases
@@ -244,8 +288,10 @@ def get_user_tag_db_path() -> Path | None:
 DATABASE_URL = f"sqlite:///{IMG_DB_PATH.resolve()}?check_same_thread=False"
 
 
-def create_db_engine(database_url: str = DATABASE_URL) -> Engine:
+def create_db_engine(database_url: str | None = None) -> Engine:
     """指定された URL で SQLAlchemy エンジンを作成し、イベントリスナーを設定します。"""
+    if database_url is None:
+        database_url = DATABASE_URL
     logger.info(f"Creating SQLAlchemy engine for: {database_url}")
     engine = create_engine(
         database_url,
@@ -400,15 +446,19 @@ def create_project_session_factory(project_db_path: Path) -> sessionmaker[Sessio
 
 # --- デフォルトの Engine と Session Factory --- #
 # 通常のアプリケーション実行時に使用される
-default_engine = create_db_engine(DATABASE_URL)
+default_engine: Engine | None = None
 _default_session_factory: sessionmaker[Session] | None = None
 logger.info(f"Default database core initialized. Image DB: {IMG_DB_PATH} (Tag DB managed via public API)")
 
 
 def _get_default_session_factory() -> sessionmaker[Session]:
     """Prepare the default project DB lazily and return its session factory."""
-    global default_engine, _default_session_factory
+    global DB_DIR, IMG_DB_PATH, DATABASE_URL, default_engine, _default_session_factory
     if _default_session_factory is None:
+        if IMG_DB_PATH == DB_DIR / IMG_DB_FILENAME:
+            DB_DIR = ensure_default_db_dir()
+            IMG_DB_PATH = DB_DIR / IMG_DB_FILENAME
+        DATABASE_URL = f"sqlite:///{IMG_DB_PATH.resolve()}?check_same_thread=False"
         default_engine = _prepare_project_database(IMG_DB_PATH)
         _default_session_factory = create_session_factory(default_engine)
     return _default_session_factory

--- a/src/lorairo/database/db_core.py
+++ b/src/lorairo/database/db_core.py
@@ -125,8 +125,6 @@ def ensure_default_db_dir() -> Path:
     if configured_dir is not None:
         configured_dir.mkdir(parents=True, exist_ok=True)
         return configured_dir
-    if DB_DIR.exists():
-        return DB_DIR
     return _resolve_auto_project_dir(create=True)
 
 

--- a/tests/unit/database/test_db_core_lazy_init.py
+++ b/tests/unit/database/test_db_core_lazy_init.py
@@ -168,6 +168,7 @@ class TestDefaultDbDirectoryLazyInit:
             f"sqlite:///{(preview_dir / db_core.IMG_DB_FILENAME).resolve()}?check_same_thread=False",
         )
         monkeypatch.setattr(db_core, "_default_session_factory", None)
+        monkeypatch.setattr(db_core, "_default_db_dir_materialized", False)
         monkeypatch.setattr(db_core, "_prepare_project_database", lambda db_path: object())
         monkeypatch.setattr(db_core, "create_session_factory", lambda engine: lambda: session)
 
@@ -203,6 +204,7 @@ class TestDefaultDbDirectoryLazyInit:
         monkeypatch.setattr(db_core, "DB_DIR", preview_dir)
         monkeypatch.setattr(db_core, "IMG_DB_PATH", preview_dir / db_core.IMG_DB_FILENAME)
         monkeypatch.setattr(db_core, "_default_session_factory", None)
+        monkeypatch.setattr(db_core, "_default_db_dir_materialized", False)
         monkeypatch.setattr(db_core, "_prepare_project_database", lambda db_path: object())
         monkeypatch.setattr(db_core, "create_session_factory", lambda engine: lambda: session)
 
@@ -212,3 +214,35 @@ class TestDefaultDbDirectoryLazyInit:
         assert db_core.DB_DIR.parent == data_root
         assert db_core.DB_DIR.name > preview_dir.name
         assert db_core.IMG_DB_PATH == db_core.DB_DIR / db_core.IMG_DB_FILENAME
+
+    def test_default_session_local_reuses_materialized_auto_project_dir(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ):
+        """タグ DB 初期化などで作成済みの自動プロジェクトは default session でも再利用する。"""
+        import lorairo.database.db_core as db_core
+
+        session = object()
+        data_root = tmp_path / "lorairo_data"
+        monkeypatch.setattr(
+            db_core,
+            "dir_config",
+            {
+                "database_dir": "",
+                "database_base_dir": str(data_root),
+                "database_project_name": "main_dataset",
+            },
+        )
+        monkeypatch.setattr(db_core, "_default_db_dir_materialized", False)
+
+        materialized_dir = db_core.ensure_default_db_dir()
+        monkeypatch.setattr(db_core, "DB_DIR", materialized_dir)
+        monkeypatch.setattr(db_core, "IMG_DB_PATH", materialized_dir / db_core.IMG_DB_FILENAME)
+        monkeypatch.setattr(db_core, "_default_session_factory", None)
+        monkeypatch.setattr(db_core, "_prepare_project_database", lambda db_path: object())
+        monkeypatch.setattr(db_core, "create_session_factory", lambda engine: lambda: session)
+
+        assert db_core.DefaultSessionLocal() is session
+
+        assert db_core.DB_DIR == materialized_dir
+        assert db_core.IMG_DB_PATH == materialized_dir / db_core.IMG_DB_FILENAME
+        assert len(list(data_root.glob("main_dataset_*"))) == 1

--- a/tests/unit/database/test_db_core_lazy_init.py
+++ b/tests/unit/database/test_db_core_lazy_init.py
@@ -180,3 +180,35 @@ class TestDefaultDbDirectoryLazyInit:
         assert db_core.DB_DIR.parent == data_root
         assert db_core.DB_DIR.name.startswith("main_dataset_")
         assert db_core.IMG_DB_PATH == db_core.DB_DIR / db_core.IMG_DB_FILENAME
+
+    def test_default_session_local_recomputes_auto_project_dir_when_preview_exists(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ):
+        """import 時の候補が先に作られていても、明示利用時に次の連番を採番する。"""
+        import lorairo.database.db_core as db_core
+
+        session = object()
+        data_root = tmp_path / "lorairo_data"
+        monkeypatch.setattr(
+            db_core,
+            "dir_config",
+            {
+                "database_dir": "",
+                "database_base_dir": str(data_root),
+                "database_project_name": "main_dataset",
+            },
+        )
+        preview_dir = db_core._resolve_auto_project_dir(create=False)
+        preview_dir.mkdir(parents=True)
+        monkeypatch.setattr(db_core, "DB_DIR", preview_dir)
+        monkeypatch.setattr(db_core, "IMG_DB_PATH", preview_dir / db_core.IMG_DB_FILENAME)
+        monkeypatch.setattr(db_core, "_default_session_factory", None)
+        monkeypatch.setattr(db_core, "_prepare_project_database", lambda db_path: object())
+        monkeypatch.setattr(db_core, "create_session_factory", lambda engine: lambda: session)
+
+        assert db_core.DefaultSessionLocal() is session
+
+        assert db_core.DB_DIR != preview_dir
+        assert db_core.DB_DIR.parent == data_root
+        assert db_core.DB_DIR.name > preview_dir.name
+        assert db_core.IMG_DB_PATH == db_core.DB_DIR / db_core.IMG_DB_FILENAME

--- a/tests/unit/database/test_db_core_lazy_init.py
+++ b/tests/unit/database/test_db_core_lazy_init.py
@@ -1,7 +1,11 @@
 """db_core の遅延初期化（ensure_tag_db_initialized）のユニットテスト。"""
 
+import os
+import shutil
+import subprocess
+import sys
 from pathlib import Path
-from unittest.mock import MagicMock, call, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -104,3 +108,75 @@ class TestEnsureTagDbInitialized:
             path = db_core.get_user_tag_db_path()
             assert isinstance(path, Path)
             assert path.name == "user_tags.sqlite"
+
+
+class TestDefaultDbDirectoryLazyInit:
+    """デフォルト DB ディレクトリの遅延作成を検証する。"""
+
+    def test_import_does_not_create_repo_root_project_dir(self):
+        """db_core import だけでは repo 直下 lorairo_data に自動プロジェクトを作らない。"""
+        repo_root = Path(__file__).resolve().parents[3]
+        data_root = repo_root / "lorairo_data"
+        before = set(data_root.glob("main_dataset_*")) if data_root.exists() else set()
+        env = os.environ.copy()
+        env.pop("PYTEST_CURRENT_TEST", None)
+        env["PYTHONPATH"] = str(repo_root / "src") + os.pathsep + env.get("PYTHONPATH", "")
+        script = (
+            "import lorairo.database.db_core as db_core; print(db_core.DB_DIR); print(db_core.IMG_DB_PATH)"
+        )
+
+        try:
+            subprocess.run(
+                [sys.executable, "-c", script],
+                cwd=repo_root,
+                env=env,
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+            after = set(data_root.glob("main_dataset_*")) if data_root.exists() else set()
+            assert after == before
+        finally:
+            after_cleanup = set(data_root.glob("main_dataset_*")) if data_root.exists() else set()
+            for created_path in after_cleanup - before:
+                if created_path.is_dir() and not any(created_path.iterdir()):
+                    shutil.rmtree(created_path)
+
+    def test_default_session_local_creates_auto_project_dir_for_empty_database_dir(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ):
+        """database_dir が空なら DefaultSessionLocal() の明示利用時にだけ自動作成する。"""
+        import lorairo.database.db_core as db_core
+
+        session = object()
+        data_root = tmp_path / "lorairo_data"
+        monkeypatch.setattr(
+            db_core,
+            "dir_config",
+            {
+                "database_dir": "",
+                "database_base_dir": str(data_root),
+                "database_project_name": "main_dataset",
+            },
+        )
+        preview_dir = db_core._resolve_auto_project_dir(create=False)
+        monkeypatch.setattr(db_core, "DB_DIR", preview_dir)
+        monkeypatch.setattr(db_core, "IMG_DB_PATH", preview_dir / db_core.IMG_DB_FILENAME)
+        monkeypatch.setattr(
+            db_core,
+            "DATABASE_URL",
+            f"sqlite:///{(preview_dir / db_core.IMG_DB_FILENAME).resolve()}?check_same_thread=False",
+        )
+        monkeypatch.setattr(db_core, "_default_session_factory", None)
+        monkeypatch.setattr(db_core, "_prepare_project_database", lambda db_path: object())
+        monkeypatch.setattr(db_core, "create_session_factory", lambda engine: lambda: session)
+
+        assert not data_root.exists()
+
+        assert db_core.DefaultSessionLocal() is session
+
+        assert data_root.exists()
+        assert db_core.DB_DIR.exists()
+        assert db_core.DB_DIR.parent == data_root
+        assert db_core.DB_DIR.name.startswith("main_dataset_")
+        assert db_core.IMG_DB_PATH == db_core.DB_DIR / db_core.IMG_DB_FILENAME


### PR DESCRIPTION
## Summary
- avoid creating auto project directories when importing db_core
- create/ensure the default DB directory only when the default DB is explicitly used
- add regression coverage for import-only behavior and explicit default DB creation

Fixes #472

## Tests
- UV_PROJECT_ENVIRONMENT=/workspaces/LoRAIro/.venv uv run pytest tests/unit/database/test_db_core_lazy_init.py tests/unit/database/test_resolve_stored_path.py tests/integration/test_project_directory_integration.py tests/unit/test_configuration_service.py -q
- UV_PROJECT_ENVIRONMENT=/workspaces/LoRAIro/.venv uv run ruff check src/lorairo/database/db_core.py tests/unit/database/test_db_core_lazy_init.py
- git diff --check