### PR TITLE
docs: codify Codex shared uv environment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,7 +48,13 @@
 - When running `uv` from a `/tmp/worktrees/` checkout, use the shared execution environment `/workspaces/LoRAIro/.venv`.
   Codex sessions should set this once in `.codex/config.toml` under `[shell_environment_policy.set]` as
   `UV_PROJECT_ENVIRONMENT = "/workspaces/LoRAIro/.venv"` and then run normal commands like `uv run ruff ...`.
-  In shells where that environment is not configured, use `UV_PROJECT_ENVIRONMENT=/workspaces/LoRAIro/.venv uv ...` explicitly. Do not create a worktree-local `.venv` unless there is a specific technical reason. If the shared environment cannot be used, only a bare `uv` help/inspection command is allowed without `UV_PROJECT_ENVIRONMENT`.
+  This path is the canonical devcontainer path; if it does not exist in a different environment, stop and configure that environment's actual shared LoRAIro `.venv` instead of letting `uv` create a new one at the wrong path.
+  Do not prefix every Codex command with `UV_PROJECT_ENVIRONMENT=...`; it creates unnecessary command-approval friction and hides the normal command shape.
+  In shells where that environment is not configured, use `UV_PROJECT_ENVIRONMENT=/workspaces/LoRAIro/.venv uv ...` explicitly as a fallback.
+  Do not create a worktree-local `.venv` unless there is a specific technical reason. If the shared environment cannot be used, only a bare `uv` help/inspection command is allowed without `UV_PROJECT_ENVIRONMENT`.
+  A worktree-local `.venv` symlink to `/workspaces/LoRAIro/.venv` is only a fallback when the agent environment cannot set `UV_PROJECT_ENVIRONMENT`; treat it as shared mutable state, not as an isolated venv.
+  Run verification commands from the target worktree. For CLI smoke tests, read-only checks, or parallel worker verification, use `uv run --no-sync` plus an explicit `PYTHONPATH` pointing at the target worktree `src` and local package `src` directories when editable-install ambiguity matters.
+  Treat default-sync `uv run`, `uv sync`, dependency updates, and other environment-mutating `uv` operations as shared `.venv` writes; do not run them concurrently across workers, and sequence them deliberately.
 - Agent-created PRs should normally be created ready for review, not draft. When a draft PR exists because the user explicitly asked to keep it draft, mark it ready for review as soon as the user allows review, then immediately start or resume PR maintenance automation: poll CI, watch bot review artifacts/comments, repair actionable findings in the PR worktree, reply in Japanese, merge when safe, and report the final monitored state.
 - After creating an agent PR, explicitly verify `gh pr view "$PR" --json isDraft -q .isDraft`. If it is
   `true`, run `gh pr ready "$PR"` and re-check. Do not set up `gh pr merge --auto` while the PR is still draft.

--- a/docs/decisions/0051-codex-worktree-shared-uv-environment.md
+++ b/docs/decisions/0051-codex-worktree-shared-uv-environment.md
@@ -1,0 +1,59 @@
+# 0051. Codex worktree shared uv environment
+
+## Status
+
+Accepted
+
+## Context
+
+LoRAIro agents implement issue work in dedicated git worktrees under `/tmp/worktrees/`.
+Creating a separate `.venv` in each worktree is too expensive for this repository because
+dependency installation and model/cache downloads can consume substantial time and disk space.
+
+The repository already standardizes on reusing `/workspaces/LoRAIro/.venv` from worktrees via
+`UV_PROJECT_ENVIRONMENT`. However, passing
+`UV_PROJECT_ENVIRONMENT=/workspaces/LoRAIro/.venv uv ...` in every Codex command changes the command
+shape that Codex approval rules see, which creates avoidable approval friction. A shared virtual
+environment also remains mutable state, so verification must avoid accidentally using the wrong
+checkout's editable install.
+
+Claude Code behavior is being validated separately. This decision records the Codex-side rule only.
+
+## Decision
+
+Codex sessions must set `UV_PROJECT_ENVIRONMENT=/workspaces/LoRAIro/.venv` once in the Codex shell
+environment policy, then run normal commands such as `uv run pytest ...` from the target worktree.
+Codex should not prefix every command with `UV_PROJECT_ENVIRONMENT=...` unless the shell environment
+policy is unavailable. Because default `uv run` may sync the shared environment, it is only the
+normal shape for single-agent commands where environment mutation is acceptable or intentionally
+serialized.
+
+`/workspaces/LoRAIro/.venv` is the canonical LoRAIro devcontainer path. If a different runtime
+mounts the repository elsewhere, the Codex environment must point at that runtime's existing shared
+LoRAIro `.venv`; it must not let `uv` create a new virtual environment at a stale or nonexistent
+path.
+
+Worktree-local `.venv` directories must not be created for normal Codex work. A `.venv` symlink to
+`/workspaces/LoRAIro/.venv` is acceptable only as a fallback when the agent environment cannot set
+`UV_PROJECT_ENVIRONMENT`; it must be treated as shared mutable state rather than an isolated
+environment.
+
+For read-only verification or CLI smoke tests where the executed checkout must be unambiguous,
+Codex must run from the target worktree with `uv run --no-sync` and set an explicit `PYTHONPATH`
+that points at that worktree's `src` and local package `src` directories. `uv run --no-sync`
+prevents environment syncing, while `PYTHONPATH` pins imports to the target worktree.
+
+Environment-mutating `uv` operations such as `uv sync`, dependency updates, and lockfile changes
+must not run concurrently against the shared `.venv`. Default-sync `uv run` is also treated as an
+environment-mutating operation for parallel worker coordination.
+
+## Consequences
+
+- Codex commands keep their normal shape (`uv run ...`), reducing repeated approval friction.
+- Worktrees avoid duplicate virtual environments and duplicate heavy dependency/model downloads.
+- The shared `.venv` remains mutable state, so smoke tests that prove a worktree change may need
+  `PYTHONPATH` to pin the executed code and `--no-sync` to avoid changing the environment.
+- Parallel Codex workers can still share the `.venv`, but default-sync `uv run` and `uv sync`
+  operations must be serialized.
+- `.venv` symlinks remain an emergency fallback, not the default worktree setup.
+- Claude Code-specific behavior can be documented separately without coupling it to Codex policy.


### PR DESCRIPTION
## Summary
- Codify the Codex-side shared `/workspaces/LoRAIro/.venv` rule for `/tmp/worktrees/` checkouts.
- Document that Codex should set `UV_PROJECT_ENVIRONMENT` once in shell environment policy and then use normal `uv run ...` commands instead of prefixing every command.
- Record ADR 0051 with the symlink fallback, required `PYTHONPATH` for unambiguous CLI smoke checks, `--no-sync` guidance, and shared-env mutation caveats.

## Scope
This PR intentionally covers only the Codex side of #594. Claude Code validation and any Claude-specific rule changes are being handled separately.

## Verification
- `git diff --check`
- `PYTHONPATH=/tmp/worktrees/issue-594-codex-uv-env/src:/tmp/worktrees/issue-594-codex-uv-env/local_packages/genai-tag-db-tools/src:/tmp/worktrees/issue-594-codex-uv-env/local_packages/image-annotator-lib/src uv run --no-sync python -c 'import os, sys; print(os.environ.get("UV_PROJECT_ENVIRONMENT")); print(sys.prefix); print(sys.path[:3])'` from `/tmp/worktrees/issue-594-codex-uv-env`, confirming the shared env is `/workspaces/LoRAIro/.venv` and the target worktree paths lead `sys.path`.\n\nCloses part of #594.