### PR TITLE
feat: add moderation preflight for WebAPI annotation

### DIFF
--- a/docs/decisions/0042-openai-moderation-webapi-preflight.md
+++ b/docs/decisions/0042-openai-moderation-webapi-preflight.md
@@ -1,0 +1,27 @@
+# 0042. OpenAI Moderation WebAPI Preflight
+
+## Context
+
+WebAPI annotation can send images to downstream provider models before LoRAIro has a usable rating row. Existing refusal and rating filters prevent repeat sends for known refused or `X` / `XXX` images, but unrated images still need a preflight decision before normal WebAPI annotation.
+
+## Decision
+
+Normal GUI and CLI WebAPI annotation paths run `openai/omni-moderation-latest` for DB-registered images whose latest rating is missing, `UNRATED`, or otherwise not usable for a send decision. Moderation results are stored in the existing `ratings` table using the existing OpenAI moderation model row and `openai_moderation_v1` rating scheme. No new schema flag is added.
+
+Known latest ratings remain authoritative:
+
+- `X` / `XXX` skip WebAPI annotation without another moderation call.
+- `PG` / `PG-13` / `R` proceed without another moderation call.
+- unknown file paths pass through because no `ratings.image_id` target exists.
+
+If moderation cannot run or does not produce a saved rating for an unrated image, LoRAIro fails closed for that image: the image is skipped, an `error_records` row records the reason, and the rest of the batch continues.
+
+## Rationale
+
+This keeps the rating table as the single source of truth for WebAPI send decisions and reuses the existing image-annotator-lib OpenAI moderation converter. A fixed fail-closed policy avoids accidentally sending unrated images when the OpenAI key, network, or moderation API is unavailable.
+
+Provider Batch automatic two-stage orchestration is not included here. The existing manual `rating_preflight` batch task remains available, while this ADR covers the normal GUI/CLI annotation path.
+
+## Consequences
+
+Tests must cover existing-rating skip/allow, unrated moderation allow/block, moderation failure, and no-op local-model selections. The model registry must keep `openai/omni-moderation-latest` mapped to the `ratings` model type, and future moderation model changes must preserve `openai_moderation_v1` mapping compatibility.

--- a/src/lorairo/cli/commands/annotate.py
+++ b/src/lorairo/cli/commands/annotate.py
@@ -28,6 +28,7 @@ if TYPE_CHECKING:
     from lorairo.database.repository.model import ModelRepository
     from lorairo.services.batch_import_service import BatchImportResult
 
+from lorairo.annotations.annotation_logic import AnnotationLogic
 from lorairo.api.batch_import import import_batch_annotations
 from lorairo.api.exceptions import (
     AnnotationFailedError,
@@ -37,8 +38,14 @@ from lorairo.api.exceptions import (
 )
 from lorairo.api.project import get_project as api_get_project
 from lorairo.cli._console import make_console
+from lorairo.database.db_core import resolve_stored_path
 from lorairo.database.filter_criteria import ImageFilterCriteria
+from lorairo.services.model_registry_protocol import selection_includes_webapi_model
 from lorairo.services.model_route_service import validate_api_keys_for_models
+from lorairo.services.moderation_preflight_service import (
+    ModerationPreflightService,
+    build_annotation_logic_runner,
+)
 from lorairo.services.service_container import get_service_container
 from lorairo.utils.log import logger
 
@@ -247,6 +254,7 @@ class _StreamAnnotateSummary:
     total_results: int = 0
     saved: int = 0
     skipped: int = 0
+    preflight_skipped: int = 0
     save_errors: int = 0
     any_success: bool = False
     error_models: set[str] = field(default_factory=set)
@@ -259,6 +267,7 @@ def _stream_annotate(
     annotator: Any,
     save_service: Any,
     resolved_litellm_ids: list[str],
+    moderation_preflight_service: ModerationPreflightService | None = None,
 ) -> _StreamAnnotateSummary:
     """レコードを chunk 単位でロード→アノテーション→DB 保存する (Issue #536 / #537)。
 
@@ -294,13 +303,24 @@ def _stream_annotate(
         task = progress.add_task("Running annotation...", total=len(records_to_process))
 
         for chunk in _iter_record_batches(records_to_process, batch_size):
+            original_chunk_size = len(chunk)
+            if moderation_preflight_service is not None:
+                chunk, skipped_count = _apply_moderation_preflight_to_records(
+                    chunk,
+                    moderation_preflight_service,
+                )
+                summary.preflight_skipped += skipped_count
+                if not chunk:
+                    progress.advance(task, advance=original_chunk_size)
+                    continue
+
             # Issue #537: FATAL (メモリ枯渇) は ImageLoadMemoryError で送出される。
             images, loaded, failed = _load_batch_images(chunk)
             summary.total_loaded += loaded
             summary.total_failed += failed
 
             if not images:
-                progress.advance(task, advance=len(chunk))
+                progress.advance(task, advance=original_chunk_size)
                 continue
 
             try:
@@ -315,9 +335,35 @@ def _stream_annotate(
                 for img in images:
                     img.close()
 
-            progress.advance(task, advance=len(chunk))
+            progress.advance(task, advance=original_chunk_size)
 
     return summary
+
+
+def _apply_moderation_preflight_to_records(
+    records_chunk: list[dict[str, Any]],
+    moderation_preflight_service: ModerationPreflightService,
+) -> tuple[list[dict[str, Any]], int]:
+    """Filter a CLI annotation chunk through OpenAI moderation preflight."""
+    path_to_record: dict[str, dict[str, Any]] = {}
+    passthrough_records: list[dict[str, Any]] = []
+
+    for record in records_chunk:
+        stored_path = record.get("stored_image_path")
+        if not stored_path:
+            passthrough_records.append(record)
+            continue
+        path_to_record[str(resolve_stored_path(str(stored_path)))] = record
+
+    if not path_to_record:
+        return records_chunk, 0
+
+    result = moderation_preflight_service.apply(list(path_to_record))
+    allowed = [path_to_record[path] for path in result.allowed_paths if path in path_to_record]
+    skipped_count = result.skipped_count
+    if skipped_count:
+        console.print(f"[yellow]Moderation preflight skipped {skipped_count} image(s)[/yellow]")
+    return passthrough_records + allowed, skipped_count
 
 
 def _annotate_and_save_chunk(
@@ -377,8 +423,15 @@ def _finalize_annotation_run(summary: _StreamAnnotateSummary, resolved_litellm_i
         typer.Exit: ロード不可・結果ゼロ・全モデル失敗の場合 (code=1)。
     """
     console.print(f"[green]Loaded {summary.total_loaded} image(s) ({summary.total_failed} failed)[/green]")
+    if summary.preflight_skipped:
+        console.print(f"[yellow]Moderation preflight skipped {summary.preflight_skipped} image(s)[/yellow]")
 
     if summary.total_loaded == 0:
+        if summary.preflight_skipped > 0:
+            console.print(
+                "[green]Annotation completed: all selected images were skipped by preflight[/green]"
+            )
+            return
         console.print("[red]Error:[/red] No images could be loaded for annotation")
         raise typer.Exit(code=1)
 
@@ -416,6 +469,7 @@ def _finalize_annotation_run(summary: _StreamAnnotateSummary, resolved_litellm_i
     summary_table.add_row("Results", str(summary.total_results))
     summary_table.add_row("Saved to DB", str(summary.saved))
     summary_table.add_row("Skipped", str(summary.skipped))
+    summary_table.add_row("Preflight Skipped", str(summary.preflight_skipped))
 
     console.print(summary_table)
 
@@ -736,6 +790,25 @@ def run(
 
         # アノテーション実行 (Issue #536: チャンクストリーミング)
         console.print("[cyan]Starting annotation...[/cyan]")
+        try:
+            should_preflight = selection_includes_webapi_model(resolved_litellm_ids, annotator)
+        except Exception as e:
+            logger.warning(
+                f"WebAPI model detection failed; moderation preflight skipped: {e}", exc_info=True
+            )
+            should_preflight = False
+
+        moderation_preflight_service = None
+        if should_preflight:
+            moderation_logic = AnnotationLogic(annotator)
+            moderation_preflight_service = ModerationPreflightService(
+                image_repo=container.db_manager.image_repo,
+                model_repo=container.db_manager.model_repo,
+                error_record_repo=container.db_manager.error_record_repo,
+                annotation_save_service=container.annotation_save_service,
+                config_service=config,
+                moderation_runner=build_annotation_logic_runner(moderation_logic.execute_annotation),
+            )
 
         try:
             summary = _stream_annotate(
@@ -744,6 +817,7 @@ def run(
                 annotator=annotator,
                 save_service=container.annotation_save_service,
                 resolved_litellm_ids=resolved_litellm_ids,
+                moderation_preflight_service=moderation_preflight_service,
             )
         except ImageLoadMemoryError as e:
             console.print(f"[red]Error:[/red] Memory/resource exhaustion during image load: {e}")

--- a/src/lorairo/cli/commands/annotate.py
+++ b/src/lorairo/cli/commands/annotate.py
@@ -28,7 +28,6 @@ if TYPE_CHECKING:
     from lorairo.database.repository.model import ModelRepository
     from lorairo.services.batch_import_service import BatchImportResult
 
-from lorairo.annotations.annotation_logic import AnnotationLogic
 from lorairo.api.batch_import import import_batch_annotations
 from lorairo.api.exceptions import (
     AnnotationFailedError,
@@ -800,6 +799,8 @@ def run(
 
         moderation_preflight_service = None
         if should_preflight:
+            from lorairo.annotations.annotation_logic import AnnotationLogic
+
             moderation_logic = AnnotationLogic(annotator)
             moderation_preflight_service = ModerationPreflightService(
                 image_repo=container.db_manager.image_repo,

--- a/src/lorairo/cli/commands/annotate.py
+++ b/src/lorairo/cli/commands/annotate.py
@@ -426,7 +426,7 @@ def _finalize_annotation_run(summary: _StreamAnnotateSummary, resolved_litellm_i
         console.print(f"[yellow]Moderation preflight skipped {summary.preflight_skipped} image(s)[/yellow]")
 
     if summary.total_loaded == 0:
-        if summary.preflight_skipped > 0:
+        if summary.preflight_skipped > 0 and summary.total_failed == 0:
             console.print(
                 "[green]Annotation completed: all selected images were skipped by preflight[/green]"
             )

--- a/src/lorairo/gui/workers/annotation_worker.py
+++ b/src/lorairo/gui/workers/annotation_worker.py
@@ -19,6 +19,11 @@ from lorairo.services.model_registry_protocol import (
     ModelRegistryServiceProtocol,
     selection_includes_webapi_model,
 )
+from lorairo.services.moderation_preflight_service import (
+    MODERATION_LITELLM_MODEL_ID,
+    ModerationPreflightService,
+    build_annotation_logic_runner,
+)
 from lorairo.utils.log import logger
 
 from .base import CancellationError, LoRAIroWorkerBase
@@ -489,7 +494,7 @@ class AnnotationWorker(LoRAIroWorkerBase["AnnotationExecutionResult"]):
                 total_count=len(self.image_paths),
             )
             self._check_cancellation()
-            self._apply_refusal_prefilter()
+            preflight_errors = self._apply_refusal_prefilter()
 
             self._refresh_input_phash_cache()
 
@@ -498,6 +503,7 @@ class AnnotationWorker(LoRAIroWorkerBase["AnnotationExecutionResult"]):
             self._check_cancellation()
 
             merged_results, model_errors = self._run_annotation()
+            model_errors = preflight_errors + model_errors
 
             # Phase 2: DB保存(90-95%)
             self._report_progress(
@@ -552,7 +558,7 @@ class AnnotationWorker(LoRAIroWorkerBase["AnnotationExecutionResult"]):
             self._error_already_recorded = True
             raise
 
-    def _apply_refusal_prefilter(self) -> None:
+    def _apply_refusal_prefilter(self) -> list[ModelErrorDetail]:
         """refusal を持つ画像を `self.image_paths` から除外する (Worker 内実行版)。
 
         ADR 0023 Phase 1.5 (Issue #42, Codex P2 r3209342204): GUI スレッド上で
@@ -577,7 +583,7 @@ class AnnotationWorker(LoRAIroWorkerBase["AnnotationExecutionResult"]):
                 "refusal filter スキップ (WebAPI 不在 or registry lookup 失敗): "
                 f"litellm_model_ids={self.litellm_model_ids}"
             )
-            return
+            return []
 
         save_service = AnnotationSaveService(
             annotation_repo=self.db_manager.annotation_repo,
@@ -588,13 +594,23 @@ class AnnotationWorker(LoRAIroWorkerBase["AnnotationExecutionResult"]):
         original_count = len(self.image_paths)
         try:
             filtered_image_paths = save_service.filter_refused_image_paths(self.image_paths)
-            self.image_paths = save_service.filter_excluded_by_rating(filtered_image_paths)
+            rating_filtered_paths = save_service.filter_excluded_by_rating(filtered_image_paths)
+            preflight_service = ModerationPreflightService(
+                image_repo=self.db_manager.image_repo,
+                model_repo=self.db_manager.model_repo,
+                error_record_repo=self.db_manager.error_record_repo,
+                annotation_save_service=save_service,
+                config_service=self.db_manager.config_service,
+                moderation_runner=build_annotation_logic_runner(self.annotation_logic.execute_annotation),
+            )
+            preflight_result = preflight_service.apply(rating_filtered_paths)
+            self.image_paths = preflight_result.allowed_paths
         except Exception as exc:
             logger.warning(
                 f"refusal filter 実行失敗; filter skip して annotation 続行: {exc}",
                 exc_info=True,
             )
-            return
+            return []
 
         excluded = original_count - len(self.image_paths)
         if excluded > 0:
@@ -602,6 +618,15 @@ class AnnotationWorker(LoRAIroWorkerBase["AnnotationExecutionResult"]):
                 f"prefilter 適用: {original_count}件 → {len(self.image_paths)}件 "
                 f"(refusal + rating 除外: {excluded}件)"
             )
+        return [
+            ModelErrorDetail(
+                model_name=MODERATION_LITELLM_MODEL_ID,
+                image_path=Path(skip.image_path).name,
+                error_message=skip.message,
+                error_type=skip.reason,
+            )
+            for skip in preflight_result.skipped
+        ]
 
     def _save_results_to_database(
         self, results: PHashAnnotationResults

--- a/src/lorairo/services/moderation_preflight_service.py
+++ b/src/lorairo/services/moderation_preflight_service.py
@@ -1,0 +1,380 @@
+"""OpenAI moderation preflight for WebAPI annotation sends."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass, field
+from typing import Any, Protocol
+
+from sqlalchemy.exc import IntegrityError
+
+from lorairo.database.repository.error_record import ErrorRecordRepository
+from lorairo.database.repository.image import ImageRepository
+from lorairo.database.repository.model import ModelRepository
+from lorairo.services.annotation_save_service import AnnotationSaveResult, AnnotationSaveService
+from lorairo.services.configuration_service import ConfigurationService
+from lorairo.utils.log import logger
+
+MODERATION_LITELLM_MODEL_ID = "openai/omni-moderation-latest"
+MODERATION_PROVIDER = "openai"
+MODERATION_ERROR_TYPE_MISSING_KEY = "moderation_preflight_missing_openai_key"
+MODERATION_ERROR_TYPE_FAILED = "moderation_preflight_failed"
+MODERATION_ERROR_TYPE_NO_RATING = "moderation_preflight_no_rating"
+MODERATION_ERROR_TYPE_BLOCKED = "moderation_preflight_blocked"
+
+
+class ModerationRunner(Protocol):
+    """Callable boundary for running a single moderation model over image paths."""
+
+    def __call__(
+        self,
+        *,
+        image_paths: list[str],
+        litellm_model_ids: list[str],
+        phash_list: list[str] | None = None,
+    ) -> Any: ...
+
+
+@dataclass(frozen=True)
+class ModerationPreflightSkip:
+    """Per-image moderation preflight skip reason."""
+
+    image_path: str
+    image_id: int | None
+    reason: str
+    message: str
+
+
+@dataclass(frozen=True)
+class ModerationPreflightResult:
+    """Summary of filtering candidates before WebAPI annotation."""
+
+    allowed_paths: list[str]
+    skipped: list[ModerationPreflightSkip] = field(default_factory=list)
+    moderated_count: int = 0
+    existing_rating_allowed_count: int = 0
+    existing_rating_blocked_count: int = 0
+    unknown_path_count: int = 0
+    failure_count: int = 0
+
+    @property
+    def skipped_count(self) -> int:
+        return len(self.skipped)
+
+
+class ModerationPreflightService:
+    """Run moderation for unrated images before WebAPI annotation."""
+
+    _ALLOW_RATINGS = frozenset({"PG", "PG-13", "R"})
+    _BLOCK_RATINGS = frozenset({"X", "XXX"})
+
+    def __init__(
+        self,
+        *,
+        image_repo: ImageRepository,
+        model_repo: ModelRepository,
+        error_record_repo: ErrorRecordRepository,
+        annotation_save_service: AnnotationSaveService,
+        config_service: ConfigurationService,
+        moderation_runner: ModerationRunner,
+    ) -> None:
+        self._image_repo = image_repo
+        self._model_repo = model_repo
+        self._error_record_repo = error_record_repo
+        self._annotation_save_service = annotation_save_service
+        self._config_service = config_service
+        self._moderation_runner = moderation_runner
+
+    def apply(self, image_paths: list[str]) -> ModerationPreflightResult:
+        """Return image paths that may proceed to WebAPI annotation."""
+        if not image_paths:
+            return ModerationPreflightResult(allowed_paths=[])
+
+        path_to_image_id = self._image_repo.get_image_ids_by_filepaths(image_paths)
+        known_ids = [image_id for image_id in set(path_to_image_id.values()) if image_id is not None]
+        latest_rating_map = (
+            self._image_repo.get_latest_normalized_ratings_by_image_ids(known_ids) if known_ids else {}
+        )
+
+        allowed_paths: list[str] = []
+        preflight_paths: list[str] = []
+        skipped: list[ModerationPreflightSkip] = []
+        existing_allowed = 0
+        existing_blocked = 0
+        unknown_paths = 0
+
+        for image_path in image_paths:
+            image_id = path_to_image_id.get(image_path)
+            if image_id is None:
+                allowed_paths.append(image_path)
+                unknown_paths += 1
+                continue
+
+            normalized = self._normalize_rating(latest_rating_map.get(image_id))
+            if normalized in self._BLOCK_RATINGS:
+                skipped.append(
+                    self._record_skip(
+                        image_path=image_path,
+                        image_id=image_id,
+                        reason=MODERATION_ERROR_TYPE_BLOCKED,
+                        message=f"latest rating blocks WebAPI annotation: {normalized}",
+                    )
+                )
+                existing_blocked += 1
+            elif normalized in self._ALLOW_RATINGS:
+                allowed_paths.append(image_path)
+                existing_allowed += 1
+            else:
+                preflight_paths.append(image_path)
+
+        if preflight_paths:
+            preflight_result = self._moderate_unrated_paths(preflight_paths, path_to_image_id)
+            preflight_allowed = set(preflight_result.allowed_paths)
+            allowed_paths.extend(path for path in preflight_paths if path in preflight_allowed)
+            skipped.extend(preflight_result.skipped)
+            moderated_count = preflight_result.moderated_count
+            failure_count = preflight_result.failure_count
+        else:
+            moderated_count = 0
+            failure_count = 0
+
+        if skipped:
+            logger.info(
+                f"moderation preflight: allowed={len(allowed_paths)} skipped={len(skipped)} "
+                f"moderated={moderated_count}"
+            )
+
+        return ModerationPreflightResult(
+            allowed_paths=allowed_paths,
+            skipped=skipped,
+            moderated_count=moderated_count,
+            existing_rating_allowed_count=existing_allowed,
+            existing_rating_blocked_count=existing_blocked,
+            unknown_path_count=unknown_paths,
+            failure_count=failure_count,
+        )
+
+    @staticmethod
+    def _normalize_rating(value: str | None) -> str | None:
+        return value.strip().upper() if isinstance(value, str) and value.strip() else None
+
+    def _moderate_unrated_paths(
+        self,
+        image_paths: list[str],
+        path_to_image_id: Mapping[str, int | None],
+    ) -> ModerationPreflightResult:
+        missing_key = self._missing_openai_key()
+        if missing_key is not None:
+            skipped = [
+                self._record_skip(
+                    image_path=path,
+                    image_id=path_to_image_id.get(path),
+                    reason=MODERATION_ERROR_TYPE_MISSING_KEY,
+                    message=missing_key,
+                )
+                for path in image_paths
+            ]
+            return ModerationPreflightResult(
+                allowed_paths=[],
+                skipped=skipped,
+                failure_count=len(skipped),
+            )
+
+        try:
+            model_id = self._ensure_moderation_model_id()
+            phash_list = self._build_phash_list(image_paths)
+        except Exception as exc:
+            message = f"moderation preflight setup failed: {exc}"
+            logger.warning(message, exc_info=True)
+            skipped = [
+                self._record_skip(
+                    image_path=path,
+                    image_id=path_to_image_id.get(path),
+                    reason=MODERATION_ERROR_TYPE_FAILED,
+                    message=message,
+                )
+                for path in image_paths
+            ]
+            return ModerationPreflightResult(
+                allowed_paths=[],
+                skipped=skipped,
+                failure_count=len(skipped),
+            )
+        if phash_list is None:
+            skipped = [
+                self._record_skip(
+                    image_path=path,
+                    image_id=path_to_image_id.get(path),
+                    reason=MODERATION_ERROR_TYPE_FAILED,
+                    message="moderation preflight could not resolve registered pHash",
+                )
+                for path in image_paths
+            ]
+            return ModerationPreflightResult(
+                allowed_paths=[],
+                skipped=skipped,
+                failure_count=len(skipped),
+            )
+
+        try:
+            results = self._moderation_runner(
+                image_paths=image_paths,
+                litellm_model_ids=[MODERATION_LITELLM_MODEL_ID],
+                phash_list=phash_list,
+            )
+            save_result = self._annotation_save_service.save_annotation_results(results)
+        except Exception as exc:
+            message = f"moderation preflight failed: {exc}"
+            logger.warning(message, exc_info=True)
+            skipped = [
+                self._record_skip(
+                    image_path=path,
+                    image_id=path_to_image_id.get(path),
+                    reason=MODERATION_ERROR_TYPE_FAILED,
+                    message=message,
+                )
+                for path in image_paths
+            ]
+            return ModerationPreflightResult(
+                allowed_paths=[],
+                skipped=skipped,
+                failure_count=len(skipped),
+            )
+
+        logger.debug(
+            f"moderation preflight saved ratings with model_id={model_id}: "
+            f"success={save_result.success_count} skip={save_result.skip_count} error={save_result.error_count}"
+        )
+        return self._decide_after_moderation(
+            image_paths=image_paths,
+            path_to_image_id=path_to_image_id,
+            save_result=save_result,
+        )
+
+    def _missing_openai_key(self) -> str | None:
+        try:
+            key = self._config_service.get_setting("api", "openai_key", "")
+        except Exception as exc:
+            return f"OpenAI API key lookup failed for moderation preflight: {exc}"
+        if isinstance(key, str) and key.strip():
+            return None
+        return "OpenAI API key is required for moderation preflight"
+
+    def _ensure_moderation_model_id(self) -> int:
+        existing = self._model_repo.get_model_by_litellm_id(MODERATION_LITELLM_MODEL_ID)
+        if existing is not None:
+            return int(existing.id)
+
+        try:
+            return self._model_repo.insert_model(
+                name=MODERATION_LITELLM_MODEL_ID,
+                provider=MODERATION_PROVIDER,
+                model_types=["ratings"],
+                litellm_model_id=MODERATION_LITELLM_MODEL_ID,
+                requires_api_key=True,
+            )
+        except IntegrityError:
+            existing = self._model_repo.get_model_by_litellm_id(MODERATION_LITELLM_MODEL_ID)
+            if existing is not None:
+                return int(existing.id)
+            raise
+
+    def _build_phash_list(self, image_paths: list[str]) -> list[str] | None:
+        path_to_phash = self._image_repo.get_phashes_by_filepaths(image_paths)
+        phashes = [path_to_phash.get(path) for path in image_paths]
+        if any(phash is None for phash in phashes):
+            return None
+        return [str(phash) for phash in phashes]
+
+    def _decide_after_moderation(
+        self,
+        *,
+        image_paths: list[str],
+        path_to_image_id: Mapping[str, int | None],
+        save_result: AnnotationSaveResult,
+    ) -> ModerationPreflightResult:
+        image_ids = [image_id for image_id in path_to_image_id.values() if image_id is not None]
+        latest = self._image_repo.get_latest_normalized_ratings_by_image_ids(list(set(image_ids)))
+
+        allowed_paths: list[str] = []
+        skipped: list[ModerationPreflightSkip] = []
+        for image_path in image_paths:
+            image_id = path_to_image_id.get(image_path)
+            normalized = self._normalize_rating(latest.get(image_id)) if image_id is not None else None
+            if normalized in self._BLOCK_RATINGS:
+                skipped.append(
+                    self._record_skip(
+                        image_path=image_path,
+                        image_id=image_id,
+                        reason=MODERATION_ERROR_TYPE_BLOCKED,
+                        message=f"moderation rating blocks WebAPI annotation: {normalized}",
+                    )
+                )
+            elif normalized in self._ALLOW_RATINGS:
+                allowed_paths.append(image_path)
+            else:
+                skipped.append(
+                    self._record_skip(
+                        image_path=image_path,
+                        image_id=image_id,
+                        reason=MODERATION_ERROR_TYPE_NO_RATING,
+                        message="moderation preflight did not produce a usable saved rating",
+                    )
+                )
+
+        failure_count = save_result.error_count + sum(
+            1 for skip in skipped if skip.reason == MODERATION_ERROR_TYPE_NO_RATING
+        )
+        return ModerationPreflightResult(
+            allowed_paths=allowed_paths,
+            skipped=skipped,
+            moderated_count=len(image_paths),
+            failure_count=failure_count,
+        )
+
+    def _record_skip(
+        self,
+        *,
+        image_path: str,
+        image_id: int | None,
+        reason: str,
+        message: str,
+    ) -> ModerationPreflightSkip:
+        try:
+            self._error_record_repo.save_error_record(
+                operation_type="annotation",
+                error_type=reason,
+                error_message=message,
+                image_id=image_id,
+                file_path=image_path,
+                model_name=MODERATION_LITELLM_MODEL_ID,
+            )
+        except Exception:
+            logger.warning(
+                f"moderation preflight skip reason could not be saved: path={image_path}",
+                exc_info=True,
+            )
+        return ModerationPreflightSkip(
+            image_path=image_path,
+            image_id=image_id,
+            reason=reason,
+            message=message,
+        )
+
+
+def build_annotation_logic_runner(execute_annotation: Callable[..., Any]) -> ModerationRunner:
+    """Adapt `AnnotationLogic.execute_annotation` to the moderation runner protocol."""
+
+    def _run(
+        *,
+        image_paths: list[str],
+        litellm_model_ids: list[str],
+        phash_list: list[str] | None = None,
+    ) -> Any:
+        return execute_annotation(
+            image_paths=image_paths,
+            litellm_model_ids=litellm_model_ids,
+            phash_list=phash_list,
+        )
+
+    return _run

--- a/src/lorairo/services/moderation_preflight_service.py
+++ b/src/lorairo/services/moderation_preflight_service.py
@@ -224,21 +224,14 @@ class ModerationPreflightService:
             )
             save_result = self._annotation_save_service.save_annotation_results(results)
         except Exception as exc:
-            message = f"moderation preflight failed: {exc}"
-            logger.warning(message, exc_info=True)
-            skipped = [
-                self._record_skip(
-                    image_path=path,
-                    image_id=path_to_image_id.get(path),
-                    reason=MODERATION_ERROR_TYPE_FAILED,
-                    message=message,
-                )
-                for path in image_paths
-            ]
-            return ModerationPreflightResult(
-                allowed_paths=[],
-                skipped=skipped,
-                failure_count=len(skipped),
+            logger.warning(
+                f"moderation preflight batch failed; retrying per image: {exc}",
+                exc_info=True,
+            )
+            return self._moderate_unrated_paths_individually(
+                image_paths=image_paths,
+                path_to_image_id=path_to_image_id,
+                phash_list=phash_list,
             )
 
         logger.debug(
@@ -249,6 +242,55 @@ class ModerationPreflightService:
             image_paths=image_paths,
             path_to_image_id=path_to_image_id,
             save_result=save_result,
+        )
+
+    def _moderate_unrated_paths_individually(
+        self,
+        *,
+        image_paths: list[str],
+        path_to_image_id: Mapping[str, int | None],
+        phash_list: list[str],
+    ) -> ModerationPreflightResult:
+        allowed_paths: list[str] = []
+        skipped: list[ModerationPreflightSkip] = []
+        failure_count = 0
+
+        for image_path, phash in zip(image_paths, phash_list, strict=True):
+            try:
+                results = self._moderation_runner(
+                    image_paths=[image_path],
+                    litellm_model_ids=[MODERATION_LITELLM_MODEL_ID],
+                    phash_list=[phash],
+                )
+                save_result = self._annotation_save_service.save_annotation_results(results)
+                decision = self._decide_after_moderation(
+                    image_paths=[image_path],
+                    path_to_image_id=path_to_image_id,
+                    save_result=save_result,
+                )
+            except Exception as exc:
+                message = f"moderation preflight failed: {exc}"
+                logger.warning(message, exc_info=True)
+                skipped.append(
+                    self._record_skip(
+                        image_path=image_path,
+                        image_id=path_to_image_id.get(image_path),
+                        reason=MODERATION_ERROR_TYPE_FAILED,
+                        message=message,
+                    )
+                )
+                failure_count += 1
+                continue
+
+            allowed_paths.extend(decision.allowed_paths)
+            skipped.extend(decision.skipped)
+            failure_count += decision.failure_count
+
+        return ModerationPreflightResult(
+            allowed_paths=allowed_paths,
+            skipped=skipped,
+            moderated_count=len(image_paths),
+            failure_count=failure_count,
         )
 
     def _missing_openai_key(self) -> str | None:

--- a/tests/unit/cli/test_annotate_streaming.py
+++ b/tests/unit/cli/test_annotate_streaming.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
+import typer
 from PIL import Image
 from typer.testing import CliRunner
 
@@ -293,3 +294,12 @@ def test_finalize_annotation_run_all_preflight_skipped_is_success() -> None:
     summary = _StreamAnnotateSummary(preflight_skipped=2)
 
     _finalize_annotation_run(summary, ["openai/gpt-4o-mini"])
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+def test_finalize_annotation_run_preflight_skip_plus_load_failure_is_error() -> None:
+    summary = _StreamAnnotateSummary(total_failed=1, preflight_skipped=1)
+
+    with pytest.raises(typer.Exit):
+        _finalize_annotation_run(summary, ["openai/gpt-4o-mini"])

--- a/tests/unit/cli/test_annotate_streaming.py
+++ b/tests/unit/cli/test_annotate_streaming.py
@@ -14,6 +14,11 @@ import pytest
 from PIL import Image
 from typer.testing import CliRunner
 
+from lorairo.cli.commands.annotate import (
+    _apply_moderation_preflight_to_records,
+    _finalize_annotation_run,
+    _StreamAnnotateSummary,
+)
 from lorairo.cli.main import app
 from lorairo.services.annotation_save_service import AnnotationSaveResult
 from lorairo.services.project_management_service import ProjectManagementService
@@ -257,3 +262,34 @@ def test_non_positive_batch_size_is_rejected(bad_value: str) -> None:
     )
 
     assert result.exit_code != 0
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+def test_apply_moderation_preflight_filters_records(tmp_path: Path) -> None:
+    """CLI chunk preflight drops skipped image records before image loading."""
+    keep = tmp_path / "keep.jpg"
+    skip = tmp_path / "skip.jpg"
+    Image.new("RGB", (8, 8)).save(keep)
+    Image.new("RGB", (8, 8)).save(skip)
+    records = [
+        {"id": 1, "stored_image_path": str(keep)},
+        {"id": 2, "stored_image_path": str(skip)},
+    ]
+    service = MagicMock()
+    service.apply.return_value = MagicMock(allowed_paths=[str(keep)], skipped_count=1)
+
+    filtered, skipped_count = _apply_moderation_preflight_to_records(records, service)
+
+    assert filtered == [records[0]]
+    assert skipped_count == 1
+    service.apply.assert_called_once_with([str(keep), str(skip)])
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+def test_finalize_annotation_run_all_preflight_skipped_is_success() -> None:
+    """A batch with only moderation-preflight skips is not a fatal annotation failure."""
+    summary = _StreamAnnotateSummary(preflight_skipped=2)
+
+    _finalize_annotation_run(summary, ["openai/gpt-4o-mini"])

--- a/tests/unit/gui/workers/test_annotation_worker.py
+++ b/tests/unit/gui/workers/test_annotation_worker.py
@@ -760,6 +760,13 @@ class TestApplyRefusalPrefilter:
         registry.get_available_models.return_value = infos
         return registry
 
+    @staticmethod
+    def _patch_preflight(monkeypatch, aw_mod, allowed_paths):
+        preflight = Mock()
+        preflight.apply.return_value = SimpleNamespace(allowed_paths=allowed_paths, skipped=[])
+        monkeypatch.setattr(aw_mod, "ModerationPreflightService", lambda **kwargs: preflight)
+        return preflight
+
     def test_filter_applied_when_webapi_model_selected(self, mock_annotation_logic, monkeypatch):
         """WebAPI モデル選択時は filter が適用され image_paths が更新される。"""
         from lorairo.gui.workers import annotation_worker as aw_mod
@@ -773,6 +780,7 @@ class TestApplyRefusalPrefilter:
         mock_save_service.filter_refused_image_paths = Mock(return_value=["/path/img1.jpg"])
         mock_save_service.filter_excluded_by_rating = Mock(return_value=["/path/img1.jpg"])
         monkeypatch.setattr(aw_mod, "AnnotationSaveService", lambda **kwargs: mock_save_service)
+        self._patch_preflight(monkeypatch, aw_mod, ["/path/img1.jpg"])
 
         worker = self._make_worker(
             mock_annotation_logic,
@@ -805,6 +813,7 @@ class TestApplyRefusalPrefilter:
         )
         mock_save_service.filter_excluded_by_rating = Mock(return_value=["/path/img1.jpg"])
         monkeypatch.setattr(aw_mod, "AnnotationSaveService", lambda **kwargs: mock_save_service)
+        self._patch_preflight(monkeypatch, aw_mod, ["/path/img1.jpg"])
 
         worker = self._make_worker(
             mock_annotation_logic,
@@ -919,6 +928,7 @@ class TestApplyRefusalPrefilter:
             return_value=["/path/img1.jpg", "/path/img2.jpg"]
         )
         monkeypatch.setattr(aw_mod, "AnnotationSaveService", lambda **kwargs: mock_save_service)
+        self._patch_preflight(monkeypatch, aw_mod, ["/path/img1.jpg", "/path/img2.jpg"])
 
         worker = self._make_worker(
             mock_annotation_logic,

--- a/tests/unit/services/test_moderation_preflight_service.py
+++ b/tests/unit/services/test_moderation_preflight_service.py
@@ -161,3 +161,31 @@ def test_moderation_without_saved_rating_fails_closed(deps: dict[str, Mock]) -> 
     assert result.allowed_paths == []
     assert [skip.reason for skip in result.skipped] == [MODERATION_ERROR_TYPE_NO_RATING]
     assert result.failure_count == 1
+
+
+@pytest.mark.unit
+def test_batch_moderation_failure_retries_per_image(deps: dict[str, Mock]) -> None:
+    deps["image_repo"].get_image_ids_by_filepaths.return_value = {
+        "/img/bad.png": 1,
+        "/img/good.png": 2,
+    }
+    deps["image_repo"].get_latest_normalized_ratings_by_image_ids.side_effect = [
+        {},
+        {2: "PG"},
+    ]
+    deps["image_repo"].get_phashes_by_filepaths.return_value = {
+        "/img/bad.png": "phash-1",
+        "/img/good.png": "phash-2",
+    }
+    deps["runner"].side_effect = [
+        RuntimeError("batch load failed"),
+        RuntimeError("bad file"),
+        {"phash-2": {MODERATION_LITELLM_MODEL_ID: {"ratings": []}}},
+    ]
+
+    result = _service(deps).apply(["/img/bad.png", "/img/good.png"])
+
+    assert result.allowed_paths == ["/img/good.png"]
+    assert [skip.reason for skip in result.skipped] == [MODERATION_ERROR_TYPE_FAILED]
+    assert result.failure_count == 1
+    assert deps["runner"].call_count == 3

--- a/tests/unit/services/test_moderation_preflight_service.py
+++ b/tests/unit/services/test_moderation_preflight_service.py
@@ -1,0 +1,163 @@
+"""ModerationPreflightService tests."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+
+from lorairo.services.annotation_save_service import AnnotationSaveResult
+from lorairo.services.moderation_preflight_service import (
+    MODERATION_ERROR_TYPE_BLOCKED,
+    MODERATION_ERROR_TYPE_FAILED,
+    MODERATION_ERROR_TYPE_MISSING_KEY,
+    MODERATION_ERROR_TYPE_NO_RATING,
+    MODERATION_LITELLM_MODEL_ID,
+    ModerationPreflightService,
+)
+
+
+@pytest.fixture
+def deps() -> dict[str, Mock]:
+    image_repo = Mock()
+    model_repo = Mock()
+    annotation_repo = Mock()
+    error_record_repo = Mock()
+    save_service = Mock()
+    config_service = Mock()
+    runner = Mock()
+    config_service.get_setting.return_value = "sk-test"
+    model_repo.get_model_by_litellm_id.return_value = SimpleNamespace(id=42)
+    save_service.save_annotation_results.return_value = AnnotationSaveResult(
+        success_count=1,
+        skip_count=0,
+        error_count=0,
+        total_count=1,
+    )
+    return {
+        "image_repo": image_repo,
+        "model_repo": model_repo,
+        "annotation_repo": annotation_repo,
+        "error_record_repo": error_record_repo,
+        "save_service": save_service,
+        "config_service": config_service,
+        "runner": runner,
+    }
+
+
+def _service(deps: dict[str, Mock]) -> ModerationPreflightService:
+    return ModerationPreflightService(
+        image_repo=deps["image_repo"],
+        model_repo=deps["model_repo"],
+        error_record_repo=deps["error_record_repo"],
+        annotation_save_service=deps["save_service"],
+        config_service=deps["config_service"],
+        moderation_runner=deps["runner"],
+    )
+
+
+@pytest.mark.unit
+def test_existing_ratings_allow_and_block_without_moderation(deps: dict[str, Mock]) -> None:
+    deps["image_repo"].get_image_ids_by_filepaths.return_value = {
+        "/img/pg.png": 1,
+        "/img/r.png": 2,
+        "/img/x.png": 3,
+        "/img/missing.png": None,
+    }
+    deps["image_repo"].get_latest_normalized_ratings_by_image_ids.return_value = {
+        1: "PG",
+        2: "R",
+        3: "XXX",
+    }
+
+    result = _service(deps).apply(["/img/pg.png", "/img/r.png", "/img/x.png", "/img/missing.png"])
+
+    assert result.allowed_paths == ["/img/pg.png", "/img/r.png", "/img/missing.png"]
+    assert [skip.reason for skip in result.skipped] == [MODERATION_ERROR_TYPE_BLOCKED]
+    assert result.existing_rating_allowed_count == 2
+    assert result.existing_rating_blocked_count == 1
+    deps["runner"].assert_not_called()
+
+
+@pytest.mark.unit
+def test_unrated_moderation_allows_after_saved_safe_rating(deps: dict[str, Mock]) -> None:
+    deps["image_repo"].get_image_ids_by_filepaths.return_value = {"/img/unrated.png": 10}
+    deps["image_repo"].get_latest_normalized_ratings_by_image_ids.side_effect = [
+        {},
+        {10: "PG"},
+    ]
+    deps["image_repo"].get_phashes_by_filepaths.return_value = {"/img/unrated.png": "phash-10"}
+    deps["runner"].return_value = {"phash-10": {MODERATION_LITELLM_MODEL_ID: {"ratings": []}}}
+
+    result = _service(deps).apply(["/img/unrated.png"])
+
+    assert result.allowed_paths == ["/img/unrated.png"]
+    assert result.skipped == []
+    assert result.moderated_count == 1
+    deps["runner"].assert_called_once_with(
+        image_paths=["/img/unrated.png"],
+        litellm_model_ids=[MODERATION_LITELLM_MODEL_ID],
+        phash_list=["phash-10"],
+    )
+    deps["save_service"].save_annotation_results.assert_called_once()
+
+
+@pytest.mark.unit
+def test_unrated_moderation_blocks_after_saved_x_rating(deps: dict[str, Mock]) -> None:
+    deps["image_repo"].get_image_ids_by_filepaths.return_value = {"/img/unrated.png": 10}
+    deps["image_repo"].get_latest_normalized_ratings_by_image_ids.side_effect = [
+        {},
+        {10: "X"},
+    ]
+    deps["image_repo"].get_phashes_by_filepaths.return_value = {"/img/unrated.png": "phash-10"}
+
+    result = _service(deps).apply(["/img/unrated.png"])
+
+    assert result.allowed_paths == []
+    assert [skip.reason for skip in result.skipped] == [MODERATION_ERROR_TYPE_BLOCKED]
+    assert result.moderated_count == 1
+
+
+@pytest.mark.unit
+def test_missing_openai_key_fails_closed_for_unrated(deps: dict[str, Mock]) -> None:
+    deps["config_service"].get_setting.return_value = ""
+    deps["image_repo"].get_image_ids_by_filepaths.return_value = {"/img/unrated.png": 10}
+    deps["image_repo"].get_latest_normalized_ratings_by_image_ids.return_value = {}
+
+    result = _service(deps).apply(["/img/unrated.png"])
+
+    assert result.allowed_paths == []
+    assert [skip.reason for skip in result.skipped] == [MODERATION_ERROR_TYPE_MISSING_KEY]
+    assert result.failure_count == 1
+    deps["runner"].assert_not_called()
+
+
+@pytest.mark.unit
+def test_moderation_exception_fails_closed_for_unrated(deps: dict[str, Mock]) -> None:
+    deps["image_repo"].get_image_ids_by_filepaths.return_value = {"/img/unrated.png": 10}
+    deps["image_repo"].get_latest_normalized_ratings_by_image_ids.return_value = {}
+    deps["image_repo"].get_phashes_by_filepaths.return_value = {"/img/unrated.png": "phash-10"}
+    deps["runner"].side_effect = RuntimeError("rate limited")
+
+    result = _service(deps).apply(["/img/unrated.png"])
+
+    assert result.allowed_paths == []
+    assert [skip.reason for skip in result.skipped] == [MODERATION_ERROR_TYPE_FAILED]
+    assert result.failure_count == 1
+
+
+@pytest.mark.unit
+def test_moderation_without_saved_rating_fails_closed(deps: dict[str, Mock]) -> None:
+    deps["image_repo"].get_image_ids_by_filepaths.return_value = {"/img/unrated.png": 10}
+    deps["image_repo"].get_latest_normalized_ratings_by_image_ids.side_effect = [
+        {},
+        {},
+    ]
+    deps["image_repo"].get_phashes_by_filepaths.return_value = {"/img/unrated.png": "phash-10"}
+
+    result = _service(deps).apply(["/img/unrated.png"])
+
+    assert result.allowed_paths == []
+    assert [skip.reason for skip in result.skipped] == [MODERATION_ERROR_TYPE_NO_RATING]
+    assert result.failure_count == 1


### PR DESCRIPTION
Fixes #562.

Branch: issue-562-openai-moderation-preflight
Worktree: /tmp/worktrees/issue-562-openai-moderation-preflight
ADR: docs/decisions/0042-openai-moderation-webapi-preflight.md

## Summary
- WebAPI annotation 前に未判定画像を openai/omni-moderation-latest で事前判定する共有サービスを追加
- 既存 rating が PG/PG-13/R の画像はそのまま送信、X/XXX は送信除外、UNRATED/None/未保存は moderation 対象にする
- moderation 失敗や OpenAI key 未設定時は fail-closed で対象画像だけ skip し、error_records に理由を保存
- GUI AnnotationWorker と CLI annotate run の通常 WebAPI annotation 経路へ接続

## Verification
- UV_CACHE_DIR=/tmp/uv-cache UV_PROJECT_ENVIRONMENT=/workspaces/LoRAIro/.venv uv run ruff check src/lorairo/services/moderation_preflight_service.py src/lorairo/gui/workers/annotation_worker.py src/lorairo/cli/commands/annotate.py tests/unit/services/test_moderation_preflight_service.py tests/unit/gui/workers/test_annotation_worker.py tests/unit/cli/test_annotate_streaming.py
- UV_CACHE_DIR=/tmp/uv-cache UV_PROJECT_ENVIRONMENT=/workspaces/LoRAIro/.venv uv run pytest tests/unit/services/test_moderation_preflight_service.py tests/unit/services/test_annotation_save_service_rating_filter.py tests/unit/gui/workers/test_annotation_worker.py tests/unit/cli/test_annotate_streaming.py tests/unit/cli/test_commands_annotate.py -q