### PR TITLE
fix: defer tag DB init for CLI startup

### DIFF
--- a/docs/decisions/0050-cli-tag-db-lazy-initialization.md
+++ b/docs/decisions/0050-cli-tag-db-lazy-initialization.md
@@ -1,0 +1,39 @@
+# 0050. CLI tag DB lazy initialization
+
+## Status
+
+Accepted
+
+## Context
+
+`ServiceContainer` initialized genai-tag-db-tools databases during container construction.
+That made read-only CLI commands such as `lorairo-cli status`, `project list`, and
+`images list --limit 5` contact Hugging Face before doing any command-specific work.
+Without `HF_TOKEN`, startup could spend a long time in tag DB initialization even when the
+command did not need tag management.
+
+## Decision
+
+`ServiceContainer` construction must stay side-effect-light. It should not initialize
+genai-tag-db-tools databases by default.
+
+Tag DB initialization is deferred to the first service path that actually needs external tag DB
+access:
+
+- `ServiceContainer.tag_management_service`, before constructing `TagManagementService`.
+- `AnnotationRepository` tag ID resolution/registration, before creating a `MergedTagReader`.
+
+`ensure_tag_db_initialized()` must not rewrite the selected image database path. Project selection
+owns `db_core.IMG_DB_PATH` / `DATABASE_URL`; tag DB initialization only prepares genai-tag-db-tools
+base/user databases.
+
+## Consequences
+
+- Read-only CLI commands no longer block on tag DB initialization.
+- `lorairo-cli --help` and `version` continue avoiding service initialization side effects.
+- Tag management still initializes the external tag DB before using genai-tag-db-tools user DB
+  APIs.
+- Annotation repository construction remains cheap, but annotation tag ID resolution still
+  initializes external tag DB support when needed and continues graceful degradation if unavailable.
+- Opening tag management after `set_active_project()` no longer resets project-root resolution back
+  to the default image database.

--- a/src/lorairo/database/db_core.py
+++ b/src/lorairo/database/db_core.py
@@ -280,12 +280,10 @@ def ensure_tag_db_initialized() -> None:
     """タグDBを遅延初期化する。初回呼び出し時のみ HF Hub に接続する。"""
     import os
 
-    global _tag_db_initialized, DB_DIR, IMG_DB_PATH, DATABASE_URL, USER_TAG_DB_PATH
+    global _tag_db_initialized, DB_DIR, USER_TAG_DB_PATH
     if _tag_db_initialized:
         return
     DB_DIR = ensure_default_db_dir()
-    IMG_DB_PATH = DB_DIR / IMG_DB_FILENAME
-    DATABASE_URL = f"sqlite:///{IMG_DB_PATH.resolve()}?check_same_thread=False"
     token = os.environ.get("HF_TOKEN") or os.environ.get("HUGGINGFACE_TOKEN")
     try:
         from genai_tag_db_tools import initialize_databases

--- a/src/lorairo/database/repository/annotation_record.py
+++ b/src/lorairo/database/repository/annotation_record.py
@@ -55,6 +55,7 @@ from sqlalchemy.future import select
 from sqlalchemy.orm import Session
 
 from ...utils.log import logger
+from ..db_core import ensure_tag_db_initialized
 from ..schema import (
     AnnotationsDict,
     Caption,
@@ -106,9 +107,10 @@ class AnnotationRepository(BaseRepository):
         else:
             super().__init__(session_factory)
 
-        # 外部 tag_db 統合 (公開 API 経由、グレースフルデグラデーション対応)。
+        # 外部 tag_db 統合は実際に tag_id 解決が必要になるまで遅延する。
         # TagCleaner.clean_format() は静的メソッドなのでインスタンス化不要。
-        self.merged_reader: MergedTagReader | None = self._initialize_merged_reader()
+        self.merged_reader: MergedTagReader | None = None
+        self._merged_reader_initialized = False
         # TagRegisterService は遅延初期化 (登録時のみ必要)。
         self.tag_register_service: TagRegisterService | None = None
 
@@ -128,6 +130,7 @@ class AnnotationRepository(BaseRepository):
 
         """
         try:
+            ensure_tag_db_initialized()
             return get_default_reader()
         except Exception as e:
             logger.warning(
@@ -135,6 +138,16 @@ class AnnotationRepository(BaseRepository):
                 "Tag operations will continue without external tag_id.",
             )
             return None
+
+    def _get_merged_reader(self) -> MergedTagReader | None:
+        """外部タグDBリーダーを必要時に初期化して返す。"""
+        if self.merged_reader is not None:
+            self._merged_reader_initialized = True
+            return self.merged_reader
+        if not self._merged_reader_initialized:
+            self.merged_reader = self._initialize_merged_reader()
+            self._merged_reader_initialized = True
+        return self.merged_reader
 
     def _initialize_tag_register_service(self) -> TagRegisterService | None:
         """タグ登録サービスを初期化（遅延初期化、Qt非依存）。
@@ -149,12 +162,13 @@ class AnnotationRepository(BaseRepository):
             - 初期化失敗時はグレースフルデグラデーション（警告ログのみ、システム継続）
 
         """
-        if self.merged_reader is None:
+        merged_reader = self._get_merged_reader()
+        if merged_reader is None:
             logger.warning("MergedTagReader unavailable, cannot initialize TagRegisterService")
             return None
 
         try:
-            return TagRegisterService(reader=self.merged_reader)
+            return TagRegisterService(reader=merged_reader)
         except Exception as e:
             logger.warning(f"Failed to initialize TagRegisterService: {e}", exc_info=True)
             return None  # エラー時はNoneで継続
@@ -401,7 +415,8 @@ class AnnotationRepository(BaseRepository):
             return None
 
         # 2. MergedTagReaderが利用可能か確認
-        if self.merged_reader is None:
+        merged_reader = self._get_merged_reader()
+        if merged_reader is None:
             logger.debug(
                 f"MergedTagReader unavailable, skipping external tag search for '{normalized_tag}'",
             )
@@ -418,7 +433,7 @@ class AnnotationRepository(BaseRepository):
                 include_aliases=True,
                 include_deprecated=False,
             )
-            result = search_tags(self.merged_reader, request)
+            result = search_tags(merged_reader, request)
 
             if result.items and len(result.items) > 0:
                 tag_id: int = result.items[0].tag_id
@@ -480,7 +495,10 @@ class AnnotationRepository(BaseRepository):
             # 競合検出（他のプロセスが同時に登録）→ リトライ
             logger.warning("Race condition detected during tag registration, retrying search...")
             try:
-                retry_result = search_tags(self.merged_reader, search_request)
+                merged_reader = self._get_merged_reader()
+                if merged_reader is None:
+                    return None
+                retry_result = search_tags(merged_reader, search_request)
                 if retry_result.items and len(retry_result.items) > 0:
                     tag_id = retry_result.items[0].tag_id
                     logger.debug(f"Found tag_id {tag_id} on retry for '{normalized_tag}'")
@@ -509,13 +527,14 @@ class AnnotationRepository(BaseRepository):
             return {}
 
         # MergedTagReaderが利用不可の場合は全てNone
-        if self.merged_reader is None:
+        merged_reader = self._get_merged_reader()
+        if merged_reader is None:
             logger.debug("MergedTagReader unavailable, skipping batch tag resolution")
             return dict.fromkeys(normalized_tags)
 
         # 一括検索
         try:
-            bulk_results = self.merged_reader.search_tags_bulk(
+            bulk_results = merged_reader.search_tags_bulk(
                 list(normalized_tags),
                 format_name=None,
                 resolve_preferred=False,
@@ -617,7 +636,10 @@ class AnnotationRepository(BaseRepository):
                 include_aliases=True,
                 include_deprecated=False,
             )
-            retry_result = search_tags(self.merged_reader, retry_request)
+            merged_reader = self._get_merged_reader()
+            if merged_reader is None:
+                return None
+            retry_result = search_tags(merged_reader, retry_request)
             if retry_result.items:
                 tag_id: int = retry_result.items[0].tag_id
                 return tag_id

--- a/src/lorairo/services/service_container.py
+++ b/src/lorairo/services/service_container.py
@@ -56,7 +56,6 @@ class ServiceContainer:
             return
 
         logger.info("ServiceContainer初期化開始")
-        ensure_tag_db_initialized()
 
         # コアサービス初期化
         self._config_service: ConfigurationService | None = None
@@ -226,6 +225,7 @@ class ServiceContainer:
         if self._tag_management_service is None:
             from .tag_management_service import TagManagementService
 
+            ensure_tag_db_initialized()
             self._tag_management_service = TagManagementService()
             logger.info("TagManagementService初期化完了")
         return self._tag_management_service

--- a/tests/unit/database/repository/test_annotation_record_repository.py
+++ b/tests/unit/database/repository/test_annotation_record_repository.py
@@ -123,10 +123,10 @@ class TestExternalTagDbInitialization:
     """外部 tag_db (`MergedTagReader` / `TagRegisterService`) 初期化動作。"""
 
     def test_merged_reader_initialization_graceful_fail(self, memory_session_factory) -> None:
-        """外部 tag_db 未設定環境では `merged_reader` が None になる (warning のみ)。"""
+        """外部 tag_db reader は必要になるまで初期化されない。"""
         repo = AnnotationRepository(session_factory=memory_session_factory)
-        # in-memory SQLite には base DB が無いので None になる
         assert repo.merged_reader is None
+        assert repo._merged_reader_initialized is False
         # tag_register_service は遅延初期化なので None
         assert repo.tag_register_service is None
 
@@ -135,8 +135,30 @@ class TestExternalTagDbInitialization:
     ) -> None:
         """`merged_reader` が None なら `_initialize_tag_register_service` も None を返す。"""
         annotation_repository.merged_reader = None
+        annotation_repository._merged_reader_initialized = True
         result = annotation_repository._initialize_tag_register_service()
         assert result is None
+
+    def test_tag_resolution_initializes_external_tag_db_lazily(
+        self, annotation_repository: AnnotationRepository, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """tag_id 解決が必要になった時点で外部 tag DB reader を初期化する。"""
+        ensure_spy = Mock()
+        merged_reader = Mock()
+        merged_reader.search_tags_bulk.return_value = {"new tag": {"tag_id": 123, "deprecated": False}}
+        monkeypatch.setattr(
+            "lorairo.database.repository.annotation_record.ensure_tag_db_initialized", ensure_spy
+        )
+        monkeypatch.setattr(
+            "lorairo.database.repository.annotation_record.get_default_reader",
+            Mock(return_value=merged_reader),
+        )
+
+        result = annotation_repository.batch_resolve_tag_ids({"new tag"})
+
+        ensure_spy.assert_called_once()
+        merged_reader.search_tags_bulk.assert_called_once()
+        assert result == {"new tag": 123}
 
 
 @pytest.mark.unit

--- a/tests/unit/database/test_db_core_lazy_init.py
+++ b/tests/unit/database/test_db_core_lazy_init.py
@@ -109,6 +109,27 @@ class TestEnsureTagDbInitialized:
             assert isinstance(path, Path)
             assert path.name == "user_tags.sqlite"
 
+    def test_ensure_preserves_current_image_database_path(self):
+        """tag DB 初期化は選択中プロジェクトの image DB パスを変更しない。"""
+        mock_result = [MagicMock()]
+        with patch("genai_tag_db_tools.initialize_databases", return_value=mock_result):
+            import lorairo.database.db_core as db_core
+
+            original_img_path = db_core.IMG_DB_PATH
+            original_database_url = db_core.DATABASE_URL
+            active_project_path = Path("/tmp/active-project/image_database.db")
+            db_core.IMG_DB_PATH = active_project_path
+            db_core.DATABASE_URL = f"sqlite:///{active_project_path}?check_same_thread=False"
+
+            try:
+                db_core.ensure_tag_db_initialized()
+
+                assert db_core.IMG_DB_PATH == active_project_path
+                assert db_core.DATABASE_URL == f"sqlite:///{active_project_path}?check_same_thread=False"
+            finally:
+                db_core.IMG_DB_PATH = original_img_path
+                db_core.DATABASE_URL = original_database_url
+
 
 class TestDefaultDbDirectoryLazyInit:
     """デフォルト DB ディレクトリの遅延作成を検証する。"""

--- a/tests/unit/database/test_db_repository_tag_registration.py
+++ b/tests/unit/database/test_db_repository_tag_registration.py
@@ -21,13 +21,10 @@ class TestImageRepositoryTagRegistration:
     @pytest.fixture
     def repository(self):
         """AnnotationRepository インスタンス（MergedTagReader モック付き）"""
-        with patch(
-            "lorairo.database.repository.annotation_record.get_default_reader"
-        ) as mock_reader_factory:
-            mock_reader = Mock()
-            mock_reader_factory.return_value = mock_reader
-            repo = AnnotationRepository()
-            return repo
+        mock_reader = Mock()
+        repo = AnnotationRepository()
+        repo.merged_reader = mock_reader
+        return repo
 
     def test_tag_registration_success(self, repository, mock_session):
         """新規タグ登録成功"""

--- a/tests/unit/services/test_service_container_tag_db_lazy.py
+++ b/tests/unit/services/test_service_container_tag_db_lazy.py
@@ -1,0 +1,49 @@
+"""ServiceContainer の tag DB 遅延初期化テスト。"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from lorairo.services.service_container import ServiceContainer
+
+
+@pytest.mark.unit
+def test_container_init_does_not_initialize_tag_db(monkeypatch: pytest.MonkeyPatch) -> None:
+    """ServiceContainer 生成だけでは genai-tag-db-tools 初期化を走らせない。"""
+    ensure_spy = MagicMock()
+    monkeypatch.setattr("lorairo.services.service_container.ensure_tag_db_initialized", ensure_spy)
+
+    ServiceContainer()
+
+    ensure_spy.assert_not_called()
+
+
+@pytest.mark.unit
+def test_tag_management_service_initializes_tag_db_once(monkeypatch: pytest.MonkeyPatch) -> None:
+    """タグ管理サービス取得時だけ tag DB を初期化する。"""
+    ensure_spy = MagicMock()
+    service_cls = MagicMock()
+    service_instance = MagicMock()
+    service_cls.return_value = service_instance
+    monkeypatch.setattr("lorairo.services.service_container.ensure_tag_db_initialized", ensure_spy)
+    monkeypatch.setattr("lorairo.services.tag_management_service.TagManagementService", service_cls)
+
+    container = ServiceContainer()
+    first = container.tag_management_service
+    second = container.tag_management_service
+
+    assert first is service_instance
+    assert second is service_instance
+    ensure_spy.assert_called_once()
+
+
+@pytest.mark.unit
+def test_db_manager_creation_does_not_initialize_tag_db(monkeypatch: pytest.MonkeyPatch) -> None:
+    """DB manager 生成だけでは read-only CLI のために tag DB 初期化を走らせない。"""
+    ensure_spy = MagicMock()
+    monkeypatch.setattr("lorairo.services.service_container.ensure_tag_db_initialized", ensure_spy)
+
+    container = ServiceContainer()
+    _ = container.db_manager
+
+    ensure_spy.assert_not_called()


### PR DESCRIPTION
## Summary
- stop initializing genai-tag-db-tools during ServiceContainer construction
- initialize tag DB only when TagManagementService is requested
- document the CLI startup decision in ADR 0050

## Verification
- UV_CACHE_DIR=/tmp/uv-cache UV_PROJECT_ENVIRONMENT=/workspaces/LoRAIro/.venv uv run ruff check src/lorairo/services/service_container.py tests/unit/services/test_service_container_tag_db_lazy.py tests/unit/cli/test_main.py tests/unit/cli/test_commands_project.py tests/unit/cli/test_commands_images.py
- UV_CACHE_DIR=/tmp/uv-cache UV_PROJECT_ENVIRONMENT=/workspaces/LoRAIro/.venv uv run pytest tests/unit/services/test_service_container_tag_db_lazy.py tests/unit/services/test_service_container_signal_manager.py tests/unit/services/test_service_container_provider_batch.py tests/unit/cli/test_main.py tests/unit/cli/test_commands_project.py tests/unit/cli/test_commands_images.py -q
- PYTHONPATH=/tmp/worktrees/fix-cli-lazy-tag-db/src:/tmp/worktrees/fix-cli-lazy-tag-db/local_packages/genai-tag-db-tools/src:/tmp/worktrees/fix-cli-lazy-tag-db/local_packages/image-annotator-lib/src /workspaces/LoRAIro/.venv/bin/python -m lorairo.cli.main images list --project main_dataset --limit 5