### PR TITLE
fix: apply images list limit in database query

### DIFF
--- a/docs/decisions/0049-cli-images-list-db-limit.md
+++ b/docs/decisions/0049-cli-images-list-db-limit.md
@@ -1,0 +1,35 @@
+# ADR 0049: Apply CLI Image List Limit in the Repository Query
+
+## Status
+
+Accepted
+
+## Context
+
+`lorairo-cli images list --limit N` previously fetched every matching image record and then sliced
+the Python list in the CLI layer. On large projects this made a small listing pay the metadata cost
+for the whole dataset.
+
+The CLI still needs the total matching count so it can print `Showing N of M images.`
+
+## Decision
+
+Add `limit` and `offset` to `ImageFilterCriteria`.
+
+`ImageRepository.get_images_by_filter()` now:
+
+1. Builds the existing filtered ID query.
+2. Counts the full filtered result from a subquery.
+3. Applies stable `Image.id` ordering plus `offset` / `limit` to the ID query.
+4. Fetches annotation metadata only for the paged IDs.
+
+`lorairo-cli images list` passes its `--limit` value through `ImageFilterCriteria` instead of
+slicing after the repository call.
+
+## Consequences
+
+`get_images_by_filter()` keeps returning `(records, total_count)`. Without `limit`, behavior is
+unchanged. With `limit`, `records` contains the requested page while `total_count` remains the full
+filtered count.
+
+The query now has deterministic ID ordering for paged results.

--- a/src/lorairo/cli/commands/images.py
+++ b/src/lorairo/cli/commands/images.py
@@ -205,15 +205,13 @@ def list_images(
         container.set_active_project(project)
 
         repository = container.db_manager.image_repo
-        criteria = ImageFilterCriteria(include_nsfw=True, only_unrated=unrated)
+        criteria = ImageFilterCriteria(include_nsfw=True, only_unrated=unrated, limit=limit)
         image_records, total_count = repository.get_images_by_filter(criteria)
 
         if not image_records:
             suffix = " without ratings" if unrated else ""
             console.print(f"No images{suffix} found in project: {project}")
             return
-
-        display_records = image_records[:limit] if limit else image_records
 
         heading_suffix = " (unrated only)" if unrated else ""
         console.print(f"Images in project: {project}{heading_suffix}")
@@ -223,7 +221,7 @@ def list_images(
         table.add_column("Tags", style="green")
         table.add_column("Annotated", style="yellow")
 
-        for record in display_records:
+        for record in image_records:
             image_id = str(record.get("id", ""))
             filename = Path(record.get("stored_image_path", "")).name or str(record.get("filename", ""))
             tag_count = len(record.get("tags") or [])

--- a/src/lorairo/database/filter_criteria.py
+++ b/src/lorairo/database/filter_criteria.py
@@ -37,6 +37,8 @@ class ImageFilterCriteria:
         score_max: 最大スコア値（0.0-10.0）
         project_name: フィルタ対象プロジェクト名（Phase C完了後に有効化）
         project_id: フィルタ対象プロジェクトID（Phase C完了後に高速路）
+        limit: 取得件数上限。None の場合は無制限
+        offset: 取得開始位置
     """
 
     tags: list[str] | None = None
@@ -59,6 +61,8 @@ class ImageFilterCriteria:
     # Phase C (projects テーブル追加) 完了後に DB フィルタを有効化
     project_name: str | None = None
     project_id: int | None = None
+    limit: int | None = None
+    offset: int = 0
 
     @classmethod
     def from_kwargs(cls, **kwargs: Any) -> ImageFilterCriteria:
@@ -114,4 +118,6 @@ class ImageFilterCriteria:
             "score_max": self.score_max,
             "project_name": self.project_name,
             "project_id": self.project_id,
+            "limit": self.limit,
+            "offset": self.offset,
         }

--- a/src/lorairo/database/repository/image.py
+++ b/src/lorairo/database/repository/image.py
@@ -1688,6 +1688,31 @@ class ImageRepository(BaseRepository):
             return self._fetch_original_image_metadata(session, image_ids)
         return self._fetch_processed_image_metadata(session, image_ids, resolution)
 
+    def _apply_processed_resolution_filter(
+        self,
+        query: Select[Any],
+        resolution: int,
+    ) -> Select[Any]:
+        """処理済み画像の解像度候補が存在する画像だけに絞り込む。"""
+        if resolution == 0:
+            return query
+
+        target_area = resolution * resolution
+        exact_long_side = or_(
+            and_(ProcessedImage.width >= ProcessedImage.height, ProcessedImage.width == resolution),
+            and_(ProcessedImage.height > ProcessedImage.width, ProcessedImage.height == resolution),
+        )
+        within_area_tolerance = (
+            func.abs(target_area - (ProcessedImage.width * ProcessedImage.height)) <= target_area * 0.2
+        )
+
+        return query.where(
+            exists().where(
+                ProcessedImage.image_id == Image.id,
+                or_(exact_long_side, within_area_tolerance),
+            )
+        )
+
     def _apply_project_filter(
         self,
         query: Select[Any],
@@ -1864,6 +1889,7 @@ class ImageRepository(BaseRepository):
                     project_name=filter_criteria.project_name,
                     project_id=filter_criteria.project_id,
                 )
+                query = self._apply_processed_resolution_filter(query, filter_criteria.resolution)
 
                 count_query = select(func.count()).select_from(query.subquery())
                 total_count = session.execute(count_query).scalar_one()
@@ -1934,6 +1960,9 @@ class ImageRepository(BaseRepository):
                     score_max=filter_criteria.score_max,
                     project_name=filter_criteria.project_name,
                     project_id=filter_criteria.project_id,
+                )
+                filtered_query = self._apply_processed_resolution_filter(
+                    filtered_query, filter_criteria.resolution
                 )
 
                 count_query = select(func.count()).select_from(filtered_query.subquery())

--- a/src/lorairo/database/repository/image.py
+++ b/src/lorairo/database/repository/image.py
@@ -1865,21 +1865,28 @@ class ImageRepository(BaseRepository):
                     project_id=filter_criteria.project_id,
                 )
 
-                filtered_image_ids: list[int] = list(session.execute(query).scalars().all())
-
-                if not filtered_image_ids:
+                count_query = select(func.count()).select_from(query.subquery())
+                total_count = session.execute(count_query).scalar_one()
+                if total_count == 0:
                     logger.info("指定された条件に一致する画像が見つかりませんでした。")
                     return [], 0
 
+                paged_query = query.order_by(Image.id)
+                if filter_criteria.offset:
+                    paged_query = paged_query.offset(filter_criteria.offset)
+                if filter_criteria.limit is not None:
+                    paged_query = paged_query.limit(filter_criteria.limit)
+
+                filtered_image_ids: list[int] = list(session.execute(paged_query).scalars().all())
                 logger.debug(f"フィルタリングで {len(filtered_image_ids)} 件の候補画像IDを取得しました。")
 
                 final_metadata_list = self._fetch_filtered_metadata(
                     session, filtered_image_ids, filter_criteria.resolution
                 )
                 list_count = len(final_metadata_list)
-                logger.info(f"最終的な検索結果: {list_count} 件")
+                logger.info(f"最終的な検索結果: {list_count} 件 / 総件数: {total_count} 件")
 
-                return final_metadata_list, list_count
+                return final_metadata_list, total_count
 
             except SQLAlchemyError as e:
                 logger.error(f"画像フィルタリング検索中にエラーが発生しました: {e}", exc_info=True)

--- a/tests/unit/cli/test_commands_images.py
+++ b/tests/unit/cli/test_commands_images.py
@@ -350,12 +350,14 @@ def test_images_list_with_limit(mock_projects_dir: Path) -> None:
     ]
     with patch("lorairo.cli.commands.images.get_service_container") as mock_get_container:
         mock_container = MagicMock()
-        mock_container.db_manager.image_repo.get_images_by_filter.return_value = (fake_records, 3)
+        mock_container.db_manager.image_repo.get_images_by_filter.return_value = (fake_records[:1], 3)
         mock_get_container.return_value = mock_container
 
         result = runner.invoke(app, ["images", "list", "--project", "test-project", "--limit", "1"])
 
     assert result.exit_code == 0
+    criteria = mock_container.db_manager.image_repo.get_images_by_filter.call_args.args[0]
+    assert criteria.limit == 1
     assert "Images in project: test-project" in result.stdout
     assert "Showing 1 of 3" in result.stdout
 

--- a/tests/unit/database/repository/test_image_repository.py
+++ b/tests/unit/database/repository/test_image_repository.py
@@ -79,6 +79,28 @@ def _insert_image(
     return repo.add_original_image(info)
 
 
+def _insert_processed_image(
+    repo: ImageRepository,
+    *,
+    image_id: int,
+    filename: str = "processed.png",
+    width: int = 512,
+    height: int = 512,
+) -> int:
+    """テスト用処理済み画像を 1 件作成して id を返す。"""
+    info = {
+        "image_id": image_id,
+        "stored_image_path": f"/tmp/{filename}",
+        "width": width,
+        "height": height,
+        "has_alpha": False,
+        "filename": filename,
+    }
+    processed_id = repo.add_processed_image(info)
+    assert processed_id is not None
+    return processed_id
+
+
 @pytest.mark.unit
 class TestImageRepositoryStructure:
     """ADR 0035 段階 4 で確立した抽出構造の sanity check。"""
@@ -115,6 +137,21 @@ class TestGetImagesByFilterPaging:
 
         assert total_count == 3
         assert [record["id"] for record in results] == [first]
+
+    def test_resolution_filter_restricts_count_before_limit(
+        self, image_repository: ImageRepository
+    ) -> None:
+        """resolution 指定時は処理済み画像が合う ID だけを count/page 対象にする。"""
+        _insert_image(image_repository, uuid="u-res-missing", phash="p-res-missing")
+        matching = _insert_image(image_repository, uuid="u-res-match", phash="p-res-match")
+        _insert_processed_image(image_repository, image_id=matching, filename="res-match.png")
+
+        criteria = ImageFilterCriteria(include_nsfw=True, resolution=512, limit=1)
+        results, total_count = image_repository.get_images_by_filter(criteria)
+
+        assert total_count == 1
+        assert [record["id"] for record in results] == [matching]
+        assert image_repository.get_images_count_only(criteria) == 1
 
 
 @pytest.mark.unit

--- a/tests/unit/database/repository/test_image_repository.py
+++ b/tests/unit/database/repository/test_image_repository.py
@@ -28,6 +28,7 @@ from sqlalchemy import create_engine, select
 from sqlalchemy.orm import sessionmaker
 
 from lorairo.database.db_manager import ImageDatabaseManager
+from lorairo.database.filter_criteria import ImageFilterCriteria
 from lorairo.database.repository.base import BaseRepository
 from lorairo.database.repository.image import ImageRepository
 from lorairo.database.schema import (
@@ -94,6 +95,26 @@ class TestImageRepositoryStructure:
     def test_inherits_batch_chunk_size(self) -> None:
         """`BATCH_CHUNK_SIZE` を BaseRepository から継承する。"""
         assert ImageRepository.BATCH_CHUNK_SIZE == BaseRepository.BATCH_CHUNK_SIZE
+
+
+@pytest.mark.unit
+class TestGetImagesByFilterPaging:
+    """`get_images_by_filter` の DB 側ページング。"""
+
+    def test_limit_restricts_metadata_fetch_but_preserves_total_count(
+        self, image_repository: ImageRepository
+    ) -> None:
+        """limit 指定時も総件数を返し、メタデータ取得対象は limit 件に絞る。"""
+        first = _insert_image(image_repository, uuid="u-limit-1", phash="p-limit-1")
+        _insert_image(image_repository, uuid="u-limit-2", phash="p-limit-2")
+        _insert_image(image_repository, uuid="u-limit-3", phash="p-limit-3")
+
+        results, total_count = image_repository.get_images_by_filter(
+            ImageFilterCriteria(include_nsfw=True, limit=1)
+        )
+
+        assert total_count == 3
+        assert [record["id"] for record in results] == [first]
 
 
 @pytest.mark.unit

--- a/tests/unit/database/test_db_repository_ai_rating_filter.py
+++ b/tests/unit/database/test_db_repository_ai_rating_filter.py
@@ -110,6 +110,7 @@ class TestGetImagesByFilterAIRating:
 
         # Mock execute to return empty result
         mock_execute_result = Mock()
+        mock_execute_result.scalar_one.return_value = 0
         mock_execute_result.scalars = Mock(return_value=Mock(all=Mock(return_value=[])))
         mock_session.execute = Mock(return_value=mock_execute_result)
 

--- a/tests/unit/database/test_db_repository_score_filter.py
+++ b/tests/unit/database/test_db_repository_score_filter.py
@@ -98,6 +98,7 @@ class TestGetImagesByFilterScoreIntegration:
 
         # Mock execute to return empty result
         mock_execute_result = Mock()
+        mock_execute_result.scalar_one.return_value = 0
         mock_execute_result.scalars = Mock(return_value=Mock(all=Mock(return_value=[])))
         mock_session.execute = Mock(return_value=mock_execute_result)
 

--- a/tests/unit/test_model_sync_service.py
+++ b/tests/unit/test_model_sync_service.py
@@ -638,7 +638,7 @@ class TestReconcileModelAvailability:
         assert test_model_repository.get_model_by_litellm_id("openai/comeback").available is False
 
         # 2 回目: discovery に再出現 → reactivate
-        delisted, reactivated = model_sync_service.reconcile_model_availability(
+        _delisted, reactivated = model_sync_service.reconcile_model_availability(
             [self._stale_metadata("openai/comeback")]
         )
 


### PR DESCRIPTION
## Summary
- push `lorairo-cli images list --limit` into `ImageFilterCriteria` instead of slicing after full metadata fetch
- keep `get_images_by_filter()` returning the full filtered total count while fetching metadata only for the limited ID page
- document the repository paging contract in ADR 0049

## Verification
- `UV_CACHE_DIR=/tmp/uv-cache UV_PROJECT_ENVIRONMENT=/workspaces/LoRAIro/.venv uv run ruff check src/lorairo/database/filter_criteria.py src/lorairo/database/repository/image.py src/lorairo/cli/commands/images.py tests/unit/cli/test_commands_images.py tests/unit/database/repository/test_image_repository.py`
- `UV_CACHE_DIR=/tmp/uv-cache UV_PROJECT_ENVIRONMENT=/workspaces/LoRAIro/.venv uv run pytest tests/unit/cli/test_commands_images.py tests/unit/database/repository/test_image_repository.py -q` -> 54 passed

## Notes
No existing GitHub issue was found for `images list --limit`; this PR captures the CLI smoke finding directly.