### PR TITLE
fix: batch annotation result persistence

### DIFF
--- a/docs/decisions/0042-batch-annotation-db-save-io.md
+++ b/docs/decisions/0042-batch-annotation-db-save-io.md
@@ -1,0 +1,43 @@
+# ADR 0042: Batch Annotation DB Save I/O
+
+- **日付**: 2026-05-30
+- **ステータス**: Accepted
+- **関連 Issue**: [NEXTAltair/LoRAIro#568](https://github.com/NEXTAltair/LoRAIro/issues/568)
+- **関連 ADR**: [ADR 0012](0012-batch-tag-atomic-transaction.md),
+  [ADR 0035](0035-repository-aggregate-split-policy.md)
+
+## Context
+
+Provider Batch API の結果保存では、100 枚規模の画像に対して 1 画像ごとに
+`save_annotations()` が呼ばれ、各呼び出しが独立した SQLite transaction を commit していた。
+
+WSL2 devcontainer の `/workspaces` は 9p bind mount であり、SQLite の rollback journal と
+`synchronous=FULL` の commit が重なると、fsync とメタデータ操作がホスト側まで波及して
+LoRAIro だけでなく VSCode や OS 全体の応答性を落とす。
+
+既存の手動 tag/rating/score batch 操作は単一 transaction を採用しているが、annotation result
+保存だけが per-image commit のままだった。
+
+## Decision
+
+AnnotationRepository に複数画像をチャンク単位で保存する batch API を追加する。
+
+- 既存の `save_annotations()` は単一画像 API として維持する。
+- batch API は既存の `_save_tags()` / `_save_captions()` / `_save_scores()` /
+  `_save_score_labels()` / `_save_ratings()` を同じ session 内で再利用し、chunk ごとに 1 回だけ
+  commit する。
+- サービス層は保存対象 payload を先に組み立て、chunk save が失敗した場合だけ、その chunk を
+  per-image retry する。
+- これにより通常時の commit 数を大幅に減らしつつ、従来の部分成功・個別エラー報告を維持する。
+- SQLite engine は file-backed DB 向けに `journal_mode=WAL` と `synchronous=NORMAL` を設定する。
+- ファイルログ sink は `enqueue=True` を使い、ログファイル I/O を呼び出しスレッドから分離する。
+
+## Consequences
+
+通常の Provider Batch result 保存では 100 枚規模でも commit は chunk 数まで減る。
+
+失敗時は chunk rollback 後に per-image retry するため、失敗 chunk だけは従来相当の commit 数に戻る。
+これはエラー局所化と既存 UI/API の保存件数 reporting を優先するための意図的な tradeoff である。
+
+WAL は `-wal` / `-shm` サイドカーファイルを作る。SQLite が WAL を利用できない環境では PRAGMA
+設定失敗を warning に留め、DB 初期化自体は継続する。

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -45,6 +45,7 @@ LoRAIro の重要な設計判断を記録するドキュメント群。
 | [0039](0039-agent-pr-maintenance-automation.md) | Agent PR Maintenance Automation | 2026-05-25 | Accepted |
 | [0040](0040-local-ml-model-config-ownership.md) | Local ML Model Config Ownership | 2026-05-24 | Accepted |
 | [0041](0041-provider-batch-execution-ui-unification.md) | Provider Batch 実行 UI の個別実行フロー統一 | 2026-05-29 | Accepted |
+| [0042](0042-batch-annotation-db-save-io.md) | Batch Annotation DB Save I/O | 2026-05-30 | Accepted |
 
 ## ADR テンプレート
 

--- a/src/lorairo/database/db_core.py
+++ b/src/lorairo/database/db_core.py
@@ -310,14 +310,22 @@ def create_db_engine(database_url: str | None = None) -> Engine:
     # リスナー関数をエンジン作成時に動的に定義・登録する
 
     @event.listens_for(engine, "connect")
-    def enable_foreign_keys_listener(dbapi_connection: Any, connection_record: Any) -> None:
-        """SQLite の外部キー制約を有効にします。"""
+    def configure_sqlite_listener(dbapi_connection: Any, connection_record: Any) -> None:
+        """SQLite の外部キー制約と低 I/O 向け PRAGMA を設定します。"""
+        if engine.url.get_backend_name() != "sqlite":
+            return
+
         cursor = dbapi_connection.cursor()
         try:
             cursor.execute("PRAGMA foreign_keys=ON")
             logger.debug("PRAGMA foreign_keys=ON executed.")
+            cursor.execute("PRAGMA journal_mode=WAL")
+            journal_mode = cursor.fetchone()
+            logger.debug(f"PRAGMA journal_mode=WAL executed: {journal_mode}")
+            cursor.execute("PRAGMA synchronous=NORMAL")
+            logger.debug("PRAGMA synchronous=NORMAL executed.")
         except Exception:
-            logger.error("Failed to enable foreign keys", exc_info=True)
+            logger.warning("Failed to configure SQLite PRAGMA settings", exc_info=True)
         finally:
             cursor.close()
 

--- a/src/lorairo/database/repository/annotation_record.py
+++ b/src/lorairo/database/repository/annotation_record.py
@@ -39,6 +39,8 @@ genai-tag-db-tools (外部 tag_db) 統合を本 Repository に集約する。
 
 from __future__ import annotations
 
+from collections.abc import Sequence
+from dataclasses import dataclass
 from typing import Any, cast
 
 from genai_tag_db_tools import search_tags
@@ -69,6 +71,16 @@ from ..schema import (
 )
 from .base import BaseRepository
 from .model import ModelRepository
+
+
+@dataclass(frozen=True, slots=True)
+class AnnotationSaveItem:
+    """1画像分の annotation 保存入力。"""
+
+    image_id: int
+    annotations: AnnotationsDict
+    skip_existence_check: bool = False
+    tag_id_cache: dict[str, int | None] | None = None
 
 
 class AnnotationRepository(BaseRepository):
@@ -177,30 +189,15 @@ class AnnotationRepository(BaseRepository):
             SQLAlchemyError: データベース操作でエラーが発生した場合。
 
         """
+        item = AnnotationSaveItem(
+            image_id=image_id,
+            annotations=annotations,
+            skip_existence_check=skip_existence_check,
+            tag_id_cache=tag_id_cache,
+        )
         with self.session_factory() as session:
             try:
-                # ADR 0035 段階 5: cross-repo 呼び出しを避けるため、Image 存在チェックを
-                # 同一 session 内で inline 実行する (本 Repository は Annotation 担当だが、
-                # 親 Image の存在は前提条件のため query は必要)。
-                if not skip_existence_check:
-                    exists = session.execute(
-                        select(Image.id).where(Image.id == image_id)
-                    ).scalar_one_or_none()
-                    if exists is None:
-                        raise ValueError(f"指定された画像ID {image_id} は存在しません。")
-
-                # 各アノテーションタイプを処理
-                if annotations.get("tags"):
-                    self._save_tags(session, image_id, annotations["tags"], tag_id_cache=tag_id_cache)
-                if annotations.get("captions"):
-                    self._save_captions(session, image_id, annotations["captions"])
-                if annotations.get("scores"):
-                    self._save_scores(session, image_id, annotations["scores"])
-                if annotations.get("score_labels"):
-                    self._save_score_labels(session, image_id, annotations["score_labels"])
-                if annotations.get("ratings"):
-                    self._save_ratings(session, image_id, annotations["ratings"])
-
+                self._save_annotations_in_session(session, item)
                 session.commit()
                 logger.debug(f"画像ID {image_id} のアノテーションを保存・更新しました。")
 
@@ -211,6 +208,72 @@ class AnnotationRepository(BaseRepository):
                     exc_info=True,
                 )
                 raise
+
+    def save_annotations_batch(
+        self,
+        items: Sequence[AnnotationSaveItem],
+        *,
+        chunk_size: int | None = None,
+    ) -> int:
+        """複数画像の annotation をチャンク単位の単一トランザクションで保存する。
+
+        チャンク内は all-or-nothing。呼び出し側は例外時にチャンクを per-image
+        fallback することで、従来の部分成功カウントを維持できる。
+        """
+        if not items:
+            return 0
+
+        effective_chunk_size = chunk_size or self.BATCH_CHUNK_SIZE
+        if effective_chunk_size <= 0:
+            effective_chunk_size = len(items)
+
+        saved_count = 0
+        for start in range(0, len(items), effective_chunk_size):
+            chunk = items[start : start + effective_chunk_size]
+            with self.session_factory() as session:
+                try:
+                    for item in chunk:
+                        self._save_annotations_in_session(session, item)
+                    session.commit()
+                    saved_count += len(chunk)
+                    logger.debug(
+                        f"アノテーションをバッチ保存しました: "
+                        f"chunk={start // effective_chunk_size + 1}, saved={len(chunk)}"
+                    )
+                except Exception as e:
+                    session.rollback()
+                    logger.error(
+                        f"アノテーションのバッチ保存に失敗しました: chunk_start={start}, "
+                        f"chunk_size={len(chunk)}, error={e}",
+                        exc_info=True,
+                    )
+                    raise
+
+        return saved_count
+
+    def _save_annotations_in_session(self, session: Session, item: AnnotationSaveItem) -> None:
+        """既存 session 内で1画像分の annotation を保存する（commitしない）。"""
+        image_id = item.image_id
+        annotations = item.annotations
+        # ADR 0035 段階 5: cross-repo 呼び出しを避けるため、Image 存在チェックを
+        # 同一 session 内で inline 実行する (本 Repository は Annotation 担当だが、
+        # 親 Image の存在は前提条件のため query は必要)。
+        if not item.skip_existence_check:
+            exists = session.execute(select(Image.id).where(Image.id == image_id)).scalar_one_or_none()
+            if exists is None:
+                raise ValueError(f"指定された画像ID {image_id} は存在しません。")
+
+        # 各アノテーションタイプを処理
+        if annotations.get("tags"):
+            self._save_tags(session, image_id, annotations["tags"], tag_id_cache=item.tag_id_cache)
+        if annotations.get("captions"):
+            self._save_captions(session, image_id, annotations["captions"])
+        if annotations.get("scores"):
+            self._save_scores(session, image_id, annotations["scores"])
+        if annotations.get("score_labels"):
+            self._save_score_labels(session, image_id, annotations["score_labels"])
+        if annotations.get("ratings"):
+            self._save_ratings(session, image_id, annotations["ratings"])
 
     @staticmethod
     def _build_existing_tags_map(session: Session, image_ids: list[int]) -> dict[int, set[str]]:

--- a/src/lorairo/database/repository/annotation_record.py
+++ b/src/lorairo/database/repository/annotation_record.py
@@ -234,6 +234,9 @@ class AnnotationRepository(BaseRepository):
                 try:
                     for item in chunk:
                         self._save_annotations_in_session(session, item)
+                        # autoflush=False のため、同一 chunk 内で同じ image_id が再登場した場合も
+                        # 後続 item の upsert query が先行 item の行を参照できるよう明示 flush する。
+                        session.flush()
                     session.commit()
                     saved_count += len(chunk)
                     logger.debug(

--- a/src/lorairo/services/annotation_save_service.py
+++ b/src/lorairo/services/annotation_save_service.py
@@ -6,11 +6,11 @@ CLI・GUI・API の3経路で共有する Qt-free サービス。
 
 from __future__ import annotations
 
-from collections.abc import Mapping
+from collections.abc import Callable, Iterator, Mapping, Sequence
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
-from lorairo.database.repository.annotation_record import AnnotationRepository
+from lorairo.database.repository.annotation_record import AnnotationRepository, AnnotationSaveItem
 from lorairo.database.repository.error_record import ErrorRecordRepository
 from lorairo.database.repository.image import ImageRepository
 from lorairo.database.repository.model import ModelRepository
@@ -43,6 +43,13 @@ class AnnotationSaveResult:
 @dataclass(frozen=True)
 class _ModelRef:
     id: int
+
+
+@dataclass(frozen=True)
+class _PreparedAnnotationSave:
+    source_key: str
+    image_id: int
+    annotations: AnnotationsDict
 
 
 class AnnotationSaveService:
@@ -476,6 +483,71 @@ class AnnotationSaveService:
         logger.debug(f"画像ID {image_id} のアノテーション保存成功")
         return True
 
+    def _annotation_save_chunk_size(self) -> int:
+        chunk_size = getattr(self._annotation_repo, "BATCH_CHUNK_SIZE", 15000)
+        return chunk_size if isinstance(chunk_size, int) and chunk_size > 0 else 15000
+
+    @staticmethod
+    def _iter_chunks(
+        items: Sequence[_PreparedAnnotationSave], chunk_size: int
+    ) -> Iterator[Sequence[_PreparedAnnotationSave]]:
+        for start in range(0, len(items), chunk_size):
+            yield items[start : start + chunk_size]
+
+    def _save_prepared_batch(
+        self,
+        prepared_items: Sequence[_PreparedAnnotationSave],
+        *,
+        tag_id_cache: dict[str, int | None],
+        error_message: Callable[[_PreparedAnnotationSave, Exception], str],
+        log_message: Callable[[_PreparedAnnotationSave, Exception], str],
+    ) -> tuple[int, int, list[str]]:
+        """準備済み annotation を chunked batch 保存し、失敗 chunk は per-image retry する。"""
+        if not prepared_items:
+            return (0, 0, [])
+
+        success_count = 0
+        error_count = 0
+        error_details: list[str] = []
+        chunk_size = self._annotation_save_chunk_size()
+
+        for chunk in self._iter_chunks(prepared_items, chunk_size):
+            repo_items = [
+                AnnotationSaveItem(
+                    image_id=item.image_id,
+                    annotations=item.annotations,
+                    skip_existence_check=True,
+                    tag_id_cache=tag_id_cache if tag_id_cache else None,
+                )
+                for item in chunk
+            ]
+            try:
+                self._annotation_repo.save_annotations_batch(repo_items, chunk_size=len(repo_items))
+                success_count += len(repo_items)
+                continue
+            except Exception as e:
+                logger.warning(
+                    f"バッチDB保存に失敗しました。per-image fallbackへ切り替えます: "
+                    f"chunk_size={len(repo_items)}, error={e}"
+                )
+
+            for item in chunk:
+                try:
+                    self._annotation_repo.save_annotations(
+                        item.image_id,
+                        item.annotations,
+                        skip_existence_check=True,
+                        tag_id_cache=tag_id_cache if tag_id_cache else None,
+                    )
+                    success_count += 1
+                except Exception as e:
+                    error_msg = error_message(item, e)
+                    error_details.append(error_msg)
+                    error_count += 1
+                    logger.error(log_message(item, e), exc_info=True)
+
+        return (success_count, error_count, error_details)
+
     def save_annotation_results(self, results: Any) -> AnnotationSaveResult:
         """アノテーション結果をDBに保存する。
 
@@ -505,24 +577,49 @@ class AnnotationSaveService:
         models_cache = self._model_repo.get_models_by_litellm_ids(all_model_names)
         tag_id_cache = self._resolve_tag_ids(all_raw_tags)
 
-        success_count = 0
         skip_count = 0
         error_count = 0
         error_details: list[str] = []
+        prepared_items: list[_PreparedAnnotationSave] = []
 
         for phash, phash_annotations in results.items():
             try:
-                if self._save_single(
-                    phash, phash_annotations, phash_to_image_id, models_cache, tag_id_cache
-                ):
-                    success_count += 1
-                else:
+                image_id = phash_to_image_id.get(phash)
+                if image_id is None:
+                    logger.warning(
+                        f"pHash {phash[:8]}... に対応する画像がDBに見つかりません。スキップします。"
+                    )
                     skip_count += 1
+                    continue
+
+                annotations_dict = self._build_annotations_dict(
+                    phash_annotations, models_cache, image_id=image_id
+                )
+
+                if not annotations_dict or not any(annotations_dict.values()):
+                    logger.debug(f"画像ID {image_id} に保存するアノテーションがありません")
+                    skip_count += 1
+                    continue
+
+                prepared_items.append(
+                    _PreparedAnnotationSave(
+                        source_key=str(phash), image_id=image_id, annotations=annotations_dict
+                    )
+                )
             except Exception as e:
                 error_msg = f"phash={phash[:8]}...: {e}"
                 error_details.append(error_msg)
                 error_count += 1
                 logger.error(f"保存失敗 phash={phash[:8]}...: {e}", exc_info=True)
+
+        success_count, batch_error_count, batch_error_details = self._save_prepared_batch(
+            prepared_items,
+            tag_id_cache=tag_id_cache,
+            error_message=lambda item, e: f"phash={item.source_key[:8]}...: {e}",
+            log_message=lambda item, e: f"保存失敗 phash={item.source_key[:8]}...: {e}",
+        )
+        error_count += batch_error_count
+        error_details.extend(batch_error_details)
 
         total_count = len(results)
         logger.info(f"DB保存完了: {success_count}/{total_count}件成功")
@@ -565,10 +662,10 @@ class AnnotationSaveService:
         models_cache: dict[str, Any] = {model_name: _ModelRef(model_id)}
         tag_id_cache = self._resolve_tag_ids(all_raw_tags)
 
-        success_count = 0
         skip_count = 0
         error_count = 0
         error_details: list[str] = []
+        prepared_items: list[_PreparedAnnotationSave] = []
 
         for image_id, image_annotations in wrapped_results.items():
             try:
@@ -581,18 +678,25 @@ class AnnotationSaveService:
                     logger.debug(f"画像ID {image_id} に保存するアノテーションがありません")
                     skip_count += 1
                     continue
-                self._annotation_repo.save_annotations(
-                    image_id,
-                    annotations_dict,
-                    skip_existence_check=True,
-                    tag_id_cache=tag_id_cache if tag_id_cache else None,
+                prepared_items.append(
+                    _PreparedAnnotationSave(
+                        source_key=str(image_id), image_id=image_id, annotations=annotations_dict
+                    )
                 )
-                success_count += 1
             except Exception as e:
                 error_msg = f"image_id={image_id}: {e}"
                 error_details.append(error_msg)
                 error_count += 1
                 logger.error(f"Provider Batch result 保存失敗 image_id={image_id}: {e}", exc_info=True)
+
+        success_count, batch_error_count, batch_error_details = self._save_prepared_batch(
+            prepared_items,
+            tag_id_cache=tag_id_cache,
+            error_message=lambda item, e: f"image_id={item.image_id}: {e}",
+            log_message=lambda item, e: f"Provider Batch result 保存失敗 image_id={item.image_id}: {e}",
+        )
+        error_count += batch_error_count
+        error_details.extend(batch_error_details)
 
         total_count = len(wrapped_results)
         logger.info(f"Provider Batch result DB保存完了: {success_count}/{total_count}件成功")

--- a/src/lorairo/services/batch_import_service.py
+++ b/src/lorairo/services/batch_import_service.py
@@ -9,7 +9,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, cast
 
-from lorairo.database.repository.annotation_record import AnnotationRepository
+from lorairo.database.repository.annotation_record import AnnotationRepository, AnnotationSaveItem
 from lorairo.database.repository.image import ImageRepository
 from lorairo.database.repository.model import ModelRepository
 from lorairo.database.schema import AnnotationsDict, CaptionAnnotationData, TagAnnotationData
@@ -45,6 +45,13 @@ class BatchImportResult:
     model_name: str = ""
     unmatched_ids: list[str] = field(default_factory=list)
     error_details: list[str] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class _PreparedBatchImportSave:
+    custom_id: str
+    image_id: int
+    annotations: AnnotationsDict
 
 
 class BatchImportService:
@@ -208,23 +215,31 @@ class BatchImportService:
         tag_id_cache = self._annotation_repository.batch_resolve_tag_ids(all_tags)
 
         # 6. DB保存
-        saved = 0
+        prepared_saves: list[_PreparedBatchImportSave] = []
         save_errors = 0
         for custom_id, image_id in match_result.matched.items():
             parsed_content = parsed[custom_id]
             try:
                 annotations = self._build_annotations(parsed_content, model_id)
-                self._annotation_repository.save_annotations(
-                    image_id,
-                    annotations,
-                    skip_existence_check=True,
-                    tag_id_cache=tag_id_cache,
-                )
-                saved += 1
             except Exception as e:
                 save_errors += 1
                 error_details.append(f"保存エラー [{custom_id}] image_id={image_id}: {e}")
                 logger.debug(f"保存エラー [{custom_id}]: {e}")
+                continue
+            prepared_saves.append(
+                _PreparedBatchImportSave(
+                    custom_id=custom_id,
+                    image_id=image_id,
+                    annotations=annotations,
+                )
+            )
+
+        saved, batch_save_errors, save_error_details = self._save_prepared_annotations(
+            prepared_saves,
+            tag_id_cache=tag_id_cache,
+        )
+        save_errors += batch_save_errors
+        error_details.extend(save_error_details)
 
         logger.info(
             f"JSONL処理完了: {jsonl_path.name} - "
@@ -244,6 +259,64 @@ class BatchImportService:
             unmatched_ids=match_result.unmatched,
             error_details=error_details,
         )
+
+    def _annotation_save_chunk_size(self) -> int:
+        chunk_size = getattr(self._annotation_repository, "BATCH_CHUNK_SIZE", 15000)
+        return chunk_size if isinstance(chunk_size, int) and chunk_size > 0 else 15000
+
+    def _save_prepared_annotations(
+        self,
+        prepared_saves: list[_PreparedBatchImportSave],
+        *,
+        tag_id_cache: dict[str, int | None],
+    ) -> tuple[int, int, list[str]]:
+        if not prepared_saves:
+            return (0, 0, [])
+
+        saved = 0
+        save_errors = 0
+        error_details: list[str] = []
+        chunk_size = self._annotation_save_chunk_size()
+
+        for start in range(0, len(prepared_saves), chunk_size):
+            chunk = prepared_saves[start : start + chunk_size]
+            repo_items = [
+                AnnotationSaveItem(
+                    image_id=item.image_id,
+                    annotations=item.annotations,
+                    skip_existence_check=True,
+                    tag_id_cache=tag_id_cache,
+                )
+                for item in chunk
+            ]
+            try:
+                self._annotation_repository.save_annotations_batch(
+                    repo_items,
+                    chunk_size=len(repo_items),
+                )
+                saved += len(repo_items)
+                continue
+            except Exception as e:
+                logger.warning(
+                    f"バッチインポートDB保存に失敗しました。per-image fallbackへ切り替えます: "
+                    f"chunk_size={len(repo_items)}, error={e}"
+                )
+
+            for item in chunk:
+                try:
+                    self._annotation_repository.save_annotations(
+                        item.image_id,
+                        item.annotations,
+                        skip_existence_check=True,
+                        tag_id_cache=tag_id_cache,
+                    )
+                    saved += 1
+                except Exception as e:
+                    save_errors += 1
+                    error_details.append(f"保存エラー [{item.custom_id}] image_id={item.image_id}: {e}")
+                    logger.debug(f"保存エラー [{item.custom_id}]: {e}")
+
+        return (saved, save_errors, error_details)
 
     def _parse_jsonl_file(self, jsonl_path: Path) -> tuple[dict[str, str], str | None]:
         """JSONLファイルを読み込み、{custom_id: content} とモデル名を返す。

--- a/src/lorairo/utils/log.py
+++ b/src/lorairo/utils/log.py
@@ -164,6 +164,7 @@ def initialize_logging(log_config: dict[str, Any]) -> None:
                 rotation=rotation,  # ログローテーション設定
                 retention=5,  # 保持するローテーション済みログファイルの数
                 encoding="utf-8",
+                enqueue=True,  # ファイルI/Oを呼び出しスレッドから分離する
                 backtrace=True,  # 例外発生時のトレースバックを強化
                 diagnose=True,  # 例外発生時に変数情報を表示
             )

--- a/tests/bdd/steps/test_logging.py
+++ b/tests/bdd/steps/test_logging.py
@@ -129,6 +129,7 @@ def then_console_not_contains_message(console_capture: io.StringIO, level: str, 
 def then_logfile_contains_message(log_config: dict, level: str, message: str) -> None:
     log_path = Path(log_config["file_path"])
     assert log_path.exists(), f"ログファイルが存在しません: {log_path}"
+    logger.complete()
     content = log_path.read_text(encoding="utf-8")
     assert message in content, (
         f"メッセージ '{message}' がログファイルに見つかりません。\nファイル内容:\n{content}"
@@ -141,6 +142,7 @@ def then_logfile_not_contains_message(log_config: dict, level: str, message: str
     if not log_path.exists():
         # ファイルが存在しなければ当然含まれない
         return
+    logger.complete()
     content = log_path.read_text(encoding="utf-8")
     assert message not in content, (
         f"メッセージ '{message}' がログファイルに存在すべきではありません。\nファイル内容:\n{content}"
@@ -221,6 +223,7 @@ def then_console_contains_traceback(console_capture: io.StringIO, exception_type
 def then_logfile_contains_error(log_config: dict, message: str) -> None:
     log_path = Path(log_config["file_path"])
     assert log_path.exists(), f"ログファイルが存在しません: {log_path}"
+    logger.complete()
     content = log_path.read_text(encoding="utf-8")
     assert message in content, (
         f"エラーメッセージ '{message}' がログファイルに見つかりません。\nファイル内容:\n{content}"
@@ -231,6 +234,7 @@ def then_logfile_contains_error(log_config: dict, message: str) -> None:
 def then_logfile_contains_traceback(log_config: dict, exception_type: str) -> None:
     log_path = Path(log_config["file_path"])
     assert log_path.exists(), f"ログファイルが存在しません: {log_path}"
+    logger.complete()
     content = log_path.read_text(encoding="utf-8")
     assert exception_type in content, (
         f"'{exception_type}' のトレースバックがログファイルに見つかりません。\nファイル内容:\n{content}"

--- a/tests/unit/database/repository/test_annotation_record_repository.py
+++ b/tests/unit/database/repository/test_annotation_record_repository.py
@@ -262,6 +262,31 @@ class TestSaveAnnotations:
             rows = session.execute(select(Tag).where(Tag.image_id == image_id)).scalars().all()
             assert rows == []
 
+    def test_save_annotations_batch_flushes_duplicate_image_id_within_chunk(
+        self,
+        annotation_repository: AnnotationRepository,
+        image_id: int,
+        memory_session_factory,
+    ) -> None:
+        """同一chunk内の同じ image_id は先行itemを参照して upsert する。"""
+        annotation_repository.save_annotations_batch(
+            [
+                AnnotationSaveItem(
+                    image_id=image_id,
+                    annotations={"tags": [{"tag": "cat", "model_id": None, "tag_id": None}]},
+                ),
+                AnnotationSaveItem(
+                    image_id=image_id,
+                    annotations={"tags": [{"tag": "cat", "model_id": None, "tag_id": None}]},
+                ),
+            ]
+        )
+
+        with memory_session_factory() as session:
+            rows = session.execute(select(Tag).where(Tag.image_id == image_id)).scalars().all()
+            assert len(rows) == 1
+            assert rows[0].tag == "cat"
+
 
 @pytest.mark.unit
 class TestSaveTagsAndCaptions:

--- a/tests/unit/database/repository/test_annotation_record_repository.py
+++ b/tests/unit/database/repository/test_annotation_record_repository.py
@@ -29,7 +29,7 @@ from sqlalchemy import create_engine, select
 from sqlalchemy.orm import sessionmaker
 
 from lorairo.database.db_manager import ImageDatabaseManager
-from lorairo.database.repository.annotation_record import AnnotationRepository
+from lorairo.database.repository.annotation_record import AnnotationRepository, AnnotationSaveItem
 from lorairo.database.repository.base import BaseRepository
 from lorairo.database.schema import (
     MANUAL_EDIT_LITELLM_ID,
@@ -178,6 +178,89 @@ class TestSaveAnnotations:
             rows = session.execute(select(Tag).where(Tag.image_id == image_id)).scalars().all()
             assert len(rows) == 1
             assert rows[0].tag == "cat"
+
+    def test_save_annotations_batch_commits_once_for_multiple_images(
+        self,
+        memory_session_factory,
+    ) -> None:
+        """複数画像の annotation を1 transactionで保存する。"""
+        image_ids: list[int] = []
+        with memory_session_factory() as session:
+            for index in range(2):
+                image = Image(
+                    uuid=f"batch-anno-test-uuid-{index}",
+                    phash=f"batch-anno-test-phash-{index}",
+                    original_image_path=f"/tmp/batch-anno-{index}.png",
+                    stored_image_path=f"/tmp/batch-anno-{index}.png",
+                    width=64,
+                    height=64,
+                    format="PNG",
+                    extension=".png",
+                    filename=f"batch-anno-{index}.png",
+                )
+                session.add(image)
+                session.flush()
+                image_ids.append(image.id)
+            session.commit()
+
+        commit_count = 0
+
+        def counting_session_factory():
+            nonlocal commit_count
+            session = memory_session_factory()
+            original_commit = session.commit
+
+            def commit() -> None:
+                nonlocal commit_count
+                commit_count += 1
+                original_commit()
+
+            session.commit = commit  # type: ignore[method-assign]
+            return session
+
+        repository = AnnotationRepository(session_factory=counting_session_factory)
+        saved = repository.save_annotations_batch(
+            [
+                AnnotationSaveItem(
+                    image_id=image_ids[0],
+                    annotations={"tags": [{"tag": "cat", "model_id": None, "tag_id": None}]},
+                ),
+                AnnotationSaveItem(
+                    image_id=image_ids[1],
+                    annotations={"tags": [{"tag": "dog", "model_id": None, "tag_id": None}]},
+                ),
+            ]
+        )
+
+        assert saved == 2
+        assert commit_count == 1
+        with memory_session_factory() as session:
+            rows = session.execute(select(Tag).where(Tag.image_id.in_(image_ids))).scalars().all()
+            assert {row.tag for row in rows} == {"cat", "dog"}
+
+    def test_save_annotations_batch_rolls_back_chunk_on_failure(
+        self,
+        annotation_repository: AnnotationRepository,
+        image_id: int,
+        memory_session_factory,
+    ) -> None:
+        """chunk内の失敗時は同じ transaction の書き込みを rollback する。"""
+        with pytest.raises(ValueError, match="指定された画像ID 99999 は存在しません"):
+            annotation_repository.save_annotations_batch(
+                [
+                    AnnotationSaveItem(
+                        image_id=image_id,
+                        annotations={"tags": [{"tag": "cat", "model_id": None, "tag_id": None}]},
+                    ),
+                    AnnotationSaveItem(
+                        image_id=99999,
+                        annotations={"tags": [{"tag": "dog", "model_id": None, "tag_id": None}]},
+                    ),
+                ]
+            )
+        with memory_session_factory() as session:
+            rows = session.execute(select(Tag).where(Tag.image_id == image_id)).scalars().all()
+            assert rows == []
 
 
 @pytest.mark.unit

--- a/tests/unit/database/test_db_core_sqlite_pragmas.py
+++ b/tests/unit/database/test_db_core_sqlite_pragmas.py
@@ -1,0 +1,28 @@
+"""SQLite engine PRAGMA 設定のテスト。"""
+
+from sqlalchemy import text
+
+from lorairo.database.db_core import create_db_engine
+
+
+def test_create_db_engine_sets_file_sqlite_wal_and_normal(tmp_path) -> None:
+    db_path = tmp_path / "pragma-test.sqlite"
+    engine = create_db_engine(f"sqlite:///{db_path}?check_same_thread=False")
+
+    with engine.connect() as connection:
+        journal_mode = connection.execute(text("PRAGMA journal_mode")).scalar_one()
+        synchronous = connection.execute(text("PRAGMA synchronous")).scalar_one()
+        foreign_keys = connection.execute(text("PRAGMA foreign_keys")).scalar_one()
+
+    assert journal_mode == "wal"
+    assert synchronous == 1
+    assert foreign_keys == 1
+
+
+def test_create_db_engine_keeps_memory_sqlite_usable() -> None:
+    engine = create_db_engine("sqlite:///:memory:")
+
+    with engine.connect() as connection:
+        result = connection.execute(text("SELECT 1")).scalar_one()
+
+    assert result == 1

--- a/tests/unit/services/test_annotation_save_service.py
+++ b/tests/unit/services/test_annotation_save_service.py
@@ -61,6 +61,11 @@ def _make_success_result(
     return result
 
 
+def _first_batch_save_args(mock_repository: MagicMock) -> tuple[int, dict]:
+    item = mock_repository.save_annotations_batch.call_args[0][0][0]
+    return item.image_id, item.annotations
+
+
 @pytest.mark.unit
 def test_save_annotation_results_with_empty_results_returns_zeros(
     service: AnnotationSaveService,
@@ -99,7 +104,9 @@ def test_save_annotation_results_with_known_phashes_saves_all(
     assert result.skip_count == 0
     assert result.error_count == 0
     assert result.total_count == 2
-    assert mock_repository.save_annotations.call_count == 2
+    mock_repository.save_annotations_batch.assert_called_once()
+    assert len(mock_repository.save_annotations_batch.call_args[0][0]) == 2
+    mock_repository.save_annotations.assert_not_called()
 
 
 @pytest.mark.unit
@@ -121,10 +128,10 @@ def test_save_provider_batch_results_by_image_id_saves_without_phash_lookup(
     assert result.error_count == 0
     mock_repository.find_image_ids_by_phashes.assert_not_called()
     mock_repository.get_models_by_litellm_ids.assert_not_called()
-    mock_repository.save_annotations.assert_called_once()
-    image_id_arg = mock_repository.save_annotations.call_args[0][0]
-    annotations_arg = mock_repository.save_annotations.call_args[0][1]
-    assert image_id_arg == 7
+    mock_repository.save_annotations_batch.assert_called_once()
+    item = mock_repository.save_annotations_batch.call_args[0][0][0]
+    annotations_arg = item.annotations
+    assert item.image_id == 7
     assert annotations_arg["tags"][0]["model_id"] == 10
     assert annotations_arg["tags"][0]["tag"] == "tag1"
     assert annotations_arg["captions"][0]["caption"] == "caption"
@@ -211,8 +218,9 @@ def test_save_annotation_results_excludes_legacy_sentinel_from_lookup(
     assert result.error_count == 0
     assert result.total_count == 1
     mock_repository.get_models_by_litellm_ids.assert_called_once_with({"wdtagger"})
-    mock_repository.save_annotations.assert_called_once()
-    annotations_dict = mock_repository.save_annotations.call_args[0][1]
+    mock_repository.save_annotations_batch.assert_called_once()
+    image_id_arg, annotations_dict = _first_batch_save_args(mock_repository)
+    assert image_id_arg == 1
     assert annotations_dict["tags"] == [
         {
             "model_id": 10,
@@ -257,6 +265,7 @@ def test_save_annotation_results_handles_partial_save_failure(
     mock_model.id = 1
     mock_repository.find_image_ids_by_phashes.return_value = {"phash001": 1}
     mock_repository.get_models_by_litellm_ids.return_value = {"wdtagger": mock_model}
+    mock_repository.save_annotations_batch.side_effect = RuntimeError("batch DB write error")
     mock_repository.save_annotations.side_effect = RuntimeError("DB write error")
 
     results = {
@@ -352,10 +361,9 @@ def test_save_canonical_scorer_persists_score_labels(
 
     service.save_annotation_results(results)
 
-    # save_annotations 呼び出し時の annotations dict に score_labels が積まれている
-    assert mock_repository.save_annotations.called
-    image_id_arg = mock_repository.save_annotations.call_args[0][0]
-    annotations_arg = mock_repository.save_annotations.call_args[0][1]
+    # save_annotations_batch 呼び出し時の annotations dict に score_labels が積まれている
+    assert mock_repository.save_annotations_batch.called
+    image_id_arg, annotations_arg = _first_batch_save_args(mock_repository)
     assert image_id_arg == 1
     assert annotations_arg["score_labels"] == [
         {"model_id": 42, "label": "very aesthetic", "is_edited_manually": False}
@@ -389,7 +397,7 @@ def test_save_regression_scorer_no_score_labels(
 
     service.save_annotation_results(results)
 
-    annotations_arg = mock_repository.save_annotations.call_args[0][1]
+    _image_id_arg, annotations_arg = _first_batch_save_args(mock_repository)
     assert annotations_arg["score_labels"] == []
     assert annotations_arg["scores"] == [{"model_id": 7, "score": 7.5, "is_edited_manually": False}]
 
@@ -416,7 +424,7 @@ def test_save_multiple_labels_per_model(
 
     service.save_annotation_results(results)
 
-    annotations_arg = mock_repository.save_annotations.call_args[0][1]
+    _image_id_arg, annotations_arg = _first_batch_save_args(mock_repository)
     assert annotations_arg["score_labels"] == [
         {"model_id": 99, "label": "aesthetic", "is_edited_manually": False},
         {"model_id": 99, "label": "high_quality", "is_edited_manually": False},
@@ -561,7 +569,7 @@ def test_save_annotation_results_persists_mapped_rating(
 
     service.save_annotation_results(results)
 
-    annotations_arg = mock_repository.save_annotations.call_args[0][1]
+    _image_id_arg, annotations_arg = _first_batch_save_args(mock_repository)
     assert annotations_arg["ratings"] == [
         {
             "model_id": 42,

--- a/tests/unit/services/test_batch_import_service.py
+++ b/tests/unit/services/test_batch_import_service.py
@@ -102,7 +102,9 @@ class TestBatchImportServiceSingleFile:
         assert result.saved == 2
         assert result.save_errors == 0
         assert result.model_name == "gpt-4-turbo-2024-04-09"
-        assert mock_repository.save_annotations.call_count == 2
+        mock_repository.save_annotations_batch.assert_called_once()
+        assert len(mock_repository.save_annotations_batch.call_args[0][0]) == 2
+        mock_repository.save_annotations.assert_not_called()
 
     def test_dry_run_no_save(self, tmp_path: Path, mock_repository: MagicMock) -> None:
         """dry-runモードではsave_annotationsが呼ばれない。"""
@@ -180,6 +182,7 @@ class TestBatchImportServiceSingleFile:
 
     def test_save_error_counted(self, tmp_path: Path, mock_repository: MagicMock) -> None:
         """save_annotationsのエラーがカウントされる。"""
+        mock_repository.save_annotations_batch.side_effect = Exception("batch DB error")
         mock_repository.save_annotations.side_effect = Exception("DB error")
         records = [
             _make_batch_record("0262_1227", "Tags: 1girl\n\nCaption: text"),


### PR DESCRIPTION
## Summary
- Add chunked batch annotation persistence to reduce per-image SQLite commits during annotation result saves
- Route AnnotationSaveService and BatchImportService through the batch path with per-image fallback for failed chunks
- Configure SQLite WAL/NORMAL PRAGMAs and async file logging to reduce DB/log I/O pressure
- Record the design in ADR 0042

Closes #568

## Verification
- UV_CACHE_DIR=/tmp/uv-cache UV_PROJECT_ENVIRONMENT=/workspaces/LoRAIro/.venv uv run ruff check src/lorairo/database/repository/annotation_record.py src/lorairo/services/annotation_save_service.py src/lorairo/services/batch_import_service.py src/lorairo/database/db_core.py src/lorairo/utils/log.py tests/unit/database/repository/test_annotation_record_repository.py tests/unit/services/test_annotation_save_service.py tests/unit/services/test_batch_import_service.py tests/unit/database/test_db_core_sqlite_pragmas.py
- UV_CACHE_DIR=/tmp/uv-cache UV_PROJECT_ENVIRONMENT=/workspaces/LoRAIro/.venv uv run ruff format --check src/lorairo/database/repository/annotation_record.py src/lorairo/services/annotation_save_service.py src/lorairo/services/batch_import_service.py src/lorairo/database/db_core.py src/lorairo/utils/log.py tests/unit/database/repository/test_annotation_record_repository.py tests/unit/services/test_annotation_save_service.py tests/unit/services/test_batch_import_service.py tests/unit/database/test_db_core_sqlite_pragmas.py
- UV_CACHE_DIR=/tmp/uv-cache UV_PROJECT_ENVIRONMENT=/workspaces/LoRAIro/.venv uv run pytest tests/unit/database/repository/test_annotation_record_repository.py tests/unit/services/test_annotation_save_service.py tests/unit/services/test_batch_import_service.py tests/unit/database/test_db_core_sqlite_pragmas.py -q
- UV_CACHE_DIR=/tmp/uv-cache UV_PROJECT_ENVIRONMENT=/workspaces/LoRAIro/.venv uv run pytest tests/integration/test_rating_save_integration.py tests/integration/test_provider_batch_annotation_e2e.py -q