### PR TITLE
fix: cancel log pollution and ratings index (#558)

### DIFF
--- a/src/lorairo/database/migrations/versions/b7c8d9e0f1a2_add_ix_ratings_model_id_image_id.py
+++ b/src/lorairo/database/migrations/versions/b7c8d9e0f1a2_add_ix_ratings_model_id_image_id.py
@@ -1,0 +1,25 @@
+"""Add composite index ix_ratings_model_id_image_id on ratings(model_id, image_id)
+
+Issue #558: AIレーティングフィルタ (model_id IN (...) + GROUP BY image_id) が
+ratings テーブルを model_id でスキャンしていたボトルネックを解消する。
+既存の ix_ratings_image_id は維持する。
+
+Revision ID: b7c8d9e0f1a2
+Revises: c6d7e8f9a0b1
+Create Date: 2026-05-30
+"""
+
+from alembic import op
+
+revision = "b7c8d9e0f1a2"
+down_revision = "c6d7e8f9a0b1"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_index("ix_ratings_model_id_image_id", "ratings", ["model_id", "image_id"])
+
+
+def downgrade() -> None:  # pragma: no cover
+    op.drop_index("ix_ratings_model_id_image_id", table_name="ratings")

--- a/src/lorairo/database/schema.py
+++ b/src/lorairo/database/schema.py
@@ -428,7 +428,11 @@ class Rating(Base):
     image: Mapped[Image] = relationship("Image", back_populates="ratings")
     model: Mapped[Model] = relationship("Model", back_populates="ratings")
 
-    __table_args__ = (Index("ix_ratings_image_id", "image_id"),)
+    __table_args__ = (
+        Index("ix_ratings_image_id", "image_id"),
+        # AI レーティングフィルタ (model_id IN (...) + GROUP BY image_id) を index seek 化する
+        Index("ix_ratings_model_id_image_id", "model_id", "image_id"),
+    )
 
     def __repr__(self) -> str:
         return f"<Rating(id={self.id}, image_id={self.image_id}, rating='{self.normalized_rating}')>"

--- a/src/lorairo/gui/services/worker_service.py
+++ b/src/lorairo/gui/services/worker_service.py
@@ -257,9 +257,9 @@ class WorkerService(QObject):
         Raises:
             RuntimeError: ワーカー開始失敗の場合
         """
-        # 既存の検索をキャンセル
+        # 既存の検索を破棄(新検索による置換。ユーザーキャンセルではない)
         if self.current_search_worker_id:
-            logger.info(f"既存の検索をキャンセル: {self.current_search_worker_id}")
+            logger.debug(f"前回検索を破棄(新検索で置換): {self.current_search_worker_id}")
             self.worker_manager.cancel_worker(
                 self.current_search_worker_id,
                 reason=CancelReason.SEARCH_REPLACED,

--- a/src/lorairo/gui/widgets/filter_search_panel.py
+++ b/src/lorairo/gui/widgets/filter_search_panel.py
@@ -783,10 +783,10 @@ class FilterSearchPanel(QScrollArea):
             self._execute_synchronous_search()
             return
 
-        # 既存の検索をキャンセル
+        # 既存検索の置換は start_search 側が SEARCH_REPLACED で破棄する。
+        # ここで cancel_search を呼ぶと USER_REQUESTED 扱いになり誤キャンセルログ +
+        # 二重キャンセルの WARNING が出るため、pipeline 状態のリセットのみ行う。
         if self._current_search_worker_id:
-            logger.info(f"既存の検索をキャンセル: {self._current_search_worker_id}")
-            self.worker_service.cancel_search(self._current_search_worker_id)
             self._pipeline.transition_to(PipelineState.IDLE)
 
         try:

--- a/src/lorairo/gui/workers/base.py
+++ b/src/lorairo/gui/workers/base.py
@@ -159,10 +159,10 @@ class LoRAIroWorkerBase[T](QObject):
             else:
                 self._set_status(WorkerStatus.CANCELED)
                 self.canceled.emit()
-                logger.info(f"ワーカー実行キャンセル: {self.__class__.__name__}")
+                logger.debug(f"ワーカー実行キャンセル: {self.__class__.__name__}")
 
         except CancellationError as e:
-            logger.info(f"ワーカー実行キャンセル: {self.__class__.__name__}: {e}")
+            logger.debug(f"ワーカー実行キャンセル: {self.__class__.__name__}: {e}")
             self._set_status(WorkerStatus.CANCELED)
             self.canceled.emit()
 
@@ -198,7 +198,7 @@ class LoRAIroWorkerBase[T](QObject):
         """ワーカーキャンセル要求"""
         self._set_status(WorkerStatus.CANCELING)
         self.cancellation.cancel()
-        logger.info(f"ワーカーキャンセル要求: {self.__class__.__name__}")
+        logger.debug(f"ワーカーキャンセル要求: {self.__class__.__name__}")
 
     def _set_status(self, status: WorkerStatus) -> None:
         """ステータス更新"""

--- a/src/lorairo/gui/workers/manager.py
+++ b/src/lorairo/gui/workers/manager.py
@@ -153,7 +153,7 @@ class WorkerManager(QObject):
         else:
             self._finalize_canceled_if_no_terminal_signal(worker_id)
 
-        logger.info(f"ワーカーキャンセル: {worker_id}")
+        logger.debug(f"ワーカーキャンセル: {worker_id} (理由: {reason.value})")
         return True
 
     def cancel_all_workers(self, reason: CancelReason = CancelReason.SHUTDOWN) -> None:
@@ -253,7 +253,13 @@ class WorkerManager(QObject):
             WorkerOutcome.CANCELED,
             cancel_reason=cancel_reason,
         ):
-            logger.info(f"ワーカーキャンセル完了: {worker_id}")
+            # ユーザーが明示的にキャンセルした場合のみ INFO。内部的な置換
+            # (SEARCH_REPLACED 等) は運用ログを汚さないよう DEBUG に留める。
+            if cancel_reason == CancelReason.USER_REQUESTED:
+                logger.info(f"ユーザー操作でワーカーをキャンセル: {worker_id}")
+            else:
+                reason_label = cancel_reason.value if cancel_reason else "unknown"
+                logger.debug(f"ワーカーキャンセル完了: {worker_id} (理由: {reason_label})")
 
     def _finalize_canceled_if_no_terminal_signal(
         self,

--- a/src/lorairo/gui/workers/search_worker.py
+++ b/src/lorairo/gui/workers/search_worker.py
@@ -72,7 +72,7 @@ class SearchWorker(LoRAIroWorkerBase[SearchResult]):
             return result
 
         except CancellationError:
-            logger.info("検索処理がキャンセルされました")
+            logger.debug("検索処理がキャンセルされました")
             raise
 
         except Exception as e:

--- a/tests/unit/database/test_migration_a7b8c9d0e1f2_score_labels.py
+++ b/tests/unit/database/test_migration_a7b8c9d0e1f2_score_labels.py
@@ -108,6 +108,26 @@ def _create_d8_schema_with_precreated_score_labels(db_path: Path) -> None:
                 """
             )
         )
+        # ratings は 879cc87e4125 で作成済みのはず（d8e9f0a1b2c3 より前）
+        conn.execute(
+            text(
+                """
+                CREATE TABLE ratings (
+                    id INTEGER NOT NULL PRIMARY KEY,
+                    image_id INTEGER NOT NULL,
+                    model_id INTEGER NOT NULL,
+                    raw_rating_value VARCHAR NOT NULL,
+                    normalized_rating VARCHAR NOT NULL,
+                    confidence_score FLOAT,
+                    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
+                    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
+                    FOREIGN KEY(image_id) REFERENCES images (id) ON DELETE CASCADE,
+                    FOREIGN KEY(model_id) REFERENCES models (id) ON DELETE CASCADE
+                )
+                """
+            )
+        )
+        conn.execute(text("CREATE INDEX ix_ratings_image_id ON ratings (image_id)"))
         conn.execute(text("CREATE TABLE alembic_version (version_num VARCHAR(32) PRIMARY KEY)"))
         conn.execute(text("INSERT INTO alembic_version (version_num) VALUES ('d8e9f0a1b2c3')"))
     engine.dispose()

--- a/tests/unit/database/test_migration_d8e9f0a1b2c3_litellm_unique.py
+++ b/tests/unit/database/test_migration_d8e9f0a1b2c3_litellm_unique.py
@@ -62,6 +62,48 @@ def _create_legacy_schema(db_path: Path) -> None:
                 """
             )
         )
+        # ratings は 879cc87e4125 で作成済みのはず（c4d5e6f7a8b9 より前）
+        conn.execute(
+            text(
+                """
+                CREATE TABLE images (
+                    id INTEGER NOT NULL PRIMARY KEY,
+                    uuid VARCHAR NOT NULL,
+                    phash VARCHAR NOT NULL,
+                    original_image_path VARCHAR NOT NULL,
+                    stored_image_path VARCHAR NOT NULL,
+                    width INTEGER NOT NULL,
+                    height INTEGER NOT NULL,
+                    format VARCHAR NOT NULL,
+                    mode VARCHAR NOT NULL,
+                    has_alpha BOOLEAN NOT NULL,
+                    filename VARCHAR NOT NULL,
+                    extension VARCHAR NOT NULL,
+                    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
+                    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL
+                )
+                """
+            )
+        )
+        conn.execute(
+            text(
+                """
+                CREATE TABLE ratings (
+                    id INTEGER NOT NULL PRIMARY KEY,
+                    image_id INTEGER NOT NULL,
+                    model_id INTEGER NOT NULL,
+                    raw_rating_value VARCHAR NOT NULL,
+                    normalized_rating VARCHAR NOT NULL,
+                    confidence_score FLOAT,
+                    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
+                    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
+                    FOREIGN KEY(image_id) REFERENCES images (id) ON DELETE CASCADE,
+                    FOREIGN KEY(model_id) REFERENCES models (id) ON DELETE CASCADE
+                )
+                """
+            )
+        )
+        conn.execute(text("CREATE INDEX ix_ratings_image_id ON ratings (image_id)"))
         # Alembic version table を直前 head に固定
         conn.execute(text("CREATE TABLE alembic_version (version_num VARCHAR(32) PRIMARY KEY)"))
         conn.execute(text("INSERT INTO alembic_version (version_num) VALUES ('c4d5e6f7a8b9')"))

--- a/tests/unit/database/test_migration_e3f4a5b6c7d8_model_types_rename.py
+++ b/tests/unit/database/test_migration_e3f4a5b6c7d8_model_types_rename.py
@@ -56,6 +56,48 @@ def _create_schema_at_d8e9f0a1b2c3(db_path: Path) -> None:
                 """
             )
         )
+        # ratings は 879cc87e4125 で作成済みのはず（d8e9f0a1b2c3 より前）
+        conn.execute(
+            text(
+                """
+                CREATE TABLE images (
+                    id INTEGER NOT NULL PRIMARY KEY,
+                    uuid VARCHAR NOT NULL,
+                    phash VARCHAR NOT NULL,
+                    original_image_path VARCHAR NOT NULL,
+                    stored_image_path VARCHAR NOT NULL,
+                    width INTEGER NOT NULL,
+                    height INTEGER NOT NULL,
+                    format VARCHAR NOT NULL,
+                    mode VARCHAR NOT NULL,
+                    has_alpha BOOLEAN NOT NULL,
+                    filename VARCHAR NOT NULL,
+                    extension VARCHAR NOT NULL,
+                    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
+                    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL
+                )
+                """
+            )
+        )
+        conn.execute(
+            text(
+                """
+                CREATE TABLE ratings (
+                    id INTEGER NOT NULL PRIMARY KEY,
+                    image_id INTEGER NOT NULL,
+                    model_id INTEGER NOT NULL,
+                    raw_rating_value VARCHAR NOT NULL,
+                    normalized_rating VARCHAR NOT NULL,
+                    confidence_score FLOAT,
+                    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
+                    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
+                    FOREIGN KEY(image_id) REFERENCES images (id) ON DELETE CASCADE,
+                    FOREIGN KEY(model_id) REFERENCES models (id) ON DELETE CASCADE
+                )
+                """
+            )
+        )
+        conn.execute(text("CREATE INDEX ix_ratings_image_id ON ratings (image_id)"))
         conn.execute(text("CREATE TABLE alembic_version (version_num VARCHAR(32) PRIMARY KEY)"))
         conn.execute(text("INSERT INTO alembic_version (version_num) VALUES ('d8e9f0a1b2c3')"))
     engine.dispose()

--- a/tests/unit/database/test_migration_f1b2c3d4e5f6_ratings_backfill.py
+++ b/tests/unit/database/test_migration_f1b2c3d4e5f6_ratings_backfill.py
@@ -91,6 +91,48 @@ def _create_schema_at_f0(db_path: Path) -> None:
                 "INSERT INTO model_function_associations (model_id, type_id) VALUES (1, 1), (2, 1), (3, 2)"
             )
         )
+        # ratings は 879cc87e4125 で作成済みのはず（f0a1b2c3d4e5 より前）
+        conn.execute(
+            text(
+                """
+                CREATE TABLE images (
+                    id INTEGER NOT NULL PRIMARY KEY,
+                    uuid VARCHAR NOT NULL,
+                    phash VARCHAR NOT NULL,
+                    original_image_path VARCHAR NOT NULL,
+                    stored_image_path VARCHAR NOT NULL,
+                    width INTEGER NOT NULL,
+                    height INTEGER NOT NULL,
+                    format VARCHAR NOT NULL,
+                    mode VARCHAR NOT NULL,
+                    has_alpha BOOLEAN NOT NULL,
+                    filename VARCHAR NOT NULL,
+                    extension VARCHAR NOT NULL,
+                    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
+                    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL
+                )
+                """
+            )
+        )
+        conn.execute(
+            text(
+                """
+                CREATE TABLE ratings (
+                    id INTEGER NOT NULL PRIMARY KEY,
+                    image_id INTEGER NOT NULL,
+                    model_id INTEGER NOT NULL,
+                    raw_rating_value VARCHAR NOT NULL,
+                    normalized_rating VARCHAR NOT NULL,
+                    confidence_score FLOAT,
+                    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
+                    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
+                    FOREIGN KEY(image_id) REFERENCES images (id) ON DELETE CASCADE,
+                    FOREIGN KEY(model_id) REFERENCES models (id) ON DELETE CASCADE
+                )
+                """
+            )
+        )
+        conn.execute(text("CREATE INDEX ix_ratings_image_id ON ratings (image_id)"))
         conn.execute(text("CREATE TABLE alembic_version (version_num VARCHAR(32) PRIMARY KEY)"))
         conn.execute(text("INSERT INTO alembic_version (version_num) VALUES ('f0a1b2c3d4e5')"))
     engine.dispose()

--- a/tests/unit/gui/workers/test_manager.py
+++ b/tests/unit/gui/workers/test_manager.py
@@ -3,6 +3,7 @@
 from unittest.mock import Mock
 
 import pytest
+from loguru import logger as loguru_logger
 
 from lorairo.gui.workers.manager import WorkerManager
 from lorairo.gui.workers.terminal import CancelReason, WorkerOutcome
@@ -11,6 +12,15 @@ from lorairo.gui.workers.terminal import CancelReason, WorkerOutcome
 @pytest.fixture
 def manager(qapp):
     return WorkerManager()
+
+
+@pytest.fixture
+def loguru_records():
+    """loguru の出力 record を捕捉する (caplog は loguru を確実に拾わないため専用 sink)。"""
+    records: list = []
+    sink_id = loguru_logger.add(lambda msg: records.append(msg.record), level="DEBUG")
+    yield records
+    loguru_logger.remove(sink_id)
 
 
 class TestWorkerManagerInit:
@@ -282,3 +292,52 @@ class TestWorkerManagerCancellation:
         assert terminal_mock.call_args.args[0].outcome is WorkerOutcome.CANCELED
         count_mock.assert_called_once_with(0)
         all_finished_mock.assert_called_once()
+
+
+class TestCancelLogReason:
+    """Issue #558: 内部置換キャンセルが「キャンセル」として INFO に出ないことを検証する。"""
+
+    def _setup_worker(self, manager, reason: CancelReason) -> None:
+        manager.active_workers["worker-1"] = {
+            "worker": Mock(),
+            "thread": Mock(),
+            "auto_cleanup": True,
+            "cancel_reason": reason,
+        }
+
+    def test_user_requested_cancel_logs_info(self, manager, loguru_records):
+        self._setup_worker(manager, CancelReason.USER_REQUESTED)
+
+        manager._on_worker_canceled("worker-1")
+
+        info_msgs = [r["message"] for r in loguru_records if r["level"].name == "INFO"]
+        assert any("ユーザー操作でワーカーをキャンセル" in m for m in info_msgs)
+
+    def test_search_replaced_cancel_does_not_log_info(self, manager, loguru_records):
+        self._setup_worker(manager, CancelReason.SEARCH_REPLACED)
+
+        manager._on_worker_canceled("worker-1")
+
+        info_msgs = [r["message"] for r in loguru_records if r["level"].name == "INFO"]
+        # 内部置換は INFO に「キャンセル」を出さない (誤キャンセルログ防止)
+        assert not any("キャンセル" in m for m in info_msgs)
+        # DEBUG には reason 付きで残る
+        debug_msgs = [r["message"] for r in loguru_records if r["level"].name == "DEBUG"]
+        assert any("search_replaced" in m for m in debug_msgs)
+
+    def test_cancel_worker_logs_reason_at_debug(self, manager, loguru_records):
+        worker = Mock()
+        thread = Mock()
+        thread.isRunning.return_value = False
+        manager.active_workers["worker-1"] = {
+            "worker": worker,
+            "thread": thread,
+            "auto_cleanup": True,
+        }
+
+        manager.cancel_worker("worker-1", reason=CancelReason.SEARCH_REPLACED)
+
+        info_msgs = [r["message"] for r in loguru_records if r["level"].name == "INFO"]
+        assert not any(m.startswith("ワーカーキャンセル: worker-1") for m in info_msgs)
+        debug_msgs = [r["message"] for r in loguru_records if r["level"].name == "DEBUG"]
+        assert any("search_replaced" in m for m in debug_msgs)


### PR DESCRIPTION
## Summary

- **誤キャンセルログ修正**: 新しい検索が前回を置換する際、`filter_search_panel` が `cancel_search`（`USER_REQUESTED`）を呼ぶ冗長なブロックを削除。置換は `start_search` 側の `SEARCH_REPLACED` に一本化し、ログ汚染と二重キャンセル WARNING を排除
- **ログレベル整理**: 内部置換（`SEARCH_REPLACED` 等）は DEBUG へ降格。`USER_REQUESTED`（実ユーザー操作）のみ INFO に残す。`CancelReason` の値をログ文言に含める
- **ratings インデックス追加**: `(model_id, image_id)` 複合インデックスを追加。AI レーティングフィルタの `model_id IN (...)` と多数決の `GROUP BY image_id` を index seek 化し、UNRATED 検索の性能を改善

## Test plan

- [ ] `tests/unit/gui/workers/test_manager.py::TestCancelLogReason` — `SEARCH_REPLACED` が INFO に出ないこと、`USER_REQUESTED` のみ INFO になることを loguru sink で検証
- [ ] CI-equivalent filter で pre-existing 以外の新規失敗なし（ローカルで確認済み）
- [ ] Alembic upgrade/downgrade が既存 DB に正しく適用できることを SQLite で確認済み

Closes #558

Generated with Claude Code
