### PR TITLE
chore: lower large search result log severity

### DIFF
--- a/docs/decisions/0045-large-search-result-log-level.md
+++ b/docs/decisions/0045-large-search-result-log-level.md
@@ -1,0 +1,25 @@
+# ADR 0045: Large Search Result Log Level
+
+- **日付**: 2026-05-31
+- **ステータス**: Accepted
+
+## Context
+
+通常の検索操作で結果件数が 10000 件を超えると、UI はユーザーへ注意表示する一方で、
+`update_search_preview()` が WARNING ログも出していた。大量結果自体は処理失敗ではなく、
+エラー調査時の WARNING ノイズになっていた。
+
+## Decision
+
+大量検索結果の通知ログは INFO とする。UI 側の注意表示は維持し、処理失敗、入力異常、
+タイムアウトなどの実際の問題だけを WARNING または ERROR として扱う。
+
+## Rationale
+
+DEBUG まで下げると通常操作の検索規模を追跡しづらい。INFO は正常なユーザー操作の
+観測値として残せるため、警告調査のノイズを減らしつつ運用上の文脈を保持できる。
+
+## Consequences
+
+`logs/lorairo.log` では大量検索結果が INFO として記録される。WARNING 以上で調査する
+場合は、実際の失敗や復旧が必要な状態に集中できる。

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -48,6 +48,7 @@ LoRAIro の重要な設計判断を記録するドキュメント群。
 | [0042](0042-batch-annotation-db-save-io.md) | Batch Annotation DB Save I/O | 2026-05-30 | Accepted |
 | [0043](0043-db-core-logging-loguru-unification.md) | db_core Logging Loguru Unification | 2026-05-31 | Accepted |
 | [0044](0044-provider-batch-submit-threading.md) | Provider Batch Submit Threading | 2026-05-31 | Accepted |
+| [0045](0045-large-search-result-log-level.md) | Large Search Result Log Level | 2026-05-31 | Accepted |
 
 ## ADR テンプレート
 

--- a/src/lorairo/gui/widgets/filter_search_panel.py
+++ b/src/lorairo/gui/widgets/filter_search_panel.py
@@ -937,7 +937,7 @@ class FilterSearchPanel(QScrollArea):
         LARGE_RESULT_WARNING_THRESHOLD = 10000
 
         if result_count > LARGE_RESULT_WARNING_THRESHOLD:
-            logger.warning(f"Large search result warning displayed: {result_count} items")
+            logger.info(f"Large search result warning displayed: {result_count} items")
         del preview_text  # 現在は使われていないが API 互換のため残す
         logger.debug(f"検索結果プレビュー更新: {result_count}件")
 

--- a/tests/unit/gui/widgets/test_filter_search_panel_mediator.py
+++ b/tests/unit/gui/widgets/test_filter_search_panel_mediator.py
@@ -12,6 +12,7 @@ FilterSearchPanel が以下を満たすかを検証する:
 from unittest.mock import MagicMock
 
 import pytest
+from loguru import logger as loguru_logger
 
 from lorairo.gui.widgets.filter_search import (
     CountEstimateWidget,
@@ -100,6 +101,36 @@ class TestPipelineStateMediation:
         assert panel.is_pipeline_active() is True
         panel._pipeline.transition_to(PipelineState.IDLE)
         assert panel.is_pipeline_active() is False
+
+
+class TestSearchPreviewLogging:
+    """Issue #579: 通常の大量検索結果は WARNING にしない。"""
+
+    @pytest.fixture()
+    def loguru_records(self):
+        records: list = []
+        sink_id = loguru_logger.add(lambda msg: records.append(msg.record), level="DEBUG")
+        yield records
+        loguru_logger.remove(sink_id)
+
+    def test_large_result_logs_info_not_warning(self, panel, loguru_records):
+        """10000 件超の通常プレビュー更新は INFO として記録する。"""
+        panel.update_search_preview(10001)
+
+        large_result_records = [
+            record
+            for record in loguru_records
+            if record["message"] == "Large search result warning displayed: 10001 items"
+        ]
+        assert [record["level"].name for record in large_result_records] == ["INFO"]
+
+    def test_threshold_result_does_not_log_large_result_notice(self, panel, loguru_records):
+        """閾値ちょうどは大量結果通知を出さない。"""
+        panel.update_search_preview(10000)
+
+        assert all(
+            "Large search result warning displayed" not in record["message"] for record in loguru_records
+        )
 
 
 class TestServiceInjectionMediation:


### PR DESCRIPTION
Fixes #579.

Branch: issue-579-large-search-log-level
Worktree: /tmp/worktrees/issue-579-large-search-log-level
ADR: docs/decisions/0045-large-search-result-log-level.md

## Summary
- Lower normal large-search-result preview logging from WARNING to INFO.
- Keep the existing preview/update behavior and actual failure warnings/errors unchanged.
- Add a loguru regression test for the large-result threshold.

## Verification
- `/workspaces/LoRAIro/.venv/bin/ruff check src/lorairo/gui/widgets/filter_search_panel.py tests/unit/gui/widgets/test_filter_search_panel_mediator.py`
- `/workspaces/LoRAIro/.venv/bin/pytest tests/unit/gui/widgets/test_filter_search_panel_mediator.py`

Note: `UV_PROJECT_ENVIRONMENT=/workspaces/LoRAIro/.venv uv run ...` attempted to resolve editable local_packages in the new worktree, but those worktree-local package directories do not contain package metadata. Validation used the shared environment binaries directly as required for /tmp/worktrees/ checkouts.