### PR TITLE
chore: pin shared .venv via Claude Code settings env (#594)

### DIFF
--- a/.claude/rules/git-workflow.md
+++ b/.claude/rules/git-workflow.md
@@ -56,6 +56,7 @@ make worktree-cleanup-merged
 - read-only 検証で対象 checkout を固定したい場合は、`uv run --no-sync` と `PYTHONPATH` 明示を併用する。
 - `uv` 単体の help/inspection は venv を作らないため例外として許可する
 - ワークツリー固有の `.venv` が必要な特殊事情がある場合は、理由を明示してから実行する
+- **注意**: この常設 `UV_PROJECT_ENVIRONMENT` は全 Bash コマンドに継承される。package 隔離した別 uv プロジェクト（`local_packages/genai-tag-db-tools` 等）を実行する recipe は、共有 `.venv` を誤って使わないよう自前の `UV_PROJECT_ENVIRONMENT` を明示する（`make test-genai-tag` 参照）。
 - 並列で `uv run` を実行する場合の詳細ルールは [parallel-execution.md](parallel-execution.md) を参照
 
 ### Codex / Claude Code 設定差分

--- a/.claude/rules/git-workflow.md
+++ b/.claude/rules/git-workflow.md
@@ -44,11 +44,25 @@ make worktree-cleanup-merged
 
 ## venv（ワークツリー内）
 
-- 原則としてワークツリー内に `.venv` を作らない
+- 原則としてワークツリー内に `.venv` を作らない（共有 `/workspaces/LoRAIro/.venv` を使う、named volume で高速）
 - `/tmp/worktrees/` 配下で `uv` を実行する場合は、共有実行環境 `/workspaces/LoRAIro/.venv` を使う。
-- Codex では `.codex/config.toml` の `[shell_environment_policy.set]` に
-  `UV_PROJECT_ENVIRONMENT = "/workspaces/LoRAIro/.venv"` を設定し、`uv run ruff ...` のように env prefix なしで実行する。
-- その環境設定がない shell では `UV_PROJECT_ENVIRONMENT=/workspaces/LoRAIro/.venv uv ...` を明示する。
+- **共有 `.venv` の指定はツール側の環境設定で常設し、コマンドには毎回 env prefix を付けない**のが標準運用。
+  - **Claude Code**: `.claude/settings.json` の `env` に `UV_PROJECT_ENVIRONMENT = "/workspaces/LoRAIro/.venv"` を設定済み。
+    worktree からでも素の `uv run ...` で共有 `.venv` を使える（許可は `Bash(uv *)` で済み、env prefix の個別 allowlist は不要）。
+    PreToolUse Hook (`hook_pre_commands.py`) の worktree gate も `os.environ` の `UV_PROJECT_ENVIRONMENT` を見るため、素の `uv run` を通す。
+  - **Codex**: `.codex/config.toml` の `[shell_environment_policy.set]` に
+    `UV_PROJECT_ENVIRONMENT = "/workspaces/LoRAIro/.venv"` を設定し、`uv run ruff ...` のように env prefix なしで実行する。
+- その環境設定が効かない shell（手動端末など）では `UV_PROJECT_ENVIRONMENT=/workspaces/LoRAIro/.venv uv ...` を明示する。
+- read-only 検証で対象 checkout を固定したい場合は、`uv run --no-sync` と `PYTHONPATH` 明示を併用する。
 - `uv` 単体の help/inspection は venv を作らないため例外として許可する
 - ワークツリー固有の `.venv` が必要な特殊事情がある場合は、理由を明示してから実行する
 - 並列で `uv run` を実行する場合の詳細ルールは [parallel-execution.md](parallel-execution.md) を参照
+
+### Codex / Claude Code 設定差分
+
+| | 共有 `.venv` 常設方法 | コマンド記法 |
+|---|---|---|
+| Claude Code | `.claude/settings.json` の `env` | `uv run ...`（env prefix 不要） |
+| Codex | `.codex/config.toml` の `[shell_environment_policy.set]` | `uv run ...`（env prefix 不要） |
+
+どちらも常設設定が効かない shell では `UV_PROJECT_ENVIRONMENT=/workspaces/LoRAIro/.venv uv ...` を明示する。

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -51,8 +51,7 @@
       "Bash(npx skills *)",
       "Bash(PYTHONPATH=\"\" VIRTUAL_ENV=\"\" .venv/bin/python *)",
       "Bash(UV_PROJECT_ENVIRONMENT=/workspaces/LoRAIro/.venv uv *)",
-      "Bash(QT_QPA_PLATFORM=offscreen uv run pytest *)",
-      "Bash(QT_QPA_PLATFORM=offscreen UV_PROJECT_ENVIRONMENT=/workspaces/LoRAIro/.venv uv run pytest *)"
+      "Bash(QT_QPA_PLATFORM=offscreen uv run pytest *)"
     ],
     "additionalDirectories": [
       "/tmp/worktrees/"
@@ -60,7 +59,8 @@
   },
   "env": {
     "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1",
-    "BASH_DEFAULT_TIMEOUT_MS": "5000000"
+    "BASH_DEFAULT_TIMEOUT_MS": "5000000",
+    "UV_PROJECT_ENVIRONMENT": "/workspaces/LoRAIro/.venv"
   },
   "hooks": {
     "PreToolUse": [

--- a/Makefile
+++ b/Makefile
@@ -99,7 +99,9 @@ test-runtime-webapi: _ensure-root-venv
 
 test-genai-tag: _ensure-submodules
 	@echo "Running genai-tag-db-tools tests (creates local_packages/genai-tag-db-tools/.venv)..."
-	cd local_packages/genai-tag-db-tools && uv run pytest
+	cd local_packages/genai-tag-db-tools && \
+		UV_PROJECT_ENVIRONMENT=$(CURDIR)/local_packages/genai-tag-db-tools/.venv \
+		uv run pytest
 
 test-all: _ensure-submodules
 	@echo "Running all package test sessions sequentially (ADR 0024)..."


### PR DESCRIPTION
## 概要

ISSUE #594 の **Claude Code 範囲のみ** を対応。agent worktree から素の `uv run ...` で共有 `/workspaces/LoRAIro/.venv` を使えるようにし、env prefix による許可プロンプトの揺れを解消する。Codex 範囲（`.codex/config.toml` / AGENTS.md）は別ワークツリーで対応。

## 変更内容

1. **`settings.json` env 追加**: `env` ブロックに `UV_PROJECT_ENVIRONMENT=/workspaces/LoRAIro/.venv` を常設。worktree からでも素の `uv run` が共有 `.venv` を使い、許可は既存 `Bash(uv *)` で済む。Codex の `[shell_environment_policy.set]` と対称。PreToolUse Hook (`hook_pre_commands.py`) の worktree gate も `os.environ` を見るため通る。
2. **個別 allowlist 整理**: 冗長になった QT+UV 二重 prefix の allow を削除（QT のみの allow で足りる）。`UV_PROJECT_ENVIRONMENT=... uv` の generic allow は env が効かない手動 shell の fallback として残置。
3. **`git-workflow.md` 文書化**: 共有 `.venv` 常設方針・worktree-local `.venv` 禁止・`--no-sync`/`PYTHONPATH` 使い分けを追記。Codex / Claude Code 設定差分表を追加。

## 検証

- `settings.json` の JSON 妥当性を確認済み。
- submodule (`local_packages/*`) 変更なし → CI-equivalent local test 対象外。

## 関連

- ISSUE #594
- PR #592, #593

🤖 Generated with [Claude Code](https://claude.com/claude-code)
