### PR TITLE
fix: エクスポート保存先ピッカーの配線バグ修正 (#613)

### DIFF
--- a/src/lorairo/gui/widgets/dataset_export_widget.py
+++ b/src/lorairo/gui/widgets/dataset_export_widget.py
@@ -387,13 +387,12 @@ class DatasetExportWidget(QDialog):
 
     def _get_output_directory(self) -> Path | None:
         """Get output directory from user selection."""
-        # Check if DirectoryPickerWidget has a path set
-        if hasattr(self.ui.exportDirectoryPicker, "get_directory"):
-            directory = self.ui.exportDirectoryPicker.get_directory()
-            if directory:
-                return Path(directory)
+        # インラインの DirectoryPickerWidget が選択済みパスを持っていればそれを使う
+        directory = self.ui.exportDirectoryPicker.get_selected_path()
+        if directory:
+            return Path(directory)
 
-        # Fallback to file dialog
+        # 未選択時のみファイルダイアログにフォールバック
         directory = QFileDialog.getExistingDirectory(
             self, "エクスポート先ディレクトリを選択", str(Path.home())
         )

--- a/tests/unit/gui/widgets/test_dataset_export_widget.py
+++ b/tests/unit/gui/widgets/test_dataset_export_widget.py
@@ -171,9 +171,25 @@ class TestDatasetExportWidgetExport:
         # エラー処理後は cancel ボタン無効
         assert not widget_with_images.ui.cancelButton.isEnabled()
 
-    def test_get_output_directory_fallback_when_no_picker(self, widget_with_images, monkeypatch):
-        """exportDirectoryPicker に get_directory がない場合は QFileDialog に fallback（空返却）"""
-        # auto_mock_qfiledialog で getExistingDirectory は "" を返す
+    def test_get_output_directory_uses_picker_selected_path(
+        self, widget_with_images, monkeypatch, tmp_path
+    ):
+        """インラインピッカーで選択済みのパスがそのまま使われ、QFileDialog にフォールバックしない (#613)"""
+        monkeypatch.setattr(
+            widget_with_images.ui.exportDirectoryPicker,
+            "get_selected_path",
+            lambda: str(tmp_path),
+        )
+        result = widget_with_images._get_output_directory()
+        assert result == tmp_path
+
+    def test_get_output_directory_fallback_when_picker_empty(self, widget_with_images, monkeypatch):
+        """ピッカー未選択 (空文字) のときのみ QFileDialog にフォールバックする (auto_mock で "" → None)"""
+        monkeypatch.setattr(
+            widget_with_images.ui.exportDirectoryPicker,
+            "get_selected_path",
+            lambda: "",
+        )
         result = widget_with_images._get_output_directory()
         assert result is None
 


### PR DESCRIPTION
epic #610 / 第3段階 / PR-0（孤立した先行マージ）

## 問題
`_get_output_directory()` が存在しない `get_directory` を `hasattr` で見ており常時 False。インラインの `DirectoryPickerWidget exportDirectoryPicker`（`DatasetExportWidget.ui`）が常時バイパスされ、エクスポート開始後に毎回 `QFileDialog` がポップしていた（「保存先選択がない」の正体）。

## 修正
実メソッド `get_selected_path()`（`directory_picker.py`）を使い、ピッカー選択値を実際に使う。未選択（空文字）時のみ `QFileDialog` にフォールバックする本来の意図どおりの分岐に修正。

## テスト
- `test_get_output_directory_uses_picker_selected_path`: ピッカー選択値が使われ、QFileDialog にフォールバックしない
- `test_get_output_directory_fallback_when_picker_empty`: 空時のみフォールバック
- `test_dataset_export_widget.py` 全30件 pass（worktree コードを PYTHONPATH 明示で検証）

Closes #613

🤖 Generated with [Claude Code](https://claude.com/claude-code)