### PR TITLE
feat: Provider Batch タブを統一フローに改修 (.ui 化 + Staging/ModelSelection 組込) (#550)

### DIFF
--- a/src/lorairo/gui/designer/ProviderBatchJobWidget.ui
+++ b/src/lorairo/gui/designer/ProviderBatchJobWidget.ui
@@ -1,0 +1,399 @@
+<?xml version='1.0' encoding='utf-8'?>
+<ui version="4.0">
+ <class>ProviderBatchJobWidget</class>
+ <widget class="QWidget" name="ProviderBatchJobWidget">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>960</width>
+    <height>640</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Provider Batch</string>
+  </property>
+  <layout class="QHBoxLayout" name="rootLayout">
+   <property name="spacing">
+    <number>8</number>
+   </property>
+   <property name="leftMargin">
+    <number>8</number>
+   </property>
+   <property name="topMargin">
+    <number>8</number>
+   </property>
+   <property name="rightMargin">
+    <number>8</number>
+   </property>
+   <property name="bottomMargin">
+    <number>8</number>
+   </property>
+   <item>
+    <widget class="QSplitter" name="splitterMain">
+     <property name="orientation">
+      <enum>Qt::Orientation::Horizontal</enum>
+     </property>
+     <property name="childrenCollapsible">
+      <bool>false</bool>
+     </property>
+     <widget class="QWidget" name="leftContainer" native="true">
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
+        <horstretch>1</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
+      </property>
+      <layout class="QVBoxLayout" name="leftLayout">
+       <property name="leftMargin">
+        <number>0</number>
+       </property>
+       <property name="topMargin">
+        <number>0</number>
+       </property>
+       <property name="rightMargin">
+        <number>0</number>
+       </property>
+       <property name="bottomMargin">
+        <number>0</number>
+       </property>
+       <item>
+        <widget class="StagingWidget" name="stagingWidget" native="true">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+           <horstretch>1</horstretch>
+           <verstretch>1</verstretch>
+          </sizepolicy>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="stagingButtonsLayout">
+         <item>
+          <spacer name="horizontalSpacerStaging">
+           <property name="orientation">
+            <enum>Qt::Orientation::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+         <item>
+          <widget class="QPushButton" name="buttonAddSelected">
+           <property name="text">
+            <string>選択を追加</string>
+           </property>
+           <property name="objectName">
+            <string>buttonProviderBatchAddSelected</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <widget class="QLabel" name="labelStatus">
+         <property name="text">
+          <string>Ready</string>
+         </property>
+         <property name="objectName">
+          <string>labelProviderBatchStatus</string>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QSplitter" name="splitterRight">
+      <property name="orientation">
+       <enum>Qt::Orientation::Vertical</enum>
+      </property>
+      <property name="childrenCollapsible">
+       <bool>false</bool>
+      </property>
+      <widget class="QGroupBox" name="groupBoxExecution">
+       <property name="title">
+        <string>実行設定</string>
+       </property>
+       <layout class="QVBoxLayout" name="executionLayout">
+        <item>
+         <widget class="QLabel" name="labelTarget">
+          <property name="text">
+           <string>◎ ステージング: 0 枚</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <layout class="QHBoxLayout" name="taskTypeLayout">
+          <item>
+           <widget class="QLabel" name="labelTaskType">
+            <property name="text">
+             <string>Task</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QComboBox" name="comboBoxTaskType">
+            <property name="objectName">
+             <string>comboBoxProviderBatchTaskType</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <spacer name="horizontalSpacerTaskType">
+            <property name="orientation">
+             <enum>Qt::Orientation::Horizontal</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>40</width>
+              <height>20</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+         </layout>
+        </item>
+        <item>
+         <widget class="QWidget" name="modelSelectionPlaceholder" native="true">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+            <horstretch>0</horstretch>
+            <verstretch>1</verstretch>
+           </sizepolicy>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <layout class="QFormLayout" name="paramsLayout">
+          <item row="0" column="0">
+           <widget class="QLabel" name="labelPromptProfile">
+            <property name="text">
+             <string>Prompt</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="QLineEdit" name="lineEditPromptProfile">
+            <property name="text">
+             <string>default</string>
+            </property>
+            <property name="objectName">
+             <string>lineEditProviderBatchPromptProfile</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QLabel" name="labelDescription">
+            <property name="text">
+             <string>Description</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1">
+           <widget class="QLineEdit" name="lineEditDescription">
+            <property name="objectName">
+             <string>lineEditProviderBatchDescription</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </item>
+        <item>
+         <layout class="QHBoxLayout" name="submitLayout">
+          <item>
+           <spacer name="horizontalSpacerSubmit">
+            <property name="orientation">
+             <enum>Qt::Orientation::Horizontal</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>40</width>
+              <height>20</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+          <item>
+           <widget class="QPushButton" name="buttonSubmit">
+            <property name="text">
+             <string>Submit</string>
+            </property>
+            <property name="objectName">
+             <string>buttonProviderBatchSubmit</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </item>
+       </layout>
+      </widget>
+      <widget class="QGroupBox" name="groupBoxStatus">
+       <property name="title">
+        <string>バッチジョブ状態</string>
+       </property>
+       <layout class="QVBoxLayout" name="statusLayout">
+        <item>
+         <layout class="QHBoxLayout" name="jobButtonsLayout">
+          <item>
+           <widget class="QPushButton" name="buttonRefreshJobs">
+            <property name="text">
+             <string>Refresh</string>
+            </property>
+            <property name="objectName">
+             <string>buttonProviderBatchRefreshJobs</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QPushButton" name="buttonRefreshStatus">
+            <property name="text">
+             <string>Refresh Status</string>
+            </property>
+            <property name="objectName">
+             <string>buttonProviderBatchRefreshStatus</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QPushButton" name="buttonCancel">
+            <property name="text">
+             <string>Cancel</string>
+            </property>
+            <property name="objectName">
+             <string>buttonProviderBatchCancel</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QPushButton" name="buttonFetch">
+            <property name="text">
+             <string>Fetch</string>
+            </property>
+            <property name="objectName">
+             <string>buttonProviderBatchFetch</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QPushButton" name="buttonImport">
+            <property name="text">
+             <string>Import</string>
+            </property>
+            <property name="objectName">
+             <string>buttonProviderBatchImport</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <spacer name="horizontalSpacerJobButtons">
+            <property name="orientation">
+             <enum>Qt::Orientation::Horizontal</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>40</width>
+              <height>20</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+         </layout>
+        </item>
+        <item>
+         <widget class="QTableWidget" name="tableJobs">
+          <property name="objectName">
+           <string>tableProviderBatchJobs</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <layout class="QHBoxLayout" name="detailRow">
+          <item>
+           <widget class="QGroupBox" name="groupBoxDetail">
+            <property name="title">
+             <string>Detail</string>
+            </property>
+            <layout class="QVBoxLayout" name="detailLayout">
+             <item>
+              <widget class="QTextEdit" name="textEditJobDetail">
+               <property name="readOnly">
+                <bool>true</bool>
+               </property>
+               <property name="objectName">
+                <string>textEditProviderBatchJobDetail</string>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </widget>
+          </item>
+          <item>
+           <widget class="QGroupBox" name="groupBoxItems">
+            <property name="title">
+             <string>Items</string>
+            </property>
+            <layout class="QVBoxLayout" name="itemsLayout">
+             <item>
+              <layout class="QHBoxLayout" name="itemFilterLayout">
+               <item>
+                <widget class="QLabel" name="labelItemStatus">
+                 <property name="text">
+                  <string>Status</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QComboBox" name="comboBoxItemStatus">
+                 <property name="objectName">
+                  <string>comboBoxProviderBatchItemStatus</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <spacer name="horizontalSpacerItemFilter">
+                 <property name="orientation">
+                  <enum>Qt::Orientation::Horizontal</enum>
+                 </property>
+                 <property name="sizeHint" stdset="0">
+                  <size>
+                   <width>40</width>
+                   <height>20</height>
+                  </size>
+                 </property>
+                </spacer>
+               </item>
+              </layout>
+             </item>
+             <item>
+              <widget class="QTableWidget" name="tableItems">
+               <property name="objectName">
+                <string>tableProviderBatchItems</string>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </widget>
+          </item>
+         </layout>
+        </item>
+       </layout>
+      </widget>
+     </widget>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>StagingWidget</class>
+   <extends>QWidget</extends>
+   <header>lorairo/gui/widgets/staging_widget.h</header>
+   <container>0</container>
+  </customwidget>
+ </customwidgets>
+ <resources />
+ <connections />
+</ui>

--- a/src/lorairo/gui/designer/ProviderBatchJobWidget_ui.py
+++ b/src/lorairo/gui/designer/ProviderBatchJobWidget_ui.py
@@ -1,0 +1,300 @@
+# -*- coding: utf-8 -*-
+
+################################################################################
+## Form generated from reading UI file 'ProviderBatchJobWidget.ui'
+##
+## Created by: Qt User Interface Compiler version 6.11.1
+##
+## WARNING! All changes made in this file will be lost when recompiling UI file!
+################################################################################
+
+from PySide6.QtCore import (QCoreApplication, QDate, QDateTime, QLocale,
+    QMetaObject, QObject, QPoint, QRect,
+    QSize, QTime, QUrl, Qt)
+from PySide6.QtGui import (QBrush, QColor, QConicalGradient, QCursor,
+    QFont, QFontDatabase, QGradient, QIcon,
+    QImage, QKeySequence, QLinearGradient, QPainter,
+    QPalette, QPixmap, QRadialGradient, QTransform)
+from PySide6.QtWidgets import (QApplication, QComboBox, QFormLayout, QGroupBox,
+    QHBoxLayout, QHeaderView, QLabel, QLineEdit,
+    QPushButton, QSizePolicy, QSpacerItem, QSplitter,
+    QTableWidget, QTableWidgetItem, QTextEdit, QVBoxLayout,
+    QWidget)
+
+from lorairo.gui.widgets.staging_widget import StagingWidget
+
+class Ui_ProviderBatchJobWidget(object):
+    def setupUi(self, ProviderBatchJobWidget: QWidget) -> None:
+        if not ProviderBatchJobWidget.objectName():
+            ProviderBatchJobWidget.setObjectName(u"ProviderBatchJobWidget")
+        ProviderBatchJobWidget.resize(960, 640)
+        self.rootLayout = QHBoxLayout(ProviderBatchJobWidget)
+        self.rootLayout.setSpacing(8)
+        self.rootLayout.setObjectName(u"rootLayout")
+        self.rootLayout.setContentsMargins(8, 8, 8, 8)
+        self.splitterMain = QSplitter(ProviderBatchJobWidget)
+        self.splitterMain.setObjectName(u"splitterMain")
+        self.splitterMain.setOrientation(Qt.Orientation.Horizontal)
+        self.splitterMain.setChildrenCollapsible(False)
+        self.leftContainer = QWidget(self.splitterMain)
+        self.leftContainer.setObjectName(u"leftContainer")
+        sizePolicy = QSizePolicy(QSizePolicy.Policy.Preferred, QSizePolicy.Policy.Expanding)
+        sizePolicy.setHorizontalStretch(1)
+        sizePolicy.setVerticalStretch(0)
+        sizePolicy.setHeightForWidth(self.leftContainer.sizePolicy().hasHeightForWidth())
+        self.leftContainer.setSizePolicy(sizePolicy)
+        self.leftLayout = QVBoxLayout(self.leftContainer)
+        self.leftLayout.setObjectName(u"leftLayout")
+        self.leftLayout.setContentsMargins(0, 0, 0, 0)
+        self.stagingWidget = StagingWidget(self.leftContainer)
+        self.stagingWidget.setObjectName(u"stagingWidget")
+        sizePolicy1 = QSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Expanding)
+        sizePolicy1.setHorizontalStretch(1)
+        sizePolicy1.setVerticalStretch(1)
+        sizePolicy1.setHeightForWidth(self.stagingWidget.sizePolicy().hasHeightForWidth())
+        self.stagingWidget.setSizePolicy(sizePolicy1)
+
+        self.leftLayout.addWidget(self.stagingWidget)
+
+        self.stagingButtonsLayout = QHBoxLayout()
+        self.stagingButtonsLayout.setObjectName(u"stagingButtonsLayout")
+        self.horizontalSpacerStaging = QSpacerItem(40, 20, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum)
+
+        self.stagingButtonsLayout.addItem(self.horizontalSpacerStaging)
+
+        self.buttonAddSelected = QPushButton(self.leftContainer)
+        self.buttonAddSelected.setObjectName(u"buttonAddSelected")
+
+        self.stagingButtonsLayout.addWidget(self.buttonAddSelected)
+
+
+        self.leftLayout.addLayout(self.stagingButtonsLayout)
+
+        self.labelStatus = QLabel(self.leftContainer)
+        self.labelStatus.setObjectName(u"labelStatus")
+
+        self.leftLayout.addWidget(self.labelStatus)
+
+        self.splitterMain.addWidget(self.leftContainer)
+        self.splitterRight = QSplitter(self.splitterMain)
+        self.splitterRight.setObjectName(u"splitterRight")
+        self.splitterRight.setOrientation(Qt.Orientation.Vertical)
+        self.splitterRight.setChildrenCollapsible(False)
+        self.groupBoxExecution = QGroupBox(self.splitterRight)
+        self.groupBoxExecution.setObjectName(u"groupBoxExecution")
+        self.executionLayout = QVBoxLayout(self.groupBoxExecution)
+        self.executionLayout.setObjectName(u"executionLayout")
+        self.labelTarget = QLabel(self.groupBoxExecution)
+        self.labelTarget.setObjectName(u"labelTarget")
+
+        self.executionLayout.addWidget(self.labelTarget)
+
+        self.taskTypeLayout = QHBoxLayout()
+        self.taskTypeLayout.setObjectName(u"taskTypeLayout")
+        self.labelTaskType = QLabel(self.groupBoxExecution)
+        self.labelTaskType.setObjectName(u"labelTaskType")
+
+        self.taskTypeLayout.addWidget(self.labelTaskType)
+
+        self.comboBoxTaskType = QComboBox(self.groupBoxExecution)
+        self.comboBoxTaskType.setObjectName(u"comboBoxTaskType")
+
+        self.taskTypeLayout.addWidget(self.comboBoxTaskType)
+
+        self.horizontalSpacerTaskType = QSpacerItem(40, 20, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum)
+
+        self.taskTypeLayout.addItem(self.horizontalSpacerTaskType)
+
+
+        self.executionLayout.addLayout(self.taskTypeLayout)
+
+        self.modelSelectionPlaceholder = QWidget(self.groupBoxExecution)
+        self.modelSelectionPlaceholder.setObjectName(u"modelSelectionPlaceholder")
+        sizePolicy2 = QSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Expanding)
+        sizePolicy2.setHorizontalStretch(0)
+        sizePolicy2.setVerticalStretch(1)
+        sizePolicy2.setHeightForWidth(self.modelSelectionPlaceholder.sizePolicy().hasHeightForWidth())
+        self.modelSelectionPlaceholder.setSizePolicy(sizePolicy2)
+
+        self.executionLayout.addWidget(self.modelSelectionPlaceholder)
+
+        self.paramsLayout = QFormLayout()
+        self.paramsLayout.setObjectName(u"paramsLayout")
+        self.labelPromptProfile = QLabel(self.groupBoxExecution)
+        self.labelPromptProfile.setObjectName(u"labelPromptProfile")
+
+        self.paramsLayout.setWidget(0, QFormLayout.ItemRole.LabelRole, self.labelPromptProfile)
+
+        self.lineEditPromptProfile = QLineEdit(self.groupBoxExecution)
+        self.lineEditPromptProfile.setObjectName(u"lineEditPromptProfile")
+
+        self.paramsLayout.setWidget(0, QFormLayout.ItemRole.FieldRole, self.lineEditPromptProfile)
+
+        self.labelDescription = QLabel(self.groupBoxExecution)
+        self.labelDescription.setObjectName(u"labelDescription")
+
+        self.paramsLayout.setWidget(1, QFormLayout.ItemRole.LabelRole, self.labelDescription)
+
+        self.lineEditDescription = QLineEdit(self.groupBoxExecution)
+        self.lineEditDescription.setObjectName(u"lineEditDescription")
+
+        self.paramsLayout.setWidget(1, QFormLayout.ItemRole.FieldRole, self.lineEditDescription)
+
+
+        self.executionLayout.addLayout(self.paramsLayout)
+
+        self.submitLayout = QHBoxLayout()
+        self.submitLayout.setObjectName(u"submitLayout")
+        self.horizontalSpacerSubmit = QSpacerItem(40, 20, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum)
+
+        self.submitLayout.addItem(self.horizontalSpacerSubmit)
+
+        self.buttonSubmit = QPushButton(self.groupBoxExecution)
+        self.buttonSubmit.setObjectName(u"buttonSubmit")
+
+        self.submitLayout.addWidget(self.buttonSubmit)
+
+
+        self.executionLayout.addLayout(self.submitLayout)
+
+        self.splitterRight.addWidget(self.groupBoxExecution)
+        self.groupBoxStatus = QGroupBox(self.splitterRight)
+        self.groupBoxStatus.setObjectName(u"groupBoxStatus")
+        self.statusLayout = QVBoxLayout(self.groupBoxStatus)
+        self.statusLayout.setObjectName(u"statusLayout")
+        self.jobButtonsLayout = QHBoxLayout()
+        self.jobButtonsLayout.setObjectName(u"jobButtonsLayout")
+        self.buttonRefreshJobs = QPushButton(self.groupBoxStatus)
+        self.buttonRefreshJobs.setObjectName(u"buttonRefreshJobs")
+
+        self.jobButtonsLayout.addWidget(self.buttonRefreshJobs)
+
+        self.buttonRefreshStatus = QPushButton(self.groupBoxStatus)
+        self.buttonRefreshStatus.setObjectName(u"buttonRefreshStatus")
+
+        self.jobButtonsLayout.addWidget(self.buttonRefreshStatus)
+
+        self.buttonCancel = QPushButton(self.groupBoxStatus)
+        self.buttonCancel.setObjectName(u"buttonCancel")
+
+        self.jobButtonsLayout.addWidget(self.buttonCancel)
+
+        self.buttonFetch = QPushButton(self.groupBoxStatus)
+        self.buttonFetch.setObjectName(u"buttonFetch")
+
+        self.jobButtonsLayout.addWidget(self.buttonFetch)
+
+        self.buttonImport = QPushButton(self.groupBoxStatus)
+        self.buttonImport.setObjectName(u"buttonImport")
+
+        self.jobButtonsLayout.addWidget(self.buttonImport)
+
+        self.horizontalSpacerJobButtons = QSpacerItem(40, 20, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum)
+
+        self.jobButtonsLayout.addItem(self.horizontalSpacerJobButtons)
+
+
+        self.statusLayout.addLayout(self.jobButtonsLayout)
+
+        self.tableJobs = QTableWidget(self.groupBoxStatus)
+        self.tableJobs.setObjectName(u"tableJobs")
+
+        self.statusLayout.addWidget(self.tableJobs)
+
+        self.detailRow = QHBoxLayout()
+        self.detailRow.setObjectName(u"detailRow")
+        self.groupBoxDetail = QGroupBox(self.groupBoxStatus)
+        self.groupBoxDetail.setObjectName(u"groupBoxDetail")
+        self.detailLayout = QVBoxLayout(self.groupBoxDetail)
+        self.detailLayout.setObjectName(u"detailLayout")
+        self.textEditJobDetail = QTextEdit(self.groupBoxDetail)
+        self.textEditJobDetail.setObjectName(u"textEditJobDetail")
+        self.textEditJobDetail.setReadOnly(True)
+
+        self.detailLayout.addWidget(self.textEditJobDetail)
+
+
+        self.detailRow.addWidget(self.groupBoxDetail)
+
+        self.groupBoxItems = QGroupBox(self.groupBoxStatus)
+        self.groupBoxItems.setObjectName(u"groupBoxItems")
+        self.itemsLayout = QVBoxLayout(self.groupBoxItems)
+        self.itemsLayout.setObjectName(u"itemsLayout")
+        self.itemFilterLayout = QHBoxLayout()
+        self.itemFilterLayout.setObjectName(u"itemFilterLayout")
+        self.labelItemStatus = QLabel(self.groupBoxItems)
+        self.labelItemStatus.setObjectName(u"labelItemStatus")
+
+        self.itemFilterLayout.addWidget(self.labelItemStatus)
+
+        self.comboBoxItemStatus = QComboBox(self.groupBoxItems)
+        self.comboBoxItemStatus.setObjectName(u"comboBoxItemStatus")
+
+        self.itemFilterLayout.addWidget(self.comboBoxItemStatus)
+
+        self.horizontalSpacerItemFilter = QSpacerItem(40, 20, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum)
+
+        self.itemFilterLayout.addItem(self.horizontalSpacerItemFilter)
+
+
+        self.itemsLayout.addLayout(self.itemFilterLayout)
+
+        self.tableItems = QTableWidget(self.groupBoxItems)
+        self.tableItems.setObjectName(u"tableItems")
+
+        self.itemsLayout.addWidget(self.tableItems)
+
+
+        self.detailRow.addWidget(self.groupBoxItems)
+
+
+        self.statusLayout.addLayout(self.detailRow)
+
+        self.splitterRight.addWidget(self.groupBoxStatus)
+        self.splitterMain.addWidget(self.splitterRight)
+
+        self.rootLayout.addWidget(self.splitterMain)
+
+
+        self.retranslateUi(ProviderBatchJobWidget)
+
+        QMetaObject.connectSlotsByName(ProviderBatchJobWidget)
+    # setupUi
+
+    def retranslateUi(self, ProviderBatchJobWidget: QWidget) -> None:
+        ProviderBatchJobWidget.setWindowTitle(QCoreApplication.translate("ProviderBatchJobWidget", u"Provider Batch", None))
+        self.buttonAddSelected.setText(QCoreApplication.translate("ProviderBatchJobWidget", u"\u9078\u629e\u3092\u8ffd\u52a0", None))
+        self.buttonAddSelected.setObjectName(QCoreApplication.translate("ProviderBatchJobWidget", u"buttonProviderBatchAddSelected", None))
+        self.labelStatus.setText(QCoreApplication.translate("ProviderBatchJobWidget", u"Ready", None))
+        self.labelStatus.setObjectName(QCoreApplication.translate("ProviderBatchJobWidget", u"labelProviderBatchStatus", None))
+        self.groupBoxExecution.setTitle(QCoreApplication.translate("ProviderBatchJobWidget", u"\u5b9f\u884c\u8a2d\u5b9a", None))
+        self.labelTarget.setText(QCoreApplication.translate("ProviderBatchJobWidget", u"\u25ce \u30b9\u30c6\u30fc\u30b8\u30f3\u30b0: 0 \u679a", None))
+        self.labelTaskType.setText(QCoreApplication.translate("ProviderBatchJobWidget", u"Task", None))
+        self.comboBoxTaskType.setObjectName(QCoreApplication.translate("ProviderBatchJobWidget", u"comboBoxProviderBatchTaskType", None))
+        self.labelPromptProfile.setText(QCoreApplication.translate("ProviderBatchJobWidget", u"Prompt", None))
+        self.lineEditPromptProfile.setText(QCoreApplication.translate("ProviderBatchJobWidget", u"default", None))
+        self.lineEditPromptProfile.setObjectName(QCoreApplication.translate("ProviderBatchJobWidget", u"lineEditProviderBatchPromptProfile", None))
+        self.labelDescription.setText(QCoreApplication.translate("ProviderBatchJobWidget", u"Description", None))
+        self.lineEditDescription.setObjectName(QCoreApplication.translate("ProviderBatchJobWidget", u"lineEditProviderBatchDescription", None))
+        self.buttonSubmit.setText(QCoreApplication.translate("ProviderBatchJobWidget", u"Submit", None))
+        self.buttonSubmit.setObjectName(QCoreApplication.translate("ProviderBatchJobWidget", u"buttonProviderBatchSubmit", None))
+        self.groupBoxStatus.setTitle(QCoreApplication.translate("ProviderBatchJobWidget", u"\u30d0\u30c3\u30c1\u30b8\u30e7\u30d6\u72b6\u614b", None))
+        self.buttonRefreshJobs.setText(QCoreApplication.translate("ProviderBatchJobWidget", u"Refresh", None))
+        self.buttonRefreshJobs.setObjectName(QCoreApplication.translate("ProviderBatchJobWidget", u"buttonProviderBatchRefreshJobs", None))
+        self.buttonRefreshStatus.setText(QCoreApplication.translate("ProviderBatchJobWidget", u"Refresh Status", None))
+        self.buttonRefreshStatus.setObjectName(QCoreApplication.translate("ProviderBatchJobWidget", u"buttonProviderBatchRefreshStatus", None))
+        self.buttonCancel.setText(QCoreApplication.translate("ProviderBatchJobWidget", u"Cancel", None))
+        self.buttonCancel.setObjectName(QCoreApplication.translate("ProviderBatchJobWidget", u"buttonProviderBatchCancel", None))
+        self.buttonFetch.setText(QCoreApplication.translate("ProviderBatchJobWidget", u"Fetch", None))
+        self.buttonFetch.setObjectName(QCoreApplication.translate("ProviderBatchJobWidget", u"buttonProviderBatchFetch", None))
+        self.buttonImport.setText(QCoreApplication.translate("ProviderBatchJobWidget", u"Import", None))
+        self.buttonImport.setObjectName(QCoreApplication.translate("ProviderBatchJobWidget", u"buttonProviderBatchImport", None))
+        self.tableJobs.setObjectName(QCoreApplication.translate("ProviderBatchJobWidget", u"tableProviderBatchJobs", None))
+        self.groupBoxDetail.setTitle(QCoreApplication.translate("ProviderBatchJobWidget", u"Detail", None))
+        self.textEditJobDetail.setObjectName(QCoreApplication.translate("ProviderBatchJobWidget", u"textEditProviderBatchJobDetail", None))
+        self.groupBoxItems.setTitle(QCoreApplication.translate("ProviderBatchJobWidget", u"Items", None))
+        self.labelItemStatus.setText(QCoreApplication.translate("ProviderBatchJobWidget", u"Status", None))
+        self.comboBoxItemStatus.setObjectName(QCoreApplication.translate("ProviderBatchJobWidget", u"comboBoxProviderBatchItemStatus", None))
+        self.tableItems.setObjectName(QCoreApplication.translate("ProviderBatchJobWidget", u"tableProviderBatchItems", None))
+    # retranslateUi
+

--- a/src/lorairo/gui/widgets/batch_tag_add_widget.py
+++ b/src/lorairo/gui/widgets/batch_tag_add_widget.py
@@ -150,6 +150,17 @@ class BatchTagAddWidget(QWidget):
             return
         self._staging_widget.add_image_ids(image_ids)
 
+    def get_staged_items(self) -> "OrderedDict[int, tuple[str, str]]":
+        """ステージング中の画像メタデータを返す公開 API。
+
+        ADR 0041 (#550 D): main_window はこの公開アクセサ経由でステージング画像の
+        path を構築する (旧来の _staged_images private 参照から移行)。
+
+        Returns:
+            {image_id: (filename, stored_path)} の OrderedDict（追加順）。
+        """
+        return self._staging_widget.get_staged_items()
+
     # ------------------------------------------------------------------
     # 後方互換プロパティ（Wave 2 で main_window.py 移行後に削除予定）
     # ------------------------------------------------------------------
@@ -158,11 +169,9 @@ class BatchTagAddWidget(QWidget):
     def _staged_images(self) -> "OrderedDict[int, tuple[str, str]]":
         """ステージング画像メタデータへの後方互換アクセサ。
 
-        main_window._get_staged_image_paths_for_annotation() が
-        `batch_widget._staged_images.items()` / `if not batch_widget._staged_images` で
-        参照するため、StagingWidget.get_staged_items() へ委譲して互換性を維持する。
-
-        Wave 2（#550 D）で main_window.py を get_staged_items() 経由に移行後、削除予定。
+        ADR 0041 (#550 D) で main_window は公開 get_staged_items() 経由へ移行済み。
+        本プロパティは BatchTagAddWidget の既存テスト (`widget._staged_images`) が
+        参照するため StagingWidget.get_staged_items() へ委譲して維持する。
         """
         return self._staging_widget.get_staged_items()
 

--- a/src/lorairo/gui/widgets/provider_batch_job_widget.py
+++ b/src/lorairo/gui/widgets/provider_batch_job_widget.py
@@ -1,49 +1,44 @@
-"""Provider Batch job management widget."""
+"""Provider Batch job management widget.
+
+ADR 0041: 個別実行フロー (BatchTagAddWidget) と同形の
+「ステージング → モデル選択 → 実行」統一フローに改修した Provider Batch タブ。
+
+- 左: StagingWidget (サムネイルステージング、個別実行と共通)
+- 右上: 実行設定 (task_type フィルタ → 単一選択 batch-capable ModelSelectionWidget → Submit)
+- 右下: batch 固有の job 状態表示 (Jobs / Detail / Items)
+
+batch-capable 判定ロジックは Qt-free helper (provider_batch_capability) と
+ModelSelectionWidget に集約済みで、本 widget では submit 時のパラメータ解決にのみ helper を再利用する。
+"""
 
 from __future__ import annotations
 
-import re
-from typing import Any
+from collections.abc import Callable
+from typing import Any, cast
 
 from PySide6.QtCore import Qt, Slot
-from PySide6.QtWidgets import (
-    QComboBox,
-    QFormLayout,
-    QGroupBox,
-    QHBoxLayout,
-    QLabel,
-    QLineEdit,
-    QMessageBox,
-    QPushButton,
-    QTableWidget,
-    QTableWidgetItem,
-    QTextEdit,
-    QVBoxLayout,
-    QWidget,
-)
+from PySide6.QtWidgets import QMessageBox, QTableWidget, QTableWidgetItem, QWidget
 
+from lorairo.gui.designer.ProviderBatchJobWidget_ui import Ui_ProviderBatchJobWidget
+from lorairo.gui.widgets.model_selection_widget import ModelSelectionWidget
+from lorairo.services.provider_batch_capability import (
+    direct_provider_for_model,
+    endpoint_for_task,
+)
 from lorairo.services.provider_batch_service import ProviderBatchError
 from lorairo.utils.log import logger
 
-_DIRECT_PROVIDERS = {"openai", "anthropic"}
 _TASK_TYPES = ("annotation", "rating_preflight")
-_TASK_TYPE_ENDPOINTS = {
-    "annotation": {
-        "anthropic": "/v1/messages",
-    },
-    "rating_preflight": {
-        "openai": "/v1/moderations",
-    },
-}
-_MODEL_TYPE_RATINGS = "ratings"
 _ITEM_STATUSES = ("all", "failed", "expired", "canceled")
 
 
-class ProviderBatchJobWidget(QWidget):
-    """Provider Batch job submit/list/detail widget."""
+class ProviderBatchJobWidget(QWidget, Ui_ProviderBatchJobWidget):
+    """Provider Batch job submit/list/detail widget (統一フロー)."""
 
     def __init__(self, parent: QWidget | None = None) -> None:
         super().__init__(parent)
+        setup_ui = cast(Callable[[QWidget], None], self.setupUi)
+        setup_ui(self)
         self.setObjectName("providerBatchJobWidget")
 
         self._workflow_service: Any = None
@@ -53,8 +48,54 @@ class ProviderBatchJobWidget(QWidget):
         self._dataset_state_manager: Any = None
         self._current_job_id: int | None = None
 
-        self._setup_ui()
+        # ADR 0041: placeholder を単一選択 batch-capable ModelSelectionWidget に差替
+        self._staging_widget = self.stagingWidget
+        self._model_selection_widget = self._inject_model_selection_widget()
+        self._model_selection_widget.set_single_selection_mode(True)
+
+        self._setup_combos_and_tables()
         self._connect_signals()
+        self._update_target_label()
+
+    def _inject_model_selection_widget(self) -> ModelSelectionWidget:
+        """modelSelectionPlaceholder を ModelSelectionWidget に差替える。
+
+        widget_setup_service の placeholder 差替パターンに準拠する。
+
+        Returns:
+            実行設定グループに組み込んだ ModelSelectionWidget。
+        """
+        placeholder = self.modelSelectionPlaceholder
+        layout = self.executionLayout
+        index = layout.indexOf(placeholder)
+        layout.removeWidget(placeholder)
+        placeholder.setParent(None)
+        placeholder.deleteLater()
+
+        widget = ModelSelectionWidget(mode="advanced")
+        widget.setObjectName("providerBatchModelSelection")
+        widget.setParent(self.groupBoxExecution)
+        layout.insertWidget(index, widget)
+        return widget
+
+    def _setup_combos_and_tables(self) -> None:
+        """combo / table の項目・ヘッダを設定する。"""
+        self.comboBoxTaskType.addItems(_TASK_TYPES)
+        self.comboBoxTaskType.setCurrentText("annotation")
+        self.comboBoxItemStatus.addItems(_ITEM_STATUSES)
+
+        self.tableJobs.setColumnCount(5)
+        self.tableJobs.setHorizontalHeaderLabels(
+            ["ID", "Provider", "Status", "Provider Status", "Requests"]
+        )
+        self.tableJobs.setSelectionBehavior(QTableWidget.SelectionBehavior.SelectRows)
+        self.tableJobs.setEditTriggers(QTableWidget.EditTrigger.NoEditTriggers)
+
+        self.tableItems.setColumnCount(5)
+        self.tableItems.setHorizontalHeaderLabels(
+            ["Custom ID", "Image ID", "Status", "Error Type", "Error Message"]
+        )
+        self.tableItems.setEditTriggers(QTableWidget.EditTrigger.NoEditTriggers)
 
     def set_dependencies(
         self,
@@ -68,135 +109,21 @@ class ProviderBatchJobWidget(QWidget):
         self._repository = repository
         self._model_source = model_source
         self._model_repository = model_repository
-        self.refresh_models()
+        self._model_selection_widget.set_batch_capable_filtering(
+            True, self._selected_task_type(), model_source
+        )
         self.refresh_jobs()
 
     def set_dataset_state_manager(self, dataset_state_manager: Any) -> None:
-        """Set shared dataset state for selected image ID import."""
+        """Set shared dataset state for staging import."""
         self._dataset_state_manager = dataset_state_manager
-
-    def _setup_ui(self) -> None:
-        root = QHBoxLayout(self)
-        root.setContentsMargins(8, 8, 8, 8)
-        root.setSpacing(8)
-
-        left = QVBoxLayout()
-        right = QVBoxLayout()
-        root.addLayout(left, 1)
-        root.addLayout(right, 2)
-
-        self.groupBoxSubmit = QGroupBox("Submit")
-        submit_layout = QFormLayout(self.groupBoxSubmit)
-
-        self.comboBoxModel = QComboBox()
-        self.comboBoxModel.setObjectName("comboBoxProviderBatchModel")
-        self.comboBoxModel.setMinimumWidth(320)
-        submit_layout.addRow("Model", self.comboBoxModel)
-
-        self.comboBoxTaskType = QComboBox()
-        self.comboBoxTaskType.setObjectName("comboBoxProviderBatchTaskType")
-        self.comboBoxTaskType.addItems(_TASK_TYPES)
-        self.comboBoxTaskType.setCurrentText("annotation")
-        submit_layout.addRow("Task", self.comboBoxTaskType)
-
-        self.lineEditImageIds = QLineEdit()
-        self.lineEditImageIds.setObjectName("lineEditProviderBatchImageIds")
-        self.lineEditImageIds.setPlaceholderText("1, 2, 3")
-        submit_layout.addRow("Image IDs", self.lineEditImageIds)
-
-        self.lineEditPromptProfile = QLineEdit("default")
-        self.lineEditPromptProfile.setObjectName("lineEditProviderBatchPromptProfile")
-        submit_layout.addRow("Prompt", self.lineEditPromptProfile)
-
-        self.lineEditDescription = QLineEdit()
-        self.lineEditDescription.setObjectName("lineEditProviderBatchDescription")
-        submit_layout.addRow("Description", self.lineEditDescription)
-
-        submit_buttons = QHBoxLayout()
-        self.buttonUseSelected = QPushButton("Use Selected")
-        self.buttonUseSelected.setObjectName("buttonProviderBatchUseSelected")
-        self.buttonRefreshModels = QPushButton("Refresh Models")
-        self.buttonRefreshModels.setObjectName("buttonProviderBatchRefreshModels")
-        self.buttonSubmit = QPushButton("Submit")
-        self.buttonSubmit.setObjectName("buttonProviderBatchSubmit")
-        submit_buttons.addWidget(self.buttonUseSelected)
-        submit_buttons.addWidget(self.buttonRefreshModels)
-        submit_buttons.addWidget(self.buttonSubmit)
-        submit_layout.addRow(submit_buttons)
-        left.addWidget(self.groupBoxSubmit)
-
-        self.groupBoxJobs = QGroupBox("Jobs")
-        jobs_layout = QVBoxLayout(self.groupBoxJobs)
-        job_buttons = QHBoxLayout()
-        self.buttonRefreshJobs = QPushButton("Refresh")
-        self.buttonRefreshJobs.setObjectName("buttonProviderBatchRefreshJobs")
-        self.buttonRefreshStatus = QPushButton("Refresh Status")
-        self.buttonRefreshStatus.setObjectName("buttonProviderBatchRefreshStatus")
-        self.buttonCancel = QPushButton("Cancel")
-        self.buttonCancel.setObjectName("buttonProviderBatchCancel")
-        self.buttonFetch = QPushButton("Fetch")
-        self.buttonFetch.setObjectName("buttonProviderBatchFetch")
-        self.buttonImport = QPushButton("Import")
-        self.buttonImport.setObjectName("buttonProviderBatchImport")
-        for button in (
-            self.buttonRefreshJobs,
-            self.buttonRefreshStatus,
-            self.buttonCancel,
-            self.buttonFetch,
-            self.buttonImport,
-        ):
-            job_buttons.addWidget(button)
-        jobs_layout.addLayout(job_buttons)
-
-        self.tableJobs = QTableWidget(0, 5)
-        self.tableJobs.setObjectName("tableProviderBatchJobs")
-        self.tableJobs.setHorizontalHeaderLabels(
-            ["ID", "Provider", "Status", "Provider Status", "Requests"]
-        )
-        self.tableJobs.setSelectionBehavior(QTableWidget.SelectionBehavior.SelectRows)
-        self.tableJobs.setEditTriggers(QTableWidget.EditTrigger.NoEditTriggers)
-        jobs_layout.addWidget(self.tableJobs)
-        right.addWidget(self.groupBoxJobs, 1)
-
-        detail_row = QHBoxLayout()
-        self.groupBoxDetail = QGroupBox("Detail")
-        detail_layout = QVBoxLayout(self.groupBoxDetail)
-        self.textEditJobDetail = QTextEdit()
-        self.textEditJobDetail.setObjectName("textEditProviderBatchJobDetail")
-        self.textEditJobDetail.setReadOnly(True)
-        detail_layout.addWidget(self.textEditJobDetail)
-        detail_row.addWidget(self.groupBoxDetail, 1)
-
-        self.groupBoxItems = QGroupBox("Items")
-        items_layout = QVBoxLayout(self.groupBoxItems)
-        filter_layout = QHBoxLayout()
-        filter_layout.addWidget(QLabel("Status"))
-        self.comboBoxItemStatus = QComboBox()
-        self.comboBoxItemStatus.setObjectName("comboBoxProviderBatchItemStatus")
-        self.comboBoxItemStatus.addItems(_ITEM_STATUSES)
-        filter_layout.addWidget(self.comboBoxItemStatus)
-        filter_layout.addStretch()
-        items_layout.addLayout(filter_layout)
-        self.tableItems = QTableWidget(0, 5)
-        self.tableItems.setObjectName("tableProviderBatchItems")
-        self.tableItems.setHorizontalHeaderLabels(
-            ["Custom ID", "Image ID", "Status", "Error Type", "Error Message"]
-        )
-        self.tableItems.setEditTriggers(QTableWidget.EditTrigger.NoEditTriggers)
-        items_layout.addWidget(self.tableItems)
-        detail_row.addWidget(self.groupBoxItems, 1)
-        right.addLayout(detail_row, 1)
-
-        self.labelStatus = QLabel("Ready")
-        self.labelStatus.setObjectName("labelProviderBatchStatus")
-        left.addWidget(self.labelStatus)
-        left.addStretch()
+        self._staging_widget.set_dataset_state_manager(dataset_state_manager)
 
     def _connect_signals(self) -> None:
-        self.buttonUseSelected.clicked.connect(self.use_selected_images)
-        self.buttonRefreshModels.clicked.connect(self.refresh_models)
+        self.buttonAddSelected.clicked.connect(self._staging_widget.add_selected_images)
         self.buttonSubmit.clicked.connect(self.submit_job)
-        self.comboBoxTaskType.currentTextChanged.connect(self.refresh_models)
+        self.comboBoxTaskType.currentTextChanged.connect(self._on_task_type_changed)
+        self._staging_widget.staged_images_changed.connect(self._update_target_label)
         self.buttonRefreshJobs.clicked.connect(self.refresh_jobs)
         self.buttonRefreshStatus.clicked.connect(self.refresh_selected_job_status)
         self.buttonCancel.clicked.connect(self.cancel_selected_job)
@@ -205,153 +132,59 @@ class ProviderBatchJobWidget(QWidget):
         self.tableJobs.itemSelectionChanged.connect(self._on_job_selection_changed)
         self.comboBoxItemStatus.currentTextChanged.connect(self.refresh_items)
 
-    @Slot()
-    def refresh_models(self) -> None:
-        """Refresh direct provider batch capable models."""
-        self.comboBoxModel.clear()
-        if self._model_repository is None:
-            return
-
-        task_type = self._selected_task_type()
-        try:
-            models = self._load_batch_capable_models()
-        except Exception as e:
-            logger.warning(f"Provider Batch model discovery failed: {e}")
-            models = []
-
-        for model in models:
-            provider = self._direct_provider_for_model(model)
-            if provider is None:
-                continue
-            if not self._model_supports_task_type(model, provider, task_type):
-                continue
-            endpoint = self._endpoint_for_task(provider, task_type)
-            label = f"{provider}: {model.litellm_model_id}"
-            self.comboBoxModel.addItem(
-                label,
-                {
-                    "model_id": model.id,
-                    "provider": provider,
-                    "litellm_model_id": model.litellm_model_id,
-                    "endpoint": endpoint,
-                    "task_type": task_type,
-                },
-            )
-        self.labelStatus.setText(f"{self.comboBoxModel.count()} batch-capable model(s)")
-
     def _selected_task_type(self) -> str:
         task_type = self.comboBoxTaskType.currentText()
         if task_type in _TASK_TYPES:
             return task_type
         return "annotation"
 
-    def _endpoint_for_task(self, provider: str, task_type: str) -> str:
-        provider_tasks = _TASK_TYPE_ENDPOINTS.get(task_type)
-        if provider_tasks is None:
-            provider_tasks = _TASK_TYPE_ENDPOINTS["annotation"]
-        endpoint = provider_tasks.get(provider)
-        if endpoint is None:
-            raise ValueError(f"Provider '{provider}' は task_type '{task_type}' をサポートしていません。")
-        return endpoint
-
-    @staticmethod
-    def _model_has_model_type(model: Any, model_type: str) -> bool:
-        model_types = getattr(model, "model_types", ())
-        return any(getattr(item, "name", None) == model_type for item in model_types)
-
-    def _model_supports_task_type(self, model: Any, provider: str, task_type: str) -> bool:
-        if task_type == "annotation":
-            return provider == "anthropic"
-        if task_type == "rating_preflight":
-            return provider == "openai" and self._model_has_model_type(model, _MODEL_TYPE_RATINGS)
-        return False
-
-    def _load_batch_capable_models(self) -> list[Any]:
-        source = self._model_source
-        raw_models: tuple[Any, ...] = ()
-        if source is not None and hasattr(source, "list_batch_capable_models"):
-            raw_models = tuple(source.list_batch_capable_models())
-
-        resolved: list[Any] = []
-        seen: set[str] = set()
-        for raw in raw_models:
-            litellm_id = self._litellm_id_from_batch_model(raw)
-            if not litellm_id:
-                continue
-            model = self._model_repository.get_model_by_litellm_id(litellm_id)
-            if model is not None and model.litellm_model_id not in seen:
-                resolved.append(model)
-                seen.add(model.litellm_model_id)
-
-        if resolved:
-            return resolved
-        return []
-
-    @staticmethod
-    def _litellm_id_from_batch_model(raw: Any) -> str | None:
-        if isinstance(raw, str):
-            return raw
-        value = (
-            getattr(raw, "litellm_model_id", None)
-            or getattr(raw, "model_id", None)
-            or getattr(raw, "name", None)
+    @Slot(str)
+    def _on_task_type_changed(self, _task_type: str) -> None:
+        """task_type 変更時に batch-capable フィルタを再評価する。"""
+        if self._model_source is None:
+            return
+        self._model_selection_widget.set_batch_capable_filtering(
+            True, self._selected_task_type(), self._model_source
         )
-        return str(value) if value else None
-
-    @staticmethod
-    def _direct_provider_for_model(model: Any) -> str | None:
-        provider = str(getattr(model, "provider", "") or "").lower()
-        litellm_id = str(getattr(model, "litellm_model_id", "") or "")
-        route_prefix = litellm_id.split("/", 1)[0].lower() if "/" in litellm_id else ""
-        direct = provider if provider in _DIRECT_PROVIDERS else route_prefix
-        if direct in _DIRECT_PROVIDERS:
-            return direct
-        return None
 
     @Slot()
-    def use_selected_images(self) -> None:
-        if self._dataset_state_manager is None:
-            self.labelStatus.setText("Dataset state is not available")
-            return
-        image_ids = self._dataset_state_manager.selected_image_ids
-        self.lineEditImageIds.setText(", ".join(str(image_id) for image_id in image_ids))
-        self.labelStatus.setText(f"Loaded {len(image_ids)} selected image ID(s)")
-
-    def _parse_image_ids(self) -> list[int]:
-        raw = self.lineEditImageIds.text().strip()
-        if not raw:
-            return []
-        image_ids: list[int] = []
-        for token in re.split(r"[\s,]+", raw):
-            if not token:
-                continue
-            image_id = int(token)
-            if image_id <= 0:
-                raise ValueError("image ID must be positive")
-            image_ids.append(image_id)
-        return image_ids
+    def _update_target_label(self, _image_ids: list[int] | None = None) -> None:
+        """ステージング枚数ラベルを更新する。"""
+        count = self._staging_widget.count()
+        self.labelTarget.setText(f"◎ ステージング: {count} 枚")
 
     @Slot()
     def submit_job(self) -> None:
         if self._workflow_service is None:
             self.labelStatus.setText("Provider Batch service is not available")
             return
-        model_data = self.comboBoxModel.currentData()
-        if not model_data:
-            QMessageBox.warning(self, "Provider Batch", "No batch-capable model is selected.")
+        litellm_model_id = self._model_selection_widget.get_selected_model()
+        if not litellm_model_id:
+            QMessageBox.warning(self, "Provider Batch", "バッチ対応モデルを選択してください。")
             return
         try:
-            image_ids = self._parse_image_ids()
+            image_ids = self._staging_widget.get_image_ids()
             if not image_ids:
-                raise ValueError("image IDs are required")
+                raise ValueError("ステージングに画像を追加してください。")
             task_type = self._selected_task_type()
+            model = (
+                self._model_repository.get_model_by_litellm_id(litellm_model_id)
+                if self._model_repository is not None
+                else None
+            )
+            if model is None:
+                raise ValueError(f"モデル情報が見つかりません: {litellm_model_id}")
+            provider = direct_provider_for_model(model)
+            if provider is None:
+                raise ValueError(f"direct provider を解決できません: {litellm_model_id}")
+            endpoint = endpoint_for_task(provider, task_type)
             job_id = self._workflow_service.submit_images(
-                provider=model_data["provider"],
-                endpoint=model_data["endpoint"],
-                litellm_model_id=model_data["litellm_model_id"],
+                provider=provider,
+                endpoint=endpoint,
+                litellm_model_id=litellm_model_id,
                 prompt_profile=self.lineEditPromptProfile.text().strip() or "default",
                 image_ids=image_ids,
-                model_id=model_data["model_id"],
+                model_id=model.id,
                 description=self.lineEditDescription.text().strip() or None,
                 task_type=task_type,
             )

--- a/src/lorairo/gui/window/main_window.py
+++ b/src/lorairo/gui/window/main_window.py
@@ -1530,8 +1530,8 @@ class MainWindow(QMainWindow, Ui_MainWindow):
     def _get_staged_image_paths_for_annotation(self) -> list[str]:
         """バッチタグタブのステージング画像パスを取得
 
-        BatchTagAddWidget._staged_imagesから画像IDを取得し、
-        DatasetStateManagerから実際のファイルパスに変換する。
+        BatchTagAddWidget.get_staged_items() で画像 ID とメタデータを取得し、
+        DatasetStateManager 由来の stored_path を実際のファイルパスに解決する。
 
         Returns:
             list[str]: 画像ファイルパスリスト。エラー時は空リスト。
@@ -1539,7 +1539,8 @@ class MainWindow(QMainWindow, Ui_MainWindow):
         from lorairo.database.db_core import resolve_stored_path
 
         batch_widget = getattr(self, "batchTagAddWidget", None)
-        if not batch_widget or not batch_widget._staged_images:
+        staged_items = batch_widget.get_staged_items() if batch_widget else None
+        if not staged_items:
             return []
 
         if not self.dataset_state_manager:
@@ -1547,7 +1548,7 @@ class MainWindow(QMainWindow, Ui_MainWindow):
             return []
 
         paths: list[str] = []
-        for image_id, (_, stored_path) in batch_widget._staged_images.items():
+        for image_id, (_, stored_path) in staged_items.items():
             if stored_path:
                 resolved = resolve_stored_path(stored_path)
                 if resolved and resolved.exists():
@@ -1654,8 +1655,8 @@ class MainWindow(QMainWindow, Ui_MainWindow):
         バッチタグタブのステージングリスト更新
 
         Note:
-            BatchTagAddWidget._staged_imagesはprivate属性なので直接アクセスしない。
-            代わりに_refresh_staging_list_ui()を呼び出してUI更新を委譲する。
+            ステージング状態へは直接アクセスせず、_refresh_staging_list_ui() を
+            呼び出して BatchTagAddWidget / StagingWidget に UI 更新を委譲する。
         """
         # BatchTagAddWidgetを取得（Ui_MainWindowを多重継承しているため、selfの直接の属性）
         batch_tag_widget = getattr(self, "batchTagAddWidget", None)

--- a/tests/unit/gui/widgets/test_provider_batch_job_widget.py
+++ b/tests/unit/gui/widgets/test_provider_batch_job_widget.py
@@ -1,4 +1,10 @@
-"""ProviderBatchJobWidget tests."""
+"""ProviderBatchJobWidget tests (ADR 0041 統一フロー).
+
+ModelSelectionWidget は service container を要求するため、本 widget の単体テストでは
+軽量 fake クラスに差し替えて単一選択 / batch-capable フィルタ / submit 配線を検証する。
+batch-capable 判定ロジック自体は ModelSelectionWidget / provider_batch_capability の
+個別テストでカバーされる。
+"""
 
 from __future__ import annotations
 
@@ -7,7 +13,9 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
+from PySide6.QtWidgets import QWidget
 
+import lorairo.gui.widgets.provider_batch_job_widget as widget_module
 from lorairo.gui.state.dataset_state import DatasetStateManager
 from lorairo.gui.widgets.provider_batch_job_widget import ProviderBatchJobWidget
 
@@ -60,6 +68,31 @@ def _item(**overrides):
     return SimpleNamespace(**values)
 
 
+class _FakeModelSelectionWidget(QWidget):
+    """ModelSelectionWidget の軽量スタブ (service container 非依存)。"""
+
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__()
+        self.single_selection_mode: bool | None = None
+        self.batch_filter_calls: list[tuple[bool, str, object]] = []
+        self._selected_model: str | None = None
+
+    def set_single_selection_mode(self, enabled: bool) -> None:
+        self.single_selection_mode = enabled
+
+    def set_batch_capable_filtering(self, enabled: bool, task_type: str, model_source: object) -> None:
+        self.batch_filter_calls.append((enabled, task_type, model_source))
+
+    def get_selected_model(self) -> str | None:
+        return self._selected_model
+
+
+@pytest.fixture(autouse=True)
+def _stub_model_selection(monkeypatch):
+    """ProviderBatchJobWidget が生成する ModelSelectionWidget を fake に差替える。"""
+    monkeypatch.setattr(widget_module, "ModelSelectionWidget", _FakeModelSelectionWidget)
+
+
 @pytest.fixture
 def widget(qtbot):
     provider_widget = ProviderBatchJobWidget()
@@ -76,25 +109,21 @@ def dependencies():
 
     model_repository.get_model_by_litellm_id.side_effect = lambda litellm_id: {
         "openai/gpt-4.1-mini": _model(),
-        "openrouter/openai/gpt-4.1-mini": _model(
-            id=8,
-            provider="openrouter",
-            litellm_model_id="openrouter/openai/gpt-4.1-mini",
-        ),
         "anthropic/claude-3-5-sonnet": _model(
             id=9,
             provider="anthropic",
             litellm_model_id="anthropic/claude-3-5-sonnet",
         ),
+        "openai/omni-moderation-latest": _model(
+            id=11,
+            provider="openai",
+            litellm_model_id="openai/omni-moderation-latest",
+            model_types=(SimpleNamespace(name="ratings"),),
+        ),
     }.get(litellm_id)
     repository.list_provider_batch_jobs.return_value = [_job()]
     repository.get_provider_batch_job.return_value = _job()
     repository.list_provider_batch_items.return_value = [_item()]
-    model_source.list_batch_capable_models.return_value = (
-        "openai/gpt-4.1-mini",
-        "openrouter/openai/gpt-4.1-mini",
-        "anthropic/claude-3-5-sonnet",
-    )
     workflow.submit_images.return_value = 42
     workflow.fetch_results.return_value = SimpleNamespace(items=(_item(),))
     workflow.import_results.return_value = SimpleNamespace(imported_count=1, total_count=1)
@@ -104,64 +133,62 @@ def dependencies():
 @pytest.mark.unit
 @pytest.mark.gui
 def test_initial_ui_created(widget):
-    assert widget.comboBoxModel is not None
-    assert widget.lineEditImageIds is not None
     assert widget.tableJobs.columnCount() == 5
+    assert widget.tableItems.columnCount() == 5
     assert widget.comboBoxItemStatus.count() == 4
+    assert widget.comboBoxTaskType.currentText() == "annotation"
+    assert "0 枚" in widget.labelTarget.text()
 
 
 @pytest.mark.unit
 @pytest.mark.gui
-def test_set_dependencies_filters_direct_batch_models(widget, dependencies):
+def test_model_selection_starts_in_single_mode(widget):
+    assert widget._model_selection_widget.single_selection_mode is True
+
+
+@pytest.mark.unit
+@pytest.mark.gui
+def test_set_dependencies_enables_batch_filtering_and_lists_jobs(widget, dependencies):
     workflow, repository, model_source, model_repository = dependencies
 
     widget.set_dependencies(workflow, repository, model_source, model_repository)
 
-    assert widget.comboBoxModel.count() == 1
-    labels = [widget.comboBoxModel.itemText(i) for i in range(widget.comboBoxModel.count())]
-    assert "anthropic: anthropic/claude-3-5-sonnet" in labels
-    assert all("openai/gpt-4.1-mini" not in label for label in labels)
-    assert all("openrouter" not in label for label in labels)
+    assert widget._model_selection_widget.batch_filter_calls == [(True, "annotation", model_source)]
     assert widget.tableJobs.rowCount() == 1
 
 
 @pytest.mark.unit
 @pytest.mark.gui
-def test_unresolved_batch_capable_models_do_not_fallback_to_all_models(widget):
-    workflow = MagicMock()
-    repository = MagicMock()
-    model_repository = MagicMock()
-    model_source = MagicMock()
-    model_source.list_batch_capable_models.return_value = ("openai/missing-from-db",)
-    model_repository.get_model_by_litellm_id.return_value = None
-    model_repository.get_model_objects.return_value = [_model()]
-    repository.list_provider_batch_jobs.return_value = []
-
-    widget.set_dependencies(workflow, repository, model_source, model_repository)
-
-    assert widget.comboBoxModel.count() == 0
-    model_repository.get_model_objects.assert_not_called()
-
-
-@pytest.mark.unit
-@pytest.mark.gui
-def test_use_selected_images_populates_manual_ids(widget):
-    state = DatasetStateManager()
-    state._selected_image_ids = [3, 5]
-    widget.set_dataset_state_manager(state)
-
-    widget.use_selected_images()
-
-    assert widget.lineEditImageIds.text() == "3, 5"
-    assert "2 selected" in widget.labelStatus.text()
-
-
-@pytest.mark.unit
-@pytest.mark.gui
-def test_submit_job_calls_workflow(widget, dependencies):
+def test_task_type_change_reevaluates_batch_filter(widget, dependencies):
     workflow, repository, model_source, model_repository = dependencies
     widget.set_dependencies(workflow, repository, model_source, model_repository)
-    widget.lineEditImageIds.setText("1, 2")
+
+    widget.comboBoxTaskType.setCurrentText("rating_preflight")
+
+    assert widget._model_selection_widget.batch_filter_calls[-1] == (
+        True,
+        "rating_preflight",
+        model_source,
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.gui
+def test_target_label_updates_on_staged_images_changed(widget, monkeypatch):
+    monkeypatch.setattr(widget._staging_widget, "count", lambda: 3)
+
+    widget._staging_widget.staged_images_changed.emit([1, 2, 3])
+
+    assert "3 枚" in widget.labelTarget.text()
+
+
+@pytest.mark.unit
+@pytest.mark.gui
+def test_submit_job_resolves_annotation_params(widget, dependencies, monkeypatch):
+    workflow, repository, model_source, model_repository = dependencies
+    widget.set_dependencies(workflow, repository, model_source, model_repository)
+    widget._model_selection_widget._selected_model = "anthropic/claude-3-5-sonnet"
+    monkeypatch.setattr(widget._staging_widget, "get_image_ids", lambda: [1, 2])
     widget.lineEditDescription.setText("nightly")
 
     widget.submit_job()
@@ -181,60 +208,12 @@ def test_submit_job_calls_workflow(widget, dependencies):
 
 @pytest.mark.unit
 @pytest.mark.gui
-def test_set_dependencies_filters_for_rating_preflight_task(widget):
-    workflow = MagicMock()
-    repository = MagicMock()
-    model_repository = MagicMock()
-    model_source = MagicMock()
-    model_source.list_batch_capable_models.return_value = (
-        "openai/gpt-4.1-mini",
-        "openai/omni-moderation-latest",
-        "anthropic/claude-3-5-sonnet",
-    )
-    model_repository.get_model_by_litellm_id.side_effect = lambda litellm_id: {
-        "openai/gpt-4.1-mini": _model(),
-        "openai/omni-moderation-latest": _model(
-            id=11,
-            provider="openai",
-            litellm_model_id="openai/omni-moderation-latest",
-            model_types=(SimpleNamespace(name="ratings"),),
-        ),
-        "anthropic/claude-3-5-sonnet": _model(
-            id=9,
-            provider="anthropic",
-            litellm_model_id="anthropic/claude-3-5-sonnet",
-        ),
-    }.get(litellm_id)
-    repository.list_provider_batch_jobs.return_value = []
-
+def test_submit_job_rating_preflight_uses_moderations_endpoint(widget, dependencies, monkeypatch):
+    workflow, repository, model_source, model_repository = dependencies
     widget.set_dependencies(workflow, repository, model_source, model_repository)
     widget.comboBoxTaskType.setCurrentText("rating_preflight")
-
-    assert widget.comboBoxModel.count() == 1
-    assert widget.comboBoxModel.itemText(0) == "openai: openai/omni-moderation-latest"
-
-
-@pytest.mark.unit
-@pytest.mark.gui
-def test_submit_job_rating_preflight_uses_moderations_endpoint(widget):
-    workflow = MagicMock()
-    repository = MagicMock()
-    model_repository = MagicMock()
-    model_source = MagicMock()
-    workflow.submit_images.return_value = 42
-    model_source.list_batch_capable_models.return_value = ("openai/omni-moderation-latest",)
-    model_repository.get_model_by_litellm_id.return_value = _model(
-        id=11,
-        provider="openai",
-        litellm_model_id="openai/omni-moderation-latest",
-        model_types=(SimpleNamespace(name="ratings"),),
-    )
-    repository.list_provider_batch_jobs.return_value = []
-
-    widget.set_dependencies(workflow, repository, model_source, model_repository)
-    widget.comboBoxTaskType.setCurrentText("rating_preflight")
-    widget.lineEditImageIds.setText("1, 2")
-    widget.lineEditDescription.setText("nightly")
+    widget._model_selection_widget._selected_model = "openai/omni-moderation-latest"
+    monkeypatch.setattr(widget._staging_widget, "get_image_ids", lambda: [1, 2])
 
     widget.submit_job()
 
@@ -245,9 +224,52 @@ def test_submit_job_rating_preflight_uses_moderations_endpoint(widget):
         prompt_profile="default",
         image_ids=[1, 2],
         model_id=11,
-        description="nightly",
+        description=None,
         task_type="rating_preflight",
     )
+
+
+@pytest.mark.unit
+@pytest.mark.gui
+def test_submit_job_without_model_warns(widget, dependencies, monkeypatch):
+    workflow, repository, model_source, model_repository = dependencies
+    widget.set_dependencies(workflow, repository, model_source, model_repository)
+    widget._model_selection_widget._selected_model = None
+    warning = MagicMock()
+    monkeypatch.setattr(widget_module.QMessageBox, "warning", warning)
+
+    widget.submit_job()
+
+    warning.assert_called_once()
+    workflow.submit_images.assert_not_called()
+
+
+@pytest.mark.unit
+@pytest.mark.gui
+def test_submit_job_without_staged_images_warns(widget, dependencies, monkeypatch):
+    workflow, repository, model_source, model_repository = dependencies
+    widget.set_dependencies(workflow, repository, model_source, model_repository)
+    widget._model_selection_widget._selected_model = "anthropic/claude-3-5-sonnet"
+    monkeypatch.setattr(widget._staging_widget, "get_image_ids", lambda: [])
+    warning = MagicMock()
+    monkeypatch.setattr(widget_module.QMessageBox, "warning", warning)
+
+    widget.submit_job()
+
+    warning.assert_called_once()
+    workflow.submit_images.assert_not_called()
+
+
+@pytest.mark.unit
+@pytest.mark.gui
+def test_set_dataset_state_manager_forwards_to_staging(widget, monkeypatch):
+    state = DatasetStateManager()
+    forwarded = MagicMock()
+    monkeypatch.setattr(widget._staging_widget, "set_dataset_state_manager", forwarded)
+
+    widget.set_dataset_state_manager(state)
+
+    forwarded.assert_called_once_with(state)
 
 
 @pytest.mark.unit
@@ -307,7 +329,7 @@ def test_action_handlers_catch_unexpected_errors(widget, dependencies, monkeypat
     widget.tableJobs.selectRow(0)
     workflow.cancel.side_effect = RuntimeError("adapter exploded")
     critical = MagicMock()
-    monkeypatch.setattr("lorairo.gui.widgets.provider_batch_job_widget.QMessageBox.critical", critical)
+    monkeypatch.setattr(widget_module.QMessageBox, "critical", critical)
 
     widget.cancel_selected_job()
 


### PR DESCRIPTION
## 概要

ADR 0041 **Wave 2 / Track D** (#550)。Provider Batch タブ (`ProviderBatchJobWidget`) を、個別実行フロー (`tabBatchTag`) と同形の **「ステージング → モデル選択 → 実行」** 統一フローに全面改修する。Wave 1 (#548 B / #549 C) の成果物を消費する単独所有 Wave。

Closes #550

## 変更点

### `.ui` 化 (ADR 0041 §4)
- `ProviderBatchJobWidget.ui` を新規作成し、Python 手組み `_setup_ui()` を廃止
- 多重継承パターン `class ProviderBatchJobWidget(QWidget, Ui_ProviderBatchJobWidget)`
- `StagingWidget` は customwidget promotion、`ModelSelectionWidget` は `modelSelectionPlaceholder` 差替 (widget_setup_service の既存パターン準拠)

### ステージング統一 (ADR 0041 §3/§5)
- `lineEditImageIds` / `_parse_image_ids()` / `use_selected_images()` を廃止
- 共有 `StagingWidget`（サムネイル / N/500枚 / [選択を追加] / [クリア]）を組込み、`get_image_ids()` で submit
- `labelTarget` をステージング枚数に連動

### モデル選択統一 (ADR 0041 §1/§2)
- 単一 `QComboBox` + 手動 batch-capable フィルタ8メソッドを廃止
- 単一選択 `ModelSelectionWidget` + `set_batch_capable_filtering(enabled, task_type, model_source)` に置換
- `task_type` を filter 枠（モデル選択直上）に配置、変更時にフィルタ再評価
- submit パラメータ (provider/endpoint/model_id) は Qt-free helper `provider_batch_capability` で解決（重複実装なし）

### job パネル整理
- Jobs 一覧 / Detail / Items を batch 固有の「状態表示」領域 (`groupBoxStatus`) に視覚分離。submit / list / detail / items / cancel / fetch / import は非回帰

### main_window 移行 (ADR 0041 §C follow-up)
- `_get_staged_image_paths_for_annotation` を BatchTagAddWidget の公開 `get_staged_items()` 経由へ移行（旧 `_staged_images` private 参照を解消）
- 互換 `_staged_images` プロパティは C の既存テスト群が参照するため維持

## テスト

- 新規単体: **14 passed**（初期UI / 単一選択 / batch filter 連動 / task_type 再評価 / target ラベル / submit 解決 (annotation + rating_preflight) / 未選択・未ステージング警告 / dataset_state forward / job パネル4アクション）
- 影響範囲 (batch_tag / main_window / 統合): **151 passed**
- CI-equivalent filter 全体: **3583 passed**（`test_cli_entrypoint` の1件は worktree の `uv run --no-sync` がローカル `.venv` 不在を見る環境アーティファクトで、CLI 非関与の本変更とは無関係）
- ruff format/check クリア、mypy 変更ファイルクリア

## レイアウト (after)

左=ステージング（個別実行と同形）/ 右上=実行設定（◎ステージング枚数 → Task フィルタ → 単一選択 batch-capable モデル → Submit）/ 右下=batch 固有のジョブ状態表示（Jobs + Refresh/Refresh Status/Cancel/Fetch/Import、Detail | Items）。offscreen レンダで検証済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)