### PR TITLE
feat: CLI/GUI DX 改善エピック — meta コマンド遅延ロード・ログレベル設定・GUI help 誘導 (#535)

### DIFF
--- a/docs/plans/plan_535_cli_dx_epic_agentteams.md
+++ b/docs/plans/plan_535_cli_dx_epic_agentteams.md
@@ -1,0 +1,124 @@
+# Plan: Issue #535 CLI/GUI DX エピック (Agent Teams 並列実装)
+
+- **対象 Issue**: [#535](https://github.com/NEXTAltair/LoRAIro/issues/535) (epic) / サブ [#539](https://github.com/NEXTAltair/LoRAIro/issues/539) [#540](https://github.com/NEXTAltair/LoRAIro/issues/540) [#541](https://github.com/NEXTAltair/LoRAIro/issues/541)
+- **作成日**: 2026-05-29
+- **戦略**: 2-track 並列（Track A=#539+#540 同一オーナー / Track B=#541 独立）
+
+---
+
+## 1. 要件・成功基準
+
+### #540 — meta コマンドの annotator registry 遅延ロード
+`lorairo-cli --help` 実測 **~2.2s**（registry/model discovery が走る）。annotation を実行しない meta コマンドは registry を初期化すべきでない。
+- **成功基準**: `--help` / `version` が image-annotator-lib annotator を初期化しない。`models list` 等 registry が必要なコマンドは従来どおり初期化。import-level smoke test で help/version の軽量性を証明。
+
+### #539 — CLI ログレベル設定可能化
+`cli/main.py` の `main()` で log level が `WARNING` 固定 → 運用者向け INFO 進捗が `logs/lorairo-cli.log` に残らない（#531 の診断性ギャップの原因）。
+- **成功基準**: 既定 `INFO` で phase 遷移・最終サマリーを記録。`--log-level LEVEL` で上書き可能（`WARNING` で INFO 抑制）。実 annotation を呼ばずにテスト。
+
+### #541 — `lorairo --help` から `lorairo-cli` へ誘導
+GUI launcher (`src/lorairo/main.py`, argparse) の help が `lorairo-cli` に触れていない。
+- **成功基準**: `lorairo --help` に batch/annotation/dataset 操作は `lorairo-cli --help` を案内する行を追加。既存 launcher option は不変。
+
+---
+
+## 2. 現状分析（調査結果）
+
+| 項目 | 現状 |
+|---|---|
+| CLI logging | `cli/main.py:144` `main()` で `initialize_logging({"level": "WARNING", ...})` 固定。`app()` の**前**に呼ばれる |
+| meta コマンド起動コスト | `cli.main` import 時に command モジュール → `service_container` → annotator adapter → image-annotator-lib の chain が transitive に重い import を引く（~2.2s）。command モジュールは `get_service_container()` を**関数内で遅延呼び出し**しており、重さは import-time chain 由来 |
+| GUI launcher help | `src/lorairo/main.py:167` `argparse.ArgumentParser(epilog=...)`。`使用例` のみで CLI 言及なし |
+| 既存 lazy import 方針 | ADR 0010（torch/tensorflow/onnxruntime をモジュールレベル import せず関数内 lazy import）。skill `lazy-import-refactor` あり |
+
+### #539 / #540 の相乗効果
+ログ初期化を Typer `@app.callback` に移すと、`--help` は callback を実行せず短絡終了するため重い初期化も走らない。両者は `cli/main.py` の同じ初期化フローに関わるため**同一オーナーが直列実装**するのが安全（別オーナー並列だと `cli/main.py` で衝突）。
+
+---
+
+## 3. アプローチとトレードオフ
+
+| 案 | 並列性 | 衝突 | 採否 |
+|---|---|---|---|
+| 2-track: A=#539+#540 / B=#541 | 高（A=bulk / B=独立 `lorairo/main.py`） | A 内は直列で衝突なし、B は別ファイルで衝突なし | **採用** |
+| 3-track: #539/#540/#541 個別 | 最大 | #539 と #540 が `cli/main.py` で衝突 | 不採用 |
+| 単独セッション順次 | なし | なし | 代替可（規模小なら） |
+
+---
+
+## 4. 実装方針
+
+### Track A — #540 → #539（この順、同一オーナー、`cli/main.py` 中心）
+
+**#540 lazy import（先に構造を確立）** — skill `lazy-import-refactor` を使用:
+1. `-X importtime` で `import lorairo.cli.main` の重い import 源を pinpoint（image-annotator-lib / litellm / torch 系）。
+2. ADR 0010 に倣い、重い import を関数内/遅延化。具体的には `cli/main.py` の module-top `from lorairo.cli.commands import ...` / `from lorairo.services.service_container import get_service_container` 経由で transitive に走る重い import を切る。候補:
+   - command モジュール（annotate/models 等）が import 時に annotator adapter / image-annotator-lib を引く箇所を関数内 import へ。
+   - `service_container` の重い import を lazy 化（`importlib.import_module` or 関数内 import）。
+3. `models list` 等 registry 必須コマンドは従来どおり動くことを保証。
+4. **import-level smoke test**: subprocess で `lorairo-cli --help` / `version` 実行後に `image_annotator_lib` が `sys.modules` に**入っていない**ことを assert（conftest のグローバルモックに影響されない subprocess 方式）。
+
+**#539 log level**:
+1. ログ初期化を `@app.callback()` へ移し、`--log-level LEVEL`（既定 `INFO`）option を追加。`main()` の hard-coded `WARNING` 初期化を整理。
+2. INFO に phase 遷移・最終サマリー、per-item は DEBUG（`.claude/rules/logging.md` 準拠）。`--log-level WARNING` で INFO 抑制。
+3. `--help` で callback 非実行＝ログ初期化も走らない（#540 と整合）。
+4. テスト: `CliRunner` + `initialize_logging` を mock/spy し、`--log-level` 値が反映されることを検証（実 annotation 不要）。
+
+**Track A ファイル所有**: `src/lorairo/cli/main.py`、必要に応じ `src/lorairo/cli/commands/*.py` / `src/lorairo/services/service_container.py` の import 行、`tests/unit/cli/test_*`（log-level テスト + import-lightness smoke test、別ファイル新規）。
+
+### Track B — #541（独立、`src/lorairo/main.py`）
+1. `parse_arguments()` の `epilog`（または description）に `lorairo-cli --help` への誘導行を追加（GUI option は不変、CLI コマンドツリーは複製しない）。
+2. テスト: `lorairo --help` 出力（argparse help text）に `lorairo-cli` が含まれることを assert。
+
+**Track B ファイル所有**: `src/lorairo/main.py`、`tests/unit/...`（launcher help テスト）。
+
+> 競合回避: Track A と Track B は**別ファイル**（`cli/main.py` vs `main.py`）。worktree 分離 + 別テストファイルで衝突ゼロ。
+
+---
+
+## 5. テスト戦略
+
+| Issue | テスト |
+|---|---|
+| #540 | subprocess smoke: `--help`/`version` 後に `image_annotator_lib` 未ロードを検証。`models list` は registry 初期化されること |
+| #539 | `--log-level` 反映（mock `initialize_logging`）、既定 INFO、`WARNING` で INFO 抑制 |
+| #541 | `lorairo --help` 出力に `lorairo-cli` 誘導行 |
+| 回帰 | 既存 `tests/unit/cli/` 全 pass、CI-equivalent filter |
+
+CI-equivalent (LoRAIro Unit): `-m "not gui_show and not calls_real_webapi and not downloads_and_runs_model and not slow"`。
+
+---
+
+## 6. リスクと対策
+
+| リスク | 対策 |
+|---|---|
+| #540 の重い import 源特定漏れ | `-X importtime` で実測 pinpoint、skill `lazy-import-refactor` で test 副作用予測 |
+| lazy 化で `models list` 等が壊れる | registry 必須コマンドの回帰テスト必須 |
+| #539/#540 の `cli/main.py` 衝突 | 同一オーナー（Track A）が #540→#539 順で直列実装 |
+| callback 移行で既存コマンドのログ初期化漏れ | callback が全 subcommand で走ることを確認、既存 CLI テスト回帰 |
+| 並列 `uv sync` venv 破損 (#222) | worktree で `PYTHONPATH=<wt>/src .venv/bin/pytest`（読み取りのみ）検証 |
+
+---
+
+## 7. チーム編成
+
+| ロール | 担当 | worktree |
+|---|---|---|
+| Team Lead | 統合・CI-equiv・PR | — |
+| Track A | #540 + #539 | `wt-535a` (`feat/issue-539-540-cli`) |
+| Track B | #541 | `wt-535b` (`feat/issue-541-gui-help`) |
+
+統合: A → B を別ファイルで結合（衝突なし想定）。完了でエピック #535 クローズ。
+
+---
+
+## 8. 次ステップ
+1. 本計画承認後、worktree 2 つ作成。
+2. Track A（skill `lazy-import-refactor` 使用）/ Track B を並列 dispatch。
+3. 統合 → CI-equivalent 検証 → PR（`Closes #539 #540 #541` / `Refs #535`）。
+
+## 参照
+- ADR 0010 (Torch Import Design) / `.claude/rules/logging.md` / `.claude/rules/testing.md`
+- skill `lazy-import-refactor`
+- `src/lorairo/cli/main.py` / `src/lorairo/main.py` / `src/lorairo/services/service_container.py`

--- a/src/lorairo/cli/main.py
+++ b/src/lorairo/cli/main.py
@@ -13,6 +13,7 @@ from lorairo.cli._early_init import early_init
 
 early_init()
 
+from enum import StrEnum
 from typing import TYPE_CHECKING, Any
 
 import typer
@@ -27,6 +28,17 @@ from lorairo.utils.log import initialize_logging
 
 if TYPE_CHECKING:
     from lorairo.services.service_container import ServiceContainer
+
+
+class LogLevel(StrEnum):
+    """`--log-level` で指定可能なログレベル。"""
+
+    DEBUG = "DEBUG"
+    INFO = "INFO"
+    WARNING = "WARNING"
+    ERROR = "ERROR"
+    CRITICAL = "CRITICAL"
+
 
 # Typer app 定義
 app = typer.Typer(
@@ -61,6 +73,35 @@ app.add_typer(annotate.app, name="annotate", help="Annotation commands")
 app.add_typer(export.app, name="export", help="Dataset export commands")
 app.add_typer(models.app, name="models", help="Model registry commands")
 app.add_typer(batch.app, name="batch", help="Provider Batch API job commands")
+
+
+@app.callback()
+def _configure(
+    log_level: LogLevel = typer.Option(
+        LogLevel.INFO,
+        "--log-level",
+        help="Logging verbosity (DEBUG/INFO/WARNING/ERROR/CRITICAL).",
+        case_sensitive=False,
+    ),
+) -> None:
+    """全サブコマンド共通の初期化フック。
+
+    Issue #539: ログレベルを ``--log-level`` で設定可能にする (既定 INFO)。
+    Issue #540: ``@app.callback()`` は ``--help`` 時には実行されないため、ここで
+    ログ初期化を行うことで help 表示時の不要な副作用を避ける。callback は各
+    サブコマンド実行時に必ず一度走る。
+    """
+    import os
+
+    os.environ.setdefault("LORAIRO_CLI_MODE", "true")
+    initialize_logging(
+        {
+            "level": log_level.value,
+            "file_path": str(DEFAULT_CLI_LOG_PATH),
+            "rotation": "25 MB",
+            "levels": {},
+        }
+    )
 
 
 # ===== トップレベルコマンド =====
@@ -134,21 +175,11 @@ def status() -> None:
 def main() -> None:
     """CLIメインエントリポイント。
 
-    ServiceContainer が NoOpSignalManager を自動選択するよう
-    LORAIRO_CLI_MODE を設定してから app を起動する。
+    ``LORAIRO_CLI_MODE`` 設定とログ初期化は ``@app.callback()`` (``_configure``)
+    でサブコマンド実行時に行う (Issue #539 / #540)。``--help`` のみの呼び出しでは
+    callback が走らないため、不要なログ初期化・副作用を避けられる。
     stdio 初期化は module top-level の ``early_init()`` で完了済。
     """
-    import os
-
-    os.environ.setdefault("LORAIRO_CLI_MODE", "true")
-    initialize_logging(
-        {
-            "level": "WARNING",  # CLI モード: DEBUG/INFO を抑制
-            "file_path": str(DEFAULT_CLI_LOG_PATH),
-            "rotation": "25 MB",
-            "levels": {},
-        }
-    )
     app()
 
 

--- a/src/lorairo/main.py
+++ b/src/lorairo/main.py
@@ -162,8 +162,15 @@ def setup_application_fonts(app: QApplication, config: dict[str, Any] | None = N
         logger.warning(f"フォント設定でエラーが発生しました: {e}")
 
 
-def parse_arguments() -> argparse.Namespace:
-    """コマンドライン引数を解析"""
+def _build_parser() -> argparse.ArgumentParser:
+    """GUI ランチャー用の argparse パーサーを構築する。
+
+    バッチ処理・アノテーション・データセット管理などの操作は GUI ランチャーの
+    対象外であり、epilog で ``lorairo-cli --help`` を案内する。
+
+    Returns:
+        構築済みの ArgumentParser。
+    """
     parser = argparse.ArgumentParser(
         description="LoRAIro - LoRA/Finetune用画像データセット管理ツール",
         formatter_class=argparse.RawDescriptionHelpFormatter,
@@ -172,6 +179,9 @@ def parse_arguments() -> argparse.Namespace:
   lorairo                    # ワークスペースGUIで起動
   lorairo --debug           # デバッグモードで起動
   lorairo --version         # バージョン表示
+
+バッチ処理・アノテーション・データセット管理などの CLI 操作:
+  lorairo-cli --help        # CLI コマンド一覧を表示
         """,
     )
 
@@ -179,7 +189,12 @@ def parse_arguments() -> argparse.Namespace:
 
     parser.add_argument("--debug", action="store_true", help="デバッグモードで起動")
 
-    return parser.parse_args()
+    return parser
+
+
+def parse_arguments() -> argparse.Namespace:
+    """コマンドライン引数を解析"""
+    return _build_parser().parse_args()
 
 
 def main() -> int:

--- a/src/lorairo/services/model_sync_service.py
+++ b/src/lorairo/services/model_sync_service.py
@@ -8,14 +8,16 @@ from __future__ import annotations
 
 import datetime
 from dataclasses import dataclass
-from typing import Any, ClassVar, Protocol, TypedDict
-
-from image_annotator_lib import AnnotatorInfo
-from image_annotator_lib.core.types import TaskCapability
+from typing import TYPE_CHECKING, Any, Protocol, TypedDict
 
 from ..database.repository.model import ModelRepository
 from ..services.configuration_service import ConfigurationService
 from ..utils.log import logger
+
+if TYPE_CHECKING:
+    # Issue #540: image-annotator-lib の import は registry 初期化 (~9s) を引き起こすため
+    # module-level import を避け、TYPE_CHECKING + 関数内 import で遅延ロードする。
+    from image_annotator_lib import AnnotatorInfo
 
 
 class ModelMetadata(TypedDict):
@@ -79,66 +81,77 @@ class MockAnnotatorLibrary:
     `AnnotatorLibraryProtocol` を満たし、5モデル分の固定データを返す。
     """
 
-    _MODELS: ClassVar[tuple[AnnotatorInfo, ...]] = (
-        AnnotatorInfo(
-            name="gpt-4o",
-            model_type="vision",
-            capabilities=frozenset({TaskCapability.TAGS, TaskCapability.CAPTIONS}),
-            is_local=False,
-            is_api=True,
-            device=None,
-            provider="openai",
-            litellm_model_id="gpt-4o",
-            max_output_tokens=1800,
-        ),
-        AnnotatorInfo(
-            name="claude-3-5-sonnet",
-            model_type="vision",
-            capabilities=frozenset({TaskCapability.TAGS, TaskCapability.CAPTIONS}),
-            is_local=False,
-            is_api=True,
-            device=None,
-            provider="anthropic",
-            litellm_model_id="claude-3-5-sonnet-20241022",
-            max_output_tokens=1800,
-        ),
-        AnnotatorInfo(
-            name="gemini-1.5-pro",
-            model_type="vision",
-            capabilities=frozenset({TaskCapability.TAGS, TaskCapability.CAPTIONS}),
-            is_local=False,
-            is_api=True,
-            device=None,
-            provider="google",
-            litellm_model_id="gemini-1.5-pro",
-            max_output_tokens=1800,
-        ),
-        AnnotatorInfo(
-            name="wd-v1-4-swinv2-tagger",
-            model_type="tagger",
-            capabilities=frozenset({TaskCapability.TAGS}),
-            is_local=True,
-            is_api=False,
-            device="cuda",
-            provider="local",
-            estimated_size_gb=1.2,
-        ),
-        AnnotatorInfo(
-            name="aesthetic-predictor",
-            model_type="scorer",
-            capabilities=frozenset({TaskCapability.SCORES}),
-            is_local=True,
-            is_api=False,
-            device="cuda",
-            provider="local",
-            estimated_size_gb=0.8,
-        ),
-    )
+    @staticmethod
+    def _build_models() -> list[AnnotatorInfo]:
+        """固定モックモデル一覧を構築する。
+
+        Issue #540: ``AnnotatorInfo`` / ``TaskCapability`` の import は
+        image-annotator-lib registry 初期化を引き起こすため、ClassVar での
+        eager 評価を避け、呼び出し時に遅延 import + 構築する。
+        """
+        from image_annotator_lib import AnnotatorInfo
+        from image_annotator_lib.core.types import TaskCapability
+
+        return [
+            AnnotatorInfo(
+                name="gpt-4o",
+                model_type="vision",
+                capabilities=frozenset({TaskCapability.TAGS, TaskCapability.CAPTIONS}),
+                is_local=False,
+                is_api=True,
+                device=None,
+                provider="openai",
+                litellm_model_id="gpt-4o",
+                max_output_tokens=1800,
+            ),
+            AnnotatorInfo(
+                name="claude-3-5-sonnet",
+                model_type="vision",
+                capabilities=frozenset({TaskCapability.TAGS, TaskCapability.CAPTIONS}),
+                is_local=False,
+                is_api=True,
+                device=None,
+                provider="anthropic",
+                litellm_model_id="claude-3-5-sonnet-20241022",
+                max_output_tokens=1800,
+            ),
+            AnnotatorInfo(
+                name="gemini-1.5-pro",
+                model_type="vision",
+                capabilities=frozenset({TaskCapability.TAGS, TaskCapability.CAPTIONS}),
+                is_local=False,
+                is_api=True,
+                device=None,
+                provider="google",
+                litellm_model_id="gemini-1.5-pro",
+                max_output_tokens=1800,
+            ),
+            AnnotatorInfo(
+                name="wd-v1-4-swinv2-tagger",
+                model_type="tagger",
+                capabilities=frozenset({TaskCapability.TAGS}),
+                is_local=True,
+                is_api=False,
+                device="cuda",
+                provider="local",
+                estimated_size_gb=1.2,
+            ),
+            AnnotatorInfo(
+                name="aesthetic-predictor",
+                model_type="scorer",
+                capabilities=frozenset({TaskCapability.SCORES}),
+                is_local=True,
+                is_api=False,
+                device="cuda",
+                provider="local",
+                estimated_size_gb=0.8,
+            ),
+        ]
 
     def list_annotator_info(self) -> list[AnnotatorInfo]:
         """モックの AnnotatorInfo 一覧"""
         logger.debug("モックライブラリから AnnotatorInfo 一覧を取得")
-        return list(self._MODELS)
+        return self._build_models()
 
 
 class ModelSyncService:
@@ -210,6 +223,8 @@ class ModelSyncService:
         else:
             logger.warning(f"Unknown library model_type: {model_type}, defaulting to ['caption']")
             db_model_types = ["caption"]
+
+        from image_annotator_lib.core.types import TaskCapability
 
         if TaskCapability.RATINGS in info.capabilities and "ratings" not in db_model_types:
             db_model_types.append("ratings")

--- a/tests/unit/cli/test_cli_import_lightness.py
+++ b/tests/unit/cli/test_cli_import_lightness.py
@@ -1,0 +1,77 @@
+"""CLI import 軽量性のリグレッションテスト (Issue #540)。
+
+`import lorairo.cli.main` (= `lorairo-cli --help` 相当の import) が
+image-annotator-lib registry 初期化や litellm の重い import を引き起こさないことを
+検証する。これらを module-import 時にロードすると `--help` が数秒かかる (#540)。
+
+検証は **subprocess** 経由で行う。pytest セッションの conftest が
+`image_annotator_lib` を `sys.modules` に inject (mock 化) しているため、
+in-process では「ロード済み」と誤検出する。fresh interpreter で確認する必要がある。
+"""
+
+import os
+import subprocess
+import sys
+
+import pytest
+
+# 子プロセスは親と同じ sys.path を継承し、同一の lorairo / local package を解決する。
+# (venv の editable install path が stale なケースでも親 path で確実に解決できる)
+_CHILD_ENV = {
+    **os.environ,
+    "PYTHONPATH": os.pathsep.join(sys.path),
+    "LORAIRO_CLI_MODE": "true",
+}
+
+
+def _run_probe(probe: str) -> subprocess.CompletedProcess[str]:
+    """fresh interpreter で probe スクリプトを実行する。"""
+    return subprocess.run(
+        [sys.executable, "-c", probe],
+        env=_CHILD_ENV,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+def test_import_main_does_not_load_image_annotator_lib() -> None:
+    """Test: `import lorairo.cli.main` で image_annotator_lib がロードされない。"""
+    probe = (
+        "import sys\n"
+        "import lorairo.cli.main\n"
+        "loaded = sorted(m for m in sys.modules if 'image_annotator_lib' in m)\n"
+        "assert not loaded, f'unexpected eager import: {loaded}'\n"
+    )
+    result = _run_probe(probe)
+    assert result.returncode == 0, f"stdout={result.stdout!r}\nstderr={result.stderr!r}"
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+def test_import_main_does_not_load_litellm() -> None:
+    """Test: `import lorairo.cli.main` で litellm がロードされない。"""
+    probe = (
+        "import sys\n"
+        "import lorairo.cli.main\n"
+        "assert 'litellm' not in sys.modules, 'litellm eagerly imported'\n"
+    )
+    result = _run_probe(probe)
+    assert result.returncode == 0, f"stdout={result.stdout!r}\nstderr={result.stderr!r}"
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+def test_app_object_available_without_heavy_imports() -> None:
+    """Test: Typer `app` オブジェクトは重い import なしで利用可能。"""
+    probe = (
+        "import sys\n"
+        "from lorairo.cli.main import app\n"
+        "import typer\n"
+        "assert isinstance(app, typer.Typer)\n"
+        "assert 'image_annotator_lib' not in sys.modules\n"
+    )
+    result = _run_probe(probe)
+    assert result.returncode == 0, f"stdout={result.stdout!r}\nstderr={result.stderr!r}"

--- a/tests/unit/cli/test_cli_log_level.py
+++ b/tests/unit/cli/test_cli_log_level.py
@@ -1,0 +1,101 @@
+"""CLI `--log-level` オプションのテスト (Issue #539)。
+
+ログ初期化は `@app.callback()` (`_configure`) でサブコマンド実行時に行われる。
+`--log-level` 未指定で既定 INFO、明示指定で該当レベルが `initialize_logging` に
+渡ることを検証する。実 annotation は呼ばず、軽量な `version` サブコマンドで検証する。
+"""
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+from typer.testing import CliRunner
+
+from lorairo.cli.main import app
+
+runner = CliRunner()
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+def test_log_level_defaults_to_info(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test: `--log-level` 未指定で initialize_logging が level=INFO で呼ばれる。"""
+    spy = MagicMock()
+    monkeypatch.setattr("lorairo.cli.main.initialize_logging", spy)
+
+    result = runner.invoke(app, ["version"])
+
+    assert result.exit_code == 0
+    spy.assert_called_once()
+    assert spy.call_args[0][0]["level"] == "INFO"
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+def test_log_level_warning(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test: `--log-level WARNING` で initialize_logging が level=WARNING で呼ばれる。"""
+    spy = MagicMock()
+    monkeypatch.setattr("lorairo.cli.main.initialize_logging", spy)
+
+    result = runner.invoke(app, ["--log-level", "WARNING", "version"])
+
+    assert result.exit_code == 0
+    spy.assert_called_once()
+    assert spy.call_args[0][0]["level"] == "WARNING"
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+def test_log_level_debug(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test: `--log-level DEBUG` で initialize_logging が level=DEBUG で呼ばれる。"""
+    spy = MagicMock()
+    monkeypatch.setattr("lorairo.cli.main.initialize_logging", spy)
+
+    result = runner.invoke(app, ["--log-level", "DEBUG", "version"])
+
+    assert result.exit_code == 0
+    spy.assert_called_once()
+    assert spy.call_args[0][0]["level"] == "DEBUG"
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+def test_log_level_case_insensitive(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test: `--log-level` は大文字小文字を区別せず正規化される。"""
+    spy = MagicMock()
+    monkeypatch.setattr("lorairo.cli.main.initialize_logging", spy)
+
+    result = runner.invoke(app, ["--log-level", "warning", "version"])
+
+    assert result.exit_code == 0
+    spy.assert_called_once()
+    assert spy.call_args[0][0]["level"] == "WARNING"
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+def test_help_does_not_initialize_logging(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test: `--help` では callback が走らず initialize_logging が呼ばれない (#540)。"""
+    spy = MagicMock()
+    monkeypatch.setattr("lorairo.cli.main.initialize_logging", spy)
+
+    result = runner.invoke(app, ["--help"])
+
+    assert result.exit_code == 0
+    spy.assert_not_called()
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+def test_log_config_preserves_path_and_rotation(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test: file_path と rotation が従来どおり維持される。"""
+    spy = MagicMock()
+    monkeypatch.setattr("lorairo.cli.main.initialize_logging", spy)
+
+    result = runner.invoke(app, ["version"])
+
+    assert result.exit_code == 0
+    config_arg = spy.call_args[0][0]
+    log_path = Path(config_arg["file_path"])
+    assert log_path.name == "lorairo-cli.log"
+    assert config_arg["rotation"] == "25 MB"

--- a/tests/unit/cli/test_commands_models.py
+++ b/tests/unit/cli/test_commands_models.py
@@ -864,7 +864,10 @@ def test_models_list_diagnostic_log_includes_config_and_key_status(mock_get_cont
     buffer = StringIO()
     handler_id = loguru_logger.add(buffer, format="{message}", level="DEBUG")
     try:
-        result = runner.invoke(app, ["models", "list", "--show-unavailable"])
+        # Issue #539: callback の initialize_logging が loguru sink を remove するため、
+        # 診断ログ捕捉専用にここでは no-op 化し、test 用 sink を維持する。
+        with patch("lorairo.cli.main.initialize_logging"):
+            result = runner.invoke(app, ["models", "list", "--show-unavailable"])
     finally:
         loguru_logger.remove(handler_id)
 

--- a/tests/unit/cli/test_main.py
+++ b/tests/unit/cli/test_main.py
@@ -163,18 +163,21 @@ def test_project_help() -> None:
 
 @pytest.mark.unit
 @pytest.mark.cli
-def test_main_configures_logging_warning_level() -> None:
-    """Test: main() が CLI モードで専用ログファイルを WARNING レベルに設定する。"""
-    with patch("lorairo.cli.main.initialize_logging") as mock_init_log, patch("lorairo.cli.main.app"):
-        from lorairo.cli.main import main
+def test_callback_configures_logging_default_info(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test: @app.callback が CLI モードで専用ログファイルを既定 INFO レベルに設定する (#539)。"""
+    spy = MagicMock()
+    monkeypatch.setattr("lorairo.cli.main.initialize_logging", spy)
 
-        main()
-    mock_init_log.assert_called_once()
-    config_arg = mock_init_log.call_args[0][0]
-    assert config_arg["level"] == "WARNING"
+    result = runner.invoke(app, ["version"])
+
+    assert result.exit_code == 0
+    spy.assert_called_once()
+    config_arg = spy.call_args[0][0]
+    assert config_arg["level"] == "INFO"
     log_path = Path(config_arg["file_path"])
     assert log_path.name == "lorairo-cli.log"
     assert log_path.parent.name == "logs"
+    assert config_arg["rotation"] == "25 MB"
 
 
 # Issue #254: stdio init / Windows console code page / loguru sink クリア の test は

--- a/tests/unit/test_main_launcher_help.py
+++ b/tests/unit/test_main_launcher_help.py
@@ -1,0 +1,24 @@
+"""GUI ランチャー (``lorairo``) の help 出力に関する unit テスト。
+
+Issue #541: GUI ランチャーの help がバッチ/アノテーション/データセット操作に
+言及していないため、``lorairo-cli`` への誘導が表示されることを検証する。
+"""
+
+import pytest
+
+from lorairo.main import _build_parser
+
+
+@pytest.mark.unit
+def test_help_text_guides_to_lorairo_cli() -> None:
+    """help テキストに ``lorairo-cli`` への誘導が含まれることを検証する。"""
+    help_text = _build_parser().format_help()
+    assert "lorairo-cli" in help_text
+
+
+@pytest.mark.unit
+def test_help_text_retains_existing_options() -> None:
+    """既存の ``--debug`` / ``--version`` の記述が help に残ることを検証する。"""
+    help_text = _build_parser().format_help()
+    assert "--debug" in help_text
+    assert "--version" in help_text


### PR DESCRIPTION
## 概要

エピック #535（CLI/GUI 開発者体験改善）のサブ Issue 3 件を Agent Teams 並列実装で解決。

- **Closes #539** — CLI ログレベル設定可能化
- **Closes #540** — CLI meta コマンドの annotator registry 遅延ロード
- **Closes #541** — `lorairo --help` から `lorairo-cli` へ誘導
- **Refs #535** （完了でエピッククローズ）

## 変更内容

### #540 annotator registry 遅延ロード（`src/lorairo/services/model_sync_service.py`）
`import lorairo.cli.main` が transitive に `model_sync_service` → `from image_annotator_lib import AnnotatorInfo` を引き、import 時に image-annotator-lib registry 初期化（litellm の 168 model discovery + `register_annotators`）を起こしていた。これを lazy 化:
- `AnnotatorInfo` / `TaskCapability` を `TYPE_CHECKING` ブロックへ
- `MockAnnotatorLibrary._MODELS` ClassVar（class-def 時に eager 評価）を `_build_models()` staticmethod + 関数内遅延 import に変換
- `_map_library_model_type_to_db` の runtime 用途を関数内 import 化

**効果**: `import lorairo.cli.main` 時点で `image_annotator_lib` / `litellm` が**ロードされない**ことを確認（subprocess smoke test で検証）。`models list` 等 registry 必須コマンドは実行時に初期化され従来どおり動作。ADR 0010（lazy import）方針に準拠。

### #539 ログレベル設定可能化（`src/lorairo/cli/main.py`）
- ログ初期化を `main()` のハードコード `WARNING` から `@app.callback()` へ移行
- `--log-level LEVEL`（既定 `INFO`、case-insensitive）option を追加。`file_path` / `rotation` は維持
- `@app.callback()` は `--help` 時に走らない → ログ初期化の副作用が help 表示時に発生しない（#540 と整合）

### #541 GUI launcher help 誘導（`src/lorairo/main.py`）
- argparse epilog に「バッチ処理・アノテーション・データセット管理は `lorairo-cli --help`」を案内する行を追加
- parser 構築を `_build_parser()` に抽出（テスト容易性）。`--version` / `--debug` option は不変

## テスト

- 新規: `tests/unit/cli/test_cli_import_lightness.py`（3件、subprocess で `sys.modules` 検証）、`tests/unit/cli/test_cli_log_level.py`（6件）、`tests/unit/test_main_launcher_help.py`（2件）
- 既存: `test_main.py` / `test_commands_models.py` を callback 移行に合わせ更新
- **CI-equivalent filter で全 unit + integration スイート pass**（3446 passed, 2 skipped）

## 実装方式

Agent Teams 2-track 並列（Track A=#539+#540 `cli/main.py` 系を同一オーナー直列 / Track B=#541 `main.py` 独立）。別ファイルで衝突ゼロ。詳細は `docs/plans/plan_535_cli_dx_epic_agentteams.md`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)