### PR TITLE
fix(log): reduce worker lifecycle INFO noise and trace progress ticks (#606)

### DIFF
--- a/src/lorairo/gui/services/pipeline_control_service.py
+++ b/src/lorairo/gui/services/pipeline_control_service.py
@@ -140,10 +140,10 @@ class PipelineControlService:
         try:
             if hasattr(self.thumbnail_selector, "handle_thumbnail_page_result"):
                 self.thumbnail_selector.handle_thumbnail_page_result(thumbnail_result)
-                logger.info("ThumbnailSelectorWidget handled paged thumbnail result")
+                logger.debug("ThumbnailSelectorWidget handled paged thumbnail result")
             elif hasattr(self.thumbnail_selector, "load_thumbnails_from_result"):
                 self.thumbnail_selector.load_thumbnails_from_result(thumbnail_result)
-                logger.info("ThumbnailSelectorWidget updated with legacy thumbnail result")
+                logger.debug("ThumbnailSelectorWidget updated with legacy thumbnail result")
             else:
                 logger.warning("ThumbnailSelectorWidget result handler method not found")
 

--- a/src/lorairo/gui/services/progress_state_service.py
+++ b/src/lorairo/gui/services/progress_state_service.py
@@ -123,10 +123,10 @@ class ProgressStateService:
                 status_message = f"処理中... {current}/{total} ({percentage}%)"
                 self.status_bar.showMessage(status_message)
 
-                logger.debug(f"ワーカー進捗更新: {worker_id} - {current}/{total} ({percentage}%)")
+                logger.trace(f"ワーカー進捗更新: {worker_id} - {current}/{total} ({percentage}%)")
 
             else:
-                logger.debug(f"ワーカー進捗更新: {worker_id} - {progress}")
+                logger.trace(f"ワーカー進捗更新: {worker_id} - {progress}")
 
         except Exception as e:
             logger.warning(f"進捗更新処理エラー: {e}")

--- a/src/lorairo/gui/services/worker_service.py
+++ b/src/lorairo/gui/services/worker_service.py
@@ -427,7 +427,7 @@ class WorkerService(QObject):
         )
 
         if self.worker_manager.start_worker(worker_id, worker):
-            logger.info(
+            logger.debug(
                 f"ページサムネイル読み込み開始: page={page_num}, count={len(image_ids)}, "
                 f"request_id={request_id}, cancel_previous={cancel_previous} (ID: {worker_id})"
             )
@@ -563,7 +563,13 @@ class WorkerService(QObject):
             )
 
         self._emit_operation_started(worker_id)
-        logger.info(f"ワーカー開始: {operation_name} (ID: {worker_id})")
+        # ライフサイクルINFOはこの1層に集約。search/thumbnailは高頻度なのでDEBUGに落とす。
+        log_lifecycle = (
+            logger.info
+            if self._resolve_worker_type(worker_id) in ("batch_reg", "batch_import", "annotation")
+            else logger.debug
+        )
+        log_lifecycle(f"ワーカー開始: {operation_name} (ID: {worker_id})")
 
     def _resolve_worker_type(self, worker_id: str) -> str:
         """worker_idプレフィックスからワーカー種別を返すヘルパー。"""
@@ -588,7 +594,11 @@ class WorkerService(QObject):
             if attr and getattr(self, attr) == worker_id:
                 setattr(self, attr, None)
 
-        logger.info(f"ワーカー完了: {worker_id}")
+        # ライフサイクルINFOはこの1層に集約。search/thumbnailは高頻度なのでDEBUGに落とす。
+        log_lifecycle = (
+            logger.info if worker_type in ("batch_reg", "batch_import", "annotation") else logger.debug
+        )
+        log_lifecycle(f"ワーカー完了: {worker_id}")
 
     def _on_worker_error(self, worker_id: str, error: str) -> None:
         """ワーカーエラーハンドラ - 互換エラーシグナルとcurrent idの更新のみ行う"""

--- a/src/lorairo/gui/widgets/filter_search_panel.py
+++ b/src/lorairo/gui/widgets/filter_search_panel.py
@@ -956,7 +956,7 @@ class FilterSearchPanel(QScrollArea):
     def update_pipeline_progress(self, message: str, current_progress: float, end_progress: float) -> None:
         """Pipeline 進捗表示の更新 (ModernProgressManager に移行済みのため無効化)。"""
         del end_progress
-        logger.debug(
+        logger.trace(
             f"Progress update delegated to ModernProgressManager: {message} ({current_progress * 100:.1f}%)",
         )
 

--- a/src/lorairo/gui/workers/base.py
+++ b/src/lorairo/gui/workers/base.py
@@ -148,14 +148,14 @@ class LoRAIroWorkerBase[T](QObject):
         """
         try:
             self._set_status(WorkerStatus.RUNNING)
-            logger.info(f"ワーカー実行開始: {self.__class__.__name__}")
+            logger.debug(f"ワーカー実行開始: {self.__class__.__name__}")
 
             result = self.execute()
 
             if not self.cancellation.is_canceled():
                 self._set_status(WorkerStatus.COMPLETED)
                 self.finished.emit(result)
-                logger.info(f"ワーカー実行完了: {self.__class__.__name__}")
+                logger.debug(f"ワーカー実行完了: {self.__class__.__name__}")
             else:
                 self._set_status(WorkerStatus.CANCELED)
                 self.canceled.emit()

--- a/src/lorairo/gui/workers/manager.py
+++ b/src/lorairo/gui/workers/manager.py
@@ -96,7 +96,7 @@ class WorkerManager(QObject):
         self.worker_started.emit(worker_id)
         self.active_worker_count_changed.emit(len(self.active_workers))
 
-        logger.info(f"ワーカー開始: {worker_id} ({worker.__class__.__name__})")
+        logger.debug(f"ワーカー開始: {worker_id} ({worker.__class__.__name__})")
         return True
 
     def cancel_worker(
@@ -226,7 +226,7 @@ class WorkerManager(QObject):
     def _on_worker_finished(self, worker_id: str, result: Any) -> None:
         """ワーカー完了イベントハンドラー"""
         if self._finalize_terminal(worker_id, WorkerOutcome.SUCCEEDED, result=result):
-            logger.info(f"ワーカー完了: {worker_id}")
+            logger.debug(f"ワーカー完了: {worker_id}")
 
     def _cleanup_thread(self, worker_id: str, thread: QThread) -> None:
         """スレッドのクリーンアップ処理"""

--- a/src/lorairo/gui/workers/modern_progress_manager.py
+++ b/src/lorairo/gui/workers/modern_progress_manager.py
@@ -89,7 +89,7 @@ class ModernProgressManager(QObject):
         """
         dialog = self._progress_dialogs.get(worker_id)
         if not dialog:
-            logger.debug(f"プログレスダイアログが見つかりません: {worker_id}")
+            logger.trace(f"プログレスダイアログが見つかりません: {worker_id}")
             return
 
         # プログレス値更新
@@ -106,7 +106,7 @@ class ModernProgressManager(QObject):
 
         dialog.setLabelText(message)
 
-        logger.debug(f"プログレス更新: {worker_id} - {progress.percentage}% - {message}")
+        logger.trace(f"プログレス更新: {worker_id} - {progress.percentage}% - {message}")
 
     def update_batch_progress(self, worker_id: str, current: int, total: int, filename: str) -> None:
         """

--- a/src/lorairo/gui/workers/thumbnail_worker.py
+++ b/src/lorairo/gui/workers/thumbnail_worker.py
@@ -89,7 +89,7 @@ class ThumbnailWorker(LoRAIroWorkerBase[ThumbnailLoadResult]):
             )
 
         if self.page_num is not None:
-            logger.info(
+            logger.debug(
                 f"サムネイル読み込み開始: page={self.page_num}, 件数={total_count}, request_id={self.request_id}"
             )
         else:
@@ -161,7 +161,7 @@ class ThumbnailWorker(LoRAIroWorkerBase[ThumbnailLoadResult]):
             ],
         )
 
-        logger.info(
+        logger.debug(
             f"サムネイル読み込み完了: page={self.page_num}, 成功={len(loaded_thumbnails)}, "
             f"失敗={failed_count}, 処理時間={processing_time:.3f}秒"
         )


### PR DESCRIPTION
## 概要

DEBUG レベルで GUI を操作した際のワーカーログ過剰出力を解消する。`.claude/rules/logging.md` と ADR 0047（per-item firehose は TRACE）/ ADR 0045 に準拠。

Closes #606

## 背景

検索結果（例: 308件）を1回表示するだけで、サムネイルが page1→4 と自動ページングし、1ページあたり約10行の INFO が base / manager / worker_service の **3層で重複**して出力されていた（1検索でサムネイル関連だけで約40行 INFO + 約50行 DEBUG）。「多層重複ログ禁止」「N件のうち1件は DEBUG」に違反していた。

## 変更（ログレベルのみ、ロジック非変更・8ファイル）

### ① ワーカーライフサイクル INFO を1層に集約
- `workers/base.py` / `workers/manager.py` の汎用ライフサイクル INFO → DEBUG
- `services/worker_service.py`: `_resolve_worker_type()` で出し分け。`batch_reg` / `batch_import` / `annotation`（単発・長時間・ユーザー起点）は INFO 維持、`search` / `thumbnail`（高頻度）は DEBUG。→ INFO で残るライフサイクルログをこの1層のみに集約。

### ② サムネイルのページ単位ログ → DEBUG
- `workers/thumbnail_worker.py` のページ単位 start/complete（非ページ版サマリーは INFO 維持）
- `services/worker_service.py` の `ページサムネイル読み込み開始`

### ③ pipeline のページごと INFO → DEBUG
- `services/pipeline_control_service.py` の thumbnail result ハンドラ（検索ごと1回の pagination initialized は INFO 維持）

### ④ 進捗 tick firehose → TRACE（ADR 0047）
- `workers/modern_progress_manager.py` / `services/progress_state_service.py` / `widgets/filter_search_panel.py` の per-tick 進捗ログ

## 効果

- INFO 実行時: サムネイルページングのライフサイクルログが消え、検索/登録のサマリーのみ
- DEBUG 実行時: 操作単位で読める量に回復（per-tick firehose は TRACE で既定抑制）

## 検証

- ruff format/check: pass
- mypy -p lorairo: Success, no issues (176 files)
- pytest（CI-equivalent filter）: **3716 passed, 2 skipped**
- 既存 caplog テスト（test_manager.py）との干渉なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)
