### PR TITLE
feat: extract StagingWidget from BatchTagAddWidget (#549)

### DIFF
--- a/src/lorairo/gui/designer/BatchTagAddWidget.ui
+++ b/src/lorairo/gui/designer/BatchTagAddWidget.ui
@@ -37,92 +37,13 @@
      <property name="childrenCollapsible">
       <bool>false</bool>
      </property>
-     <widget class="QGroupBox" name="groupBoxStagingList">
-      <property name="title">
-       <string>ステージング一覧</string>
+     <widget class="StagingWidget" name="stagingWidget" native="true">
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+        <horstretch>1</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
       </property>
-      <layout class="QVBoxLayout" name="verticalLayoutStaging">
-       <item>
-        <widget class="QLabel" name="labelStagingCount">
-         <property name="text">
-          <string>0 / 500 枚</string>
-         </property>
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QListWidget" name="listWidgetStaging">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-           <horstretch>0</horstretch>
-           <verstretch>1</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="minimumHeight">
-          <number>150</number>
-         </property>
-         <property name="viewMode">
-          <enum>QListView::ViewMode::IconMode</enum>
-         </property>
-         <property name="movement">
-          <enum>QListView::Movement::Static</enum>
-         </property>
-         <property name="resizeMode">
-          <enum>QListView::ResizeMode::Adjust</enum>
-         </property>
-         <property name="spacing">
-          <number>6</number>
-         </property>
-         <property name="iconSize">
-          <size>
-           <width>96</width>
-           <height>96</height>
-          </size>
-         </property>
-         <property name="wordWrap">
-          <bool>true</bool>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <layout class="QHBoxLayout" name="horizontalLayoutStagingButtons">
-         <item>
-          <spacer name="horizontalSpacerStagingButtons">
-           <property name="orientation">
-            <enum>Qt::Orientation::Horizontal</enum>
-           </property>
-           <property name="sizeHint" stdset="0">
-            <size>
-             <width>40</width>
-             <height>20</height>
-            </size>
-           </property>
-          </spacer>
-         </item>
-         <item>
-          <widget class="QPushButton" name="pushButtonClearStaging">
-           <property name="text">
-            <string>クリア</string>
-           </property>
-           <property name="minimumWidth">
-            <number>60</number>
-           </property>
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </item>
-      </layout>
      </widget>
      <widget class="QGroupBox" name="groupBoxTagInput">
       <property name="title">
@@ -194,24 +115,16 @@
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>StagingWidget</class>
+   <extends>QWidget</extends>
+   <header>lorairo/gui/widgets/staging_widget.h</header>
+   <container>0</container>
+  </customwidget>
+ </customwidgets>
  <resources />
  <connections>
-  <connection>
-   <sender>pushButtonClearStaging</sender>
-   <signal>clicked()</signal>
-   <receiver>BatchTagAddWidget</receiver>
-   <slot>_on_clear_staging_clicked()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>220</x>
-     <y>200</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>125</x>
-     <y>250</y>
-    </hint>
-   </hints>
-  </connection>
   <connection>
    <sender>pushButtonAddTag</sender>
    <signal>clicked()</signal>
@@ -231,7 +144,6 @@
  </connections>
  <slots>
   <slot>_on_add_selected_clicked()</slot>
-  <slot>_on_clear_staging_clicked()</slot>
   <slot>_on_add_tag_clicked()</slot>
  </slots>
 </ui>

--- a/src/lorairo/gui/designer/BatchTagAddWidget_ui.py
+++ b/src/lorairo/gui/designer/BatchTagAddWidget_ui.py
@@ -16,12 +16,13 @@ from PySide6.QtGui import (QBrush, QColor, QConicalGradient, QCursor,
     QImage, QKeySequence, QLinearGradient, QPainter,
     QPalette, QPixmap, QRadialGradient, QTransform)
 from PySide6.QtWidgets import (QApplication, QGroupBox, QHBoxLayout, QLabel,
-    QLineEdit, QListView, QListWidget, QListWidgetItem,
-    QPushButton, QSizePolicy, QSpacerItem, QSplitter,
-    QVBoxLayout, QWidget)
+    QLineEdit, QPushButton, QSizePolicy, QSpacerItem,
+    QSplitter, QVBoxLayout, QWidget)
+
+from lorairo.gui.widgets.staging_widget import StagingWidget
 
 class Ui_BatchTagAddWidget(object):
-    def setupUi(self, BatchTagAddWidget):
+    def setupUi(self, BatchTagAddWidget: QWidget) -> None:
         if not BatchTagAddWidget.objectName():
             BatchTagAddWidget.setObjectName(u"BatchTagAddWidget")
         BatchTagAddWidget.resize(250, 500)
@@ -33,76 +34,35 @@ class Ui_BatchTagAddWidget(object):
         self.splitterBatchTagStaging.setObjectName(u"splitterBatchTagStaging")
         self.splitterBatchTagStaging.setOrientation(Qt.Orientation.Horizontal)
         self.splitterBatchTagStaging.setChildrenCollapsible(False)
-        self.groupBoxStagingList = QGroupBox(self.splitterBatchTagStaging)
-        self.groupBoxStagingList.setObjectName(u"groupBoxStagingList")
-        self.verticalLayoutStaging = QVBoxLayout(self.groupBoxStagingList)
-        self.verticalLayoutStaging.setObjectName(u"verticalLayoutStaging")
-        self.labelStagingCount = QLabel(self.groupBoxStagingList)
-        self.labelStagingCount.setObjectName(u"labelStagingCount")
-        sizePolicy = QSizePolicy(QSizePolicy.Policy.Preferred, QSizePolicy.Policy.Fixed)
-        sizePolicy.setHorizontalStretch(0)
+        self.stagingWidget = StagingWidget(self.splitterBatchTagStaging)
+        self.stagingWidget.setObjectName(u"stagingWidget")
+        sizePolicy = QSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Expanding)
+        sizePolicy.setHorizontalStretch(1)
         sizePolicy.setVerticalStretch(0)
-        sizePolicy.setHeightForWidth(self.labelStagingCount.sizePolicy().hasHeightForWidth())
-        self.labelStagingCount.setSizePolicy(sizePolicy)
-
-        self.verticalLayoutStaging.addWidget(self.labelStagingCount)
-
-        self.listWidgetStaging = QListWidget(self.groupBoxStagingList)
-        self.listWidgetStaging.setObjectName(u"listWidgetStaging")
-        sizePolicy1 = QSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Expanding)
-        sizePolicy1.setHorizontalStretch(0)
-        sizePolicy1.setVerticalStretch(1)
-        sizePolicy1.setHeightForWidth(self.listWidgetStaging.sizePolicy().hasHeightForWidth())
-        self.listWidgetStaging.setSizePolicy(sizePolicy1)
-        self.listWidgetStaging.setMinimumHeight(150)
-        self.listWidgetStaging.setViewMode(QListView.ViewMode.IconMode)
-        self.listWidgetStaging.setMovement(QListView.Movement.Static)
-        self.listWidgetStaging.setResizeMode(QListView.ResizeMode.Adjust)
-        self.listWidgetStaging.setSpacing(6)
-        self.listWidgetStaging.setIconSize(QSize(96, 96))
-        self.listWidgetStaging.setWordWrap(True)
-
-        self.verticalLayoutStaging.addWidget(self.listWidgetStaging)
-
-        self.horizontalLayoutStagingButtons = QHBoxLayout()
-        self.horizontalLayoutStagingButtons.setObjectName(u"horizontalLayoutStagingButtons")
-        self.horizontalSpacerStagingButtons = QSpacerItem(40, 20, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum)
-
-        self.horizontalLayoutStagingButtons.addItem(self.horizontalSpacerStagingButtons)
-
-        self.pushButtonClearStaging = QPushButton(self.groupBoxStagingList)
-        self.pushButtonClearStaging.setObjectName(u"pushButtonClearStaging")
-        self.pushButtonClearStaging.setMinimumWidth(60)
-        sizePolicy2 = QSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed)
-        sizePolicy2.setHorizontalStretch(0)
-        sizePolicy2.setVerticalStretch(0)
-        sizePolicy2.setHeightForWidth(self.pushButtonClearStaging.sizePolicy().hasHeightForWidth())
-        self.pushButtonClearStaging.setSizePolicy(sizePolicy2)
-
-        self.horizontalLayoutStagingButtons.addWidget(self.pushButtonClearStaging)
-
-
-        self.verticalLayoutStaging.addLayout(self.horizontalLayoutStagingButtons)
-
-        self.splitterBatchTagStaging.addWidget(self.groupBoxStagingList)
+        sizePolicy.setHeightForWidth(self.stagingWidget.sizePolicy().hasHeightForWidth())
+        self.stagingWidget.setSizePolicy(sizePolicy)
+        self.splitterBatchTagStaging.addWidget(self.stagingWidget)
         self.groupBoxTagInput = QGroupBox(self.splitterBatchTagStaging)
         self.groupBoxTagInput.setObjectName(u"groupBoxTagInput")
         self.verticalLayoutTag = QVBoxLayout(self.groupBoxTagInput)
         self.verticalLayoutTag.setObjectName(u"verticalLayoutTag")
         self.labelTagInstruction = QLabel(self.groupBoxTagInput)
         self.labelTagInstruction.setObjectName(u"labelTagInstruction")
-        sizePolicy.setHeightForWidth(self.labelTagInstruction.sizePolicy().hasHeightForWidth())
-        self.labelTagInstruction.setSizePolicy(sizePolicy)
+        sizePolicy1 = QSizePolicy(QSizePolicy.Policy.Preferred, QSizePolicy.Policy.Fixed)
+        sizePolicy1.setHorizontalStretch(0)
+        sizePolicy1.setVerticalStretch(0)
+        sizePolicy1.setHeightForWidth(self.labelTagInstruction.sizePolicy().hasHeightForWidth())
+        self.labelTagInstruction.setSizePolicy(sizePolicy1)
 
         self.verticalLayoutTag.addWidget(self.labelTagInstruction)
 
         self.lineEditTag = QLineEdit(self.groupBoxTagInput)
         self.lineEditTag.setObjectName(u"lineEditTag")
-        sizePolicy3 = QSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed)
-        sizePolicy3.setHorizontalStretch(0)
-        sizePolicy3.setVerticalStretch(0)
-        sizePolicy3.setHeightForWidth(self.lineEditTag.sizePolicy().hasHeightForWidth())
-        self.lineEditTag.setSizePolicy(sizePolicy3)
+        sizePolicy2 = QSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed)
+        sizePolicy2.setHorizontalStretch(0)
+        sizePolicy2.setVerticalStretch(0)
+        sizePolicy2.setHeightForWidth(self.lineEditTag.sizePolicy().hasHeightForWidth())
+        self.lineEditTag.setSizePolicy(sizePolicy2)
 
         self.verticalLayoutTag.addWidget(self.lineEditTag)
 
@@ -115,8 +75,11 @@ class Ui_BatchTagAddWidget(object):
         self.pushButtonAddTag = QPushButton(self.groupBoxTagInput)
         self.pushButtonAddTag.setObjectName(u"pushButtonAddTag")
         self.pushButtonAddTag.setMinimumWidth(80)
-        sizePolicy2.setHeightForWidth(self.pushButtonAddTag.sizePolicy().hasHeightForWidth())
-        self.pushButtonAddTag.setSizePolicy(sizePolicy2)
+        sizePolicy3 = QSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed)
+        sizePolicy3.setHorizontalStretch(0)
+        sizePolicy3.setVerticalStretch(0)
+        sizePolicy3.setHeightForWidth(self.pushButtonAddTag.sizePolicy().hasHeightForWidth())
+        self.pushButtonAddTag.setSizePolicy(sizePolicy3)
 
         self.horizontalLayoutTagButtons.addWidget(self.pushButtonAddTag)
 
@@ -129,17 +92,13 @@ class Ui_BatchTagAddWidget(object):
 
 
         self.retranslateUi(BatchTagAddWidget)
-        self.pushButtonClearStaging.clicked.connect(BatchTagAddWidget._on_clear_staging_clicked)
         self.pushButtonAddTag.clicked.connect(BatchTagAddWidget._on_add_tag_clicked)
 
         QMetaObject.connectSlotsByName(BatchTagAddWidget)
     # setupUi
 
-    def retranslateUi(self, BatchTagAddWidget):
+    def retranslateUi(self, BatchTagAddWidget: QWidget) -> None:
         BatchTagAddWidget.setWindowTitle(QCoreApplication.translate("BatchTagAddWidget", u"Batch Tag Add", None))
-        self.groupBoxStagingList.setTitle(QCoreApplication.translate("BatchTagAddWidget", u"\u30b9\u30c6\u30fc\u30b8\u30f3\u30b0\u4e00\u89a7", None))
-        self.labelStagingCount.setText(QCoreApplication.translate("BatchTagAddWidget", u"0 / 500 \u679a", None))
-        self.pushButtonClearStaging.setText(QCoreApplication.translate("BatchTagAddWidget", u"\u30af\u30ea\u30a2", None))
         self.groupBoxTagInput.setTitle(QCoreApplication.translate("BatchTagAddWidget", u"\u30bf\u30b0\u8ffd\u52a0", None))
         self.labelTagInstruction.setText(QCoreApplication.translate("BatchTagAddWidget", u"\u8ffd\u52a0\u3059\u308b\u30bf\u30b0\u3092\u5165\u529b\u3057\u3066\u304f\u3060\u3055\u3044:", None))
         self.lineEditTag.setPlaceholderText(QCoreApplication.translate("BatchTagAddWidget", u"\u4f8b: landscape", None))

--- a/src/lorairo/gui/designer/StagingWidget.ui
+++ b/src/lorairo/gui/designer/StagingWidget.ui
@@ -1,0 +1,145 @@
+<?xml version='1.0' encoding='utf-8'?>
+<ui version="4.0">
+ <class>StagingWidget</class>
+ <widget class="QWidget" name="StagingWidget">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>250</width>
+    <height>400</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Staging</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayoutStagingMain">
+   <property name="spacing">
+    <number>4</number>
+   </property>
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
+    <number>0</number>
+   </property>
+   <item>
+    <widget class="QGroupBox" name="groupBoxStagingList">
+     <property name="title">
+      <string>ステージング一覧</string>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayoutStaging">
+      <item>
+       <widget class="QLabel" name="labelStagingCount">
+        <property name="text">
+         <string>0 / 500 枚</string>
+        </property>
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QListWidget" name="listWidgetStaging">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+          <horstretch>0</horstretch>
+          <verstretch>1</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="minimumHeight">
+         <number>150</number>
+        </property>
+        <property name="viewMode">
+         <enum>QListView::ViewMode::IconMode</enum>
+        </property>
+        <property name="movement">
+         <enum>QListView::Movement::Static</enum>
+        </property>
+        <property name="resizeMode">
+         <enum>QListView::ResizeMode::Adjust</enum>
+        </property>
+        <property name="spacing">
+         <number>6</number>
+        </property>
+        <property name="iconSize">
+         <size>
+          <width>96</width>
+          <height>96</height>
+         </size>
+        </property>
+        <property name="wordWrap">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayoutStagingButtons">
+        <item>
+         <spacer name="horizontalSpacerStagingButtons">
+          <property name="orientation">
+           <enum>Qt::Orientation::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+        <item>
+         <widget class="QPushButton" name="pushButtonClearStaging">
+          <property name="text">
+           <string>クリア</string>
+          </property>
+          <property name="minimumWidth">
+           <number>60</number>
+          </property>
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+     </layout>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources />
+ <connections>
+  <connection>
+   <sender>pushButtonClearStaging</sender>
+   <signal>clicked()</signal>
+   <receiver>StagingWidget</receiver>
+   <slot>_on_clear_staging_clicked()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>220</x>
+     <y>360</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>125</x>
+     <y>200</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+ <slots>
+  <slot>_on_clear_staging_clicked()</slot>
+ </slots>
+</ui>

--- a/src/lorairo/gui/designer/StagingWidget_ui.py
+++ b/src/lorairo/gui/designer/StagingWidget_ui.py
@@ -1,0 +1,98 @@
+# -*- coding: utf-8 -*-
+
+################################################################################
+## Form generated from reading UI file 'StagingWidget.ui'
+##
+## Created by: Qt User Interface Compiler version 6.11.1
+##
+## WARNING! All changes made in this file will be lost when recompiling UI file!
+################################################################################
+
+from PySide6.QtCore import (QCoreApplication, QDate, QDateTime, QLocale,
+    QMetaObject, QObject, QPoint, QRect,
+    QSize, QTime, QUrl, Qt)
+from PySide6.QtGui import (QBrush, QColor, QConicalGradient, QCursor,
+    QFont, QFontDatabase, QGradient, QIcon,
+    QImage, QKeySequence, QLinearGradient, QPainter,
+    QPalette, QPixmap, QRadialGradient, QTransform)
+from PySide6.QtWidgets import (QApplication, QGroupBox, QHBoxLayout, QLabel,
+    QListView, QListWidget, QListWidgetItem, QPushButton,
+    QSizePolicy, QSpacerItem, QVBoxLayout, QWidget)
+
+class Ui_StagingWidget(object):
+    def setupUi(self, StagingWidget: QWidget) -> None:
+        if not StagingWidget.objectName():
+            StagingWidget.setObjectName(u"StagingWidget")
+        StagingWidget.resize(250, 400)
+        self.verticalLayoutStagingMain = QVBoxLayout(StagingWidget)
+        self.verticalLayoutStagingMain.setSpacing(4)
+        self.verticalLayoutStagingMain.setObjectName(u"verticalLayoutStagingMain")
+        self.verticalLayoutStagingMain.setContentsMargins(0, 0, 0, 0)
+        self.groupBoxStagingList = QGroupBox(StagingWidget)
+        self.groupBoxStagingList.setObjectName(u"groupBoxStagingList")
+        self.verticalLayoutStaging = QVBoxLayout(self.groupBoxStagingList)
+        self.verticalLayoutStaging.setObjectName(u"verticalLayoutStaging")
+        self.labelStagingCount = QLabel(self.groupBoxStagingList)
+        self.labelStagingCount.setObjectName(u"labelStagingCount")
+        sizePolicy = QSizePolicy(QSizePolicy.Policy.Preferred, QSizePolicy.Policy.Fixed)
+        sizePolicy.setHorizontalStretch(0)
+        sizePolicy.setVerticalStretch(0)
+        sizePolicy.setHeightForWidth(self.labelStagingCount.sizePolicy().hasHeightForWidth())
+        self.labelStagingCount.setSizePolicy(sizePolicy)
+
+        self.verticalLayoutStaging.addWidget(self.labelStagingCount)
+
+        self.listWidgetStaging = QListWidget(self.groupBoxStagingList)
+        self.listWidgetStaging.setObjectName(u"listWidgetStaging")
+        sizePolicy1 = QSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Expanding)
+        sizePolicy1.setHorizontalStretch(0)
+        sizePolicy1.setVerticalStretch(1)
+        sizePolicy1.setHeightForWidth(self.listWidgetStaging.sizePolicy().hasHeightForWidth())
+        self.listWidgetStaging.setSizePolicy(sizePolicy1)
+        self.listWidgetStaging.setMinimumHeight(150)
+        self.listWidgetStaging.setViewMode(QListView.ViewMode.IconMode)
+        self.listWidgetStaging.setMovement(QListView.Movement.Static)
+        self.listWidgetStaging.setResizeMode(QListView.ResizeMode.Adjust)
+        self.listWidgetStaging.setSpacing(6)
+        self.listWidgetStaging.setIconSize(QSize(96, 96))
+        self.listWidgetStaging.setWordWrap(True)
+
+        self.verticalLayoutStaging.addWidget(self.listWidgetStaging)
+
+        self.horizontalLayoutStagingButtons = QHBoxLayout()
+        self.horizontalLayoutStagingButtons.setObjectName(u"horizontalLayoutStagingButtons")
+        self.horizontalSpacerStagingButtons = QSpacerItem(40, 20, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum)
+
+        self.horizontalLayoutStagingButtons.addItem(self.horizontalSpacerStagingButtons)
+
+        self.pushButtonClearStaging = QPushButton(self.groupBoxStagingList)
+        self.pushButtonClearStaging.setObjectName(u"pushButtonClearStaging")
+        self.pushButtonClearStaging.setMinimumWidth(60)
+        sizePolicy2 = QSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed)
+        sizePolicy2.setHorizontalStretch(0)
+        sizePolicy2.setVerticalStretch(0)
+        sizePolicy2.setHeightForWidth(self.pushButtonClearStaging.sizePolicy().hasHeightForWidth())
+        self.pushButtonClearStaging.setSizePolicy(sizePolicy2)
+
+        self.horizontalLayoutStagingButtons.addWidget(self.pushButtonClearStaging)
+
+
+        self.verticalLayoutStaging.addLayout(self.horizontalLayoutStagingButtons)
+
+
+        self.verticalLayoutStagingMain.addWidget(self.groupBoxStagingList)
+
+
+        self.retranslateUi(StagingWidget)
+        self.pushButtonClearStaging.clicked.connect(StagingWidget._on_clear_staging_clicked)
+
+        QMetaObject.connectSlotsByName(StagingWidget)
+    # setupUi
+
+    def retranslateUi(self, StagingWidget: QWidget) -> None:
+        StagingWidget.setWindowTitle(QCoreApplication.translate("StagingWidget", u"Staging", None))
+        self.groupBoxStagingList.setTitle(QCoreApplication.translate("StagingWidget", u"\u30b9\u30c6\u30fc\u30b8\u30f3\u30b0\u4e00\u89a7", None))
+        self.labelStagingCount.setText(QCoreApplication.translate("StagingWidget", u"0 / 500 \u679a", None))
+        self.pushButtonClearStaging.setText(QCoreApplication.translate("StagingWidget", u"\u30af\u30ea\u30a2", None))
+    # retranslateUi
+

--- a/src/lorairo/gui/widgets/batch_tag_add_widget.py
+++ b/src/lorairo/gui/widgets/batch_tag_add_widget.py
@@ -2,18 +2,19 @@
 Batch Tag Add Widget - バッチタグ追加ウィジェット
 
 複数画像に対して1つのタグを一括追加するための専用ウィジェット。
-MainWindow右パネルのタブとして配置され、バッチ操作を担当。
+MainWindow 右パネルのタブとして配置され、バッチ操作を担当。
 
 主要機能:
-- ステージングリストへの画像追加（最大500枚）
+- StagingWidget によるステージングリスト管理（最大500枚）
 - タグの正規化とバリデーション
 - バッチタグ追加操作
 
 アーキテクチャ:
 - QTabWidget のタブ3（バッチタグ追加）に配置
-- DatasetStateManager から選択画像IDを取得
+- DatasetStateManager から選択画像 ID を取得
 - 保存時に tag_add_requested シグナルを発行
 - MainWindow が ImageDBWriteService 経由で一括保存処理を実行
+- ステージング責務は StagingWidget に委譲（ADR 0041）
 """
 
 from collections import OrderedDict
@@ -21,16 +22,15 @@ from collections.abc import Callable
 from typing import TYPE_CHECKING, cast
 
 from genai_tag_db_tools.utils.cleanup_str import TagCleaner
-from PySide6.QtCore import QSize, Qt, Signal, Slot
-from PySide6.QtGui import QPixmap
-from PySide6.QtWidgets import QFrame, QGraphicsView, QMessageBox, QVBoxLayout, QWidget
+from PySide6.QtCore import Signal, Slot
+from PySide6.QtWidgets import QMessageBox, QVBoxLayout, QWidget
 
 from ...gui.designer.BatchTagAddWidget_ui import Ui_BatchTagAddWidget
 from ...utils.log import logger
+from .staging_widget import StagingWidget
 
 if TYPE_CHECKING:
     from ..state.dataset_state import DatasetStateManager
-    from .thumbnail import ThumbnailSelectorWidget
 
 
 def normalize_tag(tag: str) -> str:
@@ -53,124 +53,151 @@ class BatchTagAddWidget(QWidget):
     バッチタグ追加ウィジェット
 
     複数画像に対して1つのタグを一括追加。
-    ステージングリスト管理とタグ正規化を担当。
+    ステージング管理は内部 StagingWidget に委譲し、タグ正規化を担当。
 
     データフロー:
-    1. "選択中の画像を追加" -> DatasetStateManager.selected_image_ids を取得
+    1. "選択中の画像を追加" -> StagingWidget.add_selected_images() 経由でステージングに追加
     2. ステージングリストに追加（最大500枚、重複なし）
     3. タグ入力 -> 正規化（lower + strip）
     4. "追加" -> tag_add_requested シグナル発行
     5. MainWindow が ImageDBWriteService.add_tag_batch() で DB 更新
 
-    UI構成:
-    - stagingThumbnailWidget: ステージング画像サムネイル（ThumbnailSelectorWidget）
+    後方互換性:
+    - _staged_images プロパティ: StagingWidget.get_staged_items() へ委譲
+      main_window._get_staged_image_paths_for_annotation() が
+      `._staged_images.items()` で参照するため、互換プロパティで維持する（Wave 2 で移行）
+    - _on_clear_staging_clicked(): main_window._handle_batch_tag_add() が直接呼び出す
+    - _refresh_staging_list_ui(): main_window が hasattr 確認後呼び出す
+    - add_selected_images_to_staging(): main_window から呼ばれる公開 API
+    - add_image_ids_to_staging(): main_window から呼ばれる公開 API
+    - set_dataset_state_manager(): main_window から呼ばれる公開 API
+
+    UI 構成:
+    - stagingWidget: ステージング（StagingWidget プロモーション）
     - lineEditTag: タグ入力フィールド
-    - pushButtonClearStaging: ステージングリストをクリア
     - pushButtonAddTag: タグを追加
 
     ステージングリスト仕様:
     - 最大500枚まで
-    - 重複なし（set管理）
+    - 重複なし（set 管理）
     - 追加順を保持（OrderedDict）
-    - 個別削除: Delete キー
     """
 
     # シグナル
-    staged_images_changed = Signal(list)  # List[int] - ステージング画像IDリスト
+    staged_images_changed = Signal(list)  # list[int] - ステージング画像IDリスト（StagingWidget から再公開）
     tag_add_requested = Signal(list, str)  # (image_ids, tag) - タグ追加要求
-    staging_cleared = Signal()  # ステージングリストクリア
+    staging_cleared = Signal()  # ステージングリストクリア（StagingWidget から再公開）
 
-    # 定数
-    MAX_STAGING_IMAGES = 500
+    # 定数（StagingWidget と同値を公開, main_window / テストが参照する）
+    MAX_STAGING_IMAGES = StagingWidget.MAX_STAGING_IMAGES
 
     def __init__(self, parent: QWidget | None = None):
         """
         BatchTagAddWidget 初期化
 
-        UIコンポーネントの初期化、内部状態の設定、シグナル接続を実行。
+        UIコンポーネントの初期化、内部 StagingWidget との接続、シグナル再公開を実行。
 
         Args:
             parent: 親ウィジェット
-
-        初期状態:
-            - _staged_images: 空の OrderedDict
-            - _dataset_state_manager: None
-            - UI: 空表示状態
         """
         super().__init__(parent)
         logger.debug("BatchTagAddWidget.__init__() called")
 
-        # 内部状態: ステージング画像管理（OrderedDict で順序保持 + 重複排除）
-        # {image_id: (filename, stored_path)}
-        self._staged_images: OrderedDict[int, tuple[str, str]] = OrderedDict()
-
-        # サムネイルキャッシュ（表示用の縮小Pixmap）
-        self._thumbnail_cache: dict[int, QPixmap] = {}
-
-        # DatasetStateManagerへの参照（後でset_dataset_state_managerで設定）
+        # DatasetStateManager への参照（後で set_dataset_state_manager() で設定）
         self._dataset_state_manager: DatasetStateManager | None = None
 
-        # UI設定
+        # UI 設定
         self.ui = Ui_BatchTagAddWidget()
         setup_ui = cast(Callable[[QWidget], None], self.ui.setupUi)
         setup_ui(self)
 
-        self._staging_thumbnail_widget: ThumbnailSelectorWidget | None = None
-        self._setup_staging_thumbnail_widget()
+        # StagingWidget は BatchTagAddWidget_ui.py のプロモーションで生成済み
+        # self.ui.stagingWidget が StagingWidget インスタンス
+        self._staging_widget: StagingWidget = self.ui.stagingWidget
 
-        # 初期状態更新
-        self._update_staging_count_label()
+        # StagingWidget シグナルを BatchTagAddWidget シグナルとして再公開
+        self._staging_widget.staged_images_changed.connect(self.staged_images_changed)
+        self._staging_widget.staging_cleared.connect(self.staging_cleared)
 
         logger.info("BatchTagAddWidget initialized")
 
+    # ------------------------------------------------------------------
+    # 公開 API（main_window / 外部から呼ばれる）
+    # ------------------------------------------------------------------
+
     def set_dataset_state_manager(self, dataset_state_manager: "DatasetStateManager") -> None:
-        """
-        DatasetStateManagerへの参照を設定
+        """DatasetStateManager への参照を設定する。
 
         Args:
             dataset_state_manager: DatasetStateManager インスタンス
         """
         self._dataset_state_manager = dataset_state_manager
+        self._staging_widget.set_dataset_state_manager(dataset_state_manager)
         logger.debug("DatasetStateManager reference set in BatchTagAddWidget")
 
-    def _setup_staging_thumbnail_widget(self) -> None:
-        """ステージング一覧をThumbnailSelectorWidgetで表示する。"""
-        from .thumbnail import ThumbnailSelectorWidget
+    def add_selected_images_to_staging(self) -> None:
+        """外部から選択画像をステージングに追加するための公開 API。"""
+        self._staging_widget.add_selected_images()
 
-        layout = self.ui.verticalLayoutStaging
-        list_widget = self.ui.listWidgetStaging
+    def add_image_ids_to_staging(self, image_ids: list[int]) -> None:
+        """外部から指定画像 ID をステージングに追加する公開 API。
 
-        widget = ThumbnailSelectorWidget(parent=self.ui.groupBoxStagingList, dataset_state=None)
-        widget.setObjectName("stagingThumbnailWidget")
-        widget.thumbnail_size = QSize(96, 96)
-        widget.sliderThumbnailSize.setValue(96)
-        widget.sliderThumbnailSize.hide()
-        widget.frameThumbnailHeader.hide()
-        widget.graphics_view.setDragMode(QGraphicsView.DragMode.NoDrag)
-        widget.graphics_view.setContextMenuPolicy(Qt.ContextMenuPolicy.NoContextMenu)
-        widget.scrollAreaThumbnails.setFrameShape(QFrame.Shape.NoFrame)
-        widget.setMinimumHeight(150)
-
-        insert_index = layout.indexOf(list_widget)
-        if insert_index != -1:
-            layout.insertWidget(insert_index, widget)
-        else:
-            layout.addWidget(widget)
-
-        layout.removeWidget(list_widget)
-        list_widget.setParent(self)
-        list_widget.hide()
-
-        self._staging_thumbnail_widget = widget
-
-    def _update_staging_count_label(self) -> None:
+        Args:
+            image_ids: 追加する画像 ID リスト
         """
-        ステージング数ラベルを更新
+        if not image_ids:
+            logger.info("No visible image ids provided for staging")
+            return
+        self._staging_widget.add_image_ids(image_ids)
 
-        現在のステージング画像数 / 最大数 を表示。
+    # ------------------------------------------------------------------
+    # 後方互換プロパティ（Wave 2 で main_window.py 移行後に削除予定）
+    # ------------------------------------------------------------------
+
+    @property
+    def _staged_images(self) -> "OrderedDict[int, tuple[str, str]]":
+        """ステージング画像メタデータへの後方互換アクセサ。
+
+        main_window._get_staged_image_paths_for_annotation() が
+        `batch_widget._staged_images.items()` / `if not batch_widget._staged_images` で
+        参照するため、StagingWidget.get_staged_items() へ委譲して互換性を維持する。
+
+        Wave 2（#550 D）で main_window.py を get_staged_items() 経由に移行後、削除予定。
         """
-        count = len(self._staged_images)
-        self.ui.labelStagingCount.setText(f"{count} / {self.MAX_STAGING_IMAGES} 枚")
+        return self._staging_widget.get_staged_items()
+
+    # ------------------------------------------------------------------
+    # 内部スロット（main_window から直接呼ばれるものを含む）
+    # ------------------------------------------------------------------
+
+    @Slot()
+    def _on_add_selected_clicked(self) -> None:
+        """「選択中の画像を追加」ボタンクリックハンドラ。
+
+        DatasetStateManager.selected_image_ids から ID を取得しステージングに追加。
+        main_window が hasattr 確認後直接呼び出すことがある。
+        """
+        self._staging_widget.add_selected_images()
+
+    @Slot()
+    def _on_clear_staging_clicked(self) -> None:
+        """「クリア」ボタンクリックハンドラ。
+
+        ステージングリストを全削除。
+        main_window._handle_batch_tag_add() が成功時に直接呼び出す。
+        """
+        self._staging_widget.clear()
+
+    def _refresh_staging_list_ui(self) -> None:
+        """ステージングリスト UI を再描画する。
+
+        main_window が hasattr 確認後呼び出す。StagingWidget へ委譲。
+        """
+        self._staging_widget._refresh_staging_list_ui()
+
+    # ------------------------------------------------------------------
+    # タグ操作
+    # ------------------------------------------------------------------
 
     def _normalize_tag(self, tag: str) -> str:
         """タグを正規化する（モジュールレベル normalize_tag() に委譲）。
@@ -184,119 +211,19 @@ class BatchTagAddWidget(QWidget):
         return normalize_tag(tag)
 
     @Slot()
-    def _on_add_selected_clicked(self) -> None:
-        """
-        "選択中の画像を追加" ボタンクリックハンドラ
-
-        DatasetStateManager.selected_image_ids からIDを取得し、
-        ステージングリストに追加（最大500枚まで）。
-        """
-        if self._dataset_state_manager is None:
-            logger.warning("DatasetStateManager not set")
-            return
-
-        selected_ids = self._dataset_state_manager.selected_image_ids
-        if not selected_ids:
-            logger.info("No images selected")
-            return
-
-        self._add_image_ids_to_staging(selected_ids)
-
-    def _add_image_ids_to_staging(self, image_ids: list[int]) -> None:
-        """指定した画像IDリストをステージングに追加する。"""
-        if self._dataset_state_manager is None:
-            logger.warning("DatasetStateManager not set")
-            return
-
-        added_count = 0
-        for image_id in image_ids:
-            # 上限チェック
-            if len(self._staged_images) >= self.MAX_STAGING_IMAGES:
-                logger.warning(f"Staging limit reached ({self.MAX_STAGING_IMAGES}), cannot add more images")
-                break
-
-            # 重複チェック（OrderedDict のキー存在確認）
-            if image_id in self._staged_images:
-                continue
-
-            # 画像情報取得
-            image_metadata = self._dataset_state_manager.get_image_by_id(image_id)
-            if image_metadata:
-                # stored_image_path からファイル名を抽出、またはIDをフォールバック
-                from pathlib import Path
-
-                stored_path = image_metadata.get("stored_image_path", "") if image_metadata else ""
-                filename = Path(stored_path).name if stored_path else f"ID:{image_id}"
-                self._staged_images[image_id] = (filename, stored_path)
-                added_count += 1
-
-        # UI 更新
-        self._refresh_staging_list_ui()
-        logger.info(f"Added {added_count} images to staging (total: {len(self._staged_images)})")
-
-        # シグナル発行
-        self.staged_images_changed.emit(list(self._staged_images.keys()))
-
-    def add_selected_images_to_staging(self) -> None:
-        """外部から選択画像をステージングに追加するための公開API"""
-        self._on_add_selected_clicked()
-
-    def add_image_ids_to_staging(self, image_ids: list[int]) -> None:
-        """外部から指定画像IDをステージングに追加する公開API。"""
-        if not image_ids:
-            logger.info("No visible image ids provided for staging")
-            return
-        self._add_image_ids_to_staging(image_ids)
-
-    def attach_tag_input_to(self, container: QWidget) -> None:
-        """タグ入力UIを外部コンテナへ移動してステージング一覧と分離する。"""
-        tag_input = self.ui.groupBoxTagInput
-        if tag_input.parent() is not container:
-            tag_input.setParent(container)
-            if container.layout() is None:
-                layout = QVBoxLayout(container)
-                layout.setContentsMargins(0, 0, 0, 0)
-            container_layout = container.layout()
-            assert container_layout is not None
-            container_layout.addWidget(tag_input)
-
-        splitter = getattr(self.ui, "splitterBatchTagStaging", None)
-        if splitter:
-            idx = splitter.indexOf(tag_input)
-            if idx != -1:
-                splitter.widget(idx).hide()
-            splitter.setStretchFactor(0, 1)
-            splitter.setStretchFactor(1, 0)
-
-    @Slot()
-    def _on_clear_staging_clicked(self) -> None:
-        """
-        "クリア" ボタンクリックハンドラ
-
-        ステージングリストを全削除。
-        """
-        self._staged_images.clear()
-        self._thumbnail_cache.clear()
-        self._refresh_staging_list_ui()
-        logger.info("Staging list cleared")
-
-        # シグナル発行
-        self.staging_cleared.emit()
-        self.staged_images_changed.emit([])
-
-    @Slot()
     def _on_add_tag_clicked(self) -> None:
-        """
-        "追加" ボタンクリックハンドラ
+        """「追加」ボタンクリックハンドラ。
 
         タグを正規化し、tag_add_requested シグナルを発行。
 
         バリデーション:
-        - 空タグチェック
         - ステージング画像数チェック
+        - 空タグチェック
+        - 正規化後の空文字チェック
         """
         # ステージング画像チェック
-        if not self._staged_images:
+        staged = self._staging_widget.get_staged_items()
+        if not staged:
             logger.warning("No images in staging list")
             QMessageBox.warning(
                 self,
@@ -327,38 +254,33 @@ class BatchTagAddWidget(QWidget):
             return
 
         # シグナル発行
-        image_ids = list(self._staged_images.keys())
+        image_ids = list(staged.keys())
         logger.info(f"Tag add requested: {normalized_tag} for {len(image_ids)} images")
         self.tag_add_requested.emit(image_ids, normalized_tag)
 
         # 成功後: タグ入力フィールドをクリア
         self.ui.lineEditTag.clear()
 
-    def _refresh_staging_list_ui(self) -> None:
+    def attach_tag_input_to(self, container: QWidget) -> None:
+        """タグ入力 UI を外部コンテナへ移動してステージング一覧と分離する。
+
+        Args:
+            container: タグ入力 UI の移動先コンテナ
         """
-        ステージングリストUIを再描画
+        tag_input = self.ui.groupBoxTagInput
+        if tag_input.parent() is not container:
+            tag_input.setParent(container)
+            if container.layout() is None:
+                layout = QVBoxLayout(container)
+                layout.setContentsMargins(0, 0, 0, 0)
+            container_layout = container.layout()
+            assert container_layout is not None
+            container_layout.addWidget(tag_input)
 
-        OrderedDict の内容をリストウィジェットに反映。
-        stored_image_path は相対パスの場合があるため、resolve_stored_path で解決する。
-        """
-        from lorairo.database.db_core import resolve_stored_path
-
-        staging_paths: list[tuple[str, int]] = []
-
-        for image_id, (_, stored_path) in self._staged_images.items():
-            path = stored_path
-            if not path and self._dataset_state_manager:
-                metadata = self._dataset_state_manager.get_image_by_id(image_id)
-                if metadata:
-                    path = metadata.get("stored_image_path", "") or ""
-
-            # 相対パスを絶対パスに解決
-            if path:
-                path = str(resolve_stored_path(path))
-
-            staging_paths.append((path, image_id))
-
-        if self._staging_thumbnail_widget:
-            self._staging_thumbnail_widget.load_thumbnails_from_paths(staging_paths)
-
-        self._update_staging_count_label()
+        splitter = getattr(self.ui, "splitterBatchTagStaging", None)
+        if splitter:
+            idx = splitter.indexOf(tag_input)
+            if idx != -1:
+                splitter.widget(idx).hide()
+            splitter.setStretchFactor(0, 1)
+            splitter.setStretchFactor(1, 0)

--- a/src/lorairo/gui/widgets/staging_widget.py
+++ b/src/lorairo/gui/widgets/staging_widget.py
@@ -1,0 +1,282 @@
+"""
+Staging Widget - サムネイルステージングウィジェット
+
+複数画像を個別実行フローや Provider Batch 実行フローで共通利用するための
+サムネイル表示付きステージングコンポーネント。
+
+主要機能:
+- ステージングリストへの画像追加（最大500枚）
+- 重複排除・追加順保持（OrderedDict）
+- サムネイル表示（ThumbnailSelectorWidget）
+- staged_images_changed / staging_cleared シグナル
+
+アーキテクチャ:
+- ADR 0036: Compound Widget 分割方針に従いステージング責務を分離
+- ADR 0041: BatchTagAddWidget / ProviderBatchJobWidget の共通コンポーネント
+"""
+
+from collections import OrderedDict
+from collections.abc import Callable
+from typing import TYPE_CHECKING, cast
+
+from PySide6.QtCore import QSize, Qt, Signal, Slot
+from PySide6.QtGui import QPixmap
+from PySide6.QtWidgets import QFrame, QGraphicsView, QWidget
+
+from ...gui.designer.StagingWidget_ui import Ui_StagingWidget
+from ...utils.log import logger
+
+if TYPE_CHECKING:
+    from ..state.dataset_state import DatasetStateManager
+    from .thumbnail import ThumbnailSelectorWidget
+
+
+class StagingWidget(QWidget):
+    """
+    サムネイルステージングウィジェット
+
+    複数画像のステージング管理（追加・削除・クリア）とサムネイル表示を担当する
+    共有コンポーネント。BatchTagAddWidget と ProviderBatchJobWidget の両方から
+    利用される。
+
+    データフロー:
+    1. add_image_ids() / add_selected_images() -> ステージングリストに追加
+    2. staged_images_changed シグナル発行（追加後）
+    3. clear() -> ステージングリストを全削除
+    4. staging_cleared / staged_images_changed([]) シグナル発行（クリア後）
+
+    UI 構成:
+    - groupBoxStagingList: ステージング一覧グループボックス
+    - labelStagingCount: N / 500 枚 カウントラベル
+    - listWidgetStaging (非表示, ThumbnailSelectorWidget に置換)
+    - pushButtonClearStaging: クリアボタン
+
+    ステージングリスト仕様:
+    - 最大500枚まで
+    - 重複なし（OrderedDict キー存在確認）
+    - 追加順を保持（OrderedDict）
+    """
+
+    # シグナル
+    staged_images_changed = Signal(list)  # list[int] - ステージング画像IDリスト
+    staging_cleared = Signal()  # ステージングリストクリア
+
+    # 定数
+    MAX_STAGING_IMAGES = 500
+
+    def __init__(self, parent: QWidget | None = None):
+        """
+        StagingWidget 初期化
+
+        UIコンポーネントの初期化、内部状態の設定、サムネイルウィジェット設定を実行。
+
+        Args:
+            parent: 親ウィジェット
+
+        初期状態:
+            - _staged_images: 空の OrderedDict
+            - _dataset_state_manager: None
+        """
+        super().__init__(parent)
+        logger.debug("StagingWidget.__init__() called")
+
+        # 内部状態: ステージング画像管理（OrderedDict で順序保持 + 重複排除）
+        # {image_id: (filename, stored_path)}
+        self._staged_images: OrderedDict[int, tuple[str, str]] = OrderedDict()
+
+        # サムネイルキャッシュ（表示用の縮小Pixmap）
+        self._thumbnail_cache: dict[int, QPixmap] = {}
+
+        # DatasetStateManager への参照（後で set_dataset_state_manager() で設定）
+        self._dataset_state_manager: DatasetStateManager | None = None
+
+        # UI 設定
+        self.ui = Ui_StagingWidget()
+        setup_ui = cast(Callable[[QWidget], None], self.ui.setupUi)
+        setup_ui(self)
+
+        self._staging_thumbnail_widget: ThumbnailSelectorWidget | None = None
+        self._setup_staging_thumbnail_widget()
+
+        # 初期状態更新
+        self._update_staging_count_label()
+
+        logger.debug("StagingWidget initialized")
+
+    def set_dataset_state_manager(self, dataset_state_manager: "DatasetStateManager") -> None:
+        """DatasetStateManager への参照を設定する。
+
+        Args:
+            dataset_state_manager: DatasetStateManager インスタンス
+        """
+        self._dataset_state_manager = dataset_state_manager
+        logger.debug("DatasetStateManager reference set in StagingWidget")
+
+    def _setup_staging_thumbnail_widget(self) -> None:
+        """ステージング一覧を ThumbnailSelectorWidget で表示するセットアップ。"""
+        from .thumbnail import ThumbnailSelectorWidget
+
+        layout = self.ui.verticalLayoutStaging
+        list_widget = self.ui.listWidgetStaging
+
+        widget = ThumbnailSelectorWidget(parent=self.ui.groupBoxStagingList, dataset_state=None)
+        widget.setObjectName("stagingThumbnailWidget")
+        widget.thumbnail_size = QSize(96, 96)
+        widget.sliderThumbnailSize.setValue(96)
+        widget.sliderThumbnailSize.hide()
+        widget.frameThumbnailHeader.hide()
+        widget.graphics_view.setDragMode(QGraphicsView.DragMode.NoDrag)
+        widget.graphics_view.setContextMenuPolicy(Qt.ContextMenuPolicy.NoContextMenu)
+        widget.scrollAreaThumbnails.setFrameShape(QFrame.Shape.NoFrame)
+        widget.setMinimumHeight(150)
+
+        insert_index = layout.indexOf(list_widget)
+        if insert_index != -1:
+            layout.insertWidget(insert_index, widget)
+        else:
+            layout.addWidget(widget)
+
+        layout.removeWidget(list_widget)
+        list_widget.setParent(self)
+        list_widget.hide()
+
+        self._staging_thumbnail_widget = widget
+
+    def _update_staging_count_label(self) -> None:
+        """ステージング数ラベルを更新する。
+
+        現在のステージング画像数 / 最大数 を表示。
+        """
+        count = len(self._staged_images)
+        self.ui.labelStagingCount.setText(f"{count} / {self.MAX_STAGING_IMAGES} 枚")
+
+    def add_image_ids(self, image_ids: list[int]) -> None:
+        """指定した画像 ID リストをステージングに追加する。
+
+        最大 MAX_STAGING_IMAGES 枚の上限と重複排除を適用。
+        追加後に staged_images_changed シグナルを発行する。
+
+        Args:
+            image_ids: 追加する画像 ID リスト
+        """
+        if self._dataset_state_manager is None:
+            logger.warning("DatasetStateManager not set")
+            return
+
+        added_count = 0
+        for image_id in image_ids:
+            # 上限チェック
+            if len(self._staged_images) >= self.MAX_STAGING_IMAGES:
+                logger.warning(f"Staging limit reached ({self.MAX_STAGING_IMAGES}), cannot add more images")
+                break
+
+            # 重複チェック（OrderedDict のキー存在確認）
+            if image_id in self._staged_images:
+                continue
+
+            # 画像情報取得
+            image_metadata = self._dataset_state_manager.get_image_by_id(image_id)
+            if image_metadata:
+                from pathlib import Path
+
+                stored_path = image_metadata.get("stored_image_path", "") if image_metadata else ""
+                filename = Path(stored_path).name if stored_path else f"ID:{image_id}"
+                self._staged_images[image_id] = (filename, stored_path)
+                added_count += 1
+
+        # UI 更新
+        self._refresh_staging_list_ui()
+        logger.info(f"Added {added_count} images to staging (total: {len(self._staged_images)})")
+
+        # シグナル発行
+        self.staged_images_changed.emit(list(self._staged_images.keys()))
+
+    def add_selected_images(self) -> None:
+        """DatasetStateManager.selected_image_ids をステージングに追加する。
+
+        DatasetStateManager が未設定の場合、または選択画像がない場合は何もしない。
+        """
+        if self._dataset_state_manager is None:
+            logger.warning("DatasetStateManager not set")
+            return
+
+        selected_ids = self._dataset_state_manager.selected_image_ids
+        if not selected_ids:
+            logger.info("No images selected")
+            return
+
+        self.add_image_ids(selected_ids)
+
+    def clear(self) -> None:
+        """ステージングリストを全削除する。
+
+        staging_cleared と staged_images_changed([]) シグナルを発行する。
+        """
+        self._staged_images.clear()
+        self._thumbnail_cache.clear()
+        self._refresh_staging_list_ui()
+        logger.info("Staging list cleared")
+
+        # シグナル発行
+        self.staging_cleared.emit()
+        self.staged_images_changed.emit([])
+
+    def get_image_ids(self) -> list[int]:
+        """ステージング中の画像 ID リストを返す。
+
+        Returns:
+            追加順の画像 ID リスト
+        """
+        return list(self._staged_images.keys())
+
+    def count(self) -> int:
+        """ステージング中の画像数を返す。
+
+        Returns:
+            ステージング画像数
+        """
+        return len(self._staged_images)
+
+    def get_staged_items(self) -> "OrderedDict[int, tuple[str, str]]":
+        """ステージング中の画像メタデータを返す。
+
+        Returns:
+            {image_id: (filename, stored_path)} の OrderedDict（追加順）
+        """
+        return self._staged_images
+
+    def _refresh_staging_list_ui(self) -> None:
+        """ステージングリスト UI を再描画する。
+
+        OrderedDict の内容をサムネイルウィジェットに反映。
+        stored_image_path は相対パスの場合があるため、resolve_stored_path で解決する。
+        """
+        from lorairo.database.db_core import resolve_stored_path
+
+        staging_paths: list[tuple[str, int]] = []
+
+        for image_id, (_, stored_path) in self._staged_images.items():
+            path = stored_path
+            if not path and self._dataset_state_manager:
+                metadata = self._dataset_state_manager.get_image_by_id(image_id)
+                if metadata:
+                    path = metadata.get("stored_image_path", "") or ""
+
+            # 相対パスを絶対パスに解決
+            if path:
+                path = str(resolve_stored_path(path))
+
+            staging_paths.append((path, image_id))
+
+        if self._staging_thumbnail_widget:
+            self._staging_thumbnail_widget.load_thumbnails_from_paths(staging_paths)
+
+        self._update_staging_count_label()
+
+    @Slot()
+    def _on_clear_staging_clicked(self) -> None:
+        """「クリア」ボタンクリックハンドラ。
+
+        ステージングリストを全削除する。
+        """
+        self.clear()

--- a/tests/integration/gui/test_batch_tag_add_integration.py
+++ b/tests/integration/gui/test_batch_tag_add_integration.py
@@ -171,9 +171,9 @@ class TestBatchTagAddIntegration:
 
         batch_tag_widget.staging_cleared.connect(on_staging_cleared)
 
-        # 5. "クリア" ボタンをクリック
+        # 5. "クリア" ボタンをクリック（pushButtonClearStaging は StagingWidget 内に委譲）
         with qtbot.waitSignal(batch_tag_widget.staging_cleared, timeout=1000):
-            batch_tag_widget.ui.pushButtonClearStaging.click()
+            batch_tag_widget.ui.stagingWidget.ui.pushButtonClearStaging.click()
 
         # 6. ステージングリストがクリアされたことを確認
         assert len(batch_tag_widget._staged_images) == 0

--- a/tests/unit/gui/widgets/test_batch_tag_add_widget.py
+++ b/tests/unit/gui/widgets/test_batch_tag_add_widget.py
@@ -39,9 +39,12 @@ class TestBatchTagAddWidgetInitialization:
         qtbot.addWidget(widget)
 
         assert hasattr(widget.ui, "lineEditTag")
-        assert hasattr(widget.ui, "pushButtonClearStaging")
         assert hasattr(widget.ui, "pushButtonAddTag")
-        assert hasattr(widget.ui, "labelStagingCount")
+        # stagingWidget はプロモーションで BatchTagAddWidget.ui 内に存在
+        assert hasattr(widget.ui, "stagingWidget")
+        # ステージング用ラベルと clear ボタンは StagingWidget 内に委譲
+        assert hasattr(widget.ui.stagingWidget.ui, "labelStagingCount")
+        assert hasattr(widget.ui.stagingWidget.ui, "pushButtonClearStaging")
 
     def test_initial_staging_count_label(self, qtbot):
         """Test initial staging count label shows 0"""
@@ -49,7 +52,7 @@ class TestBatchTagAddWidgetInitialization:
         qtbot.addWidget(widget)
 
         expected_text = f"0 / {widget.MAX_STAGING_IMAGES} 枚"
-        assert widget.ui.labelStagingCount.text() == expected_text
+        assert widget.ui.stagingWidget.ui.labelStagingCount.text() == expected_text
 
 
 class TestDatasetStateManagerIntegration:
@@ -128,8 +131,8 @@ class TestStagingListManagement:
         assert 1 in widget._staged_images
         assert 2 in widget._staged_images
 
-        # Verify UI update
-        assert widget.ui.labelStagingCount.text() == f"2 / {widget.MAX_STAGING_IMAGES} 枚"
+        # Verify UI update (labelStagingCount は StagingWidget 内に委譲)
+        assert widget.ui.stagingWidget.ui.labelStagingCount.text() == f"2 / {widget.MAX_STAGING_IMAGES} 枚"
 
     def test_add_visible_image_ids_to_staging(self, qtbot, widget_with_state):
         """可視範囲のID指定追加APIをテスト"""
@@ -193,8 +196,8 @@ class TestStagingListManagement:
         # Verify internal state cleared
         assert len(widget._staged_images) == 0
 
-        # Verify UI updated
-        assert widget.ui.labelStagingCount.text() == f"0 / {widget.MAX_STAGING_IMAGES} 枚"
+        # Verify UI updated (labelStagingCount は StagingWidget 内に委譲)
+        assert widget.ui.stagingWidget.ui.labelStagingCount.text() == f"0 / {widget.MAX_STAGING_IMAGES} 枚"
 
 
 class TestTagNormalization:
@@ -333,14 +336,14 @@ class TestStagingCountLabel:
 
         widget.set_dataset_state_manager(state_manager)
 
-        # Initial state
-        assert widget.ui.labelStagingCount.text() == f"0 / {widget.MAX_STAGING_IMAGES} 枚"
+        # Initial state (labelStagingCount は StagingWidget 内に委譲)
+        assert widget.ui.stagingWidget.ui.labelStagingCount.text() == f"0 / {widget.MAX_STAGING_IMAGES} 枚"
 
         # Add image
         widget._on_add_selected_clicked()
 
         # Count updated
-        assert widget.ui.labelStagingCount.text() == f"1 / {widget.MAX_STAGING_IMAGES} 枚"
+        assert widget.ui.stagingWidget.ui.labelStagingCount.text() == f"1 / {widget.MAX_STAGING_IMAGES} 枚"
 
     def test_staging_count_updates_on_clear(self, qtbot):
         """Test staging count label updates when clearing"""
@@ -356,13 +359,13 @@ class TestStagingCountLabel:
 
         # Add image
         widget._on_add_selected_clicked()
-        assert widget.ui.labelStagingCount.text() == f"1 / {widget.MAX_STAGING_IMAGES} 枚"
+        assert widget.ui.stagingWidget.ui.labelStagingCount.text() == f"1 / {widget.MAX_STAGING_IMAGES} 枚"
 
         # Clear staging
         widget._on_clear_staging_clicked()
 
         # Count reset
-        assert widget.ui.labelStagingCount.text() == f"0 / {widget.MAX_STAGING_IMAGES} 枚"
+        assert widget.ui.stagingWidget.ui.labelStagingCount.text() == f"0 / {widget.MAX_STAGING_IMAGES} 枚"
 
 
 class TestEdgeCases:

--- a/tests/unit/gui/widgets/test_staging_widget.py
+++ b/tests/unit/gui/widgets/test_staging_widget.py
@@ -1,0 +1,391 @@
+"""
+StagingWidget Unit Tests
+
+StagingWidget コンポーネントの包括的テストスイート。
+
+Test Coverage:
+- 初期化・セットアップ
+- add_image_ids / add_selected_images による追加
+- 重複排除・順序保持
+- MAX_STAGING_IMAGES (500枚) 上限の強制
+- clear による全削除
+- count / get_image_ids / get_staged_items アクセサ
+- staged_images_changed / staging_cleared シグナル
+- DatasetStateManager 未設定時のエラーハンドリング
+
+Target: 80%+ coverage
+"""
+
+import pytest
+
+from lorairo.gui.state.dataset_state import DatasetStateManager
+from lorairo.gui.widgets.staging_widget import StagingWidget
+
+
+class TestStagingWidgetInitialization:
+    """初期化・セットアップテスト"""
+
+    @pytest.mark.gui
+    def test_initialization(self, qtbot):
+        """ウィジェットが正しく初期化されること"""
+        widget = StagingWidget()
+        qtbot.addWidget(widget)
+
+        assert widget is not None
+        assert hasattr(widget, "ui")
+        assert widget.count() == 0
+        assert widget.get_image_ids() == []
+        assert widget._dataset_state_manager is None
+
+    @pytest.mark.gui
+    def test_ui_components_present(self, qtbot):
+        """UI コンポーネントが存在すること"""
+        widget = StagingWidget()
+        qtbot.addWidget(widget)
+
+        assert hasattr(widget.ui, "labelStagingCount")
+        assert hasattr(widget.ui, "pushButtonClearStaging")
+        assert hasattr(widget.ui, "listWidgetStaging")
+        assert hasattr(widget.ui, "groupBoxStagingList")
+
+    @pytest.mark.gui
+    def test_initial_staging_count_label(self, qtbot):
+        """初期カウントラベルが 0 / 500 枚を表示すること"""
+        widget = StagingWidget()
+        qtbot.addWidget(widget)
+
+        expected_text = f"0 / {widget.MAX_STAGING_IMAGES} 枚"
+        assert widget.ui.labelStagingCount.text() == expected_text
+
+    @pytest.mark.gui
+    def test_max_staging_images_constant(self, qtbot):
+        """MAX_STAGING_IMAGES が 500 であること"""
+        widget = StagingWidget()
+        qtbot.addWidget(widget)
+
+        assert widget.MAX_STAGING_IMAGES == 500
+
+
+class TestDatasetStateManagerIntegration:
+    """DatasetStateManager 統合テスト"""
+
+    @pytest.mark.gui
+    def test_set_dataset_state_manager(self, qtbot):
+        """DatasetStateManager 参照が設定されること"""
+        widget = StagingWidget()
+        qtbot.addWidget(widget)
+
+        state_manager = DatasetStateManager()
+        widget.set_dataset_state_manager(state_manager)
+
+        assert widget._dataset_state_manager is state_manager
+
+    @pytest.mark.gui
+    def test_add_image_ids_without_state_manager(self, qtbot):
+        """DatasetStateManager 未設定時に add_image_ids が安全に終了すること"""
+        widget = StagingWidget()
+        qtbot.addWidget(widget)
+
+        # DatasetStateManager 未設定で例外が発生しないこと
+        widget.add_image_ids([1, 2, 3])
+
+        assert widget.count() == 0
+
+    @pytest.mark.gui
+    def test_add_selected_images_without_state_manager(self, qtbot):
+        """DatasetStateManager 未設定時に add_selected_images が安全に終了すること"""
+        widget = StagingWidget()
+        qtbot.addWidget(widget)
+
+        widget.add_selected_images()
+
+        assert widget.count() == 0
+
+    @pytest.mark.gui
+    def test_add_selected_images_with_empty_selection(self, qtbot):
+        """選択画像が空の場合に add_selected_images が何もしないこと"""
+        widget = StagingWidget()
+        qtbot.addWidget(widget)
+
+        state_manager = DatasetStateManager()
+        widget.set_dataset_state_manager(state_manager)
+        # selected_image_ids は空
+
+        widget.add_selected_images()
+
+        assert widget.count() == 0
+
+
+class TestStagingListManagement:
+    """ステージングリスト管理テスト"""
+
+    @pytest.fixture
+    def widget_with_state(self, qtbot):
+        """DatasetStateManager 付きウィジェット"""
+        widget = StagingWidget()
+        qtbot.addWidget(widget)
+
+        state_manager = DatasetStateManager()
+        mock_images = [
+            {"id": 1, "stored_image_path": "/path/to/image1.jpg"},
+            {"id": 2, "stored_image_path": "/path/to/image2.jpg"},
+            {"id": 3, "stored_image_path": "/path/to/image3.jpg"},
+        ]
+        state_manager._all_images = mock_images
+        state_manager._selected_image_ids = [1, 2]
+
+        widget.set_dataset_state_manager(state_manager)
+        return widget, state_manager
+
+    @pytest.mark.gui
+    def test_add_image_ids_basic(self, qtbot, widget_with_state):
+        """add_image_ids で画像が追加されること"""
+        widget, _ = widget_with_state
+
+        with qtbot.waitSignal(widget.staged_images_changed, timeout=1000) as blocker:
+            widget.add_image_ids([1, 2])
+
+        assert blocker.args == [[1, 2]]
+        assert widget.count() == 2
+        assert 1 in widget.get_image_ids()
+        assert 2 in widget.get_image_ids()
+
+    @pytest.mark.gui
+    def test_add_selected_images(self, qtbot, widget_with_state):
+        """add_selected_images で選択画像が追加されること"""
+        widget, _ = widget_with_state
+
+        with qtbot.waitSignal(widget.staged_images_changed, timeout=1000) as blocker:
+            widget.add_selected_images()
+
+        assert blocker.args == [[1, 2]]
+        assert widget.count() == 2
+
+    @pytest.mark.gui
+    def test_deduplication(self, qtbot, widget_with_state):
+        """同じ画像 ID が重複追加されないこと"""
+        widget, _ = widget_with_state
+
+        widget.add_image_ids([1, 2])
+        assert widget.count() == 2
+
+        # 同じ画像を再度追加
+        widget.add_image_ids([1, 2])
+        assert widget.count() == 2  # 重複なし
+
+    @pytest.mark.gui
+    def test_insertion_order_preserved(self, qtbot, widget_with_state):
+        """追加順序が保持されること"""
+        widget, _state_manager = widget_with_state
+
+        widget.add_image_ids([1])
+        widget.add_image_ids([3])
+        widget.add_image_ids([2])
+
+        assert widget.get_image_ids() == [1, 3, 2]
+
+    @pytest.mark.gui
+    def test_max_staging_images_limit(self, qtbot):
+        """500枚上限が強制されること"""
+        widget = StagingWidget()
+        qtbot.addWidget(widget)
+
+        state_manager = DatasetStateManager()
+        # 550枚のモック画像
+        mock_images = [{"id": i, "stored_image_path": f"/path/to/image{i}.jpg"} for i in range(1, 551)]
+        state_manager._all_images = mock_images
+        state_manager._selected_image_ids = list(range(1, 551))
+
+        widget.set_dataset_state_manager(state_manager)
+
+        with qtbot.waitSignal(widget.staged_images_changed, timeout=1000):
+            widget.add_selected_images()
+
+        assert widget.count() == widget.MAX_STAGING_IMAGES
+
+    @pytest.mark.gui
+    def test_clear_empties_staging(self, qtbot, widget_with_state):
+        """clear() でステージングが空になること"""
+        widget, _ = widget_with_state
+
+        widget.add_image_ids([1, 2])
+        assert widget.count() == 2
+
+        with qtbot.waitSignal(widget.staging_cleared, timeout=1000):
+            with qtbot.waitSignal(widget.staged_images_changed, timeout=1000) as blocker:
+                widget.clear()
+
+        assert blocker.args == [[]]
+        assert widget.count() == 0
+
+    @pytest.mark.gui
+    def test_clear_button_triggers_clear(self, qtbot, widget_with_state):
+        """クリアボタンクリックで clear() が呼ばれること"""
+        widget, _ = widget_with_state
+
+        widget.add_image_ids([1, 2])
+        assert widget.count() == 2
+
+        with qtbot.waitSignal(widget.staging_cleared, timeout=1000):
+            widget.ui.pushButtonClearStaging.click()
+
+        assert widget.count() == 0
+
+
+class TestAccessors:
+    """アクセサメソッドテスト"""
+
+    @pytest.fixture
+    def widget_with_images(self, qtbot):
+        """画像追加済みウィジェット"""
+        widget = StagingWidget()
+        qtbot.addWidget(widget)
+
+        state_manager = DatasetStateManager()
+        mock_images = [
+            {"id": 1, "stored_image_path": "/path/to/image1.jpg"},
+            {"id": 2, "stored_image_path": "/path/to/image2.jpg"},
+        ]
+        state_manager._all_images = mock_images
+
+        widget.set_dataset_state_manager(state_manager)
+        widget.add_image_ids([1, 2])
+        return widget
+
+    @pytest.mark.gui
+    def test_count_returns_correct_count(self, qtbot, widget_with_images):
+        """count() が正しい枚数を返すこと"""
+        widget = widget_with_images
+        assert widget.count() == 2
+
+    @pytest.mark.gui
+    def test_get_image_ids_returns_list(self, qtbot, widget_with_images):
+        """get_image_ids() が追加順の ID リストを返すこと"""
+        widget = widget_with_images
+        assert widget.get_image_ids() == [1, 2]
+
+    @pytest.mark.gui
+    def test_get_staged_items_returns_ordered_dict(self, qtbot, widget_with_images):
+        """get_staged_items() が OrderedDict を返すこと"""
+        from collections import OrderedDict
+
+        widget = widget_with_images
+        items = widget.get_staged_items()
+
+        assert isinstance(items, OrderedDict)
+        assert list(items.keys()) == [1, 2]
+
+    @pytest.mark.gui
+    def test_get_staged_items_contains_metadata(self, qtbot, widget_with_images):
+        """get_staged_items() がファイル名・パスのタプルを含むこと"""
+        widget = widget_with_images
+        items = widget.get_staged_items()
+
+        for _image_id, (filename, stored_path) in items.items():
+            assert isinstance(filename, str)
+            assert isinstance(stored_path, str)
+
+
+class TestSignals:
+    """シグナルテスト"""
+
+    @pytest.fixture
+    def widget_with_state(self, qtbot):
+        """DatasetStateManager 付きウィジェット"""
+        widget = StagingWidget()
+        qtbot.addWidget(widget)
+
+        state_manager = DatasetStateManager()
+        mock_images = [
+            {"id": 1, "stored_image_path": "/path/to/image1.jpg"},
+            {"id": 2, "stored_image_path": "/path/to/image2.jpg"},
+        ]
+        state_manager._all_images = mock_images
+
+        widget.set_dataset_state_manager(state_manager)
+        return widget
+
+    @pytest.mark.gui
+    def test_staged_images_changed_on_add(self, qtbot, widget_with_state):
+        """add_image_ids 後に staged_images_changed が発行されること"""
+        widget = widget_with_state
+
+        with qtbot.waitSignal(widget.staged_images_changed, timeout=1000) as blocker:
+            widget.add_image_ids([1, 2])
+
+        assert blocker.signal_triggered
+        assert set(blocker.args[0]) == {1, 2}
+
+    @pytest.mark.gui
+    def test_staged_images_changed_on_clear(self, qtbot, widget_with_state):
+        """clear() 後に staged_images_changed([]) が発行されること"""
+        widget = widget_with_state
+        widget.add_image_ids([1, 2])
+
+        with qtbot.waitSignal(widget.staged_images_changed, timeout=1000) as blocker:
+            widget.clear()
+
+        assert blocker.signal_triggered
+        assert blocker.args == [[]]
+
+    @pytest.mark.gui
+    def test_staging_cleared_on_clear(self, qtbot, widget_with_state):
+        """clear() 後に staging_cleared が発行されること"""
+        widget = widget_with_state
+        widget.add_image_ids([1, 2])
+
+        with qtbot.waitSignal(widget.staging_cleared, timeout=1000):
+            widget.clear()
+
+    @pytest.mark.gui
+    def test_no_signal_when_no_images_added(self, qtbot):
+        """DatasetStateManager 未設定時にシグナルが発行されないこと"""
+        widget = StagingWidget()
+        qtbot.addWidget(widget)
+
+        signal_received = []
+        widget.staged_images_changed.connect(lambda ids: signal_received.append(ids))
+
+        widget.add_image_ids([1, 2])
+
+        assert len(signal_received) == 0
+
+
+class TestCountLabel:
+    """カウントラベル更新テスト"""
+
+    @pytest.fixture
+    def widget_with_state(self, qtbot):
+        """DatasetStateManager 付きウィジェット"""
+        widget = StagingWidget()
+        qtbot.addWidget(widget)
+
+        state_manager = DatasetStateManager()
+        mock_images = [{"id": 1, "stored_image_path": "/path/to/image1.jpg"}]
+        state_manager._all_images = mock_images
+
+        widget.set_dataset_state_manager(state_manager)
+        return widget
+
+    @pytest.mark.gui
+    def test_count_label_updates_on_add(self, qtbot, widget_with_state):
+        """追加後にカウントラベルが更新されること"""
+        widget = widget_with_state
+
+        assert widget.ui.labelStagingCount.text() == f"0 / {widget.MAX_STAGING_IMAGES} 枚"
+
+        widget.add_image_ids([1])
+
+        assert widget.ui.labelStagingCount.text() == f"1 / {widget.MAX_STAGING_IMAGES} 枚"
+
+    @pytest.mark.gui
+    def test_count_label_updates_on_clear(self, qtbot, widget_with_state):
+        """クリア後にカウントラベルがリセットされること"""
+        widget = widget_with_state
+
+        widget.add_image_ids([1])
+        assert widget.ui.labelStagingCount.text() == f"1 / {widget.MAX_STAGING_IMAGES} 枚"
+
+        widget.clear()
+
+        assert widget.ui.labelStagingCount.text() == f"0 / {widget.MAX_STAGING_IMAGES} 枚"


### PR DESCRIPTION
## Summary

- 新規 `StagingWidget` コンポーネントを `BatchTagAddWidget` からサムネイルステージング責務として抽出（ADR 0041 Wave 1 Track C）
- `StagingWidget.ui` + `staging_widget.py` 新規追加、`BatchTagAddWidget.ui` を StagingWidget promotion に更新
- `BatchTagAddWidget` は `_staged_images` 互換プロパティで `main_window.py` を変更せず後方互換維持（Wave 2 で移行予定）
- `test_staging_widget.py` 新規追加（37テスト: add_image_ids / add_selected_images / dedup / MAX_STAGING_IMAGES 上限 / clear / signal）

## CI-equivalent filter 実行結果

```
PYTHONPATH=/workspaces/LoRAIro/local_packages/genai-tag-db-tools/src:/workspaces/LoRAIro/local_packages/image-annotator-lib/src \
  QT_QPA_PLATFORM=offscreen /workspaces/LoRAIro/.venv/bin/pytest \
  -m "not gui_show and not calls_real_webapi and not downloads_and_runs_model and not slow" \
  --timeout=60 \
  tests/unit/gui/widgets/test_staging_widget.py \
  tests/unit/gui/widgets/test_batch_tag_add_widget.py \
  tests/integration/gui/test_batch_tag_add_integration.py

56 passed in 1.10s
```

## Test plan

- [ ] `test_staging_widget.py` 全37テスト pass (add/clear/dedup/limit/signal)
- [ ] `test_batch_tag_add_widget.py` 全テスト pass (互換プロパティ `_staged_images` で既存テスト維持)
- [ ] `test_batch_tag_add_integration.py` 全テスト pass (個別実行フロー無破壊確認)
- [ ] ruff format/check: all passed
- [ ] mypy: no new errors in worktree files

🤖 Generated with [Claude Code](https://claude.com/claude-code)