### PR TITLE
fix: unify db_core logging to loguru (#572)

### DIFF
--- a/docs/decisions/0043-db-core-logging-loguru-unification.md
+++ b/docs/decisions/0043-db-core-logging-loguru-unification.md
@@ -1,0 +1,53 @@
+# ADR 0043: db_core Logging Loguru Unification
+
+- **日付**: 2026-05-31
+- **ステータス**: Accepted
+- **関連 Issue**: [NEXTAltair/LoRAIro#572](https://github.com/NEXTAltair/LoRAIro/issues/572)
+- **関連 ADR**: [ADR 0042](0042-batch-annotation-db-save-io.md)
+
+## Context
+
+`db_core.py` だけが loguru ではなく標準 `logging` (`logging.getLogger`) を使っていた。
+`log.py` の `initialize_logging()` には標準 logging → loguru のブリッジ (InterceptHandler 等)
+が無いため、db_core が出すログ (engine 生成・PRAGMA 適用・`get_db_session()` の
+トランザクション失敗 ERROR + traceback) は loguru の file / stderr sink に乗らず、
+`logs/lorairo.log` に一切記録されなかった。
+
+特に問題だったのは:
+
+- `get_db_session()` のトランザクション失敗 `logger.error(..., exc_info=True)` の traceback が
+  ファイルログに残らず、DB 書き込み失敗の事後調査ができない。
+- ADR 0042 (#569) で追加した `PRAGMA journal_mode=WAL` 適用ログをアプリログで確認できない。
+
+加えて調査中に 2 点が判明した:
+
+- loguru の `logger.error(msg, exc_info=True)` は標準 logging 互換の `exc_info` を解釈せず、
+  traceback を出力しない。loguru では `logger.opt(exception=True)` を使う必要がある。
+- db_core の初期化ログは module-level (import 時) で出力されており、これは
+  `initialize_logging()` より前に実行されるため、どのロガーを使っても file sink に乗らない。
+
+## Decision
+
+db_core のログを loguru に統一する。InterceptHandler による標準 logging 全体の集約は採らない。
+
+- `db_core.py` を `from ..utils.log import logger` (loguru) に統一する。
+- `exc_info=True` を渡していた 3 箇所を `logger.opt(exception=True)` に変換する。
+  `LOG_FORMAT` に `{exception}` は **追加しない** — `opt(exception=True)` は format に
+  `{exception}` が無くても traceback を付加し、両方を使うと traceback が二重出力されるため
+  (実機検証で確認)。
+- module-level の初期化ログを `_get_default_session_factory()` の遅延ブロックへ移動し、
+  実際に default DB を準備する (= `initialize_logging()` 後の) タイミングで出力する。
+
+## Consequences
+
+DB 層のログ (engine 生成・PRAGMA 適用・トランザクション失敗 traceback・初期化完了) が
+loguru file sink に乗り、`logs/lorairo.log` に記録される。ADR 0042 の WAL 適用も
+アプリログで確認可能になる。
+
+SQLAlchemy / Alembic 等の外部ライブラリが出す標準 logging ログは依然 loguru に集約されない。
+これらも捕捉したくなった場合は `initialize_logging()` に loguru 公式の InterceptHandler を
+追加する案 (案B) を将来検討する。本 ADR はアプリコード (db_core) の規約統一に限定し、
+YAGNI に従ってライブラリログ集約は見送る。
+
+> 注: `docs/decisions/` には 0042 番台のファイルが複数存在する (索引未登録の番号衝突)。
+> 本 ADR は索引に登録済みの 0042 の次として 0043 を採番した。番号衝突の整理は別タスク。

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -46,6 +46,7 @@ LoRAIro の重要な設計判断を記録するドキュメント群。
 | [0040](0040-local-ml-model-config-ownership.md) | Local ML Model Config Ownership | 2026-05-24 | Accepted |
 | [0041](0041-provider-batch-execution-ui-unification.md) | Provider Batch 実行 UI の個別実行フロー統一 | 2026-05-29 | Accepted |
 | [0042](0042-batch-annotation-db-save-io.md) | Batch Annotation DB Save I/O | 2026-05-30 | Accepted |
+| [0043](0043-db-core-logging-loguru-unification.md) | db_core Logging Loguru Unification | 2026-05-31 | Accepted |
 
 ## ADR テンプレート
 

--- a/src/lorairo/database/db_core.py
+++ b/src/lorairo/database/db_core.py
@@ -358,7 +358,7 @@ def _ensure_model_types_seeded(engine: Engine) -> None:
             return
         session.add_all(missing)
         session.commit()
-        logger.info("Seeded model_types rows: %s", ", ".join(model.name for model in missing))
+        logger.info(f"Seeded model_types rows: {', '.join(model.name for model in missing)}")
 
 
 def _make_alembic_config(project_db_path: Path) -> Any:
@@ -421,17 +421,16 @@ def _prepare_project_database(project_db_path: Path) -> Engine:
         Base.metadata.create_all(engine)
         _ensure_model_types_seeded(engine)
         _stamp_alembic_head(project_db_path)
-        logger.info("Initialized new project DB schema and stamped Alembic head: %s", project_db_path)
+        logger.info(f"Initialized new project DB schema and stamped Alembic head: {project_db_path}")
         return engine
 
     if _has_alembic_version_table(engine):
         _upgrade_alembic_head(project_db_path)
-        logger.info("Applied pending Alembic migrations for project DB: %s", project_db_path)
+        logger.info(f"Applied pending Alembic migrations for project DB: {project_db_path}")
     else:
         logger.warning(
             "Project DB has existing tables but no alembic_version table; "
-            "leaving migration state unchanged: %s",
-            project_db_path,
+            f"leaving migration state unchanged: {project_db_path}"
         )
 
     Base.metadata.create_all(engine)

--- a/src/lorairo/database/db_core.py
+++ b/src/lorairo/database/db_core.py
@@ -5,7 +5,6 @@
 `config/lorairo.toml` から読み込まれます。
 """
 
-import logging
 from collections.abc import Callable, Generator
 from contextlib import contextmanager
 from pathlib import Path
@@ -17,9 +16,7 @@ from sqlalchemy.engine import Engine
 from sqlalchemy.orm import Session, sessionmaker
 
 from ..utils.config import get_config
-
-# Configure logging
-logger = logging.getLogger(__name__)
+from ..utils.log import logger
 
 # --- Configuration --- #
 
@@ -282,7 +279,7 @@ def ensure_tag_db_initialized() -> None:
         _tag_db_initialized = True
         logger.info(f"Tag databases initialized: {len(results)} base DB(s) + user DB at {USER_TAG_DB_PATH}")
     except Exception as e:
-        logger.error(f"Failed to initialize tag databases: {e}.", exc_info=True)
+        logger.opt(exception=True).error(f"Failed to initialize tag databases: {e}.")
         raise RuntimeError("Tag database initialization failed") from e
 
 
@@ -325,7 +322,7 @@ def create_db_engine(database_url: str | None = None) -> Engine:
             cursor.execute("PRAGMA synchronous=NORMAL")
             logger.debug("PRAGMA synchronous=NORMAL executed.")
         except Exception:
-            logger.warning("Failed to configure SQLite PRAGMA settings", exc_info=True)
+            logger.opt(exception=True).warning("Failed to configure SQLite PRAGMA settings")
         finally:
             cursor.close()
 
@@ -462,7 +459,6 @@ def create_project_session_factory(project_db_path: Path) -> sessionmaker[Sessio
 # 通常のアプリケーション実行時に使用される
 default_engine: Engine | None = None
 _default_session_factory: sessionmaker[Session] | None = None
-logger.info(f"Default database core initialized. Image DB: {IMG_DB_PATH} (Tag DB managed via public API)")
 
 
 def _get_default_session_factory() -> sessionmaker[Session]:
@@ -475,6 +471,11 @@ def _get_default_session_factory() -> sessionmaker[Session]:
         DATABASE_URL = f"sqlite:///{IMG_DB_PATH.resolve()}?check_same_thread=False"
         default_engine = _prepare_project_database(IMG_DB_PATH)
         _default_session_factory = create_session_factory(default_engine)
+        # 初期化ログは import 時 (= initialize_logging 前) ではなく、実際に default DB を
+        # 準備したこのタイミングで出力する。これにより loguru file sink に確実に乗る (#572)。
+        logger.info(
+            f"データベースコアが初期化されました。画像DB: {IMG_DB_PATH} (タグDBは公開API経由で管理)"
+        )
     return _default_session_factory
 
 
@@ -505,14 +506,9 @@ def get_db_session(
         # logger.debug(f"Committing DB session {id(db)}.")
         db.commit()
     except Exception:
-        logger.error(f"Transaction failed in DB session {id(db)}. Rolling back.", exc_info=True)
+        logger.opt(exception=True).error(f"Transaction failed in DB session {id(db)}. Rolling back.")
         db.rollback()
         raise  # 例外を再発生させて上位に伝播
     finally:
         # logger.debug(f"Closing DB session {id(db)}.")
         db.close()
-
-
-# --- 初期化ログ ---
-
-logger.info(f"データベースコアが初期化されました。画像DB: {IMG_DB_PATH} (タグDBは公開API経由で管理)")

--- a/tests/unit/database/test_db_core_logging.py
+++ b/tests/unit/database/test_db_core_logging.py
@@ -1,0 +1,99 @@
+"""db_core のログが loguru sink に捕捉されることを検証する (Issue #572)。
+
+db_core.py が標準 ``logging`` を使っていると、これらのログは loguru の
+file/stderr sink に乗らず ``logs/lorairo.log`` に記録されない。本テストは
+db_core が loguru logger を使い、DB 層のログ (engine 生成・PRAGMA 適用・
+トランザクション失敗 ERROR) が loguru sink に捕捉されることを保証する。
+"""
+
+import io
+from collections.abc import Iterator
+
+import pytest
+from loguru import logger
+
+from lorairo.database.db_core import (
+    create_db_engine,
+    create_session_factory,
+    get_db_session,
+)
+
+
+@pytest.fixture
+def loguru_sink() -> Iterator[io.StringIO]:
+    """loguru に一時 StringIO sink を追加し、テスト後に除去する。
+
+    enqueue 済みログを確実に取り込むため、読み出し前に ``logger.complete()``
+    を呼ぶこと。
+    """
+    sink = io.StringIO()
+    sink_id = logger.add(sink, level=0, format="{message}", colorize=False)
+    try:
+        yield sink
+    finally:
+        logger.remove(sink_id)
+
+
+def test_create_db_engine_logs_engine_creation_to_loguru(loguru_sink: io.StringIO) -> None:
+    """create_db_engine の engine 生成 INFO ログが loguru sink に捕捉される。"""
+    create_db_engine("sqlite:///:memory:")
+    logger.complete()
+
+    assert "Creating SQLAlchemy engine" in loguru_sink.getvalue()
+
+
+def test_sqlite_pragma_logged_to_loguru(loguru_sink: io.StringIO) -> None:
+    """SQLite connect 時の PRAGMA 設定 DEBUG ログが loguru sink に捕捉される。
+
+    #569 で追加した ``PRAGMA journal_mode=WAL`` 適用の確認手段が loguru 経由で
+    機能することを保証する。``:memory:`` でも connect listener は発火し、
+    ``foreign_keys=ON`` の PRAGMA ログが出力される。
+    """
+    engine = create_db_engine("sqlite:///:memory:")
+    with engine.connect():
+        pass
+    logger.complete()
+
+    assert "PRAGMA" in loguru_sink.getvalue()
+
+
+def test_get_db_session_logs_transaction_failure_to_loguru(loguru_sink: io.StringIO) -> None:
+    """トランザクション失敗時の ERROR + traceback が loguru sink に捕捉される。
+
+    #572 の主目的: DB 書き込み失敗のスタックトレースが ``logs/lorairo.log``
+    に残ることを保証する。
+    """
+    engine = create_db_engine("sqlite:///:memory:")
+    factory = create_session_factory(engine)
+
+    with pytest.raises(ValueError, match="boom"), get_db_session(factory):
+        raise ValueError("boom")
+    logger.complete()
+
+    output = loguru_sink.getvalue()
+    assert "Transaction failed" in output
+    assert "ValueError" in output
+
+
+def test_default_session_factory_logs_init_to_loguru(
+    loguru_sink: io.StringIO, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """default session factory の初回準備で DB core 初期化 INFO が loguru sink に出る。
+
+    module-level ではなく遅延 (関数内) でログを出すことで initialize_logging 後に
+    実行され、file sink に確実に乗る (#572)。
+    """
+    import lorairo.database.db_core as db_core
+
+    monkeypatch.setattr(db_core, "_default_session_factory", None)
+    monkeypatch.setattr(db_core, "ensure_default_db_dir", lambda: db_core.DB_DIR)
+    monkeypatch.setattr(
+        db_core,
+        "_prepare_project_database",
+        lambda path: create_db_engine("sqlite:///:memory:"),
+    )
+
+    db_core._get_default_session_factory()
+    logger.complete()
+
+    assert "データベースコアが初期化されました" in loguru_sink.getvalue()

--- a/tests/unit/database/test_db_core_logging.py
+++ b/tests/unit/database/test_db_core_logging.py
@@ -97,3 +97,24 @@ def test_default_session_factory_logs_init_to_loguru(
     logger.complete()
 
     assert "データベースコアが初期化されました" in loguru_sink.getvalue()
+
+
+def test_ensure_model_types_seeded_logs_resolved_names(loguru_sink: io.StringIO) -> None:
+    """seeding ログが ``%s`` リテラルではなく実際の model 名を出力する (#572 PR レビュー)。
+
+    loguru は ``%s`` スタイルの引数展開を行わないため、f-string でないと model 名が
+    落ちて ``%s`` がそのまま残る。
+    """
+    from lorairo.database.db_core import _ensure_model_types_seeded
+    from lorairo.database.schema import Base
+
+    engine = create_db_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+
+    _ensure_model_types_seeded(engine)
+    logger.complete()
+
+    output = loguru_sink.getvalue()
+    assert "Seeded model_types rows:" in output
+    assert "%s" not in output
+    assert "tags" in output


### PR DESCRIPTION
## 概要

`db_core.py` だけが標準 logging を使い、DB 層のログ (engine 生成・PRAGMA 適用・
`get_db_session` のトランザクション失敗 ERROR + traceback) が loguru file sink に
乗らず `logs/lorairo.log` に記録されなかった問題を修正 (#572)。

特に `get_db_session` のトランザクション失敗 traceback がファイルログに残らず、
DB 書き込み失敗の事後調査ができない点が問題だった。ADR 0042 (#569) で追加した
`PRAGMA journal_mode=WAL` 適用ログがアプリログで確認できなかったのも同根。

## 変更内容

- `db_core.py` を `from ..utils.log import logger` (loguru) に統一
- `exc_info=True` を `logger.opt(exception=True)` に変換 (3箇所)。loguru は
  `exc_info` を解釈せず traceback を出さないため。`LOG_FORMAT` への `{exception}`
  追加は traceback 二重出力になるため行わない (実機検証で確認)
- module-level の初期化ログを `_get_default_session_factory` の遅延ブロックへ移動
  (import 時 = `initialize_logging` 前に出力され file sink に乗らなかった問題を解消)
- ADR 0043 を追加

## テスト

- 新規 `tests/unit/database/test_db_core_logging.py` 4件 (TDD: RED→GREEN を確認)
  - engine 生成 / PRAGMA / トランザクション失敗 traceback / 初期化ログの loguru 捕捉
- mypy: no issues (175 files)、ruff: clean
- 回帰: torch 非依存 **3574 passed**、カバレッジ **86.92%**

## 補足

- ローカル devcontainer で torch (`libcudnn.so.9`) 不在による画像処理系テスト 19件が
  collection/import 失敗するが、本変更とは無関係 (db_core を main 相当に戻しても
  同一失敗することを `git stash` で実証)。CI には cudnn があるため影響なし
- `docs/decisions/` の 0042 番号 3 重複 (索引未登録) は別タスク

Close #572

🤖 Generated with [Claude Code](https://claude.com/claude-code)
