### PR TITLE
feat: route annotation outcomes by error_code

### DIFF
--- a/docs/decisions/0023-pydanticai-litellm-webapi-inference-boundary.md
+++ b/docs/decisions/0023-pydanticai-litellm-webapi-inference-boundary.md
@@ -669,6 +669,50 @@ image_id 集合を WebAPI annotation 対象から除外する。`get_error_image
 
 将来の refusal reason taxonomy (専用カラム / 専用テーブル) は別 ADR で検討。
 
+## Phase 1.5 amendment (Issue #599 — error_code routing)
+
+iam-lib #134 の Annotation Outcome Contract 構造化に合わせ、LoRAIro 消費側は
+`UnifiedAnnotationResult.error` prefix decode から `UnifiedAnnotationResult.error_code`
+ベースの routing へ移行する。
+
+### 意味論の境界
+
+`SAFETY_REFUSAL` / `CONTENT_POLICY_REFUSAL` / `EMPTY_ANNOTATION` は iam-lib にとって
+library error ではない。推論は完了しており、使える annotation output が無い outcome である。
+一方 LoRAIro では、同じ outcome を annotation 対象から除外すべき状態として扱い、
+`error_records` に記録して以後の WebAPI annotation 送信から除外する。これは無駄な
+API 課金と refusal / empty annotation ループを防ぐための LoRAIro 側 policy である。
+
+### 連携契約 (lib ↔ LoRAIro)
+
+iam-lib は sync WebAPI annotation の degenerate outcome を
+`UnifiedAnnotationResult(error_code=<code>, retryable=<bool>, error=<message>)`
+として返す。LoRAIro は exception class 名や error message prefix を runtime 判定に使わず、
+`error_code` のみで routing する。
+
+```text
+lib側  UnifiedAnnotationResult.error_code = "EMPTY_ANNOTATION"
+                ↓
+LoRAIro側  error_records.error_type = "EMPTY_ANNOTATION"
+                ↓
+LoRAIro側  filter_refused_image_paths() で次回送信時に除外
+```
+
+記録対象 code は以下に限定する。
+
+- `SAFETY_REFUSAL`
+- `CONTENT_POLICY_REFUSAL`
+- `EMPTY_ANNOTATION`
+
+`PROVIDER_ERROR` など retryable / transport 系 outcome は従来通り warning skip とし、
+`error_records` に記録しない。Worker レベルの fatal exception 記録経路とは分けて扱う。
+
+### 既存データ
+
+既存 DB に残る `SafetyRefusalError` / `ContentPolicyRefusalError` の `error_type` は、
+Alembic data migration で `SAFETY_REFUSAL` / `CONTENT_POLICY_REFUSAL` に正規化する。
+runtime filter は legacy exception 名を許容せず、code 文字列のみを SSoT とする。
+
 ## Phase 2 完了 (Issue #41 — `api_model_id` field 廃止)
 
 ADR 0023 line 73「``available_api_models.toml`` 由来の旧 ``api_model_id`` は本 ADR

--- a/src/lorairo/database/migrations/versions/c8d9e0f1a2b3_normalize_annotation_outcome_error_types.py
+++ b/src/lorairo/database/migrations/versions/c8d9e0f1a2b3_normalize_annotation_outcome_error_types.py
@@ -1,0 +1,68 @@
+"""Normalize annotation outcome error_type values
+
+Issue #599 changes WebAPI annotation outcome routing from exception-name
+prefixes to structured iam-lib error_code strings. Existing unresolved
+refusal rows must be normalized so the send-before filter remains code-only.
+
+Revision ID: c8d9e0f1a2b3
+Revises: b7c8d9e0f1a2
+Create Date: 2026-06-01
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "c8d9e0f1a2b3"
+down_revision: str | None = "b7c8d9e0f1a2"
+branch_labels: str | None = None
+depends_on: str | None = None
+
+
+def _error_records_exists() -> bool:
+    bind = op.get_bind()
+    return "error_records" in sa.inspect(bind).get_table_names()
+
+
+def upgrade() -> None:
+    if not _error_records_exists():
+        return
+    op.execute(
+        """
+        UPDATE error_records
+        SET error_type = 'SAFETY_REFUSAL'
+        WHERE operation_type = 'annotation'
+          AND error_type = 'SafetyRefusalError'
+        """
+    )
+    op.execute(
+        """
+        UPDATE error_records
+        SET error_type = 'CONTENT_POLICY_REFUSAL'
+        WHERE operation_type = 'annotation'
+          AND error_type = 'ContentPolicyRefusalError'
+        """
+    )
+
+
+def downgrade() -> None:
+    if not _error_records_exists():
+        return
+    op.execute(
+        """
+        UPDATE error_records
+        SET error_type = 'SafetyRefusalError'
+        WHERE operation_type = 'annotation'
+          AND error_type = 'SAFETY_REFUSAL'
+        """
+    )
+    op.execute(
+        """
+        UPDATE error_records
+        SET error_type = 'ContentPolicyRefusalError'
+        WHERE operation_type = 'annotation'
+          AND error_type = 'CONTENT_POLICY_REFUSAL'
+        """
+    )

--- a/src/lorairo/database/repository/error_record.py
+++ b/src/lorairo/database/repository/error_record.py
@@ -127,7 +127,7 @@ class ErrorRecordRepository(BaseRepository):
             resolved: True = 解決済み (resolved_at IS NOT NULL)、
                 False = 未解決 (resolved_at IS NULL)。
             error_types: 特定 error_type のみに絞る (例:
-                ["SafetyRefusalError", "ContentPolicyRefusalError"])。
+                ["SAFETY_REFUSAL", "CONTENT_POLICY_REFUSAL"])。
                 None = 全 type。ADR 0023 Phase 1.5 の送信前 filter で使用。
 
         Returns:

--- a/src/lorairo/services/annotation_save_service.py
+++ b/src/lorairo/services/annotation_save_service.py
@@ -246,13 +246,13 @@ class AnnotationSaveService:
             "confidence_score": confidence,
         }
 
-    # ADR 0023 Phase 1.5 (Issue #42): image-annotator-lib 側で refusal を検出した
-    # 場合、UnifiedAnnotationResult.error は f"{type(refusal_exc).__name__}: {msg}"
-    # 形式の文字列で乗ってくる。LoRAIro 側はこの prefix を string match で decode
-    # して error_records に記録する (型 import せず文字列 prefix のみで疎結合に保つ)。
-    _REFUSAL_ERROR_PREFIXES: tuple[str, ...] = (
-        "SafetyRefusalError:",
-        "ContentPolicyRefusalError:",
+    # ADR 0023 Phase 1.5 amendment (Issue #599): iam-lib は refusal / empty annotation
+    # を library error ではなく structured outcome として返す。LoRAIro ではこれらを
+    # annotation 対象から除外すべき outcome として error_records に記録する。
+    _ANNOTATION_OUTCOME_RECORD_ERROR_CODES: tuple[str, ...] = (
+        "SAFETY_REFUSAL",
+        "CONTENT_POLICY_REFUSAL",
+        "EMPTY_ANNOTATION",
     )
 
     # legacy migration 行の fallback sentinel: __legacy_<id>__.
@@ -276,26 +276,21 @@ class AnnotationSaveService:
         return model_id.isdecimal()
 
     @classmethod
-    def _detect_refusal_error_type(cls, error: Any) -> str | None:
-        """`UnifiedAnnotationResult.error` から refusal exception type 名を抽出する。
-
-        ADR 0023 Phase 1.5: image-annotator-lib 側 `_classify_refusal()` が
-        `f"{type(refusal_exc).__name__}: {refusal_exc}"` 形式で error 文字列を
-        構築するため、prefix を startswith で判定して error_type を切り出す。
+    def _detect_annotation_outcome_error_type(cls, error_code: Any) -> str | None:
+        """`UnifiedAnnotationResult.error_code` から LoRAIro 記録対象 code を抽出する。
 
         Args:
-            error: `UnifiedAnnotationResult.error` の値 (str | None | 他)。
+            error_code: `UnifiedAnnotationResult.error_code` の値 (str | StrEnum | None | 他)。
 
         Returns:
-            "SafetyRefusalError" / "ContentPolicyRefusalError"、または非 refusal なら None。
+            `error_records.error_type` に保存する code 文字列、または記録対象外なら None。
         """
-        if not isinstance(error, str):
+        if error_code is None:
             return None
-        for prefix in cls._REFUSAL_ERROR_PREFIXES:
-            if error.startswith(prefix):
-                # prefix は ":" を含むため strip して error_type 名のみ返す
-                return prefix.rstrip(":")
-        return None
+        code = getattr(error_code, "value", error_code)
+        if not isinstance(code, str):
+            return None
+        return code if code in cls._ANNOTATION_OUTCOME_RECORD_ERROR_CODES else None
 
     def _process_model_result(
         self,
@@ -307,17 +302,17 @@ class AnnotationSaveService:
     ) -> None:
         """1モデル分のアノテーション結果をAnnotationsDictに追記する。
 
-        ADR 0023 Phase 1.5 (Issue #42): error が SafetyRefusalError /
-        ContentPolicyRefusalError の prefix を持つ場合、`error_records` に記録
-        してから skip する。`image_id is None` の場合は記録できないため warning
-        のみ出して skip する。
+        ADR 0023 Phase 1.5 amendment (Issue #599): error_code が
+        SAFETY_REFUSAL / CONTENT_POLICY_REFUSAL / EMPTY_ANNOTATION の場合、
+        `error_records` に記録してから skip する。`image_id is None` の場合は
+        記録できないため warning のみ出して skip する。
 
         Args:
             model_name: アノテーションを行ったモデル名。
             unified_result: image-annotator-lib から返された UnifiedAnnotationResult。
             models_cache: model_name → Model の事前取得キャッシュ。
             result: 追記先の AnnotationsDict。
-            image_id: 対象画像 ID。refusal を error_records に記録する際に必要。
+            image_id: 対象画像 ID。outcome を error_records に記録する際に必要。
         """
         if self._is_legacy_sentinel_model_id(model_name):
             logger.warning(
@@ -325,32 +320,37 @@ class AnnotationSaveService:
             )
             return
 
+        error_code = self._extract_field(unified_result, "error_code")
         error = self._extract_field(unified_result, "error")
-        if error:
-            refusal_type = self._detect_refusal_error_type(error)
-            if refusal_type is not None:
-                # ADR 0023 line 347-372: refusal は retry せず error_records に
-                # 記録 → 送信前 filter で除外。
-                error_message = error.split(":", 1)[1].strip() if ":" in error else ""
-                if image_id is not None:
-                    self._error_record_repo.save_error_record(
-                        operation_type="annotation",
-                        error_type=refusal_type,
-                        error_message=error_message,
-                        image_id=image_id,
-                        model_name=model_name,
-                    )
-                    logger.warning(
-                        f"Refusal recorded to error_records: model={model_name}, "
-                        f"image_id={image_id}, type={refusal_type}"
-                    )
-                else:
-                    logger.warning(
-                        f"Refusal detected but image_id missing, cannot persist: "
-                        f"model={model_name}, type={refusal_type}"
-                    )
-                return
-            logger.warning(f"モデル {model_name} エラーをスキップ")
+        retryable = self._extract_field(unified_result, "retryable")
+        outcome_error_type = self._detect_annotation_outcome_error_type(error_code)
+        if outcome_error_type is not None:
+            # LoRAIro では retry せず error_records に記録 → 送信前 filter で除外。
+            error_message = str(error or "")
+            if image_id is not None:
+                self._error_record_repo.save_error_record(
+                    operation_type="annotation",
+                    error_type=outcome_error_type,
+                    error_message=error_message,
+                    image_id=image_id,
+                    model_name=model_name,
+                )
+                logger.warning(
+                    f"Annotation outcome recorded to error_records: model={model_name}, "
+                    f"image_id={image_id}, type={outcome_error_type}"
+                )
+            else:
+                logger.warning(
+                    f"Annotation outcome detected but image_id missing, cannot persist: "
+                    f"model={model_name}, type={outcome_error_type}"
+                )
+            return
+
+        if error or error_code:
+            if retryable:
+                logger.warning(f"モデル {model_name} retryable annotation outcome をスキップ")
+            else:
+                logger.warning(f"モデル {model_name} エラーをスキップ")
             return
 
         model = models_cache.get(model_name)
@@ -410,7 +410,9 @@ class AnnotationSaveService:
             for model_name, unified_result in phash_annotations.items():
                 if self._is_legacy_sentinel_model_id(model_name):
                     continue
-                if self._extract_field(unified_result, "error"):
+                if self._extract_field(unified_result, "error") or self._extract_field(
+                    unified_result, "error_code"
+                ):
                     continue
                 all_model_names.add(model_name)
                 tags = self._extract_field(unified_result, "tags")
@@ -708,17 +710,17 @@ class AnnotationSaveService:
             error_details=error_details,
         )
 
-    # ADR 0023 Phase 1.5 (Issue #42): WebAPI annotation 対象から、過去に refusal
-    # を返した画像を除外するための送信前 filter。AnnotationWorker 等の caller が
-    # image_paths を構築した直後に呼ぶことで、無駄な API 課金 + refusal ループを防ぐ。
+    # ADR 0023 Phase 1.5 amendment (Issue #599): WebAPI annotation 対象から、過去に
+    # refusal / empty annotation outcome を返した画像を除外するための送信前 filter。
     REFUSAL_ERROR_TYPES: tuple[str, ...] = (
-        "SafetyRefusalError",
-        "ContentPolicyRefusalError",
+        "SAFETY_REFUSAL",
+        "CONTENT_POLICY_REFUSAL",
+        "EMPTY_ANNOTATION",
     )
     _RATING_EXCLUSION_VALUES: frozenset[str] = frozenset({"X", "XXX"})
 
     def filter_refused_image_paths(self, image_paths: list[str]) -> list[str]:
-        """過去に safety/content refusal を返した画像 path を除外する。
+        """過去に safety/content refusal または empty annotation を返した画像 path を除外する。
 
         **本 method は WebAPI 推論経路向けの filter** — SafetyRefusal /
         ContentPolicyRefusal は cloud provider の content policy 拒否概念で、
@@ -727,9 +729,9 @@ class AnnotationSaveService:
         WebAPI モデルが選択モデルに含まれているかの判定は呼び出し側 (`worker_service`)
         で行う (`selection_includes_webapi_model()` 参照)。
 
-        ADR 0023 line 363-369 の送信前 filter:
+        ADR 0023 Phase 1.5 amendment の送信前 filter:
             operation_type = "annotation"
-            error_type in {"SafetyRefusalError", "ContentPolicyRefusalError"}
+            error_type in {"SAFETY_REFUSAL", "CONTENT_POLICY_REFUSAL", "EMPTY_ANNOTATION"}
             resolved_at IS NULL
 
         を満たす image_id 集合を取得し、対応する image_path を除外する。
@@ -772,7 +774,7 @@ class AnnotationSaveService:
         if excluded_count > 0:
             logger.info(
                 f"WebAPI annotation 送信前 filter: 対象 {len(filtered)}件 "
-                f"(refusal 除外: {excluded_count}件)"
+                f"(outcome 除外: {excluded_count}件)"
             )
         return filtered
 

--- a/tests/bdd/features/annotation_result_save.feature
+++ b/tests/bdd/features/annotation_result_save.feature
@@ -1,15 +1,15 @@
 # language: ja
-機能: アノテーション結果の保存と安全性拒否ハンドリング
+機能: アノテーション結果の保存と outcome ハンドリング
   AnnotationSaveService は CLI/GUI/API の 3 経路で共有される Qt-free サービスで、
   推論結果を DB に保存し成功・スキップ・エラーを集計する。ADR 0023 Phase 1.5 では
-  安全性拒否 (SafetyRefusal / ContentPolicyRefusal) を error_records に記録し、
-  次回 WebAPI 送信前に対象画像を除外することで API 課金と refusal ループを防ぐ。
+  安全性拒否や空アノテーション outcome を error_records に記録し、次回 WebAPI
+  送信前に対象画像を除外することで API 課金と refusal / empty ループを防ぐ。
 
   シナリオ: 安全性拒否を受けた結果はエラーレコードに記録されスキップされる
     前提 DB に登録済みの画像が 1 件ある
     かつ AnnotationSaveService が初期化されている
-    もし その画像に対し "SafetyRefusalError: blocked due to safety policy" の結果を処理する
-    ならば エラーレコードに 1 件の "SafetyRefusalError" が記録される
+    もし その画像に対し "SAFETY_REFUSAL: blocked due to safety policy" の結果を処理する
+    ならば エラーレコードに 1 件の "SAFETY_REFUSAL" が記録される
     かつ アノテーションは保存されない
 
   シナリオ: 過去に拒否された画像は WebAPI 送信対象から除外される

--- a/tests/bdd/steps/test_annotation_result_save.py
+++ b/tests/bdd/steps/test_annotation_result_save.py
@@ -113,7 +113,7 @@ def given_unresolved_refusal(ctx: SaveContext) -> None:
     assert ctx.error_repo is not None and ctx.image_id is not None
     ctx.error_repo.save_error_record(
         operation_type="annotation",
-        error_type="SafetyRefusalError",
+        error_type="SAFETY_REFUSAL",
         error_message="blocked",
         image_id=ctx.image_id,
         model_name="openai/gpt-4o",
@@ -125,7 +125,7 @@ def given_resolved_refusal(ctx: SaveContext) -> None:
     assert ctx.repo is not None and ctx.error_repo is not None and ctx.image_id is not None
     error_id = ctx.error_repo.save_error_record(
         operation_type="annotation",
-        error_type="SafetyRefusalError",
+        error_type="SAFETY_REFUSAL",
         error_message="blocked",
         image_id=ctx.image_id,
         model_name="openai/gpt-4o",
@@ -159,6 +159,8 @@ def _make_success_result(tags: list[str]) -> MagicMock:
     """正常系 UnifiedAnnotationResult モックを生成する。"""
     result = MagicMock()
     result.error = None
+    result.error_code = None
+    result.retryable = False
     result.tags = tags
     result.captions = []
     result.scores = None
@@ -176,9 +178,10 @@ def _make_success_result(tags: list[str]) -> MagicMock:
 def when_process_refusal_result(ctx: SaveContext, error_string: str) -> None:
     assert ctx.save_service is not None and ctx.image_id is not None
     ctx.annotations_dict = {"scores": [], "tags": [], "captions": [], "ratings": []}
+    error_code, _, error_message = error_string.partition(":")
     ctx.save_service._process_model_result(
         model_name="openai/gpt-4o",
-        unified_result={"error": error_string},
+        unified_result={"error_code": error_code, "error": error_message.strip()},
         models_cache={},
         result=ctx.annotations_dict,
         image_id=ctx.image_id,

--- a/tests/integration/test_safety_refusal_records.py
+++ b/tests/integration/test_safety_refusal_records.py
@@ -1,14 +1,14 @@
-"""ADR 0023 Phase 1.5 (Issue #42): refusal → error_records → filter サイクルの統合テスト。
+"""ADR 0023 Phase 1.5 amendment (Issue #599): outcome → error_records → filter cycle.
 
-image-annotator-lib 側で検出された SafetyRefusal / ContentPolicyRefusal は
-`UnifiedAnnotationResult.error` に prefix 文字列で乗ってくるため、LoRAIro 側で
-`AnnotationSaveService._process_model_result` が prefix を decode して
-`error_records` に記録する。次回送信時は `filter_refused_image_paths` で除外する。
+iam-lib 側で検出された refusal / empty annotation は `UnifiedAnnotationResult.error_code`
+に構造化 outcome として乗ってくる。LoRAIro 側では対象 code を error_records に記録し、
+次回送信時は `filter_refused_image_paths` で除外する。
 """
 
 from __future__ import annotations
 
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 from PIL import Image
@@ -18,6 +18,11 @@ from lorairo.database.repository.annotation_record import AnnotationRepository
 from lorairo.database.repository.error_record import ErrorRecordRepository
 from lorairo.database.repository.image import ImageRepository
 from lorairo.services.annotation_save_service import AnnotationSaveService
+
+SAFETY_REFUSAL = "SAFETY_REFUSAL"
+CONTENT_POLICY_REFUSAL = "CONTENT_POLICY_REFUSAL"
+EMPTY_ANNOTATION = "EMPTY_ANNOTATION"
+PROVIDER_ERROR = "PROVIDER_ERROR"
 
 
 @pytest.fixture
@@ -70,41 +75,51 @@ def registered_image(repo: ImageRepository, tmp_path: Path) -> tuple[int, str]:
 
 
 @pytest.mark.integration
-def test_detect_refusal_error_type_safety_prefix() -> None:
-    """SafetyRefusalError prefix が正しく decode される。"""
-    detected = AnnotationSaveService._detect_refusal_error_type(
-        "SafetyRefusalError: blocked due to safety policy"
-    )
-    assert detected == "SafetyRefusalError"
+def test_detect_annotation_outcome_error_type_safety_refusal() -> None:
+    """SAFETY_REFUSAL code が記録対象として検出される。"""
+    detected = AnnotationSaveService._detect_annotation_outcome_error_type(SAFETY_REFUSAL)
+    assert detected == SAFETY_REFUSAL
 
 
 @pytest.mark.integration
-def test_detect_refusal_error_type_content_policy_prefix() -> None:
-    """ContentPolicyRefusalError prefix が正しく decode される。"""
-    detected = AnnotationSaveService._detect_refusal_error_type(
-        "ContentPolicyRefusalError: content blocked"
-    )
-    assert detected == "ContentPolicyRefusalError"
+def test_detect_annotation_outcome_error_type_content_policy_refusal() -> None:
+    """CONTENT_POLICY_REFUSAL code が記録対象として検出される。"""
+    detected = AnnotationSaveService._detect_annotation_outcome_error_type(CONTENT_POLICY_REFUSAL)
+    assert detected == CONTENT_POLICY_REFUSAL
 
 
 @pytest.mark.integration
-def test_detect_refusal_error_type_non_refusal_returns_none() -> None:
-    """非 refusal error string は None を返す。"""
-    assert AnnotationSaveService._detect_refusal_error_type("ApiTimeoutError: timeout") is None
-    assert AnnotationSaveService._detect_refusal_error_type("generic error") is None
-    assert AnnotationSaveService._detect_refusal_error_type(None) is None
-    assert AnnotationSaveService._detect_refusal_error_type({"error": "obj"}) is None
+def test_detect_annotation_outcome_error_type_empty_annotation() -> None:
+    """EMPTY_ANNOTATION code が記録対象として検出される。"""
+    detected = AnnotationSaveService._detect_annotation_outcome_error_type(EMPTY_ANNOTATION)
+    assert detected == EMPTY_ANNOTATION
 
 
 @pytest.mark.integration
-def test_process_model_result_records_safety_refusal(
+def test_detect_annotation_outcome_error_type_accepts_strenum_like_value() -> None:
+    """StrEnum 相当の value 属性を持つ code も文字列化して扱う。"""
+    code = SimpleNamespace(value=SAFETY_REFUSAL)
+    assert AnnotationSaveService._detect_annotation_outcome_error_type(code) == SAFETY_REFUSAL
+
+
+@pytest.mark.integration
+def test_detect_annotation_outcome_error_type_non_recorded_returns_none() -> None:
+    """transport 系や不正型は記録対象外として None を返す。"""
+    assert AnnotationSaveService._detect_annotation_outcome_error_type(PROVIDER_ERROR) is None
+    assert AnnotationSaveService._detect_annotation_outcome_error_type("ApiTimeoutError") is None
+    assert AnnotationSaveService._detect_annotation_outcome_error_type(None) is None
+    assert AnnotationSaveService._detect_annotation_outcome_error_type({"error": "obj"}) is None
+
+
+@pytest.mark.integration
+def test_process_model_result_records_safety_refusal_code(
     save_service: AnnotationSaveService,
     error_repo: ErrorRecordRepository,
     registered_image: tuple[int, str],
 ) -> None:
-    """SafetyRefusalError 結果が error_records に記録されることを確認。"""
+    """SAFETY_REFUSAL outcome が error_records に code 文字列で記録される。"""
     image_id, _ = registered_image
-    unified_result = {"error": "SafetyRefusalError: blocked due to safety policy"}
+    unified_result = {"error_code": SAFETY_REFUSAL, "error": "blocked due to safety policy"}
 
     result_dict: dict = {"scores": [], "tags": [], "captions": [], "ratings": []}
     save_service._process_model_result(
@@ -119,7 +134,7 @@ def test_process_model_result_records_safety_refusal(
     records = error_repo.get_error_records(operation_type="annotation")
     assert len(records) == 1
     record = records[0]
-    assert record.error_type == "SafetyRefusalError"
+    assert record.error_type == SAFETY_REFUSAL
     assert record.image_id == image_id
     assert record.model_name == "openai/gpt-4o"
     assert "blocked" in record.error_message
@@ -127,14 +142,17 @@ def test_process_model_result_records_safety_refusal(
 
 
 @pytest.mark.integration
-def test_process_model_result_records_content_policy_refusal(
+def test_process_model_result_records_content_policy_refusal_code(
     save_service: AnnotationSaveService,
     error_repo: ErrorRecordRepository,
     registered_image: tuple[int, str],
 ) -> None:
-    """ContentPolicyRefusalError 結果が error_records に記録される。"""
+    """CONTENT_POLICY_REFUSAL outcome が error_records に記録される。"""
     image_id, _ = registered_image
-    unified_result = {"error": "ContentPolicyRefusalError: finish_reason=content_filter, blocked"}
+    unified_result = {
+        "error_code": CONTENT_POLICY_REFUSAL,
+        "error": "finish_reason=content_filter, blocked",
+    }
 
     result_dict: dict = {"scores": [], "tags": [], "captions": [], "ratings": []}
     save_service._process_model_result(
@@ -147,7 +165,32 @@ def test_process_model_result_records_content_policy_refusal(
 
     records = error_repo.get_error_records(operation_type="annotation")
     assert len(records) == 1
-    assert records[0].error_type == "ContentPolicyRefusalError"
+    assert records[0].error_type == CONTENT_POLICY_REFUSAL
+
+
+@pytest.mark.integration
+def test_process_model_result_records_empty_annotation_code(
+    save_service: AnnotationSaveService,
+    error_repo: ErrorRecordRepository,
+    registered_image: tuple[int, str],
+) -> None:
+    """EMPTY_ANNOTATION outcome が error_records に記録される。"""
+    image_id, _ = registered_image
+    unified_result = {"error_code": EMPTY_ANNOTATION, "error": "all requested capabilities were empty"}
+
+    result_dict: dict = {"scores": [], "tags": [], "captions": [], "ratings": []}
+    save_service._process_model_result(
+        model_name="openai/o1",
+        unified_result=unified_result,
+        models_cache={},
+        result=result_dict,
+        image_id=image_id,
+    )
+
+    records = error_repo.get_error_records(operation_type="annotation")
+    assert len(records) == 1
+    assert records[0].error_type == EMPTY_ANNOTATION
+    assert "empty" in records[0].error_message
 
 
 @pytest.mark.integration
@@ -156,7 +199,7 @@ def test_process_model_result_skips_record_when_image_id_missing(
     error_repo: ErrorRecordRepository,
 ) -> None:
     """image_id=None の場合は error_records 記録せず warning のみ (regression check)。"""
-    unified_result = {"error": "SafetyRefusalError: blocked"}
+    unified_result = {"error_code": SAFETY_REFUSAL, "error": "blocked"}
     result_dict: dict = {"scores": [], "tags": [], "captions": [], "ratings": []}
     save_service._process_model_result(
         model_name="openai/gpt-4o",
@@ -170,14 +213,14 @@ def test_process_model_result_skips_record_when_image_id_missing(
 
 
 @pytest.mark.integration
-def test_process_model_result_non_refusal_error_still_skipped(
+def test_process_model_result_provider_error_still_skipped(
     save_service: AnnotationSaveService,
     error_repo: ErrorRecordRepository,
     registered_image: tuple[int, str],
 ) -> None:
-    """非 refusal error は従来通り skip され error_records には記録しない。"""
+    """retryable transport outcome は従来通り skip され error_records には記録しない。"""
     image_id, _ = registered_image
-    unified_result = {"error": "ApiTimeoutError: connection timeout"}
+    unified_result = {"error_code": PROVIDER_ERROR, "retryable": True, "error": "connection timeout"}
     result_dict: dict = {"scores": [], "tags": [], "captions": [], "ratings": []}
     save_service._process_model_result(
         model_name="openai/gpt-4o",
@@ -187,24 +230,24 @@ def test_process_model_result_non_refusal_error_still_skipped(
         image_id=image_id,
     )
     records = error_repo.get_error_records(operation_type="annotation")
-    # 本テストは「refusal でない error は records に書かない」を保証する。
+    # 本テストは「LoRAIro exclusion outcome でない error は records に書かない」を保証する。
     # 既存 _save_error_records 経路で記録される場合もあるが、それは別パス
     # (Worker レベルの try/except)。_process_model_result 単独では記録しない。
-    refusal_records = [r for r in records if r.error_type.endswith("RefusalError")]
-    assert len(refusal_records) == 0
+    outcome_records = [r for r in records if r.error_type in AnnotationSaveService.REFUSAL_ERROR_TYPES]
+    assert len(outcome_records) == 0
 
 
 @pytest.mark.integration
-def test_filter_refused_image_paths_excludes_unresolved_refusal(
+def test_filter_refused_image_paths_excludes_unresolved_outcome(
     save_service: AnnotationSaveService,
     error_repo: ErrorRecordRepository,
     registered_image: tuple[int, str],
 ) -> None:
-    """unresolved refusal を持つ画像は filter で除外される。"""
+    """unresolved refusal / empty outcome を持つ画像は filter で除外される。"""
     image_id, file_path = registered_image
     error_repo.save_error_record(
         operation_type="annotation",
-        error_type="SafetyRefusalError",
+        error_type=EMPTY_ANNOTATION,
         error_message="blocked",
         image_id=image_id,
         model_name="openai/gpt-4o",
@@ -227,7 +270,7 @@ def test_filter_refused_image_paths_keeps_resolved_refusal(
     image_id, file_path = registered_image
     error_id = error_repo.save_error_record(
         operation_type="annotation",
-        error_type="SafetyRefusalError",
+        error_type=SAFETY_REFUSAL,
         error_message="blocked",
         image_id=image_id,
         model_name="openai/gpt-4o",
@@ -250,7 +293,7 @@ def test_filter_refused_image_paths_other_error_types_not_excluded(
     error_repo: ErrorRecordRepository,
     registered_image: tuple[int, str],
 ) -> None:
-    """SafetyRefusal / ContentPolicy 以外の error_type は除外されない。"""
+    """refusal / empty outcome code 以外の error_type は除外されない。"""
     image_id, file_path = registered_image
     error_repo.save_error_record(
         operation_type="annotation",
@@ -295,7 +338,7 @@ def test_filter_uses_batch_resolve_for_path_to_image_id(
     image_id, file_path = registered_image
     error_repo.save_error_record(
         operation_type="annotation",
-        error_type="SafetyRefusalError",
+        error_type=SAFETY_REFUSAL,
         error_message="blocked",
         image_id=image_id,
         model_name="openai/gpt-4o",
@@ -440,7 +483,7 @@ def test_get_error_image_ids_with_error_types_filter(
     # 2 種類の error_type を追加
     error_repo.save_error_record(
         operation_type="annotation",
-        error_type="SafetyRefusalError",
+        error_type=SAFETY_REFUSAL,
         error_message="safety",
         image_id=image_id,
         model_name="openai/gpt-4o",
@@ -449,7 +492,7 @@ def test_get_error_image_ids_with_error_types_filter(
     refused = error_repo.get_error_image_ids(
         operation_type="annotation",
         resolved=False,
-        error_types=["SafetyRefusalError", "ContentPolicyRefusalError"],
+        error_types=[SAFETY_REFUSAL, CONTENT_POLICY_REFUSAL, EMPTY_ANNOTATION],
     )
     assert image_id in refused
 

--- a/tests/unit/database/repository/test_error_record_repository.py
+++ b/tests/unit/database/repository/test_error_record_repository.py
@@ -196,10 +196,10 @@ class TestGetErrorImageIds:
 
     def test_filters_by_error_types(self, error_record_repository: ErrorRecordRepository) -> None:
         """error_types フィルタで特定の error_type のみを抽出する。"""
-        _insert_error(error_record_repository, image_id=1, error_type="SafetyRefusalError")
+        _insert_error(error_record_repository, image_id=1, error_type="SAFETY_REFUSAL")
         _insert_error(error_record_repository, image_id=2, error_type="APIError")
 
-        ids = error_record_repository.get_error_image_ids(error_types=["SafetyRefusalError"])
+        ids = error_record_repository.get_error_image_ids(error_types=["SAFETY_REFUSAL"])
         assert ids == [1]
 
     def test_resolved_filter(self, error_record_repository: ErrorRecordRepository) -> None:

--- a/tests/unit/database/test_migration_c8d9e0f1a2b3_outcome_error_types.py
+++ b/tests/unit/database/test_migration_c8d9e0f1a2b3_outcome_error_types.py
@@ -1,0 +1,130 @@
+"""Alembic migration `c8d9e0f1a2b3` annotation outcome error_type normalization."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from alembic import command
+from alembic.config import Config
+from sqlalchemy import create_engine, text
+
+
+def _make_alembic_config(db_path: Path) -> Config:
+    project_root = Path(__file__).resolve().parents[3]
+    cfg = Config(str(project_root / "alembic.ini"))
+    cfg.set_main_option("script_location", str(project_root / "src/lorairo/database/migrations"))
+    cfg.set_main_option("sqlalchemy.url", f"sqlite:///{db_path}")
+    return cfg
+
+
+def _create_parent_schema(db_path: Path) -> None:
+    engine = create_engine(f"sqlite:///{db_path}")
+    with engine.begin() as conn:
+        conn.execute(
+            text(
+                """
+                CREATE TABLE error_records (
+                    id INTEGER NOT NULL PRIMARY KEY,
+                    image_id INTEGER,
+                    operation_type VARCHAR NOT NULL,
+                    error_type VARCHAR NOT NULL,
+                    error_message TEXT NOT NULL,
+                    stack_trace TEXT,
+                    file_path VARCHAR,
+                    model_name VARCHAR,
+                    resolved_at TIMESTAMP,
+                    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL
+                )
+                """
+            )
+        )
+        conn.execute(text("CREATE TABLE alembic_version (version_num VARCHAR(32) PRIMARY KEY)"))
+        conn.execute(text("INSERT INTO alembic_version (version_num) VALUES ('b7c8d9e0f1a2')"))
+    engine.dispose()
+
+
+@pytest.mark.unit
+def test_upgrade_noops_when_error_records_table_is_absent(tmp_path: Path) -> None:
+    db = tmp_path / "outcome_error_types_no_table.db"
+    engine = create_engine(f"sqlite:///{db}")
+    with engine.begin() as conn:
+        conn.execute(text("CREATE TABLE alembic_version (version_num VARCHAR(32) PRIMARY KEY)"))
+        conn.execute(text("INSERT INTO alembic_version (version_num) VALUES ('b7c8d9e0f1a2')"))
+    engine.dispose()
+
+    command.upgrade(_make_alembic_config(db), "c8d9e0f1a2b3")
+
+    engine = create_engine(f"sqlite:///{db}")
+    with engine.connect() as conn:
+        version = conn.execute(text("SELECT version_num FROM alembic_version")).scalar_one()
+    engine.dispose()
+
+    assert version == "c8d9e0f1a2b3"
+
+
+@pytest.mark.unit
+def test_upgrade_normalizes_legacy_refusal_error_types(tmp_path: Path) -> None:
+    db = tmp_path / "outcome_error_types.db"
+    _create_parent_schema(db)
+    engine = create_engine(f"sqlite:///{db}")
+    with engine.begin() as conn:
+        conn.execute(
+            text(
+                """
+                INSERT INTO error_records
+                    (operation_type, error_type, error_message, model_name)
+                VALUES
+                    ('annotation', 'SafetyRefusalError', 'blocked', 'openai/gpt-4o'),
+                    ('annotation', 'ContentPolicyRefusalError', 'blocked', 'openai/gpt-4o'),
+                    ('annotation', 'ApiTimeoutError', 'timeout', 'openai/gpt-4o'),
+                    ('registration', 'SafetyRefusalError', 'not annotation', NULL)
+                """
+            )
+        )
+    engine.dispose()
+
+    command.upgrade(_make_alembic_config(db), "c8d9e0f1a2b3")
+
+    engine = create_engine(f"sqlite:///{db}")
+    with engine.connect() as conn:
+        rows = conn.execute(text("SELECT operation_type, error_type FROM error_records ORDER BY id")).all()
+    engine.dispose()
+
+    assert rows == [
+        ("annotation", "SAFETY_REFUSAL"),
+        ("annotation", "CONTENT_POLICY_REFUSAL"),
+        ("annotation", "ApiTimeoutError"),
+        ("registration", "SafetyRefusalError"),
+    ]
+
+
+@pytest.mark.unit
+def test_downgrade_restores_legacy_refusal_error_types(tmp_path: Path) -> None:
+    db = tmp_path / "outcome_error_types.db"
+    _create_parent_schema(db)
+    engine = create_engine(f"sqlite:///{db}")
+    with engine.begin() as conn:
+        conn.execute(
+            text(
+                """
+                INSERT INTO error_records
+                    (operation_type, error_type, error_message, model_name)
+                VALUES
+                    ('annotation', 'SAFETY_REFUSAL', 'blocked', 'openai/gpt-4o'),
+                    ('annotation', 'CONTENT_POLICY_REFUSAL', 'blocked', 'openai/gpt-4o'),
+                    ('annotation', 'EMPTY_ANNOTATION', 'empty', 'openai/o1')
+                """
+            )
+        )
+    engine.dispose()
+
+    command.upgrade(_make_alembic_config(db), "c8d9e0f1a2b3")
+    command.downgrade(_make_alembic_config(db), "b7c8d9e0f1a2")
+
+    engine = create_engine(f"sqlite:///{db}")
+    with engine.connect() as conn:
+        rows = conn.execute(text("SELECT error_type FROM error_records ORDER BY id")).scalars().all()
+    engine.dispose()
+
+    assert rows == ["SafetyRefusalError", "ContentPolicyRefusalError", "EMPTY_ANNOTATION"]

--- a/tests/unit/services/test_annotation_save_service.py
+++ b/tests/unit/services/test_annotation_save_service.py
@@ -53,6 +53,8 @@ def _make_success_result(
     """
     result = MagicMock()
     result.error = None
+    result.error_code = None
+    result.retryable = False
     result.tags = tags or []
     result.captions = captions or []
     result.scores = scores
@@ -144,7 +146,9 @@ def test_save_provider_batch_results_by_image_id_records_refusal(
 ) -> None:
     """Provider Batch 経由の refusal も image_id 付き error_records に残す。"""
     refusal_result = MagicMock()
-    refusal_result.error = "SafetyRefusalError: policy refused"
+    refusal_result.error = "policy refused"
+    refusal_result.error_code = "SAFETY_REFUSAL"
+    refusal_result.retryable = False
     refusal_result.tags = []
     refusal_result.captions = []
     refusal_result.scores = None
@@ -162,7 +166,7 @@ def test_save_provider_batch_results_by_image_id_records_refusal(
     assert result.error_count == 0
     mock_repository.save_error_record.assert_called_once_with(
         operation_type="annotation",
-        error_type="SafetyRefusalError",
+        error_type="SAFETY_REFUSAL",
         error_message="policy refused",
         image_id=7,
         model_name="openai/gpt-test",


### PR DESCRIPTION
## Summary

Refs #599. Ready for LoRAIro-side review. Merge should wait until NEXTAltair/image-annotator-lib#134 finalizes the structured `UnifiedAnnotationResult.error_code` contract.

- Route LoRAIro annotation save handling by `error_code` instead of legacy `error` prefix strings.
- Persist `SAFETY_REFUSAL`, `CONTENT_POLICY_REFUSAL`, and `EMPTY_ANNOTATION` to `error_records` and exclude them from later WebAPI annotation sends.
- Keep retryable/transport outcomes such as `PROVIDER_ERROR` as warning-only skips.
- Add Alembic data migration from legacy exception-name `error_type` values to code strings.
- Amend ADR 0023 Phase 1.5 with the iam-lib non-error outcome vs LoRAIro error-record policy boundary.

## Verification

- `uv run --no-sync ruff check ...` on changed Python files
- `uv run --no-sync ruff format --check ...` on changed Python files
- `uv run --no-sync pytest tests/integration/test_safety_refusal_records.py`
- `uv run --no-sync pytest tests/unit/database/test_migration_c8d9e0f1a2b3_outcome_error_types.py`
- `uv run --no-sync pytest tests/unit/services/test_annotation_save_service.py tests/unit/database/repository/test_error_record_repository.py tests/bdd/steps/test_annotation_result_save.py`
- `PYTHONPATH=/tmp/worktrees/issue-599-error-code-routing/src:/tmp/worktrees/issue-599-error-code-routing/local_packages/image-annotator-lib/src:/tmp/worktrees/issue-599-error-code-routing/local_packages/genai-tag-db-tools/src uv run --no-sync pytest -m "not gui_show and not calls_real_webapi and not downloads_and_runs_model and not slow"`
  - Result: 3709 passed, 2 skipped, 1 deselected, 88 warnings

## Integration Note

This PR intentionally does not bump the iam-lib submodule yet. Keep merge gated until iam-lib #134 lands with the final `error_code` / `retryable` field names and `EMPTY_ANNOTATION` code.

