### PR TITLE
feat: improve rating preflight CLI discoverability

### DIFF
--- a/docs/cli-rating-preflight.md
+++ b/docs/cli-rating-preflight.md
@@ -1,0 +1,69 @@
+# CLI Rating Preflight Workflow
+
+This page shows how to assign image ratings from the CLI with OpenAI Moderation.
+Use the synchronous path for small image sets and the Provider Batch path for large sets.
+
+## Prerequisites
+
+- Configure an OpenAI API key in the CLI config.
+- Register images in a project.
+- Refresh models into the project database before submitting batch jobs.
+
+```bash
+lorairo-cli project create main_dataset
+lorairo-cli images register /path/to/images --project main_dataset
+lorairo-cli models refresh --project main_dataset
+lorairo-cli models list --category rating
+```
+
+Confirm that `openai/omni-moderation-latest` or another `openai/omni-moderation-*` rating model is listed.
+
+## Synchronous Path
+
+Use this when you want immediate results or only need to process a small set.
+
+```bash
+lorairo-cli annotate run \
+  --project main_dataset \
+  --model openai/omni-moderation-latest
+```
+
+The normal annotation save path stores moderation ratings in the `ratings` table.
+
+## Provider Batch Path
+
+Use this for larger sets where asynchronous processing is preferable.
+
+First list images that do not have ratings yet:
+
+```bash
+lorairo-cli images list --project main_dataset --unrated --limit 50
+```
+
+Submit selected image IDs to OpenAI Moderations:
+
+```bash
+lorairo-cli batch submit \
+  --project main_dataset \
+  --task-type rating_preflight \
+  --model openai/omni-moderation-latest \
+  --image-id 2 \
+  --image-id 7 \
+  --image-id 11
+```
+
+Check status, fetch normalized results if needed, then import:
+
+```bash
+lorairo-cli batch status 1 --project main_dataset
+lorairo-cli batch fetch 1 --project main_dataset
+lorairo-cli batch import 1 --project main_dataset
+```
+
+`rating_preflight` requires direct OpenAI, endpoint `/v1/moderations`, an
+`openai/omni-moderation-*` model, and a model registered with `ratings` model type.
+
+## Known Limitation
+
+Batch submit image path resolution is tracked separately in issue #528. If that bug is present in
+your build, the batch path may fail even when the workflow above is correct.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -14,6 +14,9 @@ lorairo-cli --version
 
 ## 基本的な使い方
 
+OpenAI Moderation で未評価画像に rating を付与する CLI 手順は
+[CLI Rating Preflight Workflow](cli-rating-preflight.md) を参照してください。
+
 ### ヘルプ表示
 
 ```bash

--- a/src/lorairo/cli/commands/annotate.py
+++ b/src/lorairo/cli/commands/annotate.py
@@ -308,6 +308,7 @@ def run(
 
     Examples:
         lorairo-cli annotate run --project myproject --model openai/gpt-4o
+        lorairo-cli annotate run --project myproject --model openai/omni-moderation-latest
         lorairo-cli annotate run --project myproject \\
             --model openrouter/openai/gpt-4o --model openrouter/anthropic/claude-3-5-sonnet
     """

--- a/src/lorairo/cli/commands/batch.py
+++ b/src/lorairo/cli/commands/batch.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
+from datetime import datetime
 from pathlib import Path
 from typing import Any
 
@@ -119,7 +121,26 @@ def _job_value(job: Any, name: str, default: Any = None) -> Any:
 
 
 def _format_dt(value: Any) -> str:
+    if isinstance(value, datetime):
+        return value.isoformat()
     return "" if value is None else str(value)
+
+
+def _result_item_status(item: Any) -> str:
+    if isinstance(item, Mapping):
+        return str(item.get("status", ""))
+    return str(getattr(item, "status", ""))
+
+
+def _summarize_fetch_counts(result: Any) -> tuple[int, int]:
+    items = list(getattr(result, "items", ()) or ())
+    succeeded_count = getattr(result, "succeeded_count", None)
+    failed_count = getattr(result, "failed_count", None)
+    if succeeded_count is None:
+        succeeded_count = sum(1 for item in items if _result_item_status(item).lower() == "succeeded")
+    if failed_count is None:
+        failed_count = sum(1 for item in items if _result_item_status(item).lower() == "failed")
+    return int(succeeded_count or 0), int(failed_count or 0)
 
 
 def _print_jobs_table(jobs: list[Any]) -> None:
@@ -201,7 +222,12 @@ def submit(
     prompt_profile: str = typer.Option("default", "--prompt-profile", help="Prompt profile name"),
     description: str | None = typer.Option(None, "--description", help="Provider job description"),
     task_type: str = typer.Option(
-        "annotation", "--task-type", help="Task type: annotation or rating_preflight"
+        "annotation",
+        "--task-type",
+        help=(
+            "Task type: annotation or rating_preflight. rating_preflight requires direct openai, "
+            "endpoint /v1/moderations, an openai/omni-moderation-* model, and ratings model_type."
+        ),
     ),
 ) -> None:
     """Submit registered images to a Provider Batch API job."""
@@ -218,10 +244,16 @@ def submit(
             raise typer.Exit(code=1)
         if normalized_task_type == "rating_preflight":
             if resolved_provider != "openai":
-                console.print("[red]Error:[/red] rating_preflight submit is only supported for openai.")
+                console.print(
+                    "[red]Error:[/red] rating_preflight submit is only supported for direct openai "
+                    "models such as openai/omni-moderation-latest."
+                )
                 raise typer.Exit(code=1)
             if not _model_has_model_type(db_model, "ratings"):
-                console.print("[red]Error:[/red] rating_preflight submit requires a ratings model.")
+                console.print(
+                    "[red]Error:[/red] rating_preflight submit requires a ratings model_type "
+                    "using openai/omni-moderation-*."
+                )
                 raise typer.Exit(code=1)
 
         resolved_endpoint = _resolve_submit_endpoint(resolved_provider, normalized_task_type, endpoint)
@@ -334,10 +366,11 @@ def fetch(
     try:
         container = _activate_project(project)
         result = container.provider_batch_workflow_service.fetch_results(job_id, output_dir)
+        succeeded_count, failed_count = _summarize_fetch_counts(result)
         console.print(f"[green]Provider Batch results fetched:[/green] {job_id}")
         console.print(
             f"[dim]provider_status={result.provider_status}, items={len(result.items)}, "
-            f"succeeded={result.succeeded_count or 0}, failed={result.failed_count or 0}[/dim]"
+            f"succeeded={succeeded_count}, failed={failed_count}[/dim]"
         )
         _print_artifacts(result)
     except ProviderBatchError as e:

--- a/src/lorairo/cli/commands/images.py
+++ b/src/lorairo/cli/commands/images.py
@@ -184,6 +184,11 @@ def list_images(
         min=1,
         help="Maximum number of images to display (>= 1)",
     ),
+    unrated: bool = typer.Option(
+        False,
+        "--unrated",
+        help="Show only images without any saved rating rows.",
+    ),
 ) -> None:
     """List images in a project.
 
@@ -200,16 +205,18 @@ def list_images(
         container.set_active_project(project)
 
         repository = container.db_manager.image_repo
-        criteria = ImageFilterCriteria(include_nsfw=True)
+        criteria = ImageFilterCriteria(include_nsfw=True, only_unrated=unrated)
         image_records, total_count = repository.get_images_by_filter(criteria)
 
         if not image_records:
-            console.print(f"No images found in project: {project}")
+            suffix = " without ratings" if unrated else ""
+            console.print(f"No images{suffix} found in project: {project}")
             return
 
         display_records = image_records[:limit] if limit else image_records
 
-        console.print(f"Images in project: {project}")
+        heading_suffix = " (unrated only)" if unrated else ""
+        console.print(f"Images in project: {project}{heading_suffix}")
         table = Table()
         table.add_column("ID", style="cyan")
         table.add_column("Filename")

--- a/src/lorairo/cli/commands/models.py
+++ b/src/lorairo/cli/commands/models.py
@@ -187,6 +187,8 @@ def list_models(
             include_deprecated=include_deprecated,
         )
         console.print(table)
+        if category is ModelCategoryFilter.all:
+            _print_rating_models_section(display_rows)
         # Issue #249: preference の取得元と unavailable 件数も表示
         unavailable_count = sum(1 for r in display_rows if not r.get("available", True))
         unavailable_suffix = f", unavailable={unavailable_count}" if unavailable_count > 0 else ""
@@ -260,6 +262,21 @@ def _build_available_models_table(
         table.add_row(*table_row)
 
     return table
+
+
+def _print_rating_models_section(display_rows: list[dict[str, str | bool]]) -> None:
+    """`models list` default output で rating model を見つけやすくする."""
+    rating_rows = [row for row in display_rows if row.get("category") == "rating"]
+    if not rating_rows:
+        return
+
+    table = Table(title="Rating Models")
+    table.add_column("Provider", style="bright_magenta", min_width=8, no_wrap=True)
+    table.add_column("Route", style="bright_blue", min_width=8, no_wrap=True)
+    table.add_column("Model ID", style="bright_cyan", overflow="fold", min_width=32, ratio=1)
+    for row in rating_rows:
+        table.add_row(str(row["provider"]), str(row["route"]), str(row["litellm_id"]))
+    console.print(table)
 
 
 def _format_availability(row: dict[str, str | bool]) -> str:

--- a/src/lorairo/cli/main.py
+++ b/src/lorairo/cli/main.py
@@ -36,9 +36,16 @@ app = typer.Typer(
         "Typical workflow:\n\n"
         "  1. lorairo-cli project create <name>\n\n"
         "  2. lorairo-cli images register <dir> --project <name>\n\n"
-        "  3. lorairo-cli models list  (confirm model names)\n\n"
-        "  4. lorairo-cli annotate run --project <name> --model <model>\n\n"
-        "  5. lorairo-cli export create --project <name> --tags <tag> --output <dir>"
+        "  3. lorairo-cli models refresh --project <name>\n\n"
+        "  4. lorairo-cli models list  (confirm model names)\n\n"
+        "  5. lorairo-cli annotate run --project <name> --model <model>\n\n"
+        "  6. lorairo-cli export create --project <name> --tags <tag> --output <dir>\n\n"
+        "Rating workflow with OpenAI moderation:\n\n"
+        "  Small sets: lorairo-cli annotate run --project <name> "
+        "--model openai/omni-moderation-latest\n\n"
+        "  Large sets: lorairo-cli images list --project <name> --unrated\n"
+        "              lorairo-cli batch submit --project <name> --task-type rating_preflight "
+        "--model openai/omni-moderation-latest --image-id <id>"
     ),
     add_completion=True,
     no_args_is_help=True,

--- a/src/lorairo/database/filter_criteria.py
+++ b/src/lorairo/database/filter_criteria.py
@@ -6,7 +6,7 @@ GUI/ServiceレイヤーのSearchConditionsとは分離され、DB操作の明確
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Any
 
 
@@ -28,6 +28,7 @@ class ImageFilterCriteria:
         include_untagged: タグが付いていない画像のみを対象とするか
         include_nsfw: NSFWコンテンツを含む画像を除外しないか
         include_unrated: 未評価画像を含めるか (False: 手動またはAI評価のいずれか1つ以上を持つ画像のみ)
+        only_unrated: rating が無い画像のみを対象とするか
         manual_rating_filter: 指定した手動レーティングを持つ画像のみを対象とするか
         ai_rating_filter: 指定したAI評価レーティングを持つ画像のみを対象とするか (多数決ロジック)
         manual_edit_filter: アノテーションが手動編集されたかでフィルタするか
@@ -47,6 +48,7 @@ class ImageFilterCriteria:
     include_untagged: bool = False
     include_nsfw: bool = False
     include_unrated: bool = True
+    only_unrated: bool = False
     manual_rating_filter: str | None = None
     ai_rating_filter: str | None = None
     manual_edit_filter: bool | None = None
@@ -101,6 +103,7 @@ class ImageFilterCriteria:
             "include_untagged": self.include_untagged,
             "include_nsfw": self.include_nsfw,
             "include_unrated": self.include_unrated,
+            "only_unrated": self.only_unrated,
             "manual_rating_filter": self.manual_rating_filter,
             "ai_rating_filter": self.ai_rating_filter,
             "manual_edit_filter": self.manual_edit_filter,

--- a/src/lorairo/database/repository/image.py
+++ b/src/lorairo/database/repository/image.py
@@ -1187,24 +1187,36 @@ class ImageRepository(BaseRepository):
         logger.debug("AI rating filter applied with majority vote logic")
         return query
 
-    def _apply_unrated_filter(self, query: Select[Any], include_unrated: bool) -> Select[Any]:
+    def _apply_unrated_filter(
+        self,
+        query: Select[Any],
+        include_unrated: bool,
+        only_unrated: bool = False,
+    ) -> Select[Any]:
         """クエリに未評価画像フィルタを適用します (Either-based ロジック)。
 
+        only_unrated=True の場合、Rating テーブルに行が無い画像のみを返します。
         include_unrated=False の場合、手動評価またはAI評価のいずれか1つ以上を持つ画像のみを返します。
         include_unrated=True の場合、フィルタリングを行いません。
 
         Args:
             query (Select): 適用対象のクエリ
             include_unrated (bool): 未評価画像を含めるかどうか
+            only_unrated (bool): 未評価画像のみに絞るかどうか
 
         Returns:
             Select: 未評価フィルタが適用されたクエリ
 
         """
+        has_any_rating = exists().where(Rating.image_id == Image.id).correlate(Image)
+        if only_unrated:
+            query = query.where(~has_any_rating)
+            logger.debug("Unrated filter applied: images must have no ratings")
+            return query
+
         if not include_unrated:
             # MANUAL_EDIT も含む Rating テーブルに行が存在する画像のみを返す
             # (manual rating も Rating テーブルに統一されたため OR は不要)
-            has_any_rating = exists().where(Rating.image_id == Image.id).correlate(Image)
             query = query.where(has_any_rating)
             logger.debug("Unrated filter applied: images must have at least one rating")
 
@@ -1657,6 +1669,7 @@ class ImageRepository(BaseRepository):
         include_untagged: bool,
         include_nsfw: bool,
         include_unrated: bool,
+        only_unrated: bool,
         manual_rating_filter: str | None,
         ai_rating_filter: str | None,
         manual_edit_filter: bool | None,
@@ -1678,6 +1691,7 @@ class ImageRepository(BaseRepository):
             include_untagged: タグなし画像のみ対象とするか。
             include_nsfw: NSFWコンテンツを含むか。
             include_unrated: 未評価画像を含むか。
+            only_unrated: 未評価画像のみを対象とするか。
             manual_rating_filter: 手動レーティングフィルタ。
             ai_rating_filter: AI評価フィルタ。
             manual_edit_filter: 手動編集フラグフィルタ。
@@ -1714,7 +1728,7 @@ class ImageRepository(BaseRepository):
             query = self._apply_manual_filters(query, None, manual_edit_filter, session)
 
         # Unrated Filter
-        query = self._apply_unrated_filter(query, include_unrated)
+        query = self._apply_unrated_filter(query, include_unrated, only_unrated)
 
         # NSFW Filter
         nsfw_values_to_exclude = {"r", "x", "xxx"}
@@ -1777,6 +1791,7 @@ class ImageRepository(BaseRepository):
                     include_untagged=filter_criteria.include_untagged,
                     include_nsfw=filter_criteria.include_nsfw,
                     include_unrated=filter_criteria.include_unrated,
+                    only_unrated=filter_criteria.only_unrated,
                     manual_rating_filter=filter_criteria.manual_rating_filter,
                     ai_rating_filter=filter_criteria.ai_rating_filter,
                     manual_edit_filter=filter_criteria.manual_edit_filter,
@@ -1839,6 +1854,7 @@ class ImageRepository(BaseRepository):
                     include_untagged=filter_criteria.include_untagged,
                     include_nsfw=filter_criteria.include_nsfw,
                     include_unrated=filter_criteria.include_unrated,
+                    only_unrated=filter_criteria.only_unrated,
                     manual_rating_filter=filter_criteria.manual_rating_filter,
                     ai_rating_filter=filter_criteria.ai_rating_filter,
                     manual_edit_filter=filter_criteria.manual_edit_filter,

--- a/src/lorairo/services/provider_batch_workflow_service.py
+++ b/src/lorairo/services/provider_batch_workflow_service.py
@@ -287,7 +287,8 @@ class ProviderBatchWorkflowService:
         )
         if "/" in bare_model_id or not bare_model_id.startswith("omni-moderation-"):
             raise ProviderBatchError(
-                "rating_preflight batch submit には openai moderation model が必要です"
+                "rating_preflight batch submit には openai moderation model "
+                "(openai/omni-moderation-*) が必要です"
             )
 
         return expected_endpoint

--- a/tests/integration/test_rating_save_integration.py
+++ b/tests/integration/test_rating_save_integration.py
@@ -118,6 +118,57 @@ def test_saved_ai_rating_excluded_from_unrated_and_matched_by_value(
 
 
 @pytest.mark.integration
+def test_only_unrated_filter_returns_images_without_any_rating(
+    rating_repository: ImageRepository,
+    seeded_ids: dict[str, int],
+    db_session_factory,
+) -> None:
+    """only_unrated=True は Rating 行が無い画像のみを返す。"""
+    with db_session_factory() as session:
+        rated_image_id = seeded_ids["image_id"]
+        unrated_image = Image(
+            uuid="rating-test-uuid-002",
+            phash="phash_rating_test_002",
+            original_image_path="/tmp/rating_test_2.png",
+            stored_image_path="/tmp/rating_test_2.png",
+            width=256,
+            height=256,
+            format="PNG",
+            extension=".png",
+        )
+        session.add(unrated_image)
+        session.flush()
+        session.add(
+            Rating(
+                image_id=rated_image_id,
+                model_id=seeded_ids["model_id"],
+                raw_rating_value="general",
+                normalized_rating="PG",
+                confidence_score=0.9,
+            )
+        )
+        session.commit()
+        unrated_image_id = unrated_image.id
+
+    unrated_images, unrated_count = rating_repository.get_images_by_filter(
+        ImageFilterCriteria(include_nsfw=True, only_unrated=True)
+    )
+    rated_images, rated_count = rating_repository.get_images_by_filter(
+        ImageFilterCriteria(include_nsfw=True, include_unrated=False)
+    )
+    precedence_images, precedence_count = rating_repository.get_images_by_filter(
+        ImageFilterCriteria(include_nsfw=True, include_unrated=False, only_unrated=True)
+    )
+
+    assert unrated_count == 1
+    assert unrated_images[0]["id"] == unrated_image_id
+    assert rated_count == 1
+    assert rated_images[0]["id"] == rated_image_id
+    assert precedence_count == 1
+    assert precedence_images[0]["id"] == unrated_image_id
+
+
+@pytest.mark.integration
 def test_unmappable_scheme_is_skipped(
     rating_repository: ImageRepository,
     annotation_repository: AnnotationRepository,

--- a/tests/unit/cli/test_commands_annotate.py
+++ b/tests/unit/cli/test_commands_annotate.py
@@ -106,6 +106,7 @@ def test_annotate_run_help() -> None:
 
     assert result.exit_code == 0
     assert "Run annotation on project images" in result.stdout
+    assert "openai/omni-moderation-latest" in result.stdout
 
 
 @pytest.mark.unit

--- a/tests/unit/cli/test_commands_batch.py
+++ b/tests/unit/cli/test_commands_batch.py
@@ -205,7 +205,8 @@ def test_batch_submit_help_documents_rating_preflight_constraints() -> None:
     result = runner.invoke(app, ["batch", "submit", "--help"])
 
     assert result.exit_code == 0
-    assert "rating_preflight requires direct openai" in result.stdout
+    assert "rating_preflight" in result.stdout
+    assert "requires direct openai" in result.stdout
     assert "/v1/moderations" in result.stdout
     assert "openai/omni-moderation-*" in result.stdout
     assert "ratings" in result.stdout

--- a/tests/unit/cli/test_commands_batch.py
+++ b/tests/unit/cli/test_commands_batch.py
@@ -201,6 +201,19 @@ def test_batch_submit_rating_preflight_calls_workflow_service(mock_get_container
 
 @pytest.mark.unit
 @pytest.mark.cli
+def test_batch_submit_help_documents_rating_preflight_constraints() -> None:
+    result = runner.invoke(app, ["batch", "submit", "--help"])
+
+    assert result.exit_code == 0
+    assert "rating_preflight requires direct openai" in result.stdout
+    assert "/v1/moderations" in result.stdout
+    assert "openai/omni-moderation-*" in result.stdout
+    assert "ratings" in result.stdout
+    assert "model_type" in result.stdout
+
+
+@pytest.mark.unit
+@pytest.mark.cli
 @patch("lorairo.cli.commands.batch.get_service_container")
 def test_batch_submit_rating_preflight_normalizes_endpoint_override(
     mock_get_container: MagicMock,
@@ -387,6 +400,34 @@ def test_batch_fetch_shows_artifacts(mock_get_container: MagicMock, tmp_path: Pa
     container.provider_batch_workflow_service.fetch_results.assert_called_once_with(42, tmp_path)
     assert "Provider Batch results fetched" in result.stdout
     assert "batch.jsonl" in result.stdout
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+@patch("lorairo.cli.commands.batch.get_service_container")
+def test_batch_fetch_derives_counts_from_items_when_provider_counts_missing(
+    mock_get_container: MagicMock,
+    tmp_path: Path,
+) -> None:
+    container = _container()
+    container.provider_batch_workflow_service.fetch_results.return_value = SimpleNamespace(
+        provider_status="completed",
+        items=(
+            SimpleNamespace(custom_id="img-1", status="succeeded"),
+            SimpleNamespace(custom_id="img-2", status="failed"),
+        ),
+        succeeded_count=None,
+        failed_count=None,
+        artifacts=(),
+    )
+    mock_get_container.return_value = container
+
+    result = runner.invoke(app, ["batch", "fetch", "42", "--project", "demo", "-o", str(tmp_path)])
+
+    assert result.exit_code == 0
+    assert "items=2" in result.stdout
+    assert "succeeded=1" in result.stdout
+    assert "failed=1" in result.stdout
 
 
 @pytest.mark.unit

--- a/tests/unit/cli/test_commands_images.py
+++ b/tests/unit/cli/test_commands_images.py
@@ -362,6 +362,36 @@ def test_images_list_with_limit(mock_projects_dir: Path) -> None:
 
 @pytest.mark.unit
 @pytest.mark.cli
+def test_images_list_unrated_passes_only_unrated_criteria(mock_projects_dir: Path) -> None:
+    """Test: images list --unrated は rating 未保存画像のみに絞る criteria を渡す。"""
+    runner.invoke(app, ["project", "create", "test-project"])
+
+    fake_records = [
+        {
+            "id": 1,
+            "stored_image_path": "/path/image1.jpg",
+            "tags": [],
+            "captions": [],
+            "scores": [],
+            "ratings": [],
+        }
+    ]
+    with patch("lorairo.cli.commands.images.get_service_container") as mock_get_container:
+        mock_container = MagicMock()
+        mock_container.db_manager.image_repo.get_images_by_filter.return_value = (fake_records, 1)
+        mock_get_container.return_value = mock_container
+
+        result = runner.invoke(app, ["images", "list", "--project", "test-project", "--unrated"])
+
+    assert result.exit_code == 0
+    criteria = mock_container.db_manager.image_repo.get_images_by_filter.call_args.args[0]
+    assert criteria.include_nsfw is True
+    assert criteria.only_unrated is True
+    assert "unrated only" in result.stdout
+
+
+@pytest.mark.unit
+@pytest.mark.cli
 def test_images_list_nonexistent_project(mock_projects_dir: Path) -> None:
     """Test: images list - 存在しないプロジェクトはエラー。"""
     result = runner.invoke(app, ["images", "list", "--project", "nonexistent"])

--- a/tests/unit/cli/test_commands_models.py
+++ b/tests/unit/cli/test_commands_models.py
@@ -135,6 +135,36 @@ def test_models_list_shows_local_and_webapi_with_type_column(mock_get_container)
 @pytest.mark.unit
 @pytest.mark.cli
 @patch("lorairo.cli.commands.models.get_service_container")
+def test_models_list_shows_rating_models_section(mock_get_container) -> None:
+    """models list default 出力では rating model を dedicated section でも表示する。"""
+    mock_container = MagicMock()
+    mock_container.annotator_library.list_annotator_info.return_value = [
+        _FakeAnnotatorInfo(
+            name="omni-moderation-latest",
+            model_type="rating",
+            is_local=False,
+            is_api=True,
+            provider="openai",
+            litellm_model_id="openai/omni-moderation-latest",
+        )
+    ]
+    mock_container.annotator_library.is_model_deprecated.return_value = False
+    mock_container.config_service.get_setting.side_effect = lambda section, key, default="": (
+        "sk-test" if key == "openai_key" else default
+    )
+    mock_get_container.return_value = mock_container
+
+    result = runner.invoke(app, ["models", "list"])
+
+    assert result.exit_code == 0
+    assert "Available Models" in result.stdout
+    assert "Rating Models" in result.stdout
+    assert "openai/omni-moderation-latest" in result.stdout
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+@patch("lorairo.cli.commands.models.get_service_container")
 def test_models_list_filter_type_local_only(mock_get_container) -> None:
     """--type local はローカルモデルのみ表示する。"""
     mock_container = MagicMock()

--- a/tests/unit/cli/test_main.py
+++ b/tests/unit/cli/test_main.py
@@ -19,6 +19,10 @@ def test_cli_help() -> None:
     assert result.exit_code == 0
     assert "LoRAIro" in result.stdout
     assert "AI-powered" in result.stdout
+    assert "models refresh --project" in result.stdout
+    assert "openai/omni-moderation-latest" in result.stdout
+    assert "images list --project" in result.stdout
+    assert "--unrated" in result.stdout
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary
- Add CLI discoverability for OpenAI moderation rating workflows in top-level help, annotate/batch help, and models list output
- Add images list --unrated via an only_unrated ImageFilterCriteria/repository filter
- Document the sync and Provider Batch rating preflight workflows in docs/cli-rating-preflight.md
- Improve batch fetch summary counts when provider counters are absent

Closes #527

## Tests
- UV_PROJECT_ENVIRONMENT=/workspaces/LoRAIro/.venv uv run pytest tests/unit/cli/test_main.py tests/unit/cli/test_commands_images.py tests/unit/cli/test_commands_annotate.py tests/unit/cli/test_commands_batch.py tests/unit/cli/test_commands_models.py tests/integration/test_rating_save_integration.py -q
- UV_PROJECT_ENVIRONMENT=/workspaces/LoRAIro/.venv uv run pytest tests/unit/database/test_db_repository_ai_rating_filter.py tests/unit/database/test_db_repository_project_filter.py tests/unit/services/test_search_criteria_processor.py tests/integration/test_ai_rating_filter_integration.py -q
- UV_PROJECT_ENVIRONMENT=/workspaces/LoRAIro/.venv uv run ruff check src/lorairo/cli/main.py src/lorairo/cli/commands/annotate.py src/lorairo/cli/commands/batch.py src/lorairo/cli/commands/images.py src/lorairo/cli/commands/models.py src/lorairo/database/filter_criteria.py src/lorairo/database/repository/image.py src/lorairo/services/provider_batch_workflow_service.py tests/unit/cli/test_main.py tests/unit/cli/test_commands_annotate.py tests/unit/cli/test_commands_batch.py tests/unit/cli/test_commands_images.py tests/unit/cli/test_commands_models.py tests/integration/test_rating_save_integration.py