### PR TITLE
fix: streamline provider batch status actions

### DIFF
--- a/src/lorairo/gui/designer/ProviderBatchJobWidget.ui
+++ b/src/lorairo/gui/designer/ProviderBatchJobWidget.ui
@@ -237,20 +237,10 @@
        <layout class="QVBoxLayout" name="statusLayout">
         <item>
          <layout class="QHBoxLayout" name="jobButtonsLayout">
-          <item>
-           <widget class="QPushButton" name="buttonRefreshJobs">
-            <property name="text">
-             <string>更新</string>
-            </property>
-            <property name="objectName">
-             <string>buttonProviderBatchRefreshJobs</string>
-            </property>
-           </widget>
-          </item>
-          <item>
+         <item>
            <widget class="QPushButton" name="buttonRefreshStatus">
             <property name="text">
-             <string>状態更新</string>
+             <string>状態を確認</string>
             </property>
             <property name="objectName">
              <string>buttonProviderBatchRefreshStatus</string>
@@ -264,26 +254,6 @@
             </property>
             <property name="objectName">
              <string>buttonProviderBatchCancel</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QPushButton" name="buttonFetch">
-            <property name="text">
-             <string>取得</string>
-            </property>
-            <property name="objectName">
-             <string>buttonProviderBatchFetch</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QPushButton" name="buttonImport">
-            <property name="text">
-             <string>取り込み</string>
-            </property>
-            <property name="objectName">
-             <string>buttonProviderBatchImport</string>
             </property>
            </widget>
           </item>

--- a/src/lorairo/gui/designer/ProviderBatchJobWidget_ui.py
+++ b/src/lorairo/gui/designer/ProviderBatchJobWidget_ui.py
@@ -164,11 +164,6 @@ class Ui_ProviderBatchJobWidget(object):
         self.statusLayout.setObjectName(u"statusLayout")
         self.jobButtonsLayout = QHBoxLayout()
         self.jobButtonsLayout.setObjectName(u"jobButtonsLayout")
-        self.buttonRefreshJobs = QPushButton(self.groupBoxStatus)
-        self.buttonRefreshJobs.setObjectName(u"buttonRefreshJobs")
-
-        self.jobButtonsLayout.addWidget(self.buttonRefreshJobs)
-
         self.buttonRefreshStatus = QPushButton(self.groupBoxStatus)
         self.buttonRefreshStatus.setObjectName(u"buttonRefreshStatus")
 
@@ -178,16 +173,6 @@ class Ui_ProviderBatchJobWidget(object):
         self.buttonCancel.setObjectName(u"buttonCancel")
 
         self.jobButtonsLayout.addWidget(self.buttonCancel)
-
-        self.buttonFetch = QPushButton(self.groupBoxStatus)
-        self.buttonFetch.setObjectName(u"buttonFetch")
-
-        self.jobButtonsLayout.addWidget(self.buttonFetch)
-
-        self.buttonImport = QPushButton(self.groupBoxStatus)
-        self.buttonImport.setObjectName(u"buttonImport")
-
-        self.jobButtonsLayout.addWidget(self.buttonImport)
 
         self.horizontalSpacerJobButtons = QSpacerItem(40, 20, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum)
 
@@ -279,16 +264,10 @@ class Ui_ProviderBatchJobWidget(object):
         self.buttonSubmit.setText(QCoreApplication.translate("ProviderBatchJobWidget", u"\u9001\u4fe1", None))
         self.buttonSubmit.setObjectName(QCoreApplication.translate("ProviderBatchJobWidget", u"buttonProviderBatchSubmit", None))
         self.groupBoxStatus.setTitle(QCoreApplication.translate("ProviderBatchJobWidget", u"\u30d0\u30c3\u30c1\u30b8\u30e7\u30d6\u72b6\u614b", None))
-        self.buttonRefreshJobs.setText(QCoreApplication.translate("ProviderBatchJobWidget", u"\u66f4\u65b0", None))
-        self.buttonRefreshJobs.setObjectName(QCoreApplication.translate("ProviderBatchJobWidget", u"buttonProviderBatchRefreshJobs", None))
-        self.buttonRefreshStatus.setText(QCoreApplication.translate("ProviderBatchJobWidget", u"\u72b6\u614b\u66f4\u65b0", None))
+        self.buttonRefreshStatus.setText(QCoreApplication.translate("ProviderBatchJobWidget", u"\u72b6\u614b\u3092\u78ba\u8a8d", None))
         self.buttonRefreshStatus.setObjectName(QCoreApplication.translate("ProviderBatchJobWidget", u"buttonProviderBatchRefreshStatus", None))
         self.buttonCancel.setText(QCoreApplication.translate("ProviderBatchJobWidget", u"\u30ad\u30e3\u30f3\u30bb\u30eb", None))
         self.buttonCancel.setObjectName(QCoreApplication.translate("ProviderBatchJobWidget", u"buttonProviderBatchCancel", None))
-        self.buttonFetch.setText(QCoreApplication.translate("ProviderBatchJobWidget", u"\u53d6\u5f97", None))
-        self.buttonFetch.setObjectName(QCoreApplication.translate("ProviderBatchJobWidget", u"buttonProviderBatchFetch", None))
-        self.buttonImport.setText(QCoreApplication.translate("ProviderBatchJobWidget", u"\u53d6\u308a\u8fbc\u307f", None))
-        self.buttonImport.setObjectName(QCoreApplication.translate("ProviderBatchJobWidget", u"buttonProviderBatchImport", None))
         self.tableJobs.setObjectName(QCoreApplication.translate("ProviderBatchJobWidget", u"tableProviderBatchJobs", None))
         self.groupBoxDetail.setTitle(QCoreApplication.translate("ProviderBatchJobWidget", u"\u8a73\u7d30", None))
         self.textEditJobDetail.setObjectName(QCoreApplication.translate("ProviderBatchJobWidget", u"textEditProviderBatchJobDetail", None))

--- a/src/lorairo/gui/widgets/provider_batch_job_widget.py
+++ b/src/lorairo/gui/widgets/provider_batch_job_widget.py
@@ -375,8 +375,13 @@ class ProviderBatchJobWidget(QWidget, Ui_ProviderBatchJobWidget):
 
     @Slot(QPoint)
     def _show_job_context_menu(self, position: QPoint) -> None:
+        index = self.tableJobs.indexAt(position)
+        if not index.isValid():
+            return
+        self.tableJobs.selectRow(index.row())
         if self._current_job_id is None:
             return
+        self._update_job_action_state()
         menu = QMenu(self)
         menu.addAction(self._action_fetch_results)
         menu.addAction(self._action_import_results)
@@ -416,6 +421,11 @@ class ProviderBatchJobWidget(QWidget, Ui_ProviderBatchJobWidget):
         if job_id is None or self._workflow_service is None:
             return
         try:
+            current_job = self._current_job()
+            if current_job is not None and self._job_imported(current_job):
+                self.labelStatus.setText(f"バッチAPIジョブ {job_id} は保存済みです")
+                self._update_job_action_state()
+                return
             job = self._workflow_service.refresh(job_id)
             if self._job_imported(job):
                 message = f"バッチAPIジョブ {job_id} は保存済みです"

--- a/src/lorairo/gui/widgets/provider_batch_job_widget.py
+++ b/src/lorairo/gui/widgets/provider_batch_job_widget.py
@@ -16,8 +16,9 @@ from __future__ import annotations
 from collections.abc import Callable
 from typing import Any, cast
 
-from PySide6.QtCore import Qt, Signal, Slot
-from PySide6.QtWidgets import QMessageBox, QTableWidget, QTableWidgetItem, QWidget
+from PySide6.QtCore import QPoint, Qt, Signal, Slot
+from PySide6.QtGui import QAction
+from PySide6.QtWidgets import QMenu, QMessageBox, QTableWidget, QTableWidgetItem, QWidget
 
 from lorairo.gui.designer.ProviderBatchJobWidget_ui import Ui_ProviderBatchJobWidget
 from lorairo.gui.widgets.model_selection_widget import ModelSelectionWidget
@@ -31,6 +32,9 @@ from lorairo.utils.log import logger
 
 _TASK_TYPES = ("annotation", "rating_preflight")
 _ITEM_STATUSES = ("all", "failed", "expired", "canceled")
+_CANCELABLE_STATUSES = {"submitted", "validating", "running", "canceling"}
+_COMPLETED_STATUS = "completed"
+_IMPORTED_STATUS = "imported"
 
 
 class ProviderBatchJobWidget(QWidget, Ui_ProviderBatchJobWidget):
@@ -60,8 +64,10 @@ class ProviderBatchJobWidget(QWidget, Ui_ProviderBatchJobWidget):
         self._model_selection_widget.set_single_selection_mode(True)
 
         self._setup_combos_and_tables()
+        self._setup_job_context_menu()
         self._connect_signals()
         self._update_target_label()
+        self._update_job_action_state()
 
     def _inject_model_selection_widget(self) -> ModelSelectionWidget:
         """modelSelectionPlaceholder を ModelSelectionWidget に差替える。
@@ -103,6 +109,15 @@ class ProviderBatchJobWidget(QWidget, Ui_ProviderBatchJobWidget):
         )
         self.tableItems.setEditTriggers(QTableWidget.EditTrigger.NoEditTriggers)
 
+    def _setup_job_context_menu(self) -> None:
+        """Set up recovery actions that stay out of the normal job flow."""
+        self._action_fetch_results = QAction("結果を取得", self)
+        self._action_import_results = QAction("結果を取り込み", self)
+        self._action_fetch_results.triggered.connect(self.fetch_selected_job)
+        self._action_import_results.triggered.connect(self.import_selected_job)
+        self.tableJobs.setContextMenuPolicy(Qt.ContextMenuPolicy.CustomContextMenu)
+        self.tableJobs.customContextMenuRequested.connect(self._show_job_context_menu)
+
     def set_dependencies(
         self,
         workflow_service: Any,
@@ -143,11 +158,8 @@ class ProviderBatchJobWidget(QWidget, Ui_ProviderBatchJobWidget):
         self.buttonSubmit.clicked.connect(self.submit_job)
         self.comboBoxTaskType.currentTextChanged.connect(self._on_task_type_changed)
         self._staging_widget.staged_images_changed.connect(self._update_target_label)
-        self.buttonRefreshJobs.clicked.connect(self.refresh_jobs)
         self.buttonRefreshStatus.clicked.connect(self.refresh_selected_job_status)
         self.buttonCancel.clicked.connect(self.cancel_selected_job)
-        self.buttonFetch.clicked.connect(self.fetch_selected_job)
-        self.buttonImport.clicked.connect(self.import_selected_job)
         self.tableJobs.itemSelectionChanged.connect(self._on_job_selection_changed)
         self.comboBoxItemStatus.currentTextChanged.connect(self.refresh_items)
 
@@ -219,7 +231,7 @@ class ProviderBatchJobWidget(QWidget, Ui_ProviderBatchJobWidget):
             self.labelStatus.setText("送信に失敗しました")
 
     @Slot()
-    def refresh_jobs(self) -> None:
+    def refresh_jobs(self, update_label: bool = True) -> None:
         if self._repository is None:
             return
         try:
@@ -245,7 +257,9 @@ class ProviderBatchJobWidget(QWidget, Ui_ProviderBatchJobWidget):
                 item = QTableWidgetItem(value)
                 item.setData(Qt.ItemDataRole.UserRole, job_id)
                 self.tableJobs.setItem(row, column, item)
-        self.labelStatus.setText(f"バッチAPIジョブ {len(jobs)} 件を読み込みました")
+        if update_label:
+            self.labelStatus.setText(f"バッチAPIジョブ {len(jobs)} 件を読み込みました")
+        self._update_job_action_state()
 
     def select_job(self, job_id: int) -> None:
         for row in range(self.tableJobs.rowCount()):
@@ -261,11 +275,13 @@ class ProviderBatchJobWidget(QWidget, Ui_ProviderBatchJobWidget):
             self._current_job_id = None
             self.textEditJobDetail.clear()
             self.tableItems.setRowCount(0)
+            self._update_job_action_state()
             return
         job_id = selected[0].data(Qt.ItemDataRole.UserRole)
         self._current_job_id = int(job_id)
         self.refresh_detail()
         self.refresh_items()
+        self._update_job_action_state()
 
     @Slot()
     def refresh_detail(self) -> None:
@@ -330,16 +346,88 @@ class ProviderBatchJobWidget(QWidget, Ui_ProviderBatchJobWidget):
         QMessageBox.critical(self, "バッチAPI", str(error))
         self.labelStatus.setText(f"{action} に失敗しました")
 
+    def _current_job(self) -> Any | None:
+        if self._repository is None or self._current_job_id is None:
+            return None
+        return self._repository.get_provider_batch_job(self._current_job_id)
+
+    @staticmethod
+    def _job_status(job: Any) -> str:
+        return str(getattr(job, "status", "") or "")
+
+    @staticmethod
+    def _job_imported(job: Any) -> bool:
+        return ProviderBatchJobWidget._job_status(job) == _IMPORTED_STATUS or (
+            getattr(job, "imported_at", None) is not None
+        )
+
+    @staticmethod
+    def _job_cancelable(job: Any | None) -> bool:
+        return job is not None and ProviderBatchJobWidget._job_status(job) in _CANCELABLE_STATUSES
+
+    def _update_job_action_state(self) -> None:
+        job = self._current_job()
+        has_job = job is not None
+        self.buttonRefreshStatus.setEnabled(has_job)
+        self.buttonCancel.setEnabled(self._job_cancelable(job))
+        self._action_fetch_results.setEnabled(has_job)
+        self._action_import_results.setEnabled(has_job and not self._job_imported(job))
+
+    @Slot(QPoint)
+    def _show_job_context_menu(self, position: QPoint) -> None:
+        if self._current_job_id is None:
+            return
+        menu = QMenu(self)
+        menu.addAction(self._action_fetch_results)
+        menu.addAction(self._action_import_results)
+        menu.exec(self.tableJobs.viewport().mapToGlobal(position))
+
+    def _status_message_for_job(self, job_id: int, job: Any) -> str:
+        status = self._job_status(job)
+        provider_status = str(getattr(job, "provider_status", "") or status)
+        if status in {"submitted", "validating"}:
+            return f"バッチAPIジョブ {job_id} は検証中です ({provider_status})"
+        if status in {"running", "canceling"}:
+            return f"バッチAPIジョブ {job_id} は処理中です ({provider_status})"
+        if status == "failed":
+            return f"バッチAPIジョブ {job_id} は失敗しました ({provider_status})"
+        if status == "expired":
+            return f"バッチAPIジョブ {job_id} は期限切れです ({provider_status})"
+        if status == "canceled":
+            return f"バッチAPIジョブ {job_id} はキャンセル済みです ({provider_status})"
+        return f"バッチAPIジョブ {job_id} の状態を確認しました ({provider_status})"
+
+    @staticmethod
+    def _import_result_message(job_id: int, result: Any) -> str:
+        imported_count = int(getattr(result, "imported_count", 0))
+        skipped_count = int(getattr(result, "skipped_count", 0))
+        error_count = int(getattr(result, "error_count", 0))
+        total_count = int(getattr(result, "total_count", 0))
+        if skipped_count or error_count:
+            return (
+                f"バッチAPIジョブ {job_id} の処理完了を確認し、DB保存を実行しました: "
+                f"保存 {imported_count}/{total_count} 件, スキップ {skipped_count} 件, エラー {error_count} 件"
+            )
+        return f"バッチAPIジョブ {job_id} の処理完了を確認し、DB保存が完了しました: {imported_count}/{total_count} 件"
+
     @Slot()
     def refresh_selected_job_status(self) -> None:
         job_id = self._require_current_job_id()
         if job_id is None or self._workflow_service is None:
             return
         try:
-            self._workflow_service.refresh(job_id)
-            self.labelStatus.setText(f"バッチAPIジョブ {job_id} を更新しました")
-            self.refresh_jobs()
+            job = self._workflow_service.refresh(job_id)
+            if self._job_imported(job):
+                message = f"バッチAPIジョブ {job_id} は保存済みです"
+            elif self._job_status(job) == _COMPLETED_STATUS:
+                fetch_result = self._workflow_service.fetch_results(job_id)
+                import_result = self._workflow_service.import_results(job_id, fetch_result)
+                message = self._import_result_message(job_id, import_result)
+            else:
+                message = self._status_message_for_job(job_id, job)
+            self.refresh_jobs(update_label=False)
             self.select_job(job_id)
+            self.labelStatus.setText(message)
         except ProviderBatchError as e:
             QMessageBox.warning(self, "バッチAPI", str(e))
             self.labelStatus.setText(str(e))
@@ -353,9 +441,9 @@ class ProviderBatchJobWidget(QWidget, Ui_ProviderBatchJobWidget):
             return
         try:
             self._workflow_service.cancel(job_id)
-            self.labelStatus.setText(f"バッチAPIジョブ {job_id} のキャンセルを要求しました")
-            self.refresh_jobs()
+            self.refresh_jobs(update_label=False)
             self.select_job(job_id)
+            self.labelStatus.setText(f"バッチAPIジョブ {job_id} のキャンセルを要求しました")
         except ProviderBatchError as e:
             QMessageBox.warning(self, "バッチAPI", str(e))
             self.labelStatus.setText(str(e))
@@ -374,6 +462,7 @@ class ProviderBatchJobWidget(QWidget, Ui_ProviderBatchJobWidget):
             )
             self.refresh_detail()
             self.refresh_items()
+            self._update_job_action_state()
         except ProviderBatchError as e:
             QMessageBox.warning(self, "バッチAPI", str(e))
             self.labelStatus.setText(str(e))
@@ -388,10 +477,11 @@ class ProviderBatchJobWidget(QWidget, Ui_ProviderBatchJobWidget):
         try:
             result = self._workflow_service.import_results(job_id)
             self.labelStatus.setText(
-                f"バッチAPI結果 {result.imported_count}/{result.total_count} 件を取り込みました"
+                f"バッチAPI結果 {result.imported_count}/{result.total_count} 件をDB保存しました"
             )
             self.refresh_detail()
             self.refresh_items()
+            self._update_job_action_state()
         except ProviderBatchError as e:
             QMessageBox.warning(self, "バッチAPI", str(e))
             self.labelStatus.setText(str(e))

--- a/tests/unit/gui/widgets/test_provider_batch_job_widget.py
+++ b/tests/unit/gui/widgets/test_provider_batch_job_widget.py
@@ -125,8 +125,14 @@ def dependencies():
     repository.get_provider_batch_job.return_value = _job()
     repository.list_provider_batch_items.return_value = [_item()]
     workflow.submit_images.return_value = 42
+    workflow.refresh.return_value = _job()
     workflow.fetch_results.return_value = SimpleNamespace(items=(_item(),))
-    workflow.import_results.return_value = SimpleNamespace(imported_count=1, total_count=1)
+    workflow.import_results.return_value = SimpleNamespace(
+        imported_count=1,
+        skipped_count=0,
+        error_count=0,
+        total_count=1,
+    )
     return workflow, repository, model_source, model_repository
 
 
@@ -137,6 +143,9 @@ def test_initial_ui_created(widget):
     assert widget.tableItems.columnCount() == 5
     assert widget.comboBoxItemStatus.count() == 4
     assert widget.comboBoxTaskType.currentText() == "annotation"
+    assert widget.buttonRefreshStatus.text() == "状態を確認"
+    assert not hasattr(widget, "buttonFetch")
+    assert not hasattr(widget, "buttonImport")
     assert "0 枚" in widget.labelTarget.text()
 
 
@@ -309,21 +318,155 @@ def test_job_selection_loads_detail_and_failed_items(widget, dependencies):
 
 @pytest.mark.unit
 @pytest.mark.gui
-def test_refresh_cancel_fetch_import_actions_call_workflow(widget, dependencies):
+def test_check_status_for_incomplete_job_only_refreshes_status(widget, dependencies):
     workflow, repository, model_source, model_repository = dependencies
     widget.set_dependencies(workflow, repository, model_source, model_repository)
     widget.tableJobs.selectRow(0)
 
     widget.refresh_selected_job_status()
+
+    workflow.refresh.assert_called_once_with(42)
+    workflow.fetch_results.assert_not_called()
+    workflow.import_results.assert_not_called()
+    assert "検証中" in widget.labelStatus.text()
+
+
+@pytest.mark.unit
+@pytest.mark.gui
+def test_check_status_for_completed_job_fetches_and_imports(widget, dependencies):
+    workflow, repository, model_source, model_repository = dependencies
+    workflow.refresh.return_value = _job(status="completed", provider_status="completed")
+    fetch_result = SimpleNamespace(items=(_item(),))
+    import_result = SimpleNamespace(imported_count=1, skipped_count=0, error_count=0, total_count=1)
+    workflow.fetch_results.return_value = fetch_result
+    workflow.import_results.return_value = import_result
+    widget.set_dependencies(workflow, repository, model_source, model_repository)
+    widget.tableJobs.selectRow(0)
+
+    widget.refresh_selected_job_status()
+
+    workflow.refresh.assert_called_once_with(42)
+    workflow.fetch_results.assert_called_once_with(42)
+    workflow.import_results.assert_called_once_with(42, fetch_result)
+    assert "処理完了" in widget.labelStatus.text()
+    assert "DB保存が完了" in widget.labelStatus.text()
+
+
+@pytest.mark.unit
+@pytest.mark.gui
+def test_check_status_for_imported_job_does_not_save_again(widget, dependencies):
+    workflow, repository, model_source, model_repository = dependencies
+    workflow.refresh.return_value = _job(status="imported", imported_at=datetime(2026, 1, 2, tzinfo=UTC))
+    widget.set_dependencies(workflow, repository, model_source, model_repository)
+    widget.tableJobs.selectRow(0)
+
+    widget.refresh_selected_job_status()
+
+    workflow.refresh.assert_called_once_with(42)
+    workflow.fetch_results.assert_not_called()
+    workflow.import_results.assert_not_called()
+    assert "保存済み" in widget.labelStatus.text()
+
+
+@pytest.mark.unit
+@pytest.mark.gui
+def test_check_status_for_partial_import_shows_summary(widget, dependencies):
+    workflow, repository, model_source, model_repository = dependencies
+    workflow.refresh.return_value = _job(status="completed", provider_status="completed")
+    workflow.import_results.return_value = SimpleNamespace(
+        imported_count=1,
+        skipped_count=1,
+        error_count=1,
+        total_count=3,
+    )
+    widget.set_dependencies(workflow, repository, model_source, model_repository)
+    widget.tableJobs.selectRow(0)
+
+    widget.refresh_selected_job_status()
+
+    assert "保存 1/3 件" in widget.labelStatus.text()
+    assert "スキップ 1 件" in widget.labelStatus.text()
+    assert "エラー 1 件" in widget.labelStatus.text()
+
+
+@pytest.mark.unit
+@pytest.mark.gui
+@pytest.mark.parametrize(
+    ("status", "expected"),
+    [
+        ("failed", "失敗"),
+        ("expired", "期限切れ"),
+        ("canceled", "キャンセル済み"),
+    ],
+)
+def test_check_status_for_terminal_non_importable_jobs_shows_distinct_status(
+    widget, dependencies, status, expected
+):
+    workflow, repository, model_source, model_repository = dependencies
+    workflow.refresh.return_value = _job(status=status, provider_status=status)
+    widget.set_dependencies(workflow, repository, model_source, model_repository)
+    widget.tableJobs.selectRow(0)
+
+    widget.refresh_selected_job_status()
+
+    workflow.fetch_results.assert_not_called()
+    workflow.import_results.assert_not_called()
+    assert expected in widget.labelStatus.text()
+
+
+@pytest.mark.unit
+@pytest.mark.gui
+def test_cancel_fetch_import_recovery_actions_call_workflow(widget, dependencies):
+    workflow, repository, model_source, model_repository = dependencies
+    widget.set_dependencies(workflow, repository, model_source, model_repository)
+    widget.tableJobs.selectRow(0)
+
     widget.cancel_selected_job()
     widget.fetch_selected_job()
     widget.import_selected_job()
 
-    workflow.refresh.assert_called_once_with(42)
     workflow.cancel.assert_called_once_with(42)
     workflow.fetch_results.assert_called_once_with(42)
     workflow.import_results.assert_called_once_with(42)
-    assert "バッチAPI結果 1/1 件を取り込みました" in widget.labelStatus.text()
+    assert "バッチAPI結果 1/1 件をDB保存しました" in widget.labelStatus.text()
+
+
+@pytest.mark.unit
+@pytest.mark.gui
+@pytest.mark.parametrize(
+    ("status", "cancel_enabled"),
+    [
+        ("submitted", True),
+        ("validating", True),
+        ("running", True),
+        ("canceling", True),
+        ("completed", False),
+        ("imported", False),
+        ("failed", False),
+        ("expired", False),
+        ("canceled", False),
+    ],
+)
+def test_cancel_button_is_enabled_only_for_cancelable_jobs(widget, dependencies, status, cancel_enabled):
+    workflow, repository, model_source, model_repository = dependencies
+    repository.get_provider_batch_job.return_value = _job(status=status)
+    widget.set_dependencies(workflow, repository, model_source, model_repository)
+    widget.tableJobs.selectRow(0)
+
+    assert widget.buttonCancel.isEnabled() is cancel_enabled
+
+
+@pytest.mark.unit
+@pytest.mark.gui
+def test_recovery_actions_live_in_job_context_menu(widget, dependencies):
+    workflow, repository, model_source, model_repository = dependencies
+    widget.set_dependencies(workflow, repository, model_source, model_repository)
+    widget.tableJobs.selectRow(0)
+
+    assert widget._action_fetch_results.text() == "結果を取得"
+    assert widget._action_import_results.text() == "結果を取り込み"
+    assert widget._action_fetch_results.isEnabled()
+    assert widget._action_import_results.isEnabled()
 
 
 @pytest.mark.unit

--- a/tests/unit/gui/widgets/test_provider_batch_job_widget.py
+++ b/tests/unit/gui/widgets/test_provider_batch_job_widget.py
@@ -356,13 +356,15 @@ def test_check_status_for_completed_job_fetches_and_imports(widget, dependencies
 @pytest.mark.gui
 def test_check_status_for_imported_job_does_not_save_again(widget, dependencies):
     workflow, repository, model_source, model_repository = dependencies
-    workflow.refresh.return_value = _job(status="imported", imported_at=datetime(2026, 1, 2, tzinfo=UTC))
+    repository.get_provider_batch_job.return_value = _job(
+        status="imported", imported_at=datetime(2026, 1, 2, tzinfo=UTC)
+    )
     widget.set_dependencies(workflow, repository, model_source, model_repository)
     widget.tableJobs.selectRow(0)
 
     widget.refresh_selected_job_status()
 
-    workflow.refresh.assert_called_once_with(42)
+    workflow.refresh.assert_not_called()
     workflow.fetch_results.assert_not_called()
     workflow.import_results.assert_not_called()
     assert "保存済み" in widget.labelStatus.text()
@@ -467,6 +469,38 @@ def test_recovery_actions_live_in_job_context_menu(widget, dependencies):
     assert widget._action_import_results.text() == "結果を取り込み"
     assert widget._action_fetch_results.isEnabled()
     assert widget._action_import_results.isEnabled()
+
+
+@pytest.mark.unit
+@pytest.mark.gui
+def test_context_menu_selects_row_under_cursor(widget, dependencies, monkeypatch):
+    workflow, repository, model_source, model_repository = dependencies
+    jobs = [_job(id=42), _job(id=43, provider_job_id="batch_43", status="completed")]
+    repository.list_provider_batch_jobs.return_value = jobs
+    repository.get_provider_batch_job.side_effect = lambda job_id: next(
+        job for job in jobs if job.id == job_id
+    )
+
+    class _FakeMenu:
+        def __init__(self, parent=None) -> None:
+            self.parent = parent
+            self.actions = []
+
+        def addAction(self, action) -> None:
+            self.actions.append(action)
+
+        def exec(self, _position) -> None:
+            return None
+
+    monkeypatch.setattr(widget_module, "QMenu", _FakeMenu)
+    widget.set_dependencies(workflow, repository, model_source, model_repository)
+    widget.tableJobs.selectRow(0)
+
+    second_row_position = widget.tableJobs.visualItemRect(widget.tableJobs.item(1, 0)).center()
+    widget._show_job_context_menu(second_row_position)
+
+    assert widget._current_job_id == 43
+    assert widget.tableJobs.currentRow() == 1
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary
- Replace the Provider Batch primary job action row with a single 状態を確認 action plus cancel when applicable.
- Automatically fetch and import completed jobs from 状態を確認, while avoiding duplicate imports for saved jobs.
- Move fetch/import recovery actions to the selected job context menu and cover incomplete, completed, imported, partial, and terminal states in widget tests.

Closes #560

## Verification
- UV_PROJECT_ENVIRONMENT=/workspaces/LoRAIro/.venv uv run pytest tests/unit/gui/widgets/test_provider_batch_job_widget.py -q
- UV_PROJECT_ENVIRONMENT=/workspaces/LoRAIro/.venv uv run ruff check src/lorairo/gui/widgets/provider_batch_job_widget.py tests/unit/gui/widgets/test_provider_batch_job_widget.py
- UV_PROJECT_ENVIRONMENT=/workspaces/LoRAIro/.venv uv run pytest tests/integration/test_main_window_tab_integration.py -q
- git diff --check