### PR TITLE
fix: prevent duplicate provider batch jobs on resubmit (#571)

### DIFF
--- a/docs/lessons-learned.md
+++ b/docs/lessons-learned.md
@@ -22,7 +22,7 @@ LoRAIro 開発で得られた教訓。バグパターン・設計ミス・解決
 
 - **UIファイル生成を忘れると連鎖エラー**: `.ui` ファイル変更後に `uv run python scripts/generate_ui.py` を実行しないと、`MainWindow_ui.py` が古いままで `filterSearchPanel` 等のウィジェットが見つからず起動失敗する。
 - **Signalの二重発火**: Worker完了Signalを複数箇所で接続すると同一イベントが重複処理される。接続は1箇所に統一し、Worker生成時に接続する。
-- **同期処理ボタンの再入と送信後の状態クリア** (Issue #571): `_set_submit_button_busy()` 内の `QApplication.processEvents()` はキュー済みクリックを再配信するため、送信ボタン無効化だけでは同期 submit 中の再入を防げない。`submit_job()` 冒頭の `_submit_in_progress` 再入フラグで塞ぐ。加えて Provider Batch タブは `connect_shared_staging()` で通常アノテーションタブと `OrderedDict` 実体を共有するため、送信成功時の `staging.clear()` は両タブの staging を同時に空にする（実体共有による意図的挙動。送信済み対象の再送信を構造的に防ぐ）。
+- **同期処理ボタンの再入と送信後の状態クリア** (Issue #571): `_set_submit_button_busy()` 内の `QApplication.processEvents()` はキュー済みクリックを再配信するため、送信ボタン無効化だけでは同期 submit 中の再入を防げない。`submit_job()` 冒頭の `_submit_in_progress` 再入フラグで塞ぐ。送信成功時は送信済み対象を共有ステージングから除外して再送信を構造的に防ぐが、注意点が2つある: (1) `image_ids` は submit 直前の snapshot なので `clear()` で全消去すると processEvents 中に追加された未送信画像まで失う → `remove_image_ids(送信済みID)` で送信分のみ除外する。(2) `submit_images` 成功 = provider job 作成済みで不可逆なので、後続の表示更新 (`select_job`→`refresh_detail`) が repository 例外を投げても送信成功を覆してはならない → ステージング除外と成功表示を先に確定し、表示更新は局所 try で隔離する。
 
 ## Database / SQLAlchemy
 

--- a/docs/lessons-learned.md
+++ b/docs/lessons-learned.md
@@ -22,6 +22,7 @@ LoRAIro 開発で得られた教訓。バグパターン・設計ミス・解決
 
 - **UIファイル生成を忘れると連鎖エラー**: `.ui` ファイル変更後に `uv run python scripts/generate_ui.py` を実行しないと、`MainWindow_ui.py` が古いままで `filterSearchPanel` 等のウィジェットが見つからず起動失敗する。
 - **Signalの二重発火**: Worker完了Signalを複数箇所で接続すると同一イベントが重複処理される。接続は1箇所に統一し、Worker生成時に接続する。
+- **同期処理ボタンの再入と送信後の状態クリア** (Issue #571): `_set_submit_button_busy()` 内の `QApplication.processEvents()` はキュー済みクリックを再配信するため、送信ボタン無効化だけでは同期 submit 中の再入を防げない。`submit_job()` 冒頭の `_submit_in_progress` 再入フラグで塞ぐ。加えて Provider Batch タブは `connect_shared_staging()` で通常アノテーションタブと `OrderedDict` 実体を共有するため、送信成功時の `staging.clear()` は両タブの staging を同時に空にする（実体共有による意図的挙動。送信済み対象の再送信を構造的に防ぐ）。
 
 ## Database / SQLAlchemy
 

--- a/src/lorairo/gui/widgets/provider_batch_job_widget.py
+++ b/src/lorairo/gui/widgets/provider_batch_job_widget.py
@@ -245,15 +245,17 @@ class ProviderBatchJobWidget(QWidget, Ui_ProviderBatchJobWidget):
             finally:
                 self._set_submit_button_busy(False)
             # Issue #571: submit_images 成功 = provider job 作成済み。後続の表示更新が
-            # 失敗しても送信成功を覆さないよう、送信済み対象の除外と成功表示を先に確定する。
+            # 失敗しても送信成功を覆さないよう、送信済み対象の除外を先に確定する。
             # image_ids は submit 直前の snapshot なので、送信中に追加された画像は残す。
             self._staging_widget.remove_image_ids(image_ids)
-            self.labelStatus.setText(f"バッチAPIジョブ {job_id} を送信しました")
             try:
                 self.refresh_jobs(update_label=False)
                 self.select_job(job_id)
             except Exception as e:
                 logger.warning(f"バッチAPI 送信後の一覧更新に失敗しました: {e}")
+            # refresh_jobs は list 失敗時に labelStatus を上書きする (例外は内部で握る) ため、
+            # 送信成功表示は表示更新の後に最後に確定する。
+            self.labelStatus.setText(f"バッチAPIジョブ {job_id} を送信しました")
         except (ProviderBatchError, ValueError) as e:
             QMessageBox.warning(self, "バッチAPI", str(e))
             self.labelStatus.setText(str(e))

--- a/src/lorairo/gui/widgets/provider_batch_job_widget.py
+++ b/src/lorairo/gui/widgets/provider_batch_job_widget.py
@@ -55,6 +55,8 @@ class ProviderBatchJobWidget(QWidget, Ui_ProviderBatchJobWidget):
         self._model_source: Any = None
         self._dataset_state_manager: Any = None
         self._current_job_id: int | None = None
+        # Issue #571: 同期 submit 中の processEvents 経由再入による二重送信を防ぐ再入ガード。
+        self._submit_in_progress = False
         self._submit_button_default_text = self.buttonSubmit.text()
         self._submit_button_default_style = self.buttonSubmit.styleSheet()
 
@@ -204,10 +206,14 @@ class ProviderBatchJobWidget(QWidget, Ui_ProviderBatchJobWidget):
         if self._workflow_service is None:
             self.labelStatus.setText("バッチAPIサービスを利用できません")
             return
+        # Issue #571: submit 中に再配信されたクリックを無視し、同一対象の二重ジョブ作成を防ぐ。
+        if self._submit_in_progress:
+            return
         litellm_model_id = self._model_selection_widget.get_selected_model()
         if not litellm_model_id:
             QMessageBox.warning(self, "バッチAPI", "バッチ対応モデルを選択してください。")
             return
+        self._submit_in_progress = True
         try:
             image_ids = self._staging_widget.get_image_ids()
             if not image_ids:
@@ -240,6 +246,8 @@ class ProviderBatchJobWidget(QWidget, Ui_ProviderBatchJobWidget):
                 self._set_submit_button_busy(False)
             self.refresh_jobs()
             self.select_job(job_id)
+            # Issue #571: 送信成功した対象は処理済みとして共有ステージングから除外する。
+            self._staging_widget.clear()
             self.labelStatus.setText(f"バッチAPIジョブ {job_id} を送信しました")
         except (ProviderBatchError, ValueError) as e:
             QMessageBox.warning(self, "バッチAPI", str(e))
@@ -248,6 +256,8 @@ class ProviderBatchJobWidget(QWidget, Ui_ProviderBatchJobWidget):
             logger.error(f"バッチAPI submit failed: {e}", exc_info=True)
             QMessageBox.critical(self, "バッチAPI", str(e))
             self.labelStatus.setText("送信に失敗しました")
+        finally:
+            self._submit_in_progress = False
 
     @Slot()
     def refresh_jobs(self, update_label: bool = True) -> None:

--- a/src/lorairo/gui/widgets/provider_batch_job_widget.py
+++ b/src/lorairo/gui/widgets/provider_batch_job_widget.py
@@ -244,11 +244,16 @@ class ProviderBatchJobWidget(QWidget, Ui_ProviderBatchJobWidget):
                 )
             finally:
                 self._set_submit_button_busy(False)
-            self.refresh_jobs()
-            self.select_job(job_id)
-            # Issue #571: 送信成功した対象は処理済みとして共有ステージングから除外する。
-            self._staging_widget.clear()
+            # Issue #571: submit_images 成功 = provider job 作成済み。後続の表示更新が
+            # 失敗しても送信成功を覆さないよう、送信済み対象の除外と成功表示を先に確定する。
+            # image_ids は submit 直前の snapshot なので、送信中に追加された画像は残す。
+            self._staging_widget.remove_image_ids(image_ids)
             self.labelStatus.setText(f"バッチAPIジョブ {job_id} を送信しました")
+            try:
+                self.refresh_jobs(update_label=False)
+                self.select_job(job_id)
+            except Exception as e:
+                logger.warning(f"バッチAPI 送信後の一覧更新に失敗しました: {e}")
         except (ProviderBatchError, ValueError) as e:
             QMessageBox.warning(self, "バッチAPI", str(e))
             self.labelStatus.setText(str(e))

--- a/src/lorairo/gui/widgets/staging_widget.py
+++ b/src/lorairo/gui/widgets/staging_widget.py
@@ -243,6 +243,27 @@ class StagingWidget(QWidget):
         self.staging_cleared.emit()
         self.staged_images_changed.emit([])
 
+    def remove_image_ids(self, image_ids: list[int]) -> None:
+        """指定した画像 ID のみをステージングから除外する。
+
+        送信スナップショット後に追加された画像を保持したまま、送信済み対象だけを
+        ステージングから外すために使う (Issue #571)。変更があった場合のみ
+        staged_images_changed を発行する。
+
+        Args:
+            image_ids: 除外する画像 ID リスト。
+        """
+        removed = False
+        for image_id in image_ids:
+            if image_id in self._staged_images:
+                del self._staged_images[image_id]
+                self._thumbnail_cache.pop(image_id, None)
+                removed = True
+        if not removed:
+            return
+        self._refresh_staging_list_ui()
+        self.staged_images_changed.emit(self.get_image_ids())
+
     def get_image_ids(self) -> list[int]:
         """ステージング中の画像 ID リストを返す。
 

--- a/tests/unit/gui/widgets/test_provider_batch_job_widget.py
+++ b/tests/unit/gui/widgets/test_provider_batch_job_widget.py
@@ -336,6 +336,23 @@ def test_submit_success_keeps_status_when_post_refresh_fails(widget, dependencie
 
 @pytest.mark.unit
 @pytest.mark.gui
+def test_submit_success_status_survives_refresh_jobs_failure(widget, dependencies, monkeypatch):
+    # Issue #571 review: refresh_jobs が list 失敗を内部で握って labelStatus を上書きしても
+    # 送信成功表示が残ること。
+    workflow, repository, model_source, model_repository = dependencies
+    widget.set_dependencies(workflow, repository, model_source, model_repository)
+    widget._model_selection_widget._selected_model = "anthropic/claude-3-5-sonnet"
+    monkeypatch.setattr(widget._staging_widget, "get_image_ids", lambda: [1, 2])
+    monkeypatch.setattr(widget._staging_widget, "remove_image_ids", MagicMock())
+    repository.list_provider_batch_jobs.side_effect = RuntimeError("job list boom")
+
+    widget.submit_job()
+
+    assert widget.labelStatus.text() == "バッチAPIジョブ 42 を送信しました"
+
+
+@pytest.mark.unit
+@pytest.mark.gui
 def test_submit_error_keeps_staging(widget, dependencies, monkeypatch):
     # Issue #571: 失敗時はステージングを残し、ユーザーが再試行できるようにする。
     workflow, repository, model_source, model_repository = dependencies

--- a/tests/unit/gui/widgets/test_provider_batch_job_widget.py
+++ b/tests/unit/gui/widgets/test_provider_batch_job_widget.py
@@ -301,6 +301,62 @@ def test_submit_button_recovers_after_unexpected_submit_error(widget, dependenci
 
 @pytest.mark.unit
 @pytest.mark.gui
+def test_submit_success_clears_staging(widget, dependencies, monkeypatch):
+    # Issue #571: 送信成功で共有ステージングを空にし、同一対象の再送信を構造的に防ぐ。
+    workflow, repository, model_source, model_repository = dependencies
+    widget.set_dependencies(workflow, repository, model_source, model_repository)
+    widget._model_selection_widget._selected_model = "anthropic/claude-3-5-sonnet"
+    monkeypatch.setattr(widget._staging_widget, "get_image_ids", lambda: [1, 2])
+    clear = MagicMock()
+    monkeypatch.setattr(widget._staging_widget, "clear", clear)
+
+    widget.submit_job()
+
+    clear.assert_called_once_with()
+    assert "バッチAPIジョブ 42 を送信しました" in widget.labelStatus.text()
+
+
+@pytest.mark.unit
+@pytest.mark.gui
+def test_submit_error_keeps_staging(widget, dependencies, monkeypatch):
+    # Issue #571: 失敗時はステージングを残し、ユーザーが再試行できるようにする。
+    workflow, repository, model_source, model_repository = dependencies
+    widget.set_dependencies(workflow, repository, model_source, model_repository)
+    widget._model_selection_widget._selected_model = "anthropic/claude-3-5-sonnet"
+    monkeypatch.setattr(widget._staging_widget, "get_image_ids", lambda: [1, 2])
+    monkeypatch.setattr(widget_module.QMessageBox, "warning", MagicMock())
+    clear = MagicMock()
+    monkeypatch.setattr(widget._staging_widget, "clear", clear)
+    workflow.submit_images.side_effect = widget_module.ProviderBatchError("provider rejected")
+
+    widget.submit_job()
+
+    clear.assert_not_called()
+
+
+@pytest.mark.unit
+@pytest.mark.gui
+def test_submit_job_reentrancy_guard_submits_once(widget, dependencies, monkeypatch):
+    # Issue #571: 同期 submit 中の processEvents 経由再入で二重送信されないこと。
+    workflow, repository, model_source, model_repository = dependencies
+    widget.set_dependencies(workflow, repository, model_source, model_repository)
+    widget._model_selection_widget._selected_model = "anthropic/claude-3-5-sonnet"
+    monkeypatch.setattr(widget._staging_widget, "get_image_ids", lambda: [1, 2])
+
+    def reentrant_submit(**_kwargs):
+        # 1 回目の submit 処理中にキュー済みクリックが再配信された状況を模す。
+        widget.submit_job()
+        return 42
+
+    workflow.submit_images.side_effect = reentrant_submit
+
+    widget.submit_job()
+
+    assert workflow.submit_images.call_count == 1
+
+
+@pytest.mark.unit
+@pytest.mark.gui
 def test_submit_job_rating_preflight_uses_moderations_endpoint(widget, dependencies, monkeypatch):
     workflow, repository, model_source, model_repository = dependencies
     widget.set_dependencies(workflow, repository, model_source, model_repository)

--- a/tests/unit/gui/widgets/test_provider_batch_job_widget.py
+++ b/tests/unit/gui/widgets/test_provider_batch_job_widget.py
@@ -301,18 +301,36 @@ def test_submit_button_recovers_after_unexpected_submit_error(widget, dependenci
 
 @pytest.mark.unit
 @pytest.mark.gui
-def test_submit_success_clears_staging(widget, dependencies, monkeypatch):
-    # Issue #571: 送信成功で共有ステージングを空にし、同一対象の再送信を構造的に防ぐ。
+def test_submit_success_removes_submitted_images_from_staging(widget, dependencies, monkeypatch):
+    # Issue #571: 送信成功で送信済み対象のみをステージングから除外し、再送信を構造的に防ぐ。
     workflow, repository, model_source, model_repository = dependencies
     widget.set_dependencies(workflow, repository, model_source, model_repository)
     widget._model_selection_widget._selected_model = "anthropic/claude-3-5-sonnet"
     monkeypatch.setattr(widget._staging_widget, "get_image_ids", lambda: [1, 2])
-    clear = MagicMock()
-    monkeypatch.setattr(widget._staging_widget, "clear", clear)
+    remove = MagicMock()
+    monkeypatch.setattr(widget._staging_widget, "remove_image_ids", remove)
 
     widget.submit_job()
 
-    clear.assert_called_once_with()
+    remove.assert_called_once_with([1, 2])
+    assert "バッチAPIジョブ 42 を送信しました" in widget.labelStatus.text()
+
+
+@pytest.mark.unit
+@pytest.mark.gui
+def test_submit_success_keeps_status_when_post_refresh_fails(widget, dependencies, monkeypatch):
+    # Issue #571 review: submit 成功後の一覧更新が失敗しても送信成功を覆さず除外を確定する。
+    workflow, repository, model_source, model_repository = dependencies
+    widget.set_dependencies(workflow, repository, model_source, model_repository)
+    widget._model_selection_widget._selected_model = "anthropic/claude-3-5-sonnet"
+    monkeypatch.setattr(widget._staging_widget, "get_image_ids", lambda: [1, 2])
+    remove = MagicMock()
+    monkeypatch.setattr(widget._staging_widget, "remove_image_ids", remove)
+    monkeypatch.setattr(widget, "select_job", MagicMock(side_effect=RuntimeError("detail boom")))
+
+    widget.submit_job()
+
+    remove.assert_called_once_with([1, 2])
     assert "バッチAPIジョブ 42 を送信しました" in widget.labelStatus.text()
 
 
@@ -325,13 +343,13 @@ def test_submit_error_keeps_staging(widget, dependencies, monkeypatch):
     widget._model_selection_widget._selected_model = "anthropic/claude-3-5-sonnet"
     monkeypatch.setattr(widget._staging_widget, "get_image_ids", lambda: [1, 2])
     monkeypatch.setattr(widget_module.QMessageBox, "warning", MagicMock())
-    clear = MagicMock()
-    monkeypatch.setattr(widget._staging_widget, "clear", clear)
+    remove = MagicMock()
+    monkeypatch.setattr(widget._staging_widget, "remove_image_ids", remove)
     workflow.submit_images.side_effect = widget_module.ProviderBatchError("provider rejected")
 
     widget.submit_job()
 
-    clear.assert_not_called()
+    remove.assert_not_called()
 
 
 @pytest.mark.unit

--- a/tests/unit/gui/widgets/test_staging_widget.py
+++ b/tests/unit/gui/widgets/test_staging_widget.py
@@ -231,6 +231,33 @@ class TestStagingListManagement:
 
         assert widget.count() == 0
 
+    @pytest.mark.gui
+    def test_remove_image_ids_removes_only_specified(self, qtbot, widget_with_state):
+        """remove_image_ids が指定 ID のみ除外し、他を保持すること (Issue #571)"""
+        widget, _ = widget_with_state
+        widget.add_image_ids([1, 2, 3])
+        assert widget.count() == 3
+
+        with qtbot.waitSignal(widget.staged_images_changed, timeout=1000) as blocker:
+            widget.remove_image_ids([1, 3])
+
+        assert blocker.args == [[2]]
+        assert widget.get_image_ids() == [2]
+
+    @pytest.mark.gui
+    def test_remove_image_ids_ignores_unknown_ids(self, qtbot, widget_with_state):
+        """remove_image_ids が未登録 ID では何も変更せずシグナルも出さないこと"""
+        widget, _ = widget_with_state
+        widget.add_image_ids([1, 2])
+
+        # 未登録 ID のみ指定したときは staged_images_changed を発行しない
+        received: list[list[int]] = []
+        widget.staged_images_changed.connect(received.append)
+        widget.remove_image_ids([99])
+
+        assert received == []
+        assert widget.get_image_ids() == [1, 2]
+
 
 class TestAccessors:
     """アクセサメソッドテスト"""


### PR DESCRIPTION
## 概要

Closes #571

バッチAPIタブで送信完了後に同じステージングのまま再送信すると、同一画像セットで二重のバッチジョブが作成される問題を修正する。報告ログでは同一 provider/openai・items=100 のジョブが 23 秒差で 2 件（job_id=5, 6, ともに running）作成されていた。

## 根本原因

- `submit_job()` は `_set_submit_button_busy(True)` 内の `QApplication.processEvents()` でキュー済みクリックを再配信し得るが、再入ガードが無い。
- ボタン無効化は同期 submit 呼び出し中だけで、送信完了後はステージングが残ったまま再クリックできる。

## 修正内容

- **再入ガード**: `submit_job()` 冒頭に `_submit_in_progress` フラグを追加し、submit 中の再配信クリックを無視する。
- **送信成功で staging クリア**: 送信成功した対象は処理済みとして共有 `staging.clear()` で除外する。`connect_shared_staging()` による `OrderedDict` 実体共有のため、通常アノテーションタブの staging も同時に空になる（意図的挙動）。
- **失敗時は staging 維持**: `clear()` は成功パスのみ。エラー時は再試行可能。

スキーマ変更・Alembic 移行・dedup/fingerprint 列の追加は行わない。

## テスト

TDD（RED→GREEN）で GUI 単体テスト3件を追加:

- `test_submit_success_clears_staging`: 送信成功で `staging.clear` が1回呼ばれる
- `test_submit_error_keeps_staging`: `ProviderBatchError` 時は `clear` 未呼び出し
- `test_submit_job_reentrancy_guard_submits_once`: 再入呼び出しで `submit_images` は1回のみ（実装前 193回再帰 → 実装後 1回）

| チェック | 結果 |
|---|---|
| widget 全テスト | 40 pass（既存37 回帰なし） |
| CI-equivalent（widget + integration） | 61 passed |
| ruff format / check | pass |
| mypy（175 files） | Success |

🤖 Generated with [Claude Code](https://claude.com/claude-code)