### PR TITLE
feat: add annotate run filters

### DIFF
--- a/src/lorairo/cli/commands/annotate.py
+++ b/src/lorairo/cli/commands/annotate.py
@@ -266,6 +266,55 @@ def _validate_required_api_keys(
     raise typer.Exit(code=1)
 
 
+def _build_annotation_filter_criteria(
+    model_repo: ModelRepository,
+    *,
+    unrated: bool,
+    missing_model: str | None,
+) -> tuple[ImageFilterCriteria, str | None]:
+    """annotate run のCLIオプションからDB検索条件を組み立てる。"""
+    missing_model_litellm_id = (
+        _resolve_model_identifier(model_repo, missing_model) if missing_model is not None else None
+    )
+    return (
+        ImageFilterCriteria(
+            include_nsfw=True,
+            only_unrated=unrated,
+            missing_model_litellm_id=missing_model_litellm_id,
+        ),
+        missing_model_litellm_id,
+    )
+
+
+def _handle_no_image_records(
+    project: str,
+    *,
+    filters_applied: bool,
+) -> None:
+    """DB検索結果0件時のCLIエラーを表示して終了する。"""
+    if filters_applied:
+        console.print(f"[red]Error:[/red] No images matched annotation filters for project '{project}'.")
+        raise typer.Exit(code=1)
+
+    console.print(
+        f"[red]Error:[/red] No registered images found in project '{project}'. "
+        "Run 'lorairo-cli images register' first."
+    )
+    raise typer.Exit(code=1)
+
+
+def _print_annotation_filter_summary(
+    *,
+    unrated: bool,
+    missing_model_litellm_id: str | None,
+) -> None:
+    """適用中のannotate runフィルタを表示する。"""
+    if unrated:
+        console.print("[cyan]Filter: unrated images only[/cyan]")
+    if missing_model_litellm_id is not None:
+        console.print(f"[cyan]Filter: missing model {missing_model_litellm_id}[/cyan]")
+
+
 @app.command("run")
 def run(
     project: str = typer.Option(
@@ -295,6 +344,16 @@ def run(
         "--batch-size",
         "-b",
         help="Batch size for processing",
+    ),
+    unrated: bool = typer.Option(
+        False,
+        "--unrated",
+        help="Annotate only images without any saved rating rows.",
+    ),
+    missing_model: str | None = typer.Option(
+        None,
+        "--missing-model",
+        help="Annotate only images without saved annotations from the given LiteLLM model ID.",
     ),
 ) -> None:
     """Run annotation on project images.
@@ -330,16 +389,19 @@ def run(
         # Issue #245: --model 入力を canonical litellm_model_id に解決
         # (曖昧マッチは Error で abort、ここで raise した typer.Exit は外側 except で素通り)
         resolved_litellm_ids = [_resolve_model_identifier(model_repo, ident) for ident in model]
+        criteria, missing_model_litellm_id = _build_annotation_filter_criteria(
+            model_repo,
+            unrated=unrated,
+            missing_model=missing_model,
+        )
 
-        criteria = ImageFilterCriteria(include_nsfw=True)
         image_records, total_in_db = image_repo.get_images_by_filter(criteria)
 
         if not image_records:
-            console.print(
-                f"[red]Error:[/red] No registered images found in project '{project}'. "
-                "Run 'lorairo-cli images register' first."
+            _handle_no_image_records(
+                project,
+                filters_applied=unrated or missing_model_litellm_id is not None,
             )
-            raise typer.Exit(code=1)
 
         # DB レコードから PIL 画像をロード
         pil_images, loaded_count, failed_count = _load_images_from_db(image_records)
@@ -350,6 +412,10 @@ def run(
 
         console.print(f"[cyan]Found {total_in_db} image(s) in DB[/cyan]")
         console.print(f"[cyan]Using model(s): {', '.join(resolved_litellm_ids)}[/cyan]")
+        _print_annotation_filter_summary(
+            unrated=unrated,
+            missing_model_litellm_id=missing_model_litellm_id,
+        )
         console.print(f"[green]Loaded {loaded_count} image(s) ({failed_count} failed)[/green]")
 
         annotator = container.annotator_library

--- a/src/lorairo/database/filter_criteria.py
+++ b/src/lorairo/database/filter_criteria.py
@@ -29,6 +29,7 @@ class ImageFilterCriteria:
         include_nsfw: NSFWコンテンツを含む画像を除外しないか
         include_unrated: 未評価画像を含めるか (False: 手動またはAI評価のいずれか1つ以上を持つ画像のみ)
         only_unrated: rating が無い画像のみを対象とするか
+        missing_model_litellm_id: 指定モデルのannotation行が無い画像のみを対象とするか
         manual_rating_filter: 指定した手動レーティングを持つ画像のみを対象とするか
         ai_rating_filter: 指定したAI評価レーティングを持つ画像のみを対象とするか (多数決ロジック)
         manual_edit_filter: アノテーションが手動編集されたかでフィルタするか
@@ -49,6 +50,7 @@ class ImageFilterCriteria:
     include_nsfw: bool = False
     include_unrated: bool = True
     only_unrated: bool = False
+    missing_model_litellm_id: str | None = None
     manual_rating_filter: str | None = None
     ai_rating_filter: str | None = None
     manual_edit_filter: bool | None = None
@@ -104,6 +106,7 @@ class ImageFilterCriteria:
             "include_nsfw": self.include_nsfw,
             "include_unrated": self.include_unrated,
             "only_unrated": self.only_unrated,
+            "missing_model_litellm_id": self.missing_model_litellm_id,
             "manual_rating_filter": self.manual_rating_filter,
             "ai_rating_filter": self.ai_rating_filter,
             "manual_edit_filter": self.manual_edit_filter,

--- a/src/lorairo/database/repository/image.py
+++ b/src/lorairo/database/repository/image.py
@@ -1222,6 +1222,48 @@ class ImageRepository(BaseRepository):
 
         return query
 
+    def _apply_missing_model_filter(
+        self,
+        query: Select[Any],
+        missing_model_litellm_id: str | None,
+    ) -> Select[Any]:
+        """指定モデルの annotation が無い画像のみを返すフィルタを適用する。"""
+        if not missing_model_litellm_id:
+            return query
+
+        model_id_subquery = select(Model.id).where(Model.litellm_model_id == missing_model_litellm_id)
+        has_tag = (
+            exists().where(Tag.image_id == Image.id, Tag.model_id.in_(model_id_subquery)).correlate(Image)
+        )
+        has_caption = (
+            exists()
+            .where(
+                Caption.image_id == Image.id,
+                Caption.model_id.in_(model_id_subquery),
+            )
+            .correlate(Image)
+        )
+        has_score = (
+            exists()
+            .where(
+                Score.image_id == Image.id,
+                Score.model_id.in_(model_id_subquery),
+            )
+            .correlate(Image)
+        )
+        has_rating = (
+            exists()
+            .where(
+                Rating.image_id == Image.id,
+                Rating.model_id.in_(model_id_subquery),
+            )
+            .correlate(Image)
+        )
+
+        query = query.where(not_(or_(has_tag, has_caption, has_score, has_rating)))
+        logger.debug(f"Missing model filter applied: litellm_model_id={missing_model_litellm_id}")
+        return query
+
     def _apply_nsfw_filter(self, query: Select[Any], include_nsfw: bool, session: Session) -> Select[Any]:
         """クエリにNSFWフィルタを適用します。"""
         if not include_nsfw:
@@ -1670,6 +1712,7 @@ class ImageRepository(BaseRepository):
         include_nsfw: bool,
         include_unrated: bool,
         only_unrated: bool,
+        missing_model_litellm_id: str | None,
         manual_rating_filter: str | None,
         ai_rating_filter: str | None,
         manual_edit_filter: bool | None,
@@ -1692,6 +1735,7 @@ class ImageRepository(BaseRepository):
             include_nsfw: NSFWコンテンツを含むか。
             include_unrated: 未評価画像を含むか。
             only_unrated: 未評価画像のみを対象とするか。
+            missing_model_litellm_id: 指定モデルの annotation が無い画像のみを対象とするか。
             manual_rating_filter: 手動レーティングフィルタ。
             ai_rating_filter: AI評価フィルタ。
             manual_edit_filter: 手動編集フラグフィルタ。
@@ -1729,6 +1773,9 @@ class ImageRepository(BaseRepository):
 
         # Unrated Filter
         query = self._apply_unrated_filter(query, include_unrated, only_unrated)
+
+        # Missing Model Filter
+        query = self._apply_missing_model_filter(query, missing_model_litellm_id)
 
         # NSFW Filter
         nsfw_values_to_exclude = {"r", "x", "xxx"}
@@ -1792,6 +1839,7 @@ class ImageRepository(BaseRepository):
                     include_nsfw=filter_criteria.include_nsfw,
                     include_unrated=filter_criteria.include_unrated,
                     only_unrated=filter_criteria.only_unrated,
+                    missing_model_litellm_id=filter_criteria.missing_model_litellm_id,
                     manual_rating_filter=filter_criteria.manual_rating_filter,
                     ai_rating_filter=filter_criteria.ai_rating_filter,
                     manual_edit_filter=filter_criteria.manual_edit_filter,
@@ -1855,6 +1903,7 @@ class ImageRepository(BaseRepository):
                     include_nsfw=filter_criteria.include_nsfw,
                     include_unrated=filter_criteria.include_unrated,
                     only_unrated=filter_criteria.only_unrated,
+                    missing_model_litellm_id=filter_criteria.missing_model_litellm_id,
                     manual_rating_filter=filter_criteria.manual_rating_filter,
                     ai_rating_filter=filter_criteria.ai_rating_filter,
                     manual_edit_filter=filter_criteria.manual_edit_filter,

--- a/src/lorairo/database/repository/image.py
+++ b/src/lorairo/database/repository/image.py
@@ -1251,6 +1251,14 @@ class ImageRepository(BaseRepository):
             )
             .correlate(Image)
         )
+        has_score_label = (
+            exists()
+            .where(
+                ScoreLabel.image_id == Image.id,
+                ScoreLabel.model_id.in_(model_id_subquery),
+            )
+            .correlate(Image)
+        )
         has_rating = (
             exists()
             .where(
@@ -1260,7 +1268,7 @@ class ImageRepository(BaseRepository):
             .correlate(Image)
         )
 
-        query = query.where(not_(or_(has_tag, has_caption, has_score, has_rating)))
+        query = query.where(not_(or_(has_tag, has_caption, has_score, has_score_label, has_rating)))
         logger.debug(f"Missing model filter applied: litellm_model_id={missing_model_litellm_id}")
         return query
 

--- a/tests/integration/test_rating_save_integration.py
+++ b/tests/integration/test_rating_save_integration.py
@@ -12,7 +12,7 @@ from sqlalchemy import select
 from lorairo.database.filter_criteria import ImageFilterCriteria
 from lorairo.database.repository.annotation_record import AnnotationRepository
 from lorairo.database.repository.image import ImageRepository
-from lorairo.database.schema import Image, Model, Rating
+from lorairo.database.schema import Caption, Image, Model, Rating, Score, Tag
 from lorairo.services.annotation_save_service import AnnotationSaveService
 
 _PHASH = "phash_rating_test_001"
@@ -166,6 +166,118 @@ def test_only_unrated_filter_returns_images_without_any_rating(
     assert rated_images[0]["id"] == rated_image_id
     assert precedence_count == 1
     assert precedence_images[0]["id"] == unrated_image_id
+
+
+@pytest.mark.integration
+def test_missing_model_filter_excludes_any_annotation_type_for_model(
+    rating_repository: ImageRepository,
+    seeded_ids: dict[str, int],
+    db_session_factory,
+) -> None:
+    """missing_model_litellm_id は指定モデルの全annotation種別を処理済み扱いにする。"""
+    with db_session_factory() as session:
+        images: list[Image] = []
+        for index in range(5):
+            image = Image(
+                uuid=f"missing-model-test-uuid-{index}",
+                phash=f"phash_missing_model_{index:03d}",
+                original_image_path=f"/tmp/missing_model_{index}.png",
+                stored_image_path=f"/tmp/missing_model_{index}.png",
+                width=256,
+                height=256,
+                format="PNG",
+                extension=".png",
+            )
+            session.add(image)
+            images.append(image)
+        session.flush()
+
+        model_id = seeded_ids["model_id"]
+        session.add_all(
+            [
+                Tag(image_id=images[0].id, model_id=model_id, tag="tagged"),
+                Caption(image_id=images[1].id, model_id=model_id, caption="captioned"),
+                Score(image_id=images[2].id, model_id=model_id, score=0.8),
+                Rating(
+                    image_id=images[3].id,
+                    model_id=model_id,
+                    raw_rating_value="general",
+                    normalized_rating="PG",
+                    confidence_score=0.9,
+                ),
+            ]
+        )
+        session.commit()
+        missing_image_id = images[4].id
+
+    missing_images, missing_count = rating_repository.get_images_by_filter(
+        ImageFilterCriteria(include_nsfw=True, missing_model_litellm_id=_LITELLM_ID)
+    )
+
+    assert missing_count == 2
+    assert {image["id"] for image in missing_images} == {seeded_ids["image_id"], missing_image_id}
+
+
+@pytest.mark.integration
+def test_missing_model_filter_combines_with_only_unrated(
+    rating_repository: ImageRepository,
+    seeded_ids: dict[str, int],
+    db_session_factory,
+) -> None:
+    """missing_model_litellm_id と only_unrated=True は AND 条件で絞り込む。"""
+    with db_session_factory() as session:
+        rated_without_target_model = Image(
+            uuid="missing-model-rated-uuid",
+            phash="phash_missing_model_rated",
+            original_image_path="/tmp/missing_model_rated.png",
+            stored_image_path="/tmp/missing_model_rated.png",
+            width=256,
+            height=256,
+            format="PNG",
+            extension=".png",
+        )
+        unrated_without_target_model = Image(
+            uuid="missing-model-unrated-uuid",
+            phash="phash_missing_model_unrated",
+            original_image_path="/tmp/missing_model_unrated.png",
+            stored_image_path="/tmp/missing_model_unrated.png",
+            width=256,
+            height=256,
+            format="PNG",
+            extension=".png",
+        )
+        other_model = Model(
+            name="openai/gpt-4o-mini",
+            provider="openai",
+            litellm_model_id="openai/gpt-4o-mini",
+        )
+        session.add_all([rated_without_target_model, unrated_without_target_model, other_model])
+        session.flush()
+        session.add(
+            Rating(
+                image_id=rated_without_target_model.id,
+                model_id=other_model.id,
+                raw_rating_value="general",
+                normalized_rating="PG",
+                confidence_score=0.9,
+            )
+        )
+        session.commit()
+        unrated_without_target_model_id = unrated_without_target_model.id
+
+    missing_unrated_images, missing_unrated_count = rating_repository.get_images_by_filter(
+        ImageFilterCriteria(
+            include_nsfw=True,
+            only_unrated=True,
+            missing_model_litellm_id=_LITELLM_ID,
+        )
+    )
+
+    assert missing_unrated_count == 2
+    assert {image["id"] for image in missing_unrated_images} == {
+        seeded_ids["image_id"],
+        unrated_without_target_model_id,
+    }
 
 
 @pytest.mark.integration

--- a/tests/integration/test_rating_save_integration.py
+++ b/tests/integration/test_rating_save_integration.py
@@ -12,7 +12,7 @@ from sqlalchemy import select
 from lorairo.database.filter_criteria import ImageFilterCriteria
 from lorairo.database.repository.annotation_record import AnnotationRepository
 from lorairo.database.repository.image import ImageRepository
-from lorairo.database.schema import Caption, Image, Model, Rating, Score, Tag
+from lorairo.database.schema import Caption, Image, Model, Rating, Score, ScoreLabel, Tag
 from lorairo.services.annotation_save_service import AnnotationSaveService
 
 _PHASH = "phash_rating_test_001"
@@ -177,7 +177,7 @@ def test_missing_model_filter_excludes_any_annotation_type_for_model(
     """missing_model_litellm_id は指定モデルの全annotation種別を処理済み扱いにする。"""
     with db_session_factory() as session:
         images: list[Image] = []
-        for index in range(5):
+        for index in range(6):
             image = Image(
                 uuid=f"missing-model-test-uuid-{index}",
                 phash=f"phash_missing_model_{index:03d}",
@@ -198,8 +198,9 @@ def test_missing_model_filter_excludes_any_annotation_type_for_model(
                 Tag(image_id=images[0].id, model_id=model_id, tag="tagged"),
                 Caption(image_id=images[1].id, model_id=model_id, caption="captioned"),
                 Score(image_id=images[2].id, model_id=model_id, score=0.8),
+                ScoreLabel(image_id=images[3].id, model_id=model_id, label="aesthetic"),
                 Rating(
-                    image_id=images[3].id,
+                    image_id=images[4].id,
                     model_id=model_id,
                     raw_rating_value="general",
                     normalized_rating="PG",
@@ -208,7 +209,7 @@ def test_missing_model_filter_excludes_any_annotation_type_for_model(
             ]
         )
         session.commit()
-        missing_image_id = images[4].id
+        missing_image_id = images[5].id
 
     missing_images, missing_count = rating_repository.get_images_by_filter(
         ImageFilterCriteria(include_nsfw=True, missing_model_litellm_id=_LITELLM_ID)

--- a/tests/unit/cli/test_commands_annotate.py
+++ b/tests/unit/cli/test_commands_annotate.py
@@ -578,6 +578,125 @@ def test_annotate_run_with_batch_size(
 @pytest.mark.unit
 @pytest.mark.cli
 @patch("lorairo.cli.commands.annotate.get_service_container")
+def test_annotate_run_unrated_passes_only_unrated_criteria(
+    mock_get_container,
+    test_project_with_images: tuple[Path, list[Path]],
+) -> None:
+    """Test: annotate run --unrated は rating 未保存画像のみに絞る criteria を渡す。"""
+    _project_dir, image_files = test_project_with_images
+
+    mock_container = MagicMock()
+    mock_annotator = MagicMock()
+    mock_config = MagicMock()
+
+    mock_config.get_setting.return_value = "test_key"
+    mock_annotator.annotate.return_value = {"hash1": {"tags": ["tag1"]}}
+
+    image_records = [{"id": 1, "phash": "phash0000000000000000", "stored_image_path": str(image_files[0])}]
+    mock_container.db_manager.image_repo.get_images_by_filter.return_value = (image_records, 1)
+    mock_container.annotator_library = mock_annotator
+    mock_container.config_service = mock_config
+    mock_get_container.return_value = mock_container
+
+    result = runner.invoke(
+        app,
+        [
+            "annotate",
+            "run",
+            "--project",
+            "test_dataset",
+            "--model",
+            "gpt-4o-mini",
+            "--unrated",
+        ],
+    )
+
+    assert result.exit_code == 0
+    criteria = mock_container.db_manager.image_repo.get_images_by_filter.call_args.args[0]
+    assert criteria.include_nsfw is True
+    assert criteria.only_unrated is True
+    assert criteria.missing_model_litellm_id is None
+    assert "Filter: unrated images only" in result.stdout
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+@patch("lorairo.cli.commands.annotate.get_service_container")
+def test_annotate_run_missing_model_passes_missing_model_criteria(
+    mock_get_container,
+    test_project_with_images: tuple[Path, list[Path]],
+) -> None:
+    """Test: annotate run --missing-model は指定モデル未処理画像のみに絞る criteria を渡す。"""
+    _project_dir, image_files = test_project_with_images
+
+    mock_container = MagicMock()
+    mock_annotator = MagicMock()
+    mock_config = MagicMock()
+
+    mock_config.get_setting.return_value = "test_key"
+    mock_annotator.annotate.return_value = {"hash1": {"tags": ["tag1"]}}
+
+    image_records = [{"id": 1, "phash": "phash0000000000000000", "stored_image_path": str(image_files[0])}]
+    mock_container.db_manager.image_repo.get_images_by_filter.return_value = (image_records, 1)
+    mock_container.annotator_library = mock_annotator
+    mock_container.config_service = mock_config
+    mock_get_container.return_value = mock_container
+
+    result = runner.invoke(
+        app,
+        [
+            "annotate",
+            "run",
+            "--project",
+            "test_dataset",
+            "--model",
+            "gpt-4o-mini",
+            "--missing-model",
+            "openai/omni-moderation-latest",
+        ],
+    )
+
+    assert result.exit_code == 0
+    criteria = mock_container.db_manager.image_repo.get_images_by_filter.call_args.args[0]
+    assert criteria.include_nsfw is True
+    assert criteria.only_unrated is False
+    assert criteria.missing_model_litellm_id == "openai/omni-moderation-latest"
+    assert "Filter: missing model openai/omni-moderation-latest" in result.stdout
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+@patch("lorairo.cli.commands.annotate.get_service_container")
+def test_annotate_run_filter_matches_no_images_exits_before_loading(
+    mock_get_container,
+    test_project_with_images: tuple[Path, list[Path]],
+) -> None:
+    """Test: annotate run のフィルタ結果が0件なら画像ロード前に exit 1。"""
+    mock_container = MagicMock()
+    mock_container.db_manager.image_repo.get_images_by_filter.return_value = ([], 0)
+    mock_get_container.return_value = mock_container
+
+    result = runner.invoke(
+        app,
+        [
+            "annotate",
+            "run",
+            "--project",
+            "test_dataset",
+            "--model",
+            "gpt-4o-mini",
+            "--unrated",
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert "No images matched annotation filters" in result.stdout
+    mock_container.annotator_library.annotate.assert_not_called()
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+@patch("lorairo.cli.commands.annotate.get_service_container")
 def test_annotate_run_annotation_failure(
     mock_get_container,
     test_project_with_images: tuple[Path, list[Path]],


### PR DESCRIPTION
## Summary
- add `annotate run --unrated` and `--missing-model` filters
- extend image filtering with a missing-model annotation predicate across tags/captions/scores/ratings
- add CLI and DB regression coverage for filtered annotation targets

Closes #532

## Tests
- `UV_PROJECT_ENVIRONMENT=/workspaces/LoRAIro/.venv uv run pytest tests/unit/cli/test_commands_annotate.py tests/integration/test_rating_save_integration.py -q`
- `UV_PROJECT_ENVIRONMENT=/workspaces/LoRAIro/.venv uv run ruff check src/lorairo/database/filter_criteria.py src/lorairo/database/repository/image.py src/lorairo/cli/commands/annotate.py tests/unit/cli/test_commands_annotate.py tests/integration/test_rating_save_integration.py`
- `UV_PROJECT_ENVIRONMENT=/workspaces/LoRAIro/.venv uv run ruff format --check src/lorairo/database/filter_criteria.py src/lorairo/database/repository/image.py src/lorairo/cli/commands/annotate.py tests/unit/cli/test_commands_annotate.py tests/integration/test_rating_save_integration.py`