### PR TITLE
fix: combine manual and AI rating filters with AND (#604)

### DIFF
--- a/src/lorairo/database/repository/image.py
+++ b/src/lorairo/database/repository/image.py
@@ -1801,16 +1801,14 @@ class ImageRepository(BaseRepository):
         query = self._apply_tag_filter(query, tags, excluded_tags, use_and, include_untagged)
         query = self._apply_caption_filter(query, caption)
 
-        # Rating Filters (Priority-based: manual > AI)
-        if manual_rating_filter:
-            logger.debug("Applying manual rating filter (priority over AI rating filter)")
-            query = self._apply_manual_filters(query, manual_rating_filter, manual_edit_filter, session)
-        elif ai_rating_filter:
-            logger.debug("Applying AI rating filter (no manual rating filter specified)")
+        # Rating Filters: manual / AI を独立に AND 適用する (Issue #604)
+        # 旧実装は manual と AI を排他 (if/elif) にしており、両方指定時に AI フィルタが
+        # 無視されていた。manual_rating_filter=None のとき _apply_manual_filters は
+        # manual_edit_filter のみ適用するため、無条件呼び出しで全組み合わせを網羅できる。
+        query = self._apply_manual_filters(query, manual_rating_filter, manual_edit_filter, session)
+        if ai_rating_filter:
+            logger.debug("Applying AI rating filter")
             query = self._apply_ai_rating_filter(query, ai_rating_filter)
-            query = self._apply_manual_filters(query, None, manual_edit_filter, session)
-        else:
-            query = self._apply_manual_filters(query, None, manual_edit_filter, session)
 
         # Unrated Filter
         query = self._apply_unrated_filter(query, include_unrated, only_unrated)

--- a/src/lorairo/gui/services/search_filter_service.py
+++ b/src/lorairo/gui/services/search_filter_service.py
@@ -217,8 +217,7 @@ class SearchFilterService:
             ai_rating_text = f"AIレーティング: {ai_rating_display}"
             if is_specific:
                 ai_rating_text += " (多数決)"
-            if conditions.rating_filter:
-                ai_rating_text += " ※手動レーティング優先"
+            # Issue #604: manual / AI は AND 結合 (優先関係なし)。優先注記は付けない。
             parts.append(ai_rating_text)
         if not conditions.include_nsfw:
             parts.append("NSFW除外")

--- a/tests/integration/test_rating_save_integration.py
+++ b/tests/integration/test_rating_save_integration.py
@@ -405,3 +405,50 @@ def test_manual_rating_isolated_from_ai_rating(
         ImageFilterCriteria(manual_rating_filter="PG-13")
     )
     assert manual_count == 1
+
+
+def test_manual_and_ai_rating_filters_combine_with_and(
+    rating_repository: ImageRepository,
+    annotation_repository: AnnotationRepository,
+    seeded_ids: dict[str, int],
+) -> None:
+    """manual / AI レーティングを同時指定したとき AND 結合される (Issue #604)。
+
+    対象画像は AI rating = "PG"、manual rating = "PG-13"。
+    旧実装は manual 優先で AI を無視していたため、manual=RATED + ai=PG-13 が
+    誤って 1 件ヒットしていた。AND 結合では 0 件になる。
+    非 NSFW 値 (PG / PG-13) のみ使い NSFW 除外フィルタの影響を避ける。
+    """
+    service = AnnotationSaveService(annotation_repository, image_repo=rating_repository)
+    service.save_annotation_results(
+        {_PHASH: {_LITELLM_ID: _result_with_rating("general", "danbooru4", 0.7)}}
+    )
+    annotation_repository.update_manual_rating(seeded_ids["image_id"], "PG-13")
+
+    image_id = seeded_ids["image_id"]
+
+    # manual=RATED かつ AI=PG -> 両条件成立で 1 件
+    both_pg, both_pg_count = rating_repository.get_images_by_filter(
+        ImageFilterCriteria(manual_rating_filter="RATED", ai_rating_filter="PG")
+    )
+    assert both_pg_count == 1
+    assert both_pg[0]["id"] == image_id
+
+    # manual=RATED かつ AI=PG-13 -> AI 行に PG-13 は無いので 0 件
+    # (旧バグでは manual=RATED が優先され AI が無視されて 1 件返っていた)
+    _, ratbug_count = rating_repository.get_images_by_filter(
+        ImageFilterCriteria(manual_rating_filter="RATED", ai_rating_filter="PG-13")
+    )
+    assert ratbug_count == 0
+
+    # manual=PG-13 かつ AI=PG -> 両条件成立で 1 件
+    _, specific_and_count = rating_repository.get_images_by_filter(
+        ImageFilterCriteria(manual_rating_filter="PG-13", ai_rating_filter="PG")
+    )
+    assert specific_and_count == 1
+
+    # manual=PG (実際は PG-13) かつ AI=PG -> manual 条件不成立で 0 件
+    _, mismatch_count = rating_repository.get_images_by_filter(
+        ImageFilterCriteria(manual_rating_filter="PG", ai_rating_filter="PG")
+    )
+    assert mismatch_count == 0

--- a/tests/unit/database/test_db_repository_ai_rating_filter.py
+++ b/tests/unit/database/test_db_repository_ai_rating_filter.py
@@ -129,8 +129,8 @@ class TestGetImagesByFilterAIRating:
         assert results == []
         assert count == 0
 
-    def test_priority_based_manual_over_ai(self, mock_session_and_repository):
-        """manual_rating_filter が ai_rating_filter より優先されることを確認"""
+    def test_manual_and_ai_filters_both_applied(self, mock_session_and_repository):
+        """manual / AI 両方指定時、両フィルタが AND 適用されることを確認 (Issue #604)"""
         repository, _mock_session = mock_session_and_repository
 
         # ADR 0035 段階 4: get_images_by_filter は新 ImageRepository (`_image_repo`) に
@@ -143,10 +143,9 @@ class TestGetImagesByFilterAIRating:
                 # 両方のフィルタを指定
                 repository.get_images_by_filter(manual_rating_filter="PG", ai_rating_filter="R")
 
-                # manual_rating_filter が適用され、ai_rating_filter は無視される
+                # manual / AI は排他ではなく両方適用される (Issue #604: 旧実装は AI を無視していた)
                 mock_manual.assert_called()
-                # AI filter should not be called when manual filter is specified
-                mock_ai.assert_not_called()
+                mock_ai.assert_called_once()
 
     def test_ai_rating_filter_only(self, mock_session_and_repository):
         """ai_rating_filter のみが指定された場合、適用されることを確認"""
@@ -284,8 +283,12 @@ class TestSearchFilterServiceIntegration:
         assert "PG" in preview
         assert "多数決" in preview
 
-    def test_create_search_preview_shows_priority_note(self):
-        """create_search_preview() が優先順位の注記を表示することを確認"""
+    def test_create_search_preview_shows_both_rating_filters(self):
+        """manual / AI 同時指定時、両方のレーティング条件を AND として表示する (Issue #604)。
+
+        旧実装は「※手動レーティング優先」注記を表示していたが、manual と AI は
+        独立に AND 結合されるようになったため優先関係はなく、注記も付けない。
+        """
         from unittest.mock import Mock
 
         from lorairo.gui.services.search_filter_service import SearchFilterService
@@ -304,13 +307,16 @@ class TestSearchFilterServiceIntegration:
             keywords=["test"],
             tag_logic="and",
             rating_filter="PG",  # manual
-            ai_rating_filter="R",  # AI (should show priority note)
+            ai_rating_filter="R",  # AI
         )
 
         preview = service.create_search_preview(conditions)
 
-        # プレビューに優先順位の注記が含まれることを確認
-        assert "手動レーティング優先" in preview or "※手動レーティング優先" in preview
+        # 手動・AI 両方の条件が表示される (AND)
+        assert "手動レーティング: PG" in preview
+        assert "AIレーティング: R" in preview
+        # 優先関係はなくなったため優先注記は表示しない
+        assert "手動レーティング優先" not in preview
 
 
 class TestUnratedFilter:


### PR DESCRIPTION
## 概要

Closes #604

検索フィルタで**手動レーティング条件と AI レーティング条件を同時指定すると、AI レーティングフィルタが無視される**バグを修正する。

例: 「人間レーティング済み（RATED）」+「AI レーティング = XXX」で検索すると、AI が XXX と判定していない PG / PG-13 / R / X の画像まで結果に出ていた（例: ID 977 は手動=PG・AI評価なしだが結果に含まれていた）。

## 根本原因

`src/lorairo/database/repository/image.py` の `_build_image_filter_query` で manual / AI レーティングフィルタが `if manual / elif ai` の**排他**構造になっており、`manual_rating_filter`（`"RATED"` を含む）が真だと `elif ai_rating_filter` 分岐へ入らず、AI フィルタが適用されなかった。

当初は GUI プレビューの `※手動レーティング優先` 表記やコメント `Priority-based: manual > AI` の通り「両方指定時は手動優先で AI を無視する」意図的仕様だったが、「手動でレーティング済みの中から AI が XXX と判定したものだけ見たい」という AND 検索ができず UX として不適切だった。

## 変更内容

- **`database/repository/image.py`**: `if/elif` の排他を解消し、手動フィルタを常に適用したうえで AI フィルタを独立に **AND 適用**する。`_apply_manual_filters` は `manual_rating_filter=None` のとき manual_edit_filter のみ適用するため、無条件呼び出しで全組み合わせを網羅できる。
- **`gui/services/search_filter_service.py`**: AND 化に伴い不正確になる `※手動レーティング優先` ヒントを削除（`(多数決)` 注記は維持）。
- **tests**:
  - `tests/integration/test_rating_save_integration.py`: 組み合わせ AND のリグレッションテスト `test_manual_and_ai_rating_filters_combine_with_and` を追加（旧バグの `manual=RATED + ai=PG-13 → 0件` を固定化）。
  - `tests/unit/database/test_db_repository_ai_rating_filter.py`: 旧優先挙動を前提にしていた既存テスト2件（`test_priority_based_manual_over_ai` / `..._shows_priority_note`）を AND セマンティクスに更新。

スキーマ変更・マイグレーション・config 変更はなし。

## 動作確認

稼働 DB に対し本番 `get_images_by_filter` を実行して検証:

| 条件 | 修正前 | 修正後 |
|---|---|---|
| `manual=RATED` + `ai=XXX` | 307件（PG等混入、ID 977 含む） | 「手動済み AND AI=XXX」のみ |
| AI=XXX 単独 / 手動単独 | 正常 | 不変（正常） |

## テスト結果

- `uv run ruff check src/ tests/`: ✅ pass
- `uv run mypy -p lorairo`: ✅ no issues found in 176 source files
- CI-equivalent filter: ✅ **3716 passed**, 2 skipped, 0 failed
- Coverage: **88.78%**（target 75%）

## 補足（本 PR 範囲外）

AI レーティングは多数決ロジック（`一致数 >= 総数 / 2.0`）。将来複数モデルで AI 評価を付け直すと「ちょうど 50%」の画像が複数レーティングに重複ヒットし得る点は別途要検討（本 PR の原因ではない）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
