### PR TITLE
fix: expand Loguru placeholders

### DIFF
--- a/docs/decisions/0046-loguru-placeholder-format.md
+++ b/docs/decisions/0046-loguru-placeholder-format.md
@@ -1,0 +1,24 @@
+# ADR 0046: Loguru Placeholder Format
+
+- **日付**: 2026-05-31
+- **ステータス**: Accepted
+
+## Context
+
+Loguru logger に stdlib logging 形式の `%s` / `%r` / `%d` placeholder を渡すと、
+値が展開されず、調査に必要な route_preference などの値がログに残らない。
+
+## Decision
+
+`src/lorairo` の Loguru 呼び出しでは `{}` / `{!r}` placeholder を使う。stdlib
+`logging.getLogger()` を使うコードの `%` placeholder は対象外とする。
+
+## Rationale
+
+Loguru の遅延 formatting と既存の logger 呼び出し形を保ちながら、実際の値を
+ログへ出せる。f-string への全面変更よりも差分が小さく、不要な文字列評価も避けられる。
+
+## Consequences
+
+Loguru 呼び出しに stdlib 形式 placeholder を追加しないよう、AST ベースの単体テストで
+`logger.<level>("...%s...", arg, ...)` 形式を検出する。

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -49,6 +49,7 @@ LoRAIro の重要な設計判断を記録するドキュメント群。
 | [0043](0043-db-core-logging-loguru-unification.md) | db_core Logging Loguru Unification | 2026-05-31 | Accepted |
 | [0044](0044-provider-batch-submit-threading.md) | Provider Batch Submit Threading | 2026-05-31 | Accepted |
 | [0045](0045-large-search-result-log-level.md) | Large Search Result Log Level | 2026-05-31 | Accepted |
+| [0046](0046-loguru-placeholder-format.md) | Loguru Placeholder Format | 2026-05-31 | Accepted |
 
 ## ADR テンプレート
 

--- a/src/lorairo/editor/image_processor.py
+++ b/src/lorairo/editor/image_processor.py
@@ -195,7 +195,7 @@ class ImageProcessor:
             else:
                 # サポートされていないモード
                 logger.warning(
-                    "ImageProcessor.normalize_color_profile サポートされていないモード: %s", mode
+                    "ImageProcessor.normalize_color_profile サポートされていないモード: {}", mode
                 )
                 return img.convert("RGBA") if has_alpha else img.convert("RGB")
 

--- a/src/lorairo/gui/window/configuration_window.py
+++ b/src/lorairo/gui/window/configuration_window.py
@@ -243,7 +243,7 @@ class ConfigurationWindow(QDialog):
             self._combo_box_route_preference.setCurrentIndex(idx)
         else:
             logger.warning(
-                "route_preference=%r は GUI 設定では選択できないため auto にフォールバック表示します "
+                "route_preference={!r} は GUI 設定では選択できないため auto にフォールバック表示します "
                 "(OK 押下時に auto で上書き保存)。CLI でのみ利用する場合は GUI で変更しないでください。",
                 normalized_preference,
             )

--- a/src/lorairo/services/model_route_service.py
+++ b/src/lorairo/services/model_route_service.py
@@ -440,8 +440,8 @@ def build_display_options(
         for alt in alternatives:
             if tuple(alt.model.capabilities) != preferred_caps:
                 logger.warning(
-                    "capabilities mismatch between routes: canonical_key=%s, "
-                    "preferred=%s caps=%s, alternative=%s caps=%s",
+                    "capabilities mismatch between routes: canonical_key={}, "
+                    "preferred={} caps={}, alternative={} caps={}",
                     ckey,
                     preferred.litellm_model_id,
                     preferred_caps,
@@ -497,7 +497,7 @@ def parse_route_preference(raw: str | None) -> RoutePreference:
     if normalized in _VALID_ROUTE_PREFERENCES:
         return cast(RoutePreference, normalized)
     logger.warning(
-        "Invalid route_preference value %r, falling back to 'auto'. Valid values: %s",
+        "Invalid route_preference value {!r}, falling back to 'auto'. Valid values: {}",
         raw,
         sorted(_VALID_ROUTE_PREFERENCES),
     )

--- a/src/lorairo/services/model_selection_service.py
+++ b/src/lorairo/services/model_selection_service.py
@@ -259,7 +259,7 @@ class ModelSelectionService:
         filtered = self.filter_models(criteria)
         options = build_display_options(filtered, available_providers, route_preference)
         logger.debug(
-            "load_grouped_models: filtered=%d, options=%d, preference=%s, available=%s",
+            "load_grouped_models: filtered={}, options={}, preference={}, available={}",
             len(filtered),
             len(options),
             route_preference,

--- a/src/lorairo/services/search_criteria_processor.py
+++ b/src/lorairo/services/search_criteria_processor.py
@@ -70,7 +70,7 @@ class SearchCriteriaProcessor:
             # DB検索のみの場合はDB総件数を返す。フロントエンドフィルター適用時は件数が変わるためlen(images)を返す。
             reported_count = len(images) if applied_frontend_filters else total_count
             logger.info(
-                "検索実行完了: 結果件数=%s, 総件数=%s, frontend_filter=%s",
+                "検索実行完了: 結果件数={}, 総件数={}, frontend_filter={}",
                 len(images),
                 total_count,
                 applied_frontend_filters,

--- a/tests/unit/gui/window/test_configuration_window.py
+++ b/tests/unit/gui/window/test_configuration_window.py
@@ -4,6 +4,7 @@
 ConfigurationServiceをモックで差し替え、ウィジェットの生成・値反映・収集を検証する。
 """
 
+from io import StringIO
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -263,6 +264,30 @@ class TestConfigurationWindowRoutePreference:
         assert combo is not None
         # GUI 上は auto として表示 (CLI 専用値のため)
         assert combo.currentText() == "auto"
+
+    def test_route_preference_all_warning_renders_value(self, qtbot, config_service: MagicMock) -> None:
+        """GUI 専用 fallback warning は route_preference の実値をログへ出す。"""
+        from lorairo.utils.log import logger
+
+        config_service.get_all_settings.return_value = {
+            "api": {},
+            "directories": {},
+            "log": {"level": "INFO"},
+            "image_processing": {"upscaler": "RealESRGAN_x4plus"},
+            "prompts": {"additional": ""},
+            "model_selection": {"route_preference": "all"},
+        }
+        sink = StringIO()
+        sink_id = logger.add(sink, format="{message}", level="WARNING")
+        try:
+            dlg = ConfigurationWindow(config_service=config_service)
+            qtbot.addWidget(dlg)
+        finally:
+            logger.remove(sink_id)
+
+        log_output = sink.getvalue()
+        assert "route_preference='all'" in log_output
+        assert "%r" not in log_output
 
     def test_collect_settings_includes_model_selection(self, dialog: ConfigurationWindow) -> None:
         """_collect_settings に model_selection.route_preference が含まれる。"""

--- a/tests/unit/services/test_model_route_service.py
+++ b/tests/unit/services/test_model_route_service.py
@@ -6,6 +6,7 @@ route 判定、canonical key、grouping、preference 選択、API key validation
 
 from __future__ import annotations
 
+from io import StringIO
 from types import SimpleNamespace
 
 import pytest
@@ -592,6 +593,24 @@ class TestParseRoutePreference:
     def test_invalid_value_falls_back_to_auto(self) -> None:
         """不正値は 'auto' に fallback (warning log 経路)"""
         assert parse_route_preference("bogus") == "auto"
+
+    def test_invalid_value_warning_renders_value_and_valid_values(self) -> None:
+        """Loguru warning は stdlib `%r/%s` ではなく実値を展開して出力する。"""
+        from lorairo.utils.log import logger
+
+        sink = StringIO()
+        sink_id = logger.add(sink, format="{message}", level="WARNING")
+        try:
+            assert parse_route_preference("bogus") == "auto"
+        finally:
+            logger.remove(sink_id)
+
+        log_output = sink.getvalue()
+        assert "Invalid route_preference value 'bogus'" in log_output
+        assert "%r" not in log_output
+        assert "%s" not in log_output
+        assert "openrouter" in log_output
+        assert "direct" in log_output
 
     def test_uppercase_normalized(self) -> None:
         """大文字 / strip も正規化される"""

--- a/tests/unit/test_loguru_placeholder_format.py
+++ b/tests/unit/test_loguru_placeholder_format.py
@@ -1,0 +1,48 @@
+"""Loguru placeholder format regression tests."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+LOGURU_LEVELS = {
+    "trace",
+    "debug",
+    "info",
+    "success",
+    "warning",
+    "error",
+    "critical",
+    "exception",
+}
+
+
+@pytest.mark.unit
+def test_src_lorairo_loguru_calls_do_not_use_stdlib_percent_placeholders() -> None:
+    """Loguru accepts `{}` placeholders; stdlib `%s` placeholders are not expanded."""
+    offenders: list[str] = []
+    src_root = Path(__file__).resolve().parents[2] / "src" / "lorairo"
+
+    for path in sorted(src_root.rglob("*.py")):
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            if not isinstance(node.func, ast.Attribute):
+                continue
+            if node.func.attr not in LOGURU_LEVELS:
+                continue
+            if not isinstance(node.func.value, ast.Name) or node.func.value.id != "logger":
+                continue
+            if len(node.args) < 2:
+                continue
+            message_node = node.args[0]
+            if not isinstance(message_node, ast.Constant) or not isinstance(message_node.value, str):
+                continue
+            if any(placeholder in message_node.value for placeholder in ("%s", "%r", "%d")):
+                rel_path = path.relative_to(src_root.parents[1])
+                offenders.append(f"{rel_path}:{node.lineno}: {message_node.value!r}")
+
+    assert offenders == []


### PR DESCRIPTION
Fixes #580.\n\nBranch: issue-580-loguru-placeholders\nWorktree: /tmp/worktrees/issue-580-loguru-placeholders\nADR: docs/decisions/0046-loguru-placeholder-format.md\n\n## Summary\n- Converted the confirmed Loguru stdlib-style % placeholders in src/lorairo to Loguru {} / {!r} placeholders.\n- Added rendered-output regression tests for route_preference warnings.\n- Added an AST regression test to prevent logger.<level>("...%s...", arg, ...) patterns in src/lorairo Loguru calls.\n\n## Verification\n- UV_CACHE_DIR=/tmp/uv-cache UV_PROJECT_ENVIRONMENT=/workspaces/LoRAIro/.venv uv run pytest tests/unit/services/test_model_route_service.py tests/unit/test_loguru_placeholder_format.py -q\n- UV_CACHE_DIR=/tmp/uv-cache UV_PROJECT_ENVIRONMENT=/workspaces/LoRAIro/.venv uv run pytest tests/unit/gui/window/test_configuration_window.py -q\n- UV_CACHE_DIR=/tmp/uv-cache UV_PROJECT_ENVIRONMENT=/workspaces/LoRAIro/.venv uv run ruff check src/lorairo/services/model_route_service.py src/lorairo/gui/window/configuration_window.py src/lorairo/editor/image_processor.py src/lorairo/services/model_selection_service.py src/lorairo/services/search_criteria_processor.py tests/unit/services/test_model_route_service.py tests/unit/gui/window/test_configuration_window.py tests/unit/test_loguru_placeholder_format.py