### PR TITLE
fix: show Web API models in batch tag selection

### DIFF
--- a/src/lorairo/gui/widgets/model_selection_widget.py
+++ b/src/lorairo/gui/widgets/model_selection_widget.py
@@ -92,9 +92,8 @@ if not __name__ == "__main__":
         # シグナル定義 (Issue #245: selected_litellm_model_ids を emit)
         model_selection_changed = Signal(list)  # selected_litellm_model_ids
         selection_count_changed = Signal(int, int)  # selected_count, total_count
-        WEB_API_BATCH_PLACEHOLDER = (
-            "Web APIモデルはローカルモデル絞り込みの対象外です。"
-            "開始時のモデル選択ダイアログで使用モデルを選択します。"
+        WEB_API_UNAVAILABLE_PLACEHOLDER = (
+            "利用可能なWeb APIモデルがありません。APIキー設定とモデルregistry同期状態を確認してください。"
         )
 
         # UI elements type hints (from Ui_ModelSelectionWidget via multi-inheritance)
@@ -343,30 +342,27 @@ if not __name__ == "__main__":
                 self._update_batch_capable_display()
                 return
 
-            # Issue #584: 描画対象 (placeholder 種別 + options) を _clear より前に計算し、
-            # 前回と同一なら全消し全再生成をスキップする (起動時の冗長 rebuild を吸収)。
-            show_web_api_placeholder = self._should_show_web_api_batch_placeholder()
-            if show_web_api_placeholder:
-                options: list[DisplayModelOption] = []
+            # Issue #584: 描画対象を _clear より前に計算し、前回と同一なら
+            # 全消し全再生成をスキップする (起動時の冗長 rebuild を吸収)。
+            available_providers = self._build_available_providers()
+            route_preference = self._get_route_preference()
+            # フィルタリング実行 -> DisplayModelOption 群を構築
+            if self.mode == "simple":
+                try:
+                    recommended_models = self.model_selection_service.get_recommended_models()
+                except Exception as e:
+                    logger.error(f"Failed to get recommended models: {e}")
+                    recommended_models = [m for m in self.all_models if m.is_recommended]
+                options = build_display_options(
+                    recommended_models,
+                    available_providers=available_providers,
+                    preference=route_preference,
+                )
             else:
-                available_providers = self._build_available_providers()
-                route_preference = self._get_route_preference()
-                # フィルタリング実行 -> DisplayModelOption 群を構築
-                if self.mode == "simple":
-                    try:
-                        recommended_models = self.model_selection_service.get_recommended_models()
-                    except Exception as e:
-                        logger.error(f"Failed to get recommended models: {e}")
-                        recommended_models = [m for m in self.all_models if m.is_recommended]
-                    options = build_display_options(
-                        recommended_models,
-                        available_providers=available_providers,
-                        preference=route_preference,
-                    )
-                else:
-                    options = self._apply_advanced_filters(available_providers, route_preference)
+                options = self._apply_advanced_filters(available_providers, route_preference)
 
-            signature = self._compute_render_signature(options, show_web_api_placeholder)
+            options = self._filter_unavailable_web_api_options(options)
+            signature = self._compute_render_signature(options, False)
             if signature == self._last_render_signature and self.model_checkbox_widgets:
                 # 同一フィルタ結果。既存ウィジェット (選択状態含む) をそのまま温存する
                 logger.trace("モデル表示は前回と同一のため再構築をスキップ")
@@ -377,17 +373,12 @@ if not __name__ == "__main__":
             self.filtered_options = options
             self.filtered_models = [opt.preferred.model for opt in options]
 
-            if show_web_api_placeholder:
-                self.placeholderLabel.setText(self.WEB_API_BATCH_PLACEHOLDER)
-                self.placeholderLabel.setVisible(True)
-                self._update_selection_count()
-                self._last_render_signature = signature
-                return
-
             self.placeholderLabel.setText(self._default_placeholder_text)
 
             # フィルタされたモデルがない場合
             if not options:
+                if self.current_execution_env == "APIモデルのみ":
+                    self.placeholderLabel.setText(self.WEB_API_UNAVAILABLE_PLACEHOLDER)
                 self.placeholderLabel.setVisible(True)
                 self._update_selection_count()
                 self._last_render_signature = signature
@@ -518,9 +509,13 @@ if not __name__ == "__main__":
 
             return filtered
 
-        def _should_show_web_api_batch_placeholder(self) -> bool:
-            """Batch annotation の Web API only ではローカルモデル一覧を表示しない。"""
-            return self.annotation_only_filtering and self.current_execution_env == "APIモデルのみ"
+        def _filter_unavailable_web_api_options(
+            self, options: list[DisplayModelOption]
+        ) -> list[DisplayModelOption]:
+            """Web API only 表示では API key 未設定などで実行不能な候補を除外する。"""
+            if self.current_execution_env != "APIモデルのみ":
+                return options
+            return [option for option in options if option.available]
 
         def _group_options_by_provider(
             self, options: list[DisplayModelOption]

--- a/tests/unit/gui/widgets/test_model_selection_widget.py
+++ b/tests/unit/gui/widgets/test_model_selection_widget.py
@@ -11,6 +11,7 @@ from PySide6.QtGui import QCloseEvent
 from PySide6.QtWidgets import QProgressBar, QPushButton
 
 from lorairo.gui.widgets.model_selection_widget import ModelSelectionWidget
+from lorairo.services.model_route_service import build_display_options
 
 
 def _fake_db_model(
@@ -100,18 +101,49 @@ class TestModelSelectionWidgetFilters:
     def test_set_selected_models_does_not_crash_with_empty_list(self, widget):
         widget.set_selected_models([])
 
-    def test_batch_web_api_only_shows_placeholder_without_model_rows(self, qtbot, mock_model_service):
-        """Batch annotation の Web API only では通常モデル行を表示しない"""
-        mock_model_service.load_grouped_models.return_value = []
+    def test_batch_web_api_only_shows_available_model_rows(self, qtbot, mock_model_service):
+        """Batch annotation の Web API only でも利用可能な Web API モデル行を表示する"""
+        model = _fake_db_model(
+            name="gpt-4o",
+            provider="openai",
+            litellm_model_id="openai/gpt-4o",
+            requires_api_key=True,
+            capabilities=["caption"],
+        )
+        mock_model_service.load_grouped_models.return_value = build_display_options(
+            [model], {"openai"}, "auto"
+        )
+        w = ModelSelectionWidget(model_selection_service=mock_model_service, mode="advanced")
+        qtbot.addWidget(w)
+
+        w.apply_filters(execution_env="APIモデルのみ", annotation_only=True)
+
+        criteria = mock_model_service.load_grouped_models.call_args[0][0]
+        assert criteria.execution_env == "APIモデルのみ"
+        assert criteria.annotation_only is True
+        assert w.placeholderLabel.isHidden()
+        assert list(w.model_checkbox_widgets) == ["openai/gpt-4o"]
+
+    def test_batch_web_api_only_hides_unavailable_options_and_shows_placeholder(
+        self, qtbot, mock_model_service
+    ):
+        """Web API only で API key 未設定などにより実行不能な候補だけなら placeholder を表示する"""
+        model = _fake_db_model(
+            name="gpt-4o",
+            provider="openai",
+            litellm_model_id="openai/gpt-4o",
+            requires_api_key=True,
+            capabilities=["caption"],
+        )
+        mock_model_service.load_grouped_models.return_value = build_display_options([model], set(), "auto")
         w = ModelSelectionWidget(model_selection_service=mock_model_service, mode="advanced")
         qtbot.addWidget(w)
 
         w.apply_filters(execution_env="APIモデルのみ", annotation_only=True)
 
         assert not w.placeholderLabel.isHidden()
-        assert w.placeholderLabel.text() == ModelSelectionWidget.WEB_API_BATCH_PLACEHOLDER
+        assert w.placeholderLabel.text() == ModelSelectionWidget.WEB_API_UNAVAILABLE_PLACEHOLDER
         assert w.model_checkbox_widgets == {}
-        assert w.get_selected_models() == []
 
     def test_non_batch_web_api_only_uses_normal_filtering(self, qtbot, mock_model_service):
         """通常利用時の Web API only は batch placeholder 分岐に入らない"""
@@ -121,7 +153,7 @@ class TestModelSelectionWidgetFilters:
 
         w.apply_filters(execution_env="APIモデルのみ")
 
-        assert w.placeholderLabel.text() != ModelSelectionWidget.WEB_API_BATCH_PLACEHOLDER
+        assert w.placeholderLabel.text() == ModelSelectionWidget.WEB_API_UNAVAILABLE_PLACEHOLDER
         assert mock_model_service.load_grouped_models.call_args[0][0].execution_env == "APIモデルのみ"
 
     def test_batch_annotation_filtering_passes_annotation_only_criteria(self, qtbot, mock_model_service):


### PR DESCRIPTION
## Summary
- remove the Batch Tag Web API placeholder-only branch so Web API selection uses the normal grouped model list
- filter out unavailable Web API route options before rendering, and show a clear placeholder only when no usable Web API candidates remain
- update widget tests to cover Web API row rendering and unavailable-candidate placeholder behavior

Fixes #585

Branch: issue-585-webapi-model-list-impl
Worktree: /tmp/worktrees/issue-585-webapi-model-list-impl
ADR: docs/decisions/0030-batch-annotation-model-selection-ui.md was already amended in #586.

## Verification
- UV_CACHE_DIR=/tmp/uv-cache UV_PROJECT_ENVIRONMENT=/workspaces/LoRAIro/.venv uv run pytest tests/unit/gui/widgets/test_model_selection_widget.py -q
- UV_CACHE_DIR=/tmp/uv-cache UV_PROJECT_ENVIRONMENT=/workspaces/LoRAIro/.venv uv run pytest tests/unit/services/test_model_selection_service.py -q
- UV_CACHE_DIR=/tmp/uv-cache UV_PROJECT_ENVIRONMENT=/workspaces/LoRAIro/.venv uv run ruff check src/lorairo/gui/widgets/model_selection_widget.py tests/unit/gui/widgets/test_model_selection_widget.py
- git diff --check