### PR TITLE
chore: update image-annotator-lib for provider batch models

### DIFF
--- a/docs/decisions/0041-provider-batch-execution-ui-unification.md
+++ b/docs/decisions/0041-provider-batch-execution-ui-unification.md
@@ -246,3 +246,8 @@ Wave 2 (1人・単独所有): #550 D
 **フォローアップ**
 - task_type の配置は UI 表示確認後に再評価しうる。
 - 複数モデル一括が将来必要になった場合は本 ADR を Superseded として再検討する。
+- #545 の残作業として、Provider Batch の batch-capable モデル一覧が空になる原因だった
+  `image-annotator-lib.list_batch_capable_models()` の None metadata guard を含む
+  image-annotator-lib #129 merge commit を submodule pin に取り込む。LoRAIro 側の
+  batch eligibility 判定は ADR 0038 どおり image-annotator-lib を SSoT とし、LoRAIro DB へ
+  永続化しない。


### PR DESCRIPTION
Fixes #545.\n\nBranch: fix/issue-545-image-annotator-lib-pin\nWorktree: /tmp/worktrees/issue-545-image-annotator-lib-pin\nADR: docs/decisions/0041-provider-batch-execution-ui-unification.md\n\n## Summary\n- Update local_packages/image-annotator-lib from 5adfe993 to 0c7a61a2, including image-annotator-lib #129's None metadata guard for list_batch_capable_models().\n- Record the #545 follow-up in ADR 0041, keeping batch eligibility as the image-annotator-lib SSoT per ADR 0038.\n\n## Verification\n- UV_CACHE_DIR=/tmp/uv-cache UV_PROJECT_ENVIRONMENT=/workspaces/LoRAIro/.venv uv run pytest tests/unit/services/test_provider_batch_capability.py tests/unit/gui/widgets/test_model_selection_widget.py tests/unit/gui/widgets/test_provider_batch_job_widget.py -q\n- UV_CACHE_DIR=/tmp/uv-cache UV_PROJECT_ENVIRONMENT=/workspaces/LoRAIro/.venv uv run pytest local_packages/image-annotator-lib/tests/unit/webapi/batch/test_batch_public_api.py -q\n- UV_CACHE_DIR=/tmp/uv-cache UV_PROJECT_ENVIRONMENT=/workspaces/LoRAIro/.venv uv run python -c "from image_annotator_lib.webapi.batch import list_batch_capable_models; models=list_batch_capable_models(); print(len(models)); print([m.litellm_model_id for m in models[:5]])"\n- git diff --check\n- ruff check docs/decisions/0041-provider-batch-execution-ui-unification.md (no Python files; passed)