### PR TITLE
fix: de-list WebAPI models removed from library discovery (#589)

### DIFF
--- a/docs/decisions/0048-webapi-annotation-candidate-filtering.md
+++ b/docs/decisions/0048-webapi-annotation-candidate-filtering.md
@@ -1,0 +1,66 @@
+# ADR 0048: WebAPI Annotation Candidate Filtering (Endpoint / Capability / Suitability)
+
+- **日付**: 2026-05-31
+- **ステータス**: Accepted
+- **関連 Issue**: [NEXTAltair/image-annotator-lib#130](https://github.com/NEXTAltair/image-annotator-lib/issues/130), [NEXTAltair/image-annotator-lib#131](https://github.com/NEXTAltair/image-annotator-lib/issues/131), [NEXTAltair/LoRAIro#589](https://github.com/NEXTAltair/LoRAIro/issues/589)
+- **関連 ADR**: [ADR 0021](0021-litellm-driven-model-registry.md), [ADR 0023](0023-pydanticai-litellm-webapi-inference-boundary.md), [ADR 0026](0026-on-demand-runtime-validation-strategy.md), [ADR 0038](0038-provider-batch-api-integration-strategy.md)
+
+## Context
+
+`image-annotator-lib` の WebAPI discovery (`webapi/api_model_discovery.py`) は LiteLLM 同梱 DB を runtime SSoT とし、`supports_vision` + `supports_function_calling` + `mode ∈ {chat, responses}` を満たすモデルを annotation 候補として登録する (ADR 0023 Phase 1.6)。LoRAIro はこの候補一覧を信頼して DB sync / UI 表示する。
+
+実運用で、現行の同期 annotation runtime では使えないモデルや、用途が画像 annotation に合わないモデルが候補に紛れ込む問題が表面化した。168 件の discovery 結果を分類した結果、原因の異なる複数の不適格モデルが存在した:
+
+- **`mode=responses` 専用モデル** (23 件: deep-research / codex 直 / pro ティア)。現 runtime (`webapi/model_id.py:build_pydantic_model`) は OpenAI を常に `OpenAIChatModel` (`v1/chat/completions`) で構築するため、Responses 専用モデルは実行時に 404。
+- **`tools` 非対応モデル** (例: `gpt-5-search-api` 族)。LiteLLM が `supports_function_calling=True` と報告するが、`get_model_info().supported_openai_params` には `tools` / `tool_choice` が無い。LiteLLM の capability boolean が自身の param リストと矛盾しており、現条件をすり抜ける。
+- **用途不適モデル** (TTS / computer-use / web 検索強制の search-preview)。`mode=chat` でエンドポイント上は動くが、出力 modality や対話パラダイムが画像 annotation に合わない。これらは LiteLLM metadata では判別できない (`supports_audio_output` 誤報、`supports_web_search=True` は優良モデルも持つため判定軸に使えない)。
+
+加えて消費側の問題として、LoRAIro `ModelSyncService.sync_available_models()` は register / update のみで de-list を持たず、ライブラリが提供しなくなったモデルが `discontinued_at=NULL` のまま `available=True` で残存し続ける (`Model.available = discontinued_at is None`)。
+
+これらは独立した関心事であり、ひとつの「フィルタ強度」ノブで扱うと優良モデルの巻き添え (pro ティアを「不適格」と誤排除) や本丸の取り逃し (chat-mode の用途不適モデルが残る) を招く。
+
+## Decision
+
+WebAPI annotation 候補の選別を **3 つの直交する軸** に分解し、それぞれ独立に実装する。
+
+### 軸A — エンドポイント実行可能性 (capability gate)
+現 runtime が実際に構築・実行できる endpoint のモデルのみを候補にする。現状 runtime は Chat Completions 一本 (ADR 0023 同期経路 / ADR 0038 batch も `/v1/chat/completions`) のため、annotation 候補は `mode == "chat"` に限定する。`mode=responses` は「不適格」ではなく「現 runtime 未対応」として扱い、Responses runtime 対応で gate を反転する (軸の forward path、後述)。
+
+### 軸B — capability 判定の正確化 (tool/function calling)
+ADR 0023 Phase 1.6 で確立した「tool/function calling を絞り込み主条件にする」を踏襲しつつ、LiteLLM の `supports_function_calling` boolean を盲信しない。`get_model_info().supported_openai_params` が populate されている場合は `"tools"` の実在を要求し (ground truth 優先)、未populate (Gemini / Anthropic 等) の場合のみ boolean を信頼する。これにより `tools` 非対応の search-api 族を名前非依存で除外しつつ、param を populate しない provider を巻き込まない。
+
+### 軸C — アノテーション適性 (suitability denylist)
+エンドポイント・capability が揃っても用途が画像 annotation に合わないモデルは、LiteLLM metadata で判別不能なため curated な名前 substring denylist で除外する (TTS / computer-use / web 検索強制 / data-source tool 前提の deep-research)。軸A の gate とは独立した定数・関数として実装し、軸A を反転しても denylist は維持する。denylist は test fixture で固定し、LiteLLM DB の月次 dependency review で drift を確認する。
+
+### 消費側 — de-list reconcile (LoRAIro)
+ライブラリが提供しなくなった WebAPI モデルを LoRAIro が正しく無効化できるようにする。`ModelSyncService.sync_available_models()` に reconcile ステップを追加し、現在の discovery に存在しない WebAPI モデル (`requires_api_key=True`) を soft-delete (`discontinued_at` 設定) する。ローカル ML モデルと MANUAL_EDIT sentinel は対象外。既 discontinued 行は再書き込みしない。再出現時の reactivation は既存 update 経路 (`discontinued_at=None`) が担う。これはライブラリ側フィルタとは独立した汎用的な堅牢性であり、新規 DB はライブラリ側フィルタが、既存 DB は本 de-list がカバーする。
+
+### Forward path — Responses runtime (別軸 / 次段階)
+OpenAI は Responses API を主軸化し pro / 専用ティアを Responses 専用で提供する。将来 `OpenAIResponsesModel` 経路を追加し軸A の gate を反転すれば pro ティア (gpt-5-pro / o3-pro 等) が実行可能になる。これは ADR 0023 の Chat 一本化を見直すアーキテクチャ判断であり、本 ADR のスコープ外 (別 Issue / 別 ADR)。その際も軸C denylist (deep-research 等) は維持する。
+
+## Consequences
+
+**Positive**
+- pro ティアを「不適格」と誤排除せず「runtime 未対応」として正しく区別 — 将来の Responses 対応で復活させられる。
+- search-api 族を名前非依存・metadata 駆動で除外。将来の同種モデルも自動的に弾ける。
+- 軸の分離により Responses runtime 対応時に軸A だけを反転でき、変更範囲が局所化する。
+- 既存 DB に残った stale モデルも消費側 de-list で UI から消える。
+
+**Negative / Trade-off**
+- 軸C は curated denylist のため LiteLLM DB 更新で drift し得る。月次 dependency review + test fixture 固定で緩和する。
+- 現状 OpenAI pro ティアは利用不可 (Responses runtime 未対応のため)。Forward path で解消予定。
+
+## Alternatives Considered
+
+- **`mode=responses` を一律除外するだけ**: pro ティアを「不適格」と誤ラベルし恒久排除、かつ chat-mode の用途不適モデルを取り逃す。軸の混同。却下。
+- **provider family allowlist (opt-in)**: 安全だが LiteLLM 駆動 auto-discovery (ADR 0021) の利点を殺し、新モデルごとに手動追加が必要。却下。
+- **`supports_web_search` で search モデルを除外**: gpt-5 / gemini-2.5-pro 等の優良モデルも `supports_web_search=True` を持つため 60 件規模の誤除外。却下。
+- **soft tier (recommended フラグ) で表示抑制**: 候補一覧には残るため「不適格モデルがリストアップされる」問題を解消しない。却下。
+
+## Related
+
+- ADR 0021 — LiteLLM-Driven WebAPI Model Registry (auto-discovery 基盤)
+- ADR 0023 — PydanticAI / LiteLLM WebAPI Inference Boundary (軸B の tool 主条件 / Chat 一本化の SSoT、Forward path で改訂対象)
+- ADR 0026 — On-Demand Runtime Validation Strategy (Responses runtime の実 API 検証方針)
+- ADR 0038 — Provider Batch API Integration Strategy (Chat Completions 統一の根拠)
+- `.claude/rules/dependency-management.md` — denylist drift の月次 review

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -51,6 +51,7 @@ LoRAIro の重要な設計判断を記録するドキュメント群。
 | [0045](0045-large-search-result-log-level.md) | Large Search Result Log Level | 2026-05-31 | Accepted |
 | [0046](0046-loguru-placeholder-format.md) | Loguru Placeholder Format | 2026-05-31 | Accepted |
 | [0047](0047-trace-level-for-per-item-diagnostics.md) | TRACE Level for Per-Item Diagnostics | 2026-05-31 | Accepted |
+| [0048](0048-webapi-annotation-candidate-filtering.md) | WebAPI Annotation Candidate Filtering (Endpoint / Capability / Suitability) | 2026-05-31 | Accepted |
 
 ## ADR テンプレート
 

--- a/docs/plans/plan_130_webapi_model_filtering_agentteams.md
+++ b/docs/plans/plan_130_webapi_model_filtering_agentteams.md
@@ -1,0 +1,187 @@
+# Plan: WebAPI discovery のモデル絞り込み是正 + Responses エンドポイント対応 (iam-lib #130 / LoRAIro #589)
+
+- **親 Issue**: [image-annotator-lib#130](https://github.com/NEXTAltair/image-annotator-lib/issues/130) — WebAPI discovery が annotation 不適合な OpenAI Responses/deep-research 系モデルを候補に含める
+- **連動 Issue**: [LoRAIro#589](https://github.com/NEXTAltair/LoRAIro/issues/589) — deep-research モデル選択で 404
+- **作成日**: 2026-05-31
+- **方針 (user 確定)**: 絡まった複数問題を **repo 所有権で別Issue に切り分ける**。
+  - **Issue X = iam-lib #130 (更新済, 優先)**: deep-research 等、用途外モデルがリストアップされる = **ライブラリ側の問題**。discovery の絞り込み条件を変更。
+  - **Issue Y = LoRAIro #589 (更新済)**: 提供されなくなったモデルを LoRAIro がうまく保存・参照できていない = **LoRAIro 側の問題**。de-list/discontinued 追跡。#130 クリーンアップに留まらない**汎用的な堅牢性 Issue**として単独で価値がある。
+  - **Issue Z = iam-lib #131 (新規作成済, 次段階)**: Responses エンドポイント対応 (優先度低)。
+- **設計原則**: エンドポイント互換性 (軸A) と アノテーション適性 (軸B) は **別軸**。両者をコード上も分離して実装し、Issue Z で軸A の gate だけを反転できるようにする。
+- **#589 (deep-research 404) の解消責務分担**: Issue X は **新規/fresh DB** (deep-research が二度と sync されない) を、Issue Y は **既存 DB** (sync 済 stale 行の de-list) をカバー。両方で完全解消。
+
+---
+
+## 1. 調査で確定した事実 (Evidence)
+
+### 1.1 根本原因 (軸A: エンドポイント)
+- `webapi/model_id.py:build_pydantic_model()` は OpenAI を**無条件に `OpenAIChatModel` (`v1/chat/completions`)** で構築 (model_id.py:168-173)。
+- `webapi/api_model_discovery.py:_is_litellm_model_annotation_compatible()` は `mode in {"chat", "responses"}` を許可 (api_model_discovery.py:111)。
+- → `mode=responses` 専用モデルは実行時に必ず 404 (`This model is only supported in v1/responses`)。
+- runtime は `resolve_model_ref(litellm_model_id, config)` → `build_pydantic_model(ref, ...)` の経路で、**`mode`/endpoint 情報を一切受け取らない** (provider_manager.py:156-163)。
+
+### 1.2 在庫 litellm DB の実測分類 (168件中)
+| 区分 | mode | 件数 | 代表 |
+|---|---|---|---|
+| 標準 chat (適格) | chat | 大多数 | gpt-4o, gpt-5, gpt-5.1, gpt-5.5(無印), o3, o4-mini, claude-*, gemini-2.5-pro |
+| **responses 専用** | responses | **23** | deep-research×4, codex(OpenAI直)×5, **pro ティア**(gpt-5-pro, gpt-5.2/5.4/5.5-pro, o1-pro, o3-pro +日付版) |
+| TTS (音声出力) | chat | 1 | `gemini/gemini-2.5-pro-preview-tts` |
+| computer-use (PC操作) | chat | 1 | `gemini/gemini-2.5-computer-use-preview-10-2025` |
+| search 専用 (web検索強制) | chat | 6 | `gpt-4o-search-preview`系, `gpt-5-search-api`系 |
+| moderation (rating用、別扱い) | moderation | 2 | `openai/omni-moderation-*` (ADR 0042、capabilities=["ratings"]) |
+
+- **OpenRouter 経由 codex** (`openrouter/openai/gpt-5.1-codex-max`) は `mode=chat` で**実際に動作可能**。→ 名前で "codex" 一律除外は軸A的には誤り。
+- litellm メタデータは TTS/computer-use/search を**クリーンに判別できない** (実証: `supports_audio_output=False` 誤報、`supports_web_search=True` は gpt-5 等 60件の優良モデルも持つため判定軸に使えない)。→ 軸B は curated denylist に頼らざるを得ない。
+
+### 1.3 OpenAI 上流 / プロジェクト現状の整合 (軸Aの戦略的背景)
+- OpenAI は Responses API を主軸化、Chat Completions はレガシー互換維持。pro/専用ティアは Responses 専用で Chat には載らない。
+- プロジェクトは意図的に Chat Completions 一本化: ADR 0023 (同期) / ADR 0038 line 511,514 (batch も `/v1/chat/completions` 選択) / plan_525 line 45 (PydanticAI 2.0 beta の Responses 強制切替は**不採用**、`griffe<2` pin)。
+- iam-lib に `OpenAIResponsesModel` 経路は**未実装** (grep 確認済)。pydantic_ai 1.100.0 に `OpenAIResponsesModel` クラスは**存在**する。
+- → 現アーキテクチャでは responses 専用モデルの除外は **"用途不適" ではなく "Chat runtime が実行不能"** という endpoint 理由。サブ#2 完了でこの gate は反転すべき対象。
+
+### 1.4 消費側 (LoRAIro) の de-list 欠落 (サブ#1 が iam-lib だけで完結しない根拠)
+- `Model.available` プロパティ = `discontinued_at is None` (schema.py:148-150)。
+- `ModelSyncService.sync_available_models()` は **register_new + update_existing のみ。de-list (削除/無効化) ステップが無い** (model_sync_service.py:258-290)。
+- → iam-lib が deep-research を discovery から外しても、**既に DB 登録済みの行は `discontinued_at=NULL` のまま `available=True`** で UI に残存・選択可能。これがログで `o4-mini-deep-research` が選択・送信できた事象の consumer 側原因。
+- 同期は `litellm_model_id` を key とする (ADR 0023 Phase 1.11 / #238)。
+
+---
+
+## 2. 軸の分解 (設計の骨格)
+
+| 軸 | 関心事 | サブ#1 で対応 | サブ#2 で対応 |
+|---|---|---|---|
+| **A: エンドポイント** | Chat runtime が実行可能か | responses を **endpoint-gate で除外** (mode=chat のみ許可)。"Responses 待ち" として位置づけ | `OpenAIResponsesModel` 対応で gate 反転、pro ティア復活 |
+| **B: アノテーション適性** | 用途が画像 annotation に合うか | TTS/computer-use/search/deep-research を **suitability denylist で除外** | 変更なし (denylist は維持) |
+| **C: 消費側 de-list** | 旧 sync 済モデルを DB から消すか | `ModelSyncService` に **reconcile/de-list** 追加 | 変更なし |
+
+実装上の制約: **軸A の gate と軸B の denylist をコード上分離する** (別関数 / 別定数)。サブ#2 では軸A の gate だけを反転し、軸B の denylist (deep-research 等) は残す。
+
+---
+
+## 3. サブ#1 — モデル絞り込み条件の変更 (優先)
+
+### 3.1 サブ#1A (= iam-lib #130): discovery 変更 【方針 user 確定済】
+**ファイル**: `local_packages/image-annotator-lib/src/image_annotator_lib/webapi/api_model_discovery.py`
+
+設計原則: **#45 / ADR 0023 で確定済の「tool/function calling を絞り込み主条件にする」を踏襲し、litellm `supports_function_calling` boolean が `supported_openai_params` と矛盾する不正確さを是正する。** 新機構の追加ではなく既存条件の精度向上。
+
+1. **軸A endpoint-gate**: `_SUPPORTED_LITELLM_MODES = frozenset({"chat"})` (← `responses` 削除)。
+   - docstring を「Chat Completions runtime が実行可能な mode」に更新。`responses` は #131 (Responses runtime) 待ちである旨コメント + link。
+   - 効果: responses 23件除外 (deep-research / codex-direct / pro ティア)。
+2. **軸B tool 対応の正確化** (`_is_litellm_model_annotation_compatible` を改修):
+   ```python
+   mode == "chat"
+   and info.get("supports_vision") is True
+   and info.get("supports_function_calling") is True
+   and (
+       not info.get("supported_openai_params")          # 未populate (Gemini/Anthropic等) は boolean 信頼
+       or "tools" in info["supported_openai_params"]     # populate時 (OpenAI) は tools 実在を要求
+   )
+   ```
+   - `gpt-5-search-api` 族は `supported_openai_params` に `tools` 無し → **名前非依存で metadata 駆動除外**(将来の search-api も自動)。
+   - 「未populate なら boolean 信頼」ガードで Gemini/Anthropic を巻き込まない。
+3. **軸B 残余 name denylist** (metadata が嘘 or 未populate のみ、endpoint-gate とは独立した定数/関数):
+   ```python
+   _ANNOTATION_UNSUITABLE_SUBSTR = (
+       "-tts",            # 音声出力 (Gemini, params 未populate)
+       "computer-use",    # PC操作特化 (params 未populate)
+       "-search-preview", # tools を申告するが web検索強制 (gpt-4o-search-preview)
+       "deep-research",   # data-source tool 前提。#131 で gate 反転後も除外維持 (forward-compat)
+   )
+   ```
+   - `-search-api` は手順2の metadata 条件で除外済のため denylist 不要。
+   - **codex は denylist に入れない (確定)**: OpenAI直 codex は軸A gate で除外、OpenRouter chat codex (`openrouter/openai/gpt-5.1-codex-max`) は動作可能なため残す。
+4. moderation モデルは現状維持 (ADR 0042、capabilities=["ratings"]、別経路)。
+5. **実装分離**: 軸A gate と軸B (tool 条件 + denylist) を別関数/別定数に分離 → #131 で軸A gate のみ反転、軸B denylist は維持。
+6. **ADR**: 判定根拠を ADR 0023 改訂 or 新規 ADR に記録。denylist は test fixture 固定 + 月次 dependency review で drift 確認。
+
+**テスト**: `tests/unit/webapi/test_api_model_discovery.py` (既存に追記 or 新規)
+- 除外 assert: `o3-deep-research*`, `o4-mini-deep-research*`, `gpt-5-pro`, `o3-pro`, `*-tts`, `computer-use*`, `*-search-preview*`, `*-search-api*` が discovery 結果に**出ない**。
+- 回帰ガード assert: `gpt-4o`, `gpt-5`, `gpt-5.5`, `claude-sonnet-4-5`, `gemini-2.5-pro` が**残る** (過剰除外していない)。
+- `mode=responses` 全件除外を fixture で固定。
+- litellm は `LITELLM_LOCAL_MODEL_COST_MAP=True` で同梱 DB のみ参照 (network 不要)。
+
+### 3.2 サブ#1B: LoRAIro ModelSyncService de-list (reconcile)
+**ファイル**: `src/lorairo/services/model_sync_service.py`, `src/lorairo/database/repository/model.py`
+
+1. `sync_available_models()` に **第4ステップ「reconcile/de-list」** を追加:
+   - 現在の lib discovery set (litellm_model_id) を取得。
+   - DB の **API モデル** (requires_api_key=True かつ litellm_model_id 保有、ローカル ML / 合成 moderation は除外) のうち、discovery set に**無い**行に `discontinued_at = now()` を設定 (soft-delete)。
+   - 再出現時は `discontinued_at = NULL` に戻す (update_existing 経路で復活)。
+2. `ModelSyncResult` に `delisted_count` を追加、summary に反映。
+3. Repository に de-list 用メソッド (例: `mark_discontinued(litellm_model_ids: set[str])` / 再活性化) を追加。
+
+**テスト**:
+- unit: DB に存在し lib discovery に無い API モデル → `discontinued_at` 設定 → `available==False`。
+- unit: ローカル ML / moderation 合成モデルは de-list 対象外。
+- regression: `openai/o4-mini-deep-research-2025-06-26` が sync 後 `available==False` (#589 再現防止)。
+- BDD (任意): 「discovery から外れたモデルは選択候補に出ない」シナリオ。
+
+### 3.3 統合
+1. サブ#1A を iam-lib branch で実装・PR・merge。
+2. LoRAIro 側 submodule pin を A の commit に bump (`local_packages/image-annotator-lib`)。
+3. サブ#1B を同 PR or 後続 PR で実装。
+4. **CI-equivalent filter** 実行 (submodule pin 変更を含むため Hook gate 対象):
+   - iam-lib: `-m "not downloads_and_runs_model and not calls_real_webapi"`
+   - LoRAIro: `-m "not gui_show and not calls_real_webapi and not downloads_and_runs_model and not slow"`
+5. 検証: アプリ起動 → discovery 168→~131件、UI に deep-research/tts/computer-use/search が出ない、既存 DB の stale 行が de-list される。
+
+### 3.4 サブ#1 受け入れ条件
+- [ ] discovery が OpenAI `mode=responses` を候補に含めない (unit test)。
+- [ ] `o3-deep-research*` / `o4-mini-deep-research*` が候補に出ない (unit test)。
+- [ ] tts / computer-use / search-preview / search-api が候補に出ない (unit test)。
+- [ ] 標準モデル (gpt-4o, gpt-5, claude, gemini-2.5-pro) は残る (回帰 test)。
+- [ ] 軸A gate と軸B denylist がコード上分離されている (サブ#2 で gate 反転可能)。
+- [ ] LoRAIro: discovery から消えた API モデルが DB で `available==False` になる (de-list test)。
+- [ ] `o4-mini-deep-research` が LoRAIro UI 選択候補に出ない (#589 regression)。
+- [ ] CI-equivalent filter 全 pass。
+
+---
+
+## 4. サブ#2 — Responses エンドポイント対応 (次段階、別Issue)
+
+> 優先度低。サブ#1 完了後に別 Issue / 別 ADR で着手。OpenAI の Responses 主軸化に追従し pro ティア (gpt-5-pro, o3-pro 等) を実行可能にする。
+
+**概要 (詳細はサブ#2 起票時に planning)**:
+- `model_id.py`: OpenAI `mode=responses` を `OpenAIResponsesModel` で構築する分岐を追加。`mode`/endpoint を discovery metadata → registry → `resolve_model_ref`/`build_pydantic_model` に配線 (現状 mode 非伝播)。
+- `api_model_discovery.py`: 軸A endpoint-gate を反転し responses を再許可 (軸B denylist の deep-research 等は除外維持)。
+- ADR 0023 改訂: Chat Completions 一本化 → Chat + Responses dual-endpoint。plan_525 の PydanticAI 2.0 不採用判断との整合を再評価。
+- refusal: ADR 0006 (iam-lib) が Responses refusal contract を既にカバー。
+- 構造化出力: Chat と Responses で tool schema / response shape 差異 (plan_518 で指摘済) を fixture 化。deep-research は data-source tool 配線が別途必要なため軸B で除外継続。
+- 検証: ADR 0026 On-Demand Runtime Validation に従い実 API smoke。
+
+---
+
+## 5. Agent Teams 実行体制 (サブ#1)
+
+> memory: Agent worktree isolation は壊れている → **手動 worktree + 共有 venv** で並列ディスパッチ。`UV_PROJECT_ENVIRONMENT=/workspaces/LoRAIro/.venv` 明示。並列 `uv sync` 禁止 (Issue #222)。
+
+| Track | 担当 | worktree | 担当ファイル (競合回避) |
+|---|---|---|---|
+| **A: iam-lib discovery** | discovery filter + unit test | `/tmp/worktrees/iam-130-discovery` (iam-lib branch) | `webapi/api_model_discovery.py`, `tests/unit/webapi/test_api_model_discovery.py` |
+| **B: LoRAIro de-list** | ModelSyncService reconcile + test | `/tmp/worktrees/lorairo-130-delist` (LoRAIro branch) | `services/model_sync_service.py`, `database/repository/model.py`, 対応 test |
+| **統合 (本体)** | submodule pin bump, CI-equiv, 起動検証 | 共有 checkout | `local_packages/image-annotator-lib` pin, `uv.lock` |
+
+- A と B は別 repo / 別ファイル → 独立並列可能。
+- B の end-to-end 検証は A の pin 後に実施 (依存は統合フェーズで吸収)。
+- 各 Track の調査は並列で先行可、実装後に統合フェーズで直列化。
+
+---
+
+## 6. リスクと対策
+| リスク | 対策 |
+|---|---|
+| litellm DB 月次更新で denylist が drift (新 tts/search モデル追加) | denylist を test fixture で固定、月次 dependency review で確認 (dependency-management.md) |
+| codex 除外可否の判断ミス | サブ#1 では endpoint-gate のみで自然除外 (OpenRouter codex は残す)、サブ#2 で再検討 |
+| de-list が local ML / moderation を誤って無効化 | de-list 対象を「API モデル かつ litellm_model_id 保有 かつ discovery 所有」に限定、合成 moderation を除外 test |
+| 過剰除外で優良モデルが消える | 回帰 test で標準モデル残存を assert |
+| submodule pin 変更で CI 漏れ | CI-equivalent filter を PR 前に必須実行 (Hook gate) |
+
+## 7. Related
+- iam-lib #130 (親), LoRAIro #589 (連動)
+- ADR 0023 (PydanticAI/LiteLLM WebAPI Inference Boundary) — サブ#2 で改訂対象
+- ADR 0038 (Provider Batch API Integration Strategy) — Chat Completions 統一の根拠
+- ADR 0042 (OpenAI Moderation WebAPI Preflight) — moderation モデル別扱い
+- plan_525 (CLI dependency drift) — PydanticAI 2.0 Responses 強制切替 不採用の記録
+- plan_518 (OpenAI annotation batch) — Chat vs Responses endpoint 選択経緯

--- a/src/lorairo/cli/commands/annotate.py
+++ b/src/lorairo/cli/commands/annotate.py
@@ -493,6 +493,25 @@ def _get_deprecated_models_best_effort(annotator: Any, model_names: list[str]) -
         return []
 
 
+def _abort_if_discontinued(model: Any) -> None:
+    """de-list 済 (available=False) モデルは fail-fast で abort する (Issue #589 / PR #590 review P2)。
+
+    GUI は `Model.available` でフィルタするが CLI resolver は exact ID で素通りしていたため、
+    de-list / 提供終了モデルを `annotate run --model <id>` で実行でき runtime 失敗 (404 等) を
+    招いていた。GUI と同じく discontinued なモデルを候補から除外する。
+
+    Raises:
+        typer.Exit: モデルが discontinued (`available=False`) の場合 (code=1)。
+    """
+    if not getattr(model, "available", True):
+        console.print(
+            f"[red]Error:[/red] Model '{model.litellm_model_id}' is discontinued / no longer "
+            "provided by the annotation library and cannot be used. "
+            "Run `lorairo-cli models list` to see available IDs."
+        )
+        raise typer.Exit(code=1)
+
+
 def _resolve_model_identifier(repository: ModelRepository, identifier: str) -> str:
     """ユーザー入力を canonical `litellm_model_id` に解決する (Issue #245)。
 
@@ -518,10 +537,12 @@ def _resolve_model_identifier(repository: ModelRepository, identifier: str) -> s
     """
     by_litellm = repository.get_model_by_litellm_id(identifier)
     if by_litellm is not None:
+        _abort_if_discontinued(by_litellm)
         return by_litellm.litellm_model_id
 
     by_name = repository.get_models_by_name(identifier)
     if len(by_name) == 1:
+        _abort_if_discontinued(by_name[0])
         resolved = by_name[0].litellm_model_id
         logger.debug(f"--model '{identifier}' を name 経由で {resolved} に解決")
         return resolved

--- a/src/lorairo/database/repository/model.py
+++ b/src/lorairo/database/repository/model.py
@@ -485,6 +485,54 @@ class ModelRepository(BaseRepository):
             logger.error(f"DB Modelオブジェクトの取得中にエラーが発生しました: {e}", exc_info=True)
             raise
 
+    def discontinue_api_models_absent_from(
+        self,
+        active_litellm_model_ids: set[str],
+        discontinued_at: datetime.datetime | None = None,
+    ) -> list[str]:
+        """ライブラリ discovery から消えた WebAPI モデルを discontinued にする (Issue #589)。
+
+        `ModelSyncService` の sync は register/update のみで de-list を行わないため、
+        提供されなくなった WebAPI モデルが `discontinued_at=NULL` のまま `available=True`
+        で UI に残存する。本メソッドは `active_litellm_model_ids` に含まれない WebAPI
+        モデルを soft-delete (discontinued_at 設定) する。
+
+        対象は `requires_api_key=True` の WebAPI モデルのみ。ローカル ML モデル
+        (`requires_api_key=False`) と MANUAL_EDIT sentinel は対象外。既に discontinued な
+        行は再書き込みしない (元の timestamp を保持し、冪等)。再出現時の reactivation は
+        `update_model` 経路 (`discontinued_at=None`) が担う。
+
+        Args:
+            active_litellm_model_ids: 現在 lib discovery に存在する litellm_model_id 集合。
+            discontinued_at: 設定する終了時刻。None なら現在 UTC 時刻。
+
+        Returns:
+            新たに de-list した litellm_model_id のリスト。
+        """
+        now = discontinued_at or datetime.datetime.now(datetime.UTC)
+        with self.session_factory() as session:
+            try:
+                stmt = select(Model).where(
+                    Model.requires_api_key.is_(True),
+                    Model.litellm_model_id.is_not(None),
+                    Model.discontinued_at.is_(None),
+                )
+                delisted: list[str] = []
+                for model in session.execute(stmt).scalars().all():
+                    if model.litellm_model_id in active_litellm_model_ids:
+                        continue
+                    if model.litellm_model_id == MANUAL_EDIT_LITELLM_ID:
+                        continue
+                    model.discontinued_at = now
+                    delisted.append(model.litellm_model_id)
+                if delisted:
+                    session.commit()
+                    logger.info(f"提供終了 WebAPI モデルを de-list: {len(delisted)}件")
+                return delisted
+            except SQLAlchemyError as e:
+                logger.error(f"WebAPI モデルの de-list 中にエラーが発生しました: {e}", exc_info=True)
+                raise
+
     def get_models_by_type(self, model_type_name: str) -> list[dict[str, Any]]:
         """指定されたタイプ名を持つモデルの情報を取得します。
 

--- a/src/lorairo/database/repository/model.py
+++ b/src/lorairo/database/repository/model.py
@@ -485,29 +485,32 @@ class ModelRepository(BaseRepository):
             logger.error(f"DB Modelオブジェクトの取得中にエラーが発生しました: {e}", exc_info=True)
             raise
 
-    def discontinue_api_models_absent_from(
+    def reconcile_api_model_availability(
         self,
         active_litellm_model_ids: set[str],
         discontinued_at: datetime.datetime | None = None,
-    ) -> list[str]:
-        """ライブラリ discovery から消えた WebAPI モデルを discontinued にする (Issue #589)。
+    ) -> tuple[list[str], list[str]]:
+        """WebAPI モデルの availability を lib discovery と双方向に reconcile する (Issue #589)。
 
         `ModelSyncService` の sync は register/update のみで de-list を行わないため、
         提供されなくなった WebAPI モデルが `discontinued_at=NULL` のまま `available=True`
-        で UI に残存する。本メソッドは `active_litellm_model_ids` に含まれない WebAPI
-        モデルを soft-delete (discontinued_at 設定) する。
+        で UI に残存する。本メソッドは現在の discovery (`active_litellm_model_ids`) に対し:
 
-        対象は `requires_api_key=True` の WebAPI モデルのみ。ローカル ML モデル
-        (`requires_api_key=False`) と MANUAL_EDIT sentinel は対象外。既に discontinued な
-        行は再書き込みしない (元の timestamp を保持し、冪等)。再出現時の reactivation は
-        `update_model` 経路 (`discontinued_at=None`) が担う。
+        - **de-list**: active set に**無い** WebAPI モデルを soft-delete (discontinued_at 設定)。
+        - **reactivate**: active set に**有る**が現在 discontinued な WebAPI モデルを復活
+          (discontinued_at=None)。`update_model` 経路は `_apply_simple_field_updates` が
+          `None` を無視するため reactivate できない (PR #590 review P1)。本メソッドが担う。
+
+        対象は `requires_api_key=True` の WebAPI モデルのみ。ローカル ML モデルと
+        MANUAL_EDIT sentinel は対象外。既に意図した状態の行は書き換えない (冪等)。
 
         Args:
-            active_litellm_model_ids: 現在 lib discovery に存在する litellm_model_id 集合。
-            discontinued_at: 設定する終了時刻。None なら現在 UTC 時刻。
+            active_litellm_model_ids: 現在 lib discovery で active な WebAPI モデルの
+                litellm_model_id 集合 (discontinued でないもの)。
+            discontinued_at: de-list 時に設定する終了時刻。None なら現在 UTC 時刻。
 
         Returns:
-            新たに de-list した litellm_model_id のリスト。
+            (de-list した litellm_model_id リスト, reactivate した litellm_model_id リスト)。
         """
         now = discontinued_at or datetime.datetime.now(datetime.UTC)
         with self.session_factory() as session:
@@ -515,22 +518,28 @@ class ModelRepository(BaseRepository):
                 stmt = select(Model).where(
                     Model.requires_api_key.is_(True),
                     Model.litellm_model_id.is_not(None),
-                    Model.discontinued_at.is_(None),
                 )
                 delisted: list[str] = []
+                reactivated: list[str] = []
                 for model in session.execute(stmt).scalars().all():
-                    if model.litellm_model_id in active_litellm_model_ids:
-                        continue
                     if model.litellm_model_id == MANUAL_EDIT_LITELLM_ID:
                         continue
-                    model.discontinued_at = now
-                    delisted.append(model.litellm_model_id)
-                if delisted:
+                    in_active = model.litellm_model_id in active_litellm_model_ids
+                    if model.discontinued_at is None and not in_active:
+                        model.discontinued_at = now
+                        delisted.append(model.litellm_model_id)
+                    elif model.discontinued_at is not None and in_active:
+                        model.discontinued_at = None
+                        reactivated.append(model.litellm_model_id)
+                if delisted or reactivated:
                     session.commit()
-                    logger.info(f"提供終了 WebAPI モデルを de-list: {len(delisted)}件")
-                return delisted
+                    logger.info(
+                        f"WebAPI モデル availability reconcile: "
+                        f"de-list {len(delisted)}件, reactivate {len(reactivated)}件"
+                    )
+                return delisted, reactivated
             except SQLAlchemyError as e:
-                logger.error(f"WebAPI モデルの de-list 中にエラーが発生しました: {e}", exc_info=True)
+                logger.error(f"WebAPI モデルの availability reconcile 中にエラー: {e}", exc_info=True)
                 raise
 
     def get_models_by_type(self, model_type_name: str) -> list[dict[str, Any]]:

--- a/src/lorairo/services/model_sync_service.py
+++ b/src/lorairo/services/model_sync_service.py
@@ -48,6 +48,7 @@ class ModelSyncResult:
     existing_models_updated: int
     errors: list[str]
     delisted_count: int = 0  # Issue #589: lib discovery から消えて de-list した WebAPI モデル数
+    reactivated_count: int = 0  # PR #590 review P1: lib に再出現して reactivate した WebAPI モデル数
 
     @property
     def success(self) -> bool:
@@ -62,6 +63,7 @@ class ModelSyncResult:
             f"新規登録 {self.new_models_registered}件, "
             f"更新 {self.existing_models_updated}件, "
             f"提供終了 {self.delisted_count}件, "
+            f"復活 {self.reactivated_count}件, "
             f"エラー {len(self.errors)}件"
         )
 
@@ -275,8 +277,8 @@ class ModelSyncService:
             # 3. 既存モデル更新
             update_count = self.update_existing_models(library_models)
 
-            # 4. de-list: lib discovery から消えた WebAPI モデルを discontinued にする (#589)
-            delisted_count = self.delist_removed_models(library_models)
+            # 4. availability reconcile: lib discovery と DB の availability を双方向同期 (#589)
+            delisted_count, reactivated_count = self.reconcile_model_availability(library_models)
 
             result = ModelSyncResult(
                 total_library_models=len(library_models),
@@ -284,6 +286,7 @@ class ModelSyncService:
                 existing_models_updated=update_count,
                 errors=[],
                 delisted_count=delisted_count,
+                reactivated_count=reactivated_count,
             )
 
             logger.info(f"アノテーションモデル同期完了: {result.summary}")
@@ -442,25 +445,44 @@ class ModelSyncService:
         logger.info(f"既存アノテーションモデル更新完了: {update_count}件")
         return update_count
 
-    def delist_removed_models(self, library_models: list[ModelMetadata]) -> int:
-        """lib discovery から消えた WebAPI モデルを DB 上で discontinued にする (Issue #589)。
+    def reconcile_model_availability(self, library_models: list[ModelMetadata]) -> tuple[int, int]:
+        """WebAPI モデルの availability を lib discovery と双方向 reconcile する (Issue #589)。
 
-        sync は register/update のみで de-list を行わないため、提供されなくなった WebAPI
-        モデルが `discontinued_at=NULL` のまま UI に残存する。現在の lib discovery に
-        存在しない WebAPI モデルを soft-delete する。ローカル ML モデルと MANUAL_EDIT
-        sentinel は repository 側で対象外。
+        sync は register/update のみで de-list / reactivate を行わないため、提供されなく
+        なった WebAPI モデルが UI に残存し、再提供されたモデルは復活しない。現在の
+        discovery に存在しない WebAPI モデルを de-list し、再出現したモデルを reactivate する。
+
+        PR #590 review P2: discovery に WebAPI モデルが 0 件の場合は、transient な discovery
+        障害 / local-only 結果で全 API モデルを誤って de-list するのを防ぐため reconcile を
+        スキップする。
 
         Args:
             library_models: 現在 lib discovery から取得した ModelMetadata リスト。
 
         Returns:
-            de-list した WebAPI モデル数。
+            (de-list 件数, reactivate 件数)。
         """
-        active_litellm_model_ids = {model["litellm_model_id"] for model in library_models}
-        delisted = self.db_repository.discontinue_api_models_absent_from(active_litellm_model_ids)
-        if delisted:
-            logger.info(f"提供終了 WebAPI モデルを de-list: {len(delisted)}件 ({delisted})")
-        return len(delisted)
+        # active = lib discovery 上で active (discontinued でない) な WebAPI モデル
+        active_api_model_ids = {
+            model["litellm_model_id"]
+            for model in library_models
+            if model.get("requires_api_key") and model.get("discontinued_at") is None
+        }
+        has_any_api_model = any(model.get("requires_api_key") for model in library_models)
+        if not has_any_api_model:
+            logger.warning(
+                "discovery に WebAPI モデルが 0 件。availability reconcile をスキップ "
+                "(transient な discovery 障害 / local-only 結果の可能性)。"
+            )
+            return 0, 0
+
+        delisted, reactivated = self.db_repository.reconcile_api_model_availability(active_api_model_ids)
+        if delisted or reactivated:
+            logger.info(
+                f"WebAPI モデル availability reconcile: de-list {len(delisted)}件 ({delisted}), "
+                f"reactivate {len(reactivated)}件 ({reactivated})"
+            )
+        return len(delisted), len(reactivated)
 
     def get_library_models_summary(self) -> dict[str, Any]:
         """ライブラリモデルのサマリー情報取得

--- a/src/lorairo/services/model_sync_service.py
+++ b/src/lorairo/services/model_sync_service.py
@@ -47,6 +47,7 @@ class ModelSyncResult:
     new_models_registered: int
     existing_models_updated: int
     errors: list[str]
+    delisted_count: int = 0  # Issue #589: lib discovery から消えて de-list した WebAPI モデル数
 
     @property
     def success(self) -> bool:
@@ -60,6 +61,7 @@ class ModelSyncResult:
             f"同期完了: ライブラリモデル {self.total_library_models}件, "
             f"新規登録 {self.new_models_registered}件, "
             f"更新 {self.existing_models_updated}件, "
+            f"提供終了 {self.delisted_count}件, "
             f"エラー {len(self.errors)}件"
         )
 
@@ -273,11 +275,15 @@ class ModelSyncService:
             # 3. 既存モデル更新
             update_count = self.update_existing_models(library_models)
 
+            # 4. de-list: lib discovery から消えた WebAPI モデルを discontinued にする (#589)
+            delisted_count = self.delist_removed_models(library_models)
+
             result = ModelSyncResult(
                 total_library_models=len(library_models),
                 new_models_registered=new_count,
                 existing_models_updated=update_count,
                 errors=[],
+                delisted_count=delisted_count,
             )
 
             logger.info(f"アノテーションモデル同期完了: {result.summary}")
@@ -435,6 +441,26 @@ class ModelSyncService:
 
         logger.info(f"既存アノテーションモデル更新完了: {update_count}件")
         return update_count
+
+    def delist_removed_models(self, library_models: list[ModelMetadata]) -> int:
+        """lib discovery から消えた WebAPI モデルを DB 上で discontinued にする (Issue #589)。
+
+        sync は register/update のみで de-list を行わないため、提供されなくなった WebAPI
+        モデルが `discontinued_at=NULL` のまま UI に残存する。現在の lib discovery に
+        存在しない WebAPI モデルを soft-delete する。ローカル ML モデルと MANUAL_EDIT
+        sentinel は repository 側で対象外。
+
+        Args:
+            library_models: 現在 lib discovery から取得した ModelMetadata リスト。
+
+        Returns:
+            de-list した WebAPI モデル数。
+        """
+        active_litellm_model_ids = {model["litellm_model_id"] for model in library_models}
+        delisted = self.db_repository.discontinue_api_models_absent_from(active_litellm_model_ids)
+        if delisted:
+            logger.info(f"提供終了 WebAPI モデルを de-list: {len(delisted)}件 ({delisted})")
+        return len(delisted)
 
     def get_library_models_summary(self) -> dict[str, Any]:
         """ライブラリモデルのサマリー情報取得

--- a/tests/unit/cli/test_annotate_model_resolution.py
+++ b/tests/unit/cli/test_annotate_model_resolution.py
@@ -15,12 +15,15 @@ import typer
 from lorairo.cli.commands.annotate import _resolve_model_identifier
 
 
-def _fake_model(litellm_model_id: str, name: str, provider: str | None = None) -> SimpleNamespace:
+def _fake_model(
+    litellm_model_id: str, name: str, provider: str | None = None, *, available: bool = True
+) -> SimpleNamespace:
     """`Model` 互換の軽量 fake。"""
     return SimpleNamespace(
         litellm_model_id=litellm_model_id,
         name=name,
         provider=provider,
+        available=available,
     )
 
 
@@ -100,3 +103,37 @@ class TestResolveModelIdentifier:
         _resolve_model_identifier(repository, "openai/gpt-4o")
 
         repository.get_models_by_name.assert_not_called()
+
+    def test_discontinued_litellm_match_aborts(
+        self, repository: Mock, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """de-list 済 (available=False) モデルは litellm_model_id 一致でも abort する (PR #590 review P2)。"""
+        target = _fake_model(
+            "openai/o4-mini-deep-research-2025-06-26",
+            "openai/o4-mini-deep-research-2025-06-26",
+            "openai",
+            available=False,
+        )
+        repository.get_model_by_litellm_id.return_value = target
+
+        with pytest.raises(typer.Exit) as excinfo:
+            _resolve_model_identifier(repository, "openai/o4-mini-deep-research-2025-06-26")
+
+        assert excinfo.value.exit_code == 1
+        out = capsys.readouterr().out
+        assert "openai/o4-mini-deep-research-2025-06-26" in out
+        assert "discontinued" in out
+
+    def test_discontinued_name_match_aborts(
+        self, repository: Mock, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """name 一致でも de-list 済モデルは abort する (PR #590 review P2)。"""
+        repository.get_model_by_litellm_id.return_value = None
+        repository.get_models_by_name.return_value = [
+            _fake_model("openai/removed", "removed", "openai", available=False),
+        ]
+
+        with pytest.raises(typer.Exit) as excinfo:
+            _resolve_model_identifier(repository, "removed")
+
+        assert excinfo.value.exit_code == 1

--- a/tests/unit/database/repository/test_model_repository.py
+++ b/tests/unit/database/repository/test_model_repository.py
@@ -189,3 +189,61 @@ class TestGetOrCreateManualEditModel:
             session.commit()
 
         assert first_id == second_id
+
+
+@pytest.mark.unit
+class TestDiscontinueApiModelsAbsentFrom:
+    """`discontinue_api_models_absent_from` の de-list 動作 (Issue #589)。"""
+
+    def _insert(self, repo: ModelRepository, litellm_id: str, *, requires_api_key: bool) -> int:
+        return repo.insert_model(
+            name=litellm_id,
+            provider="openai" if requires_api_key else None,
+            model_types=["multimodal"] if requires_api_key else ["tags"],
+            litellm_model_id=litellm_id,
+            requires_api_key=requires_api_key,
+        )
+
+    def test_delists_api_model_absent_from_active_set(self, model_repository: ModelRepository) -> None:
+        """active set に無い WebAPI モデルは discontinued になる。"""
+        self._insert(model_repository, "openai/keep", requires_api_key=True)
+        self._insert(model_repository, "openai/o4-mini-deep-research-2025-06-26", requires_api_key=True)
+
+        delisted = model_repository.discontinue_api_models_absent_from({"openai/keep"})
+
+        assert delisted == ["openai/o4-mini-deep-research-2025-06-26"]
+        kept = model_repository.get_model_by_litellm_id("openai/keep")
+        removed = model_repository.get_model_by_litellm_id("openai/o4-mini-deep-research-2025-06-26")
+        assert kept is not None and kept.available is True
+        assert removed is not None and removed.available is False
+
+    def test_local_ml_models_are_never_delisted(self, model_repository: ModelRepository) -> None:
+        """requires_api_key=False のローカル ML モデルは active set 外でも対象外。"""
+        self._insert(model_repository, "wd-vit-tagger-v3", requires_api_key=False)
+
+        delisted = model_repository.discontinue_api_models_absent_from(set())
+
+        assert delisted == []
+        local = model_repository.get_model_by_litellm_id("wd-vit-tagger-v3")
+        assert local is not None and local.available is True
+
+    def test_manual_edit_sentinel_is_never_delisted(self, model_repository: ModelRepository) -> None:
+        """MANUAL_EDIT sentinel は active set 外でも de-list しない。"""
+        with model_repository.session_factory() as session:
+            ModelRepository._get_or_create_manual_edit_model(session)
+            session.commit()
+
+        delisted = model_repository.discontinue_api_models_absent_from(set())
+
+        assert MANUAL_EDIT_LITELLM_ID not in delisted
+        sentinel = model_repository.get_model_by_litellm_id(MANUAL_EDIT_LITELLM_ID)
+        assert sentinel is not None and sentinel.available is True
+
+    def test_already_discontinued_is_not_rewritten(self, model_repository: ModelRepository) -> None:
+        """既に discontinued な行は再 de-list しない (idempotent)。"""
+        self._insert(model_repository, "openai/gone", requires_api_key=True)
+        first = model_repository.discontinue_api_models_absent_from(set())
+        assert first == ["openai/gone"]
+
+        second = model_repository.discontinue_api_models_absent_from(set())
+        assert second == []

--- a/tests/unit/database/repository/test_model_repository.py
+++ b/tests/unit/database/repository/test_model_repository.py
@@ -192,8 +192,8 @@ class TestGetOrCreateManualEditModel:
 
 
 @pytest.mark.unit
-class TestDiscontinueApiModelsAbsentFrom:
-    """`discontinue_api_models_absent_from` の de-list 動作 (Issue #589)。"""
+class TestReconcileApiModelAvailability:
+    """`reconcile_api_model_availability` の双方向 reconcile (Issue #589, PR #590 review P1)。"""
 
     def _insert(self, repo: ModelRepository, litellm_id: str, *, requires_api_key: bool) -> int:
         return repo.insert_model(
@@ -209,21 +209,37 @@ class TestDiscontinueApiModelsAbsentFrom:
         self._insert(model_repository, "openai/keep", requires_api_key=True)
         self._insert(model_repository, "openai/o4-mini-deep-research-2025-06-26", requires_api_key=True)
 
-        delisted = model_repository.discontinue_api_models_absent_from({"openai/keep"})
+        delisted, reactivated = model_repository.reconcile_api_model_availability({"openai/keep"})
 
         assert delisted == ["openai/o4-mini-deep-research-2025-06-26"]
+        assert reactivated == []
         kept = model_repository.get_model_by_litellm_id("openai/keep")
         removed = model_repository.get_model_by_litellm_id("openai/o4-mini-deep-research-2025-06-26")
         assert kept is not None and kept.available is True
         assert removed is not None and removed.available is False
 
+    def test_reactivates_api_model_present_again(self, model_repository: ModelRepository) -> None:
+        """以前 de-list したモデルが active set に戻ると reactivate される (P1)。"""
+        self._insert(model_repository, "openai/comeback", requires_api_key=True)
+        # 1 回目: active set 外 → de-list
+        model_repository.reconcile_api_model_availability(set())
+        assert model_repository.get_model_by_litellm_id("openai/comeback").available is False
+
+        # 2 回目: lib に再出現 → reactivate
+        delisted, reactivated = model_repository.reconcile_api_model_availability({"openai/comeback"})
+
+        assert reactivated == ["openai/comeback"]
+        assert delisted == []
+        revived = model_repository.get_model_by_litellm_id("openai/comeback")
+        assert revived is not None and revived.available is True
+
     def test_local_ml_models_are_never_delisted(self, model_repository: ModelRepository) -> None:
         """requires_api_key=False のローカル ML モデルは active set 外でも対象外。"""
         self._insert(model_repository, "wd-vit-tagger-v3", requires_api_key=False)
 
-        delisted = model_repository.discontinue_api_models_absent_from(set())
+        delisted, reactivated = model_repository.reconcile_api_model_availability(set())
 
-        assert delisted == []
+        assert delisted == [] and reactivated == []
         local = model_repository.get_model_by_litellm_id("wd-vit-tagger-v3")
         assert local is not None and local.available is True
 
@@ -233,7 +249,7 @@ class TestDiscontinueApiModelsAbsentFrom:
             ModelRepository._get_or_create_manual_edit_model(session)
             session.commit()
 
-        delisted = model_repository.discontinue_api_models_absent_from(set())
+        delisted, _ = model_repository.reconcile_api_model_availability(set())
 
         assert MANUAL_EDIT_LITELLM_ID not in delisted
         sentinel = model_repository.get_model_by_litellm_id(MANUAL_EDIT_LITELLM_ID)
@@ -242,8 +258,8 @@ class TestDiscontinueApiModelsAbsentFrom:
     def test_already_discontinued_is_not_rewritten(self, model_repository: ModelRepository) -> None:
         """既に discontinued な行は再 de-list しない (idempotent)。"""
         self._insert(model_repository, "openai/gone", requires_api_key=True)
-        first = model_repository.discontinue_api_models_absent_from(set())
-        assert first == ["openai/gone"]
+        first_delisted, _ = model_repository.reconcile_api_model_availability(set())
+        assert first_delisted == ["openai/gone"]
 
-        second = model_repository.discontinue_api_models_absent_from(set())
-        assert second == []
+        second_delisted, second_reactivated = model_repository.reconcile_api_model_availability(set())
+        assert second_delisted == [] and second_reactivated == []

--- a/tests/unit/test_model_sync_service.py
+++ b/tests/unit/test_model_sync_service.py
@@ -68,10 +68,25 @@ class TestModelSyncResult:
         assert result.total_library_models == 10
         assert result.new_models_registered == 5
         assert result.existing_models_updated == 3
+        assert result.delisted_count == 0  # Issue #589: default 0
         assert len(result.errors) == 0
 
-        expected_summary = "同期完了: ライブラリモデル 10件, 新規登録 5件, 更新 3件, エラー 0件"
+        expected_summary = (
+            "同期完了: ライブラリモデル 10件, 新規登録 5件, 更新 3件, 提供終了 0件, エラー 0件"
+        )
         assert result.summary == expected_summary
+
+    def test_sync_result_with_delisted_count(self):
+        """Issue #589: de-list 件数が summary に反映される。"""
+        result = ModelSyncResult(
+            total_library_models=10,
+            new_models_registered=0,
+            existing_models_updated=0,
+            errors=[],
+            delisted_count=2,
+        )
+        assert result.delisted_count == 2
+        assert "提供終了 2件" in result.summary
 
     def test_failed_sync_result(self):
         """エラー発生時の同期結果"""
@@ -573,3 +588,57 @@ class TestModelSyncServiceEdgeCases:
         # 例外が発生せずに処理されることを確認
         count = model_sync_service.register_new_models_to_db(invalid_models)
         assert count >= 0
+
+
+@pytest.mark.unit
+class TestDelistRemovedModels:
+    """Issue #589: lib discovery から消えた WebAPI モデルの de-list 検証。"""
+
+    @pytest.fixture
+    def model_sync_service(self, test_model_repository, mock_config_service):
+        """ModelSyncService インスタンス（実DB + MockAnnotatorLibrary）。"""
+        return ModelSyncService(db_repository=test_model_repository, config_service=mock_config_service)
+
+    def _stale_metadata(self, litellm_id: str) -> ModelMetadata:
+        return {
+            "name": litellm_id,
+            "provider": "openai",
+            "class_name": None,
+            "litellm_model_id": litellm_id,
+            "model_type": "vision",
+            "model_types": ["multimodal"],
+            "estimated_size_gb": None,
+            "requires_api_key": True,
+            "discontinued_at": None,
+        }
+
+    def test_delist_removed_models_marks_absent_api_model(self, model_sync_service, test_model_repository):
+        """active set に無い WebAPI モデルが de-list され件数が返る。"""
+        # 旧 sync で登録済の stale な WebAPI モデル
+        model_sync_service.register_new_models_to_db(
+            [self._stale_metadata("openai/o4-mini-deep-research-2025-06-26")]
+        )
+        # 現 discovery には gpt-4o のみ残っている想定
+        library_models = [self._stale_metadata("openai/gpt-4o")]
+
+        count = model_sync_service.delist_removed_models(library_models)
+
+        assert count == 1
+        removed = test_model_repository.get_model_by_litellm_id("openai/o4-mini-deep-research-2025-06-26")
+        assert removed is not None and removed.available is False
+
+    def test_sync_available_models_delists_stale_api_model(self, model_sync_service, test_model_repository):
+        """sync_available_models が stale な WebAPI モデルを de-list し result に反映する。"""
+        model_sync_service.register_new_models_to_db(
+            [self._stale_metadata("openai/o4-mini-deep-research-2025-06-26")]
+        )
+
+        result = model_sync_service.sync_available_models()
+
+        assert result.success is True
+        assert result.delisted_count >= 1
+        stale = test_model_repository.get_model_by_litellm_id("openai/o4-mini-deep-research-2025-06-26")
+        assert stale is not None and stale.available is False
+        # MockAnnotatorLibrary に含まれる gpt-4o は active のまま
+        gpt4o = test_model_repository.get_model_by_litellm_id("gpt-4o")
+        assert gpt4o is not None and gpt4o.available is True

--- a/tests/unit/test_model_sync_service.py
+++ b/tests/unit/test_model_sync_service.py
@@ -69,24 +69,28 @@ class TestModelSyncResult:
         assert result.new_models_registered == 5
         assert result.existing_models_updated == 3
         assert result.delisted_count == 0  # Issue #589: default 0
+        assert result.reactivated_count == 0  # PR #590 review P1: default 0
         assert len(result.errors) == 0
 
         expected_summary = (
-            "同期完了: ライブラリモデル 10件, 新規登録 5件, 更新 3件, 提供終了 0件, エラー 0件"
+            "同期完了: ライブラリモデル 10件, 新規登録 5件, 更新 3件, 提供終了 0件, 復活 0件, エラー 0件"
         )
         assert result.summary == expected_summary
 
-    def test_sync_result_with_delisted_count(self):
-        """Issue #589: de-list 件数が summary に反映される。"""
+    def test_sync_result_with_delisted_and_reactivated_counts(self):
+        """Issue #589 / PR #590: de-list / reactivate 件数が summary に反映される。"""
         result = ModelSyncResult(
             total_library_models=10,
             new_models_registered=0,
             existing_models_updated=0,
             errors=[],
             delisted_count=2,
+            reactivated_count=1,
         )
         assert result.delisted_count == 2
+        assert result.reactivated_count == 1
         assert "提供終了 2件" in result.summary
+        assert "復活 1件" in result.summary
 
     def test_failed_sync_result(self):
         """エラー発生時の同期結果"""
@@ -591,8 +595,8 @@ class TestModelSyncServiceEdgeCases:
 
 
 @pytest.mark.unit
-class TestDelistRemovedModels:
-    """Issue #589: lib discovery から消えた WebAPI モデルの de-list 検証。"""
+class TestReconcileModelAvailability:
+    """Issue #589 / PR #590: WebAPI モデル availability reconcile (de-list + reactivate + 空ガード)。"""
 
     @pytest.fixture
     def model_sync_service(self, test_model_repository, mock_config_service):
@@ -612,20 +616,63 @@ class TestDelistRemovedModels:
             "discontinued_at": None,
         }
 
-    def test_delist_removed_models_marks_absent_api_model(self, model_sync_service, test_model_repository):
+    def test_reconcile_marks_absent_api_model(self, model_sync_service, test_model_repository):
         """active set に無い WebAPI モデルが de-list され件数が返る。"""
-        # 旧 sync で登録済の stale な WebAPI モデル
         model_sync_service.register_new_models_to_db(
             [self._stale_metadata("openai/o4-mini-deep-research-2025-06-26")]
         )
-        # 現 discovery には gpt-4o のみ残っている想定
         library_models = [self._stale_metadata("openai/gpt-4o")]
 
-        count = model_sync_service.delist_removed_models(library_models)
+        delisted, reactivated = model_sync_service.reconcile_model_availability(library_models)
 
-        assert count == 1
+        assert delisted == 1
+        assert reactivated == 0
         removed = test_model_repository.get_model_by_litellm_id("openai/o4-mini-deep-research-2025-06-26")
         assert removed is not None and removed.available is False
+
+    def test_reconcile_reactivates_returning_model(self, model_sync_service, test_model_repository):
+        """一度 de-list したモデルが discovery に戻ると reactivate される (review P1)。"""
+        model_sync_service.register_new_models_to_db([self._stale_metadata("openai/comeback")])
+        # 1 回目: discovery から外れ de-list
+        model_sync_service.reconcile_model_availability([self._stale_metadata("openai/gpt-4o")])
+        assert test_model_repository.get_model_by_litellm_id("openai/comeback").available is False
+
+        # 2 回目: discovery に再出現 → reactivate
+        delisted, reactivated = model_sync_service.reconcile_model_availability(
+            [self._stale_metadata("openai/comeback")]
+        )
+
+        assert reactivated == 1
+        revived = test_model_repository.get_model_by_litellm_id("openai/comeback")
+        assert revived is not None and revived.available is True
+
+    def test_empty_api_discovery_skips_reconcile(self, model_sync_service, test_model_repository):
+        """discovery に WebAPI モデルが 0 件なら destructive reconcile をスキップ (review P2)。
+
+        transient discovery 障害 / local-only 結果で全 API モデルを誤って de-list しない。
+        """
+        model_sync_service.register_new_models_to_db([self._stale_metadata("openai/gpt-4o")])
+        # API モデルを含まない discovery (ローカルモデルのみ)
+        local_only: list[ModelMetadata] = [
+            {
+                "name": "wd-tagger",
+                "provider": None,
+                "class_name": None,
+                "litellm_model_id": "wd-tagger",
+                "model_type": "tagger",
+                "model_types": ["tags"],
+                "estimated_size_gb": 1.0,
+                "requires_api_key": False,
+                "discontinued_at": None,
+            }
+        ]
+
+        delisted, reactivated = model_sync_service.reconcile_model_availability(local_only)
+
+        assert delisted == 0 and reactivated == 0
+        # 既存 API モデルは de-list されない
+        gpt4o = test_model_repository.get_model_by_litellm_id("openai/gpt-4o")
+        assert gpt4o is not None and gpt4o.available is True
 
     def test_sync_available_models_delists_stale_api_model(self, model_sync_service, test_model_repository):
         """sync_available_models が stale な WebAPI モデルを de-list し result に反映する。"""


### PR DESCRIPTION
Closes #589 (consumer 側)

## 背景
`ModelSyncService.sync_available_models()` は register/update のみで de-list が無く、ライブラリ (image-annotator-lib) が提供しなくなった WebAPI モデルが DB に `discontinued_at=NULL` のまま残り `available=True` で UI に表示され続けていた (`Model.available = discontinued_at is None`)。これが deep-research が選択可能だった #589 の consumer 側原因。

設計の SSoT: ADR 0048 (本 PR で追加)。

## 変更
- `ModelRepository.discontinue_api_models_absent_from()`: lib discovery に存在しない WebAPI モデル (`requires_api_key=True`) を soft-delete。ローカル ML モデルと MANUAL_EDIT sentinel は対象外、既 discontinued 行は再書き込みしない (冪等)。再出現時の reactivation は既存 update 経路 (`discontinued_at=None`) が担う。
- `ModelSyncService.delist_removed_models()` を `sync_available_models()` の第4ステップに配線。
- `ModelSyncResult.delisted_count` 追加 (default 0)、summary に「提供終了 N件」。
- `docs/decisions/0048-webapi-annotation-candidate-filtering.md` 追加 (endpoint/capability/suitability の 3 軸 + de-list + Responses forward path)。

## #589 の責務分担
- iam-lib #130 (discovery で不適格モデルを emit しない) → **fresh DB** をカバー。
- 本 PR (sync 済 stale 行を de-list) → **既存 DB** をカバー。
- iam-lib #131 (Responses runtime 対応) → 次段階。

## テスト
- `tests/unit/database/repository/test_model_repository.py`: de-list の API/local/sentinel/冪等。
- `tests/unit/test_model_sync_service.py`: `delist_removed_models` と `sync_available_models` 統合、`delisted_count`。
- CI-equivalent filter: `-m "not gui_show and not calls_real_webapi and not downloads_and_runs_model and not slow"` → **3691 passed, 2 skipped**。

## 残作業 (本 PR 範囲外)
- submodule pin bump (iam-lib #130 / PR #132 merge 後の統合ステップ)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)