### PR TITLE
fix: show provider batch submit busy state

### DIFF
--- a/docs/decisions/0042-provider-batch-submit-button-busy.md
+++ b/docs/decisions/0042-provider-batch-submit-button-busy.md
@@ -1,0 +1,24 @@
+# 0042 Provider Batch Submit Button Busy State
+
+## Context
+
+Provider Batch submission updates the job list after `submit_images()` returns, but users do not
+always notice that the click was accepted while the provider upload/create call is running.
+
+## Decision
+
+The Provider Batch `送信` button represents only the synchronous submit call state. While
+`submit_images()` is running, the button is disabled, changes to `送信中...`, and uses a temporary
+busy style. After the call returns or raises, the button returns to the normal `送信` state.
+
+## Rationale
+
+This keeps the first UX improvement small and avoids adding popup, toast, banner, or row highlight
+behavior before it is proven necessary. The job table remains responsible for asynchronous provider
+job progress after the job has been registered.
+
+## Consequences
+
+Tests must cover both successful submission and failure paths so the button cannot remain disabled
+after a provider or validation error. Future notification work should be added as a separate UX
+iteration instead of overloading the button with asynchronous job completion state.

--- a/src/lorairo/gui/widgets/provider_batch_job_widget.py
+++ b/src/lorairo/gui/widgets/provider_batch_job_widget.py
@@ -18,7 +18,7 @@ from typing import Any, cast
 
 from PySide6.QtCore import QPoint, Qt, Signal, Slot
 from PySide6.QtGui import QAction
-from PySide6.QtWidgets import QMenu, QMessageBox, QTableWidget, QTableWidgetItem, QWidget
+from PySide6.QtWidgets import QApplication, QMenu, QMessageBox, QTableWidget, QTableWidgetItem, QWidget
 
 from lorairo.gui.designer.ProviderBatchJobWidget_ui import Ui_ProviderBatchJobWidget
 from lorairo.gui.widgets.model_selection_widget import ModelSelectionWidget
@@ -55,6 +55,8 @@ class ProviderBatchJobWidget(QWidget, Ui_ProviderBatchJobWidget):
         self._model_source: Any = None
         self._dataset_state_manager: Any = None
         self._current_job_id: int | None = None
+        self._submit_button_default_text = self.buttonSubmit.text()
+        self._submit_button_default_style = self.buttonSubmit.styleSheet()
 
         # ADR 0041: placeholder を単一選択 batch-capable ModelSelectionWidget に差替
         self._staging_widget = self.stagingWidget
@@ -184,6 +186,19 @@ class ProviderBatchJobWidget(QWidget, Ui_ProviderBatchJobWidget):
         count = self._staging_widget.count()
         self.labelTarget.setText(f"◎ ステージング: {count} 枚")
 
+    def _set_submit_button_busy(self, busy: bool) -> None:
+        """Reflect only the synchronous provider submit call state on the submit button."""
+        self.buttonSubmit.setEnabled(not busy)
+        if busy:
+            self.buttonSubmit.setText("送信中...")
+            self.buttonSubmit.setStyleSheet(
+                "QPushButton { background-color: #2f7de1; color: white; font-weight: bold; }"
+            )
+            QApplication.processEvents()
+            return
+        self.buttonSubmit.setText(self._submit_button_default_text)
+        self.buttonSubmit.setStyleSheet(self._submit_button_default_style)
+
     @Slot()
     def submit_job(self) -> None:
         if self._workflow_service is None:
@@ -209,16 +224,20 @@ class ProviderBatchJobWidget(QWidget, Ui_ProviderBatchJobWidget):
             if provider is None:
                 raise ValueError(f"direct provider を解決できません: {litellm_model_id}")
             endpoint = endpoint_for_task(provider, task_type)
-            job_id = self._workflow_service.submit_images(
-                provider=provider,
-                endpoint=endpoint,
-                litellm_model_id=litellm_model_id,
-                prompt_profile=self.lineEditPromptProfile.text().strip() or "default",
-                image_ids=image_ids,
-                model_id=model.id,
-                description=self.lineEditDescription.text().strip() or None,
-                task_type=task_type,
-            )
+            self._set_submit_button_busy(True)
+            try:
+                job_id = self._workflow_service.submit_images(
+                    provider=provider,
+                    endpoint=endpoint,
+                    litellm_model_id=litellm_model_id,
+                    prompt_profile=self.lineEditPromptProfile.text().strip() or "default",
+                    image_ids=image_ids,
+                    model_id=model.id,
+                    description=self.lineEditDescription.text().strip() or None,
+                    task_type=task_type,
+                )
+            finally:
+                self._set_submit_button_busy(False)
             self.refresh_jobs()
             self.select_job(job_id)
             self.labelStatus.setText(f"バッチAPIジョブ {job_id} を送信しました")

--- a/tests/unit/gui/widgets/test_provider_batch_job_widget.py
+++ b/tests/unit/gui/widgets/test_provider_batch_job_widget.py
@@ -236,6 +236,71 @@ def test_submit_job_resolves_annotation_params(widget, dependencies, monkeypatch
 
 @pytest.mark.unit
 @pytest.mark.gui
+def test_submit_button_shows_busy_state_only_while_submitting(widget, dependencies, monkeypatch):
+    workflow, repository, model_source, model_repository = dependencies
+    widget.set_dependencies(workflow, repository, model_source, model_repository)
+    widget._model_selection_widget._selected_model = "anthropic/claude-3-5-sonnet"
+    monkeypatch.setattr(widget._staging_widget, "get_image_ids", lambda: [1, 2])
+    default_style = widget.buttonSubmit.styleSheet()
+
+    def submit_side_effect(**_kwargs):
+        assert widget.buttonSubmit.text() == "送信中..."
+        assert widget.buttonSubmit.isEnabled() is False
+        assert "background-color" in widget.buttonSubmit.styleSheet()
+        return 42
+
+    workflow.submit_images.side_effect = submit_side_effect
+
+    widget.submit_job()
+
+    assert widget.buttonSubmit.text() == "送信"
+    assert widget.buttonSubmit.isEnabled() is True
+    assert widget.buttonSubmit.styleSheet() == default_style
+    assert "バッチAPIジョブ 42 を送信しました" in widget.labelStatus.text()
+
+
+@pytest.mark.unit
+@pytest.mark.gui
+def test_submit_button_recovers_after_provider_error(widget, dependencies, monkeypatch):
+    workflow, repository, model_source, model_repository = dependencies
+    widget.set_dependencies(workflow, repository, model_source, model_repository)
+    widget._model_selection_widget._selected_model = "anthropic/claude-3-5-sonnet"
+    monkeypatch.setattr(widget._staging_widget, "get_image_ids", lambda: [1, 2])
+    warning = MagicMock()
+    monkeypatch.setattr(widget_module.QMessageBox, "warning", warning)
+    workflow.submit_images.side_effect = widget_module.ProviderBatchError("provider rejected")
+
+    widget.submit_job()
+
+    warning.assert_called_once()
+    assert widget.buttonSubmit.text() == "送信"
+    assert widget.buttonSubmit.isEnabled() is True
+    assert widget.buttonSubmit.styleSheet() == ""
+    assert widget.labelStatus.text() == "provider rejected"
+
+
+@pytest.mark.unit
+@pytest.mark.gui
+def test_submit_button_recovers_after_unexpected_submit_error(widget, dependencies, monkeypatch):
+    workflow, repository, model_source, model_repository = dependencies
+    widget.set_dependencies(workflow, repository, model_source, model_repository)
+    widget._model_selection_widget._selected_model = "anthropic/claude-3-5-sonnet"
+    monkeypatch.setattr(widget._staging_widget, "get_image_ids", lambda: [1, 2])
+    critical = MagicMock()
+    monkeypatch.setattr(widget_module.QMessageBox, "critical", critical)
+    workflow.submit_images.side_effect = RuntimeError("adapter exploded")
+
+    widget.submit_job()
+
+    critical.assert_called_once()
+    assert widget.buttonSubmit.text() == "送信"
+    assert widget.buttonSubmit.isEnabled() is True
+    assert widget.buttonSubmit.styleSheet() == ""
+    assert widget.labelStatus.text() == "送信に失敗しました"
+
+
+@pytest.mark.unit
+@pytest.mark.gui
 def test_submit_job_rating_preflight_uses_moderations_endpoint(widget, dependencies, monkeypatch):
     workflow, repository, model_source, model_repository = dependencies
     widget.set_dependencies(workflow, repository, model_source, model_repository)


### PR DESCRIPTION
## Summary
- Fixes #559
- Branch: issue-559-submit-button-busy
- ADR: docs/decisions/0042-provider-batch-submit-button-busy.md
- Show the Provider Batch submit button as disabled `送信中...` while `submit_images()` is running
- Restore the button on success and on provider/unexpected submit errors without adding popup/toast/banner behavior

## Verification
- `UV_CACHE_DIR=/tmp/uv-cache UV_PROJECT_ENVIRONMENT=/workspaces/LoRAIro/.venv uv run pytest tests/unit/gui/widgets/test_provider_batch_job_widget.py -q`
- `UV_CACHE_DIR=/tmp/uv-cache UV_PROJECT_ENVIRONMENT=/workspaces/LoRAIro/.venv uv run ruff check src/lorairo/gui/widgets/provider_batch_job_widget.py tests/unit/gui/widgets/test_provider_batch_job_widget.py`