### PR TITLE
fix: restore tag language selector initialization

### DIFF
--- a/docs/decisions/0054-gui-tag-language-reader-initialization.md
+++ b/docs/decisions/0054-gui-tag-language-reader-initialization.md
@@ -1,0 +1,42 @@
+# 0054. GUI tag language reader initialization
+
+## Status
+
+Accepted
+
+## Context
+
+ADR 0050 made tag DB initialization lazy so read-only CLI startup does not initialize
+genai-tag-db-tools. That kept `AnnotationRepository.merged_reader` as `None` until a tag DB
+operation explicitly needs it.
+
+`WidgetSetupService.setup_selected_image_details()` still read the repository attribute directly
+during GUI setup. Because direct attribute reads do not trigger the repository lazy path, the image
+details widget received `None` and hid the tag language selector even when tag translation languages
+were available.
+
+## Decision
+
+`AnnotationRepository` exposes `get_merged_reader()` as the public accessor for callers that
+intentionally need external tag DB support.
+
+GUI selected image details setup uses that accessor and injects the returned reader into
+`SelectedImageDetailsWidget`. The `merged_reader` attribute remains an implementation cache, not the
+authoritative external API for GUI wiring.
+
+## Rationale
+
+This preserves ADR 0050's side-effect-light repository construction while making GUI translation
+support opt in at the integration boundary that needs it.
+
+The nearest alternative was making `merged_reader` a property with implicit initialization. That
+would make every attribute read potentially initialize external tag DB state and would obscure which
+runtime paths are allowed to pay that cost.
+
+## Consequences
+
+- Read-only CLI startup continues to avoid eager tag DB initialization.
+- GUI image details setup initializes the tag reader intentionally, so the tag language selector can
+  be populated when tag languages exist.
+- Tests must cover the setup integration path, not only widget behavior after a reader has already
+  been injected.

--- a/src/lorairo/database/repository/annotation_record.py
+++ b/src/lorairo/database/repository/annotation_record.py
@@ -149,6 +149,13 @@ class AnnotationRepository(BaseRepository):
             self._merged_reader_initialized = True
         return self.merged_reader
 
+    def get_merged_reader(self) -> MergedTagReader | None:
+        """外部タグDBリーダーを明示的に初期化して返す。
+
+        GUI など外部タグDB翻訳を表示面で必要とする呼び出し元向けの公開 accessor。
+        """
+        return self._get_merged_reader()
+
     def _initialize_tag_register_service(self) -> TagRegisterService | None:
         """タグ登録サービスを初期化（遅延初期化、Qt非依存）。
 

--- a/src/lorairo/gui/services/widget_setup_service.py
+++ b/src/lorairo/gui/services/widget_setup_service.py
@@ -156,7 +156,7 @@ class WidgetSetupService:
         from ...services import get_service_container
 
         service_container = get_service_container()
-        widget.set_merged_reader(service_container.db_manager.annotation_repo.merged_reader)
+        widget.set_merged_reader(service_container.db_manager.annotation_repo.get_merged_reader())
         logger.info("✅ MergedTagReader注入完了")
 
         logger.info("✅ SelectedImageDetailsWidget設定完了")

--- a/tests/unit/database/repository/test_annotation_record_repository.py
+++ b/tests/unit/database/repository/test_annotation_record_repository.py
@@ -160,6 +160,27 @@ class TestExternalTagDbInitialization:
         merged_reader.search_tags_bulk.assert_called_once()
         assert result == {"new tag": 123}
 
+    def test_public_get_merged_reader_initializes_external_tag_db_lazily(
+        self, annotation_repository: AnnotationRepository, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """GUI 統合用の公開 accessor が外部 tag DB reader を初期化する。"""
+        ensure_spy = Mock()
+        merged_reader = Mock()
+        monkeypatch.setattr(
+            "lorairo.database.repository.annotation_record.ensure_tag_db_initialized", ensure_spy
+        )
+        monkeypatch.setattr(
+            "lorairo.database.repository.annotation_record.get_default_reader",
+            Mock(return_value=merged_reader),
+        )
+
+        result = annotation_repository.get_merged_reader()
+
+        ensure_spy.assert_called_once()
+        assert result is merged_reader
+        assert annotation_repository.merged_reader is merged_reader
+        assert annotation_repository._merged_reader_initialized is True
+
 
 @pytest.mark.unit
 class TestSaveAnnotations:

--- a/tests/unit/gui/services/test_widget_setup_service.py
+++ b/tests/unit/gui/services/test_widget_setup_service.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from types import SimpleNamespace
 from unittest.mock import Mock
 
 from lorairo.gui.services.widget_setup_service import WidgetSetupService
@@ -72,3 +73,30 @@ class TestWidgetSetupServiceModelSelectionFilters:
 
         model_widget.executionEnvCombo.setVisible.assert_called_once_with(False)
         model_widget.set_annotation_only_filtering.assert_called_once_with(True)
+
+
+class TestWidgetSetupServiceSelectedImageDetails:
+    """SelectedImageDetailsWidget setup integration tests."""
+
+    def test_setup_selected_image_details_initializes_reader_for_gui(self, monkeypatch) -> None:
+        """GUI setup は lazy accessor 経由で MergedTagReader を注入する。"""
+        reader = Mock()
+        annotation_repo = Mock()
+        annotation_repo.merged_reader = None
+        annotation_repo.get_merged_reader.return_value = reader
+        service_container = SimpleNamespace(
+            db_manager=SimpleNamespace(annotation_repo=annotation_repo),
+        )
+
+        monkeypatch.setattr("lorairo.services.get_service_container", lambda: service_container)
+
+        widget = Mock()
+        main_window = SimpleNamespace(selectedImageDetailsWidget=widget)
+        dataset_state_manager = Mock()
+
+        WidgetSetupService.setup_selected_image_details(main_window, dataset_state_manager)
+
+        assert main_window.selected_image_details_widget is widget
+        widget.connect_to_dataset_state_manager.assert_called_once_with(dataset_state_manager)
+        annotation_repo.get_merged_reader.assert_called_once_with()
+        widget.set_merged_reader.assert_called_once_with(reader)


### PR DESCRIPTION
Fixes #603.

Branch: issue-603-tag-language-selector
Worktree: /tmp/worktrees/issue-603-tag-language-selector
ADR: docs/decisions/0054-gui-tag-language-reader-initialization.md

## Summary
- Add public AnnotationRepository.get_merged_reader() for callers that intentionally need external tag DB support.
- Update SelectedImageDetailsWidget setup to inject the reader via the lazy accessor instead of reading the cache attribute directly.
- Add regression coverage for the GUI setup integration path and repository accessor contract.

## Verification
- UV_CACHE_DIR=/tmp/uv-cache UV_PROJECT_ENVIRONMENT=/workspaces/LoRAIro/.venv PYTHONPATH=/tmp/worktrees/issue-603-tag-language-selector/src:/tmp/worktrees/issue-603-tag-language-selector/local_packages/genai-tag-db-tools/src:/tmp/worktrees/issue-603-tag-language-selector/local_packages/image-annotator-lib/src uv run --no-sync pytest tests/unit/gui/services/test_widget_setup_service.py tests/unit/database/repository/test_annotation_record_repository.py -q
- UV_CACHE_DIR=/tmp/uv-cache UV_PROJECT_ENVIRONMENT=/workspaces/LoRAIro/.venv PYTHONPATH=/tmp/worktrees/issue-603-tag-language-selector/src:/tmp/worktrees/issue-603-tag-language-selector/local_packages/genai-tag-db-tools/src:/tmp/worktrees/issue-603-tag-language-selector/local_packages/image-annotator-lib/src uv run --no-sync ruff check src/lorairo/database/repository/annotation_record.py src/lorairo/gui/services/widget_setup_service.py tests/unit/gui/services/test_widget_setup_service.py tests/unit/database/repository/test_annotation_record_repository.py
- UV_CACHE_DIR=/tmp/uv-cache UV_PROJECT_ENVIRONMENT=/workspaces/LoRAIro/.venv PYTHONPATH=/tmp/worktrees/issue-603-tag-language-selector/src:/tmp/worktrees/issue-603-tag-language-selector/local_packages/genai-tag-db-tools/src:/tmp/worktrees/issue-603-tag-language-selector/local_packages/image-annotator-lib/src uv run --no-sync pytest tests/unit/gui/widgets/test_selected_image_details_widget.py tests/unit/gui/widgets/test_annotation_data_display_widget.py -q