### PR TITLE
chore: Foundation - DatasetExportWidget seam 整地 (#610)

### DIFF
--- a/src/lorairo/gui/designer/DatasetExportWidget.ui
+++ b/src/lorairo/gui/designer/DatasetExportWidget.ui
@@ -111,6 +111,19 @@
            </widget>
           </item>
           <item>
+           <widget class="QLabel" name="resolutionHelpLabel">
+            <property name="text">
+             <string>※ 画像を変換せず、選択した解像度の前処理済み版を持つ画像のみが対象になります。</string>
+            </property>
+            <property name="wordWrap">
+             <bool>true</bool>
+            </property>
+            <property name="styleSheet">
+             <string notr="true">color: gray;</string>
+            </property>
+           </widget>
+          </item>
+          <item>
            <widget class="QLabel" name="exportFormatLabel">
             <property name="text">
              <string>エクスポート形式:</string>
@@ -152,9 +165,22 @@
            </layout>
           </item>
           <item>
-           <widget class="QCheckBox" name="latestOnlyCheckBox">
+           <widget class="QCheckBox" name="changedSinceCheckBox">
             <property name="text">
-             <string>最新のアノテーションのみ使用</string>
+             <string>指定日時以降に変更があった画像のみ</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QDateTimeEdit" name="changedSinceDateTimeEdit">
+            <property name="enabled">
+             <bool>false</bool>
+            </property>
+            <property name="calendarPopup">
+             <bool>true</bool>
+            </property>
+            <property name="displayFormat">
+             <string>yyyy-MM-dd HH:mm</string>
             </property>
            </widget>
           </item>

--- a/src/lorairo/gui/designer/DatasetExportWidget.ui
+++ b/src/lorairo/gui/designer/DatasetExportWidget.ui
@@ -166,8 +166,14 @@
           </item>
           <item>
            <widget class="QCheckBox" name="changedSinceCheckBox">
+            <property name="enabled">
+             <bool>false</bool>
+            </property>
             <property name="text">
              <string>指定日時以降に変更があった画像のみ</string>
+            </property>
+            <property name="toolTip">
+             <string>（#614 で実装予定）指定日時以降に AI 実行または手動編集があった画像のみを対象にします。</string>
             </property>
            </widget>
           </item>

--- a/src/lorairo/gui/designer/DatasetExportWidget_ui.py
+++ b/src/lorairo/gui/designer/DatasetExportWidget_ui.py
@@ -15,10 +15,10 @@ from PySide6.QtGui import (QBrush, QColor, QConicalGradient, QCursor,
     QFont, QFontDatabase, QGradient, QIcon,
     QImage, QKeySequence, QLinearGradient, QPainter,
     QPalette, QPixmap, QRadialGradient, QTransform)
-from PySide6.QtWidgets import (QApplication, QCheckBox, QComboBox, QGroupBox,
-    QHBoxLayout, QLabel, QProgressBar, QPushButton,
-    QRadioButton, QSizePolicy, QSplitter, QTextEdit,
-    QVBoxLayout, QWidget)
+from PySide6.QtWidgets import (QApplication, QCheckBox, QComboBox, QDateTimeEdit,
+    QGroupBox, QHBoxLayout, QLabel, QProgressBar,
+    QPushButton, QRadioButton, QSizePolicy, QSplitter,
+    QTextEdit, QVBoxLayout, QWidget)
 
 from ..widgets.directory_picker import DirectoryPickerWidget
 from ..widgets.image_preview import ImagePreviewWidget
@@ -102,6 +102,13 @@ class Ui_DatasetExportWidget(object):
 
         self.exportLayout.addWidget(self.comboBoxResolution)
 
+        self.resolutionHelpLabel = QLabel(self.exportGroupBox)
+        self.resolutionHelpLabel.setObjectName(u"resolutionHelpLabel")
+        self.resolutionHelpLabel.setWordWrap(True)
+        self.resolutionHelpLabel.setStyleSheet(u"color: gray;")
+
+        self.exportLayout.addWidget(self.resolutionHelpLabel)
+
         self.exportFormatLabel = QLabel(self.exportGroupBox)
         self.exportFormatLabel.setObjectName(u"exportFormatLabel")
         sizePolicy1.setHeightForWidth(self.exportFormatLabel.sizePolicy().hasHeightForWidth())
@@ -130,10 +137,17 @@ class Ui_DatasetExportWidget(object):
 
         self.exportLayout.addLayout(self.formatSelectionLayout)
 
-        self.latestOnlyCheckBox = QCheckBox(self.exportGroupBox)
-        self.latestOnlyCheckBox.setObjectName(u"latestOnlyCheckBox")
+        self.changedSinceCheckBox = QCheckBox(self.exportGroupBox)
+        self.changedSinceCheckBox.setObjectName(u"changedSinceCheckBox")
 
-        self.exportLayout.addWidget(self.latestOnlyCheckBox)
+        self.exportLayout.addWidget(self.changedSinceCheckBox)
+
+        self.changedSinceDateTimeEdit = QDateTimeEdit(self.exportGroupBox)
+        self.changedSinceDateTimeEdit.setObjectName(u"changedSinceDateTimeEdit")
+        self.changedSinceDateTimeEdit.setEnabled(False)
+        self.changedSinceDateTimeEdit.setCalendarPopup(True)
+
+        self.exportLayout.addWidget(self.changedSinceDateTimeEdit)
 
         self.validationResultsLabel = QLabel(self.exportGroupBox)
         self.validationResultsLabel.setObjectName(u"validationResultsLabel")
@@ -256,11 +270,13 @@ class Ui_DatasetExportWidget(object):
         self.comboBoxResolution.setItemText(2, QCoreApplication.translate("DatasetExportWidget", u"1024px", None))
         self.comboBoxResolution.setItemText(3, QCoreApplication.translate("DatasetExportWidget", u"1536px", None))
 
+        self.resolutionHelpLabel.setText(QCoreApplication.translate("DatasetExportWidget", u"\u203b \u753b\u50cf\u3092\u5909\u63db\u305b\u305a\u3001\u9078\u629e\u3057\u305f\u89e3\u50cf\u5ea6\u306e\u524d\u51e6\u7406\u6e08\u307f\u7248\u3092\u6301\u3064\u753b\u50cf\u306e\u307f\u304c\u5bfe\u8c61\u306b\u306a\u308a\u307e\u3059\u3002", None))
         self.exportFormatLabel.setText(QCoreApplication.translate("DatasetExportWidget", u"\u30a8\u30af\u30b9\u30dd\u30fc\u30c8\u5f62\u5f0f:", None))
         self.radioTxtSeparate.setText(QCoreApplication.translate("DatasetExportWidget", u"TXT\u5f62\u5f0f\uff08\u30bf\u30b0+\u30ad\u30e3\u30d7\u30b7\u30e7\u30f3\u5225\u30d5\u30a1\u30a4\u30eb\uff09", None))
         self.radioTxtMerged.setText(QCoreApplication.translate("DatasetExportWidget", u"TXT\u5f62\u5f0f\uff08\u30ad\u30e3\u30d7\u30b7\u30e7\u30f3\u7d71\u5408\uff09", None))
         self.radioJson.setText(QCoreApplication.translate("DatasetExportWidget", u"JSON\u5f62\u5f0f\uff08metadata.json\uff09", None))
-        self.latestOnlyCheckBox.setText(QCoreApplication.translate("DatasetExportWidget", u"\u6700\u65b0\u306e\u30a2\u30ce\u30c6\u30fc\u30b7\u30e7\u30f3\u306e\u307f\u4f7f\u7528", None))
+        self.changedSinceCheckBox.setText(QCoreApplication.translate("DatasetExportWidget", u"\u6307\u5b9a\u65e5\u6642\u4ee5\u964d\u306b\u5909\u66f4\u304c\u3042\u3063\u305f\u753b\u50cf\u306e\u307f", None))
+        self.changedSinceDateTimeEdit.setDisplayFormat(QCoreApplication.translate("DatasetExportWidget", u"yyyy-MM-dd HH:mm", None))
         self.validationResultsLabel.setText(QCoreApplication.translate("DatasetExportWidget", u"\u691c\u8a3c\u7d50\u679c:", None))
         self.totalImagesLabel.setText(QCoreApplication.translate("DatasetExportWidget", u"\u5bfe\u8c61\u753b\u50cf\u6570: --", None))
         self.validImagesLabel.setText(QCoreApplication.translate("DatasetExportWidget", u"\u30a8\u30af\u30b9\u30dd\u30fc\u30c8\u53ef\u80fd: --", None))

--- a/src/lorairo/gui/designer/DatasetExportWidget_ui.py
+++ b/src/lorairo/gui/designer/DatasetExportWidget_ui.py
@@ -139,6 +139,7 @@ class Ui_DatasetExportWidget(object):
 
         self.changedSinceCheckBox = QCheckBox(self.exportGroupBox)
         self.changedSinceCheckBox.setObjectName(u"changedSinceCheckBox")
+        self.changedSinceCheckBox.setEnabled(False)
 
         self.exportLayout.addWidget(self.changedSinceCheckBox)
 
@@ -276,6 +277,9 @@ class Ui_DatasetExportWidget(object):
         self.radioTxtMerged.setText(QCoreApplication.translate("DatasetExportWidget", u"TXT\u5f62\u5f0f\uff08\u30ad\u30e3\u30d7\u30b7\u30e7\u30f3\u7d71\u5408\uff09", None))
         self.radioJson.setText(QCoreApplication.translate("DatasetExportWidget", u"JSON\u5f62\u5f0f\uff08metadata.json\uff09", None))
         self.changedSinceCheckBox.setText(QCoreApplication.translate("DatasetExportWidget", u"\u6307\u5b9a\u65e5\u6642\u4ee5\u964d\u306b\u5909\u66f4\u304c\u3042\u3063\u305f\u753b\u50cf\u306e\u307f", None))
+#if QT_CONFIG(tooltip)
+        self.changedSinceCheckBox.setToolTip(QCoreApplication.translate("DatasetExportWidget", u"\uff08#614 \u3067\u5b9f\u88c5\u4e88\u5b9a\uff09\u6307\u5b9a\u65e5\u6642\u4ee5\u964d\u306b AI \u5b9f\u884c\u307e\u305f\u306f\u624b\u52d5\u7de8\u96c6\u304c\u3042\u3063\u305f\u753b\u50cf\u306e\u307f\u3092\u5bfe\u8c61\u306b\u3057\u307e\u3059\u3002", None))
+#endif // QT_CONFIG(tooltip)
         self.changedSinceDateTimeEdit.setDisplayFormat(QCoreApplication.translate("DatasetExportWidget", u"yyyy-MM-dd HH:mm", None))
         self.validationResultsLabel.setText(QCoreApplication.translate("DatasetExportWidget", u"\u691c\u8a3c\u7d50\u679c:", None))
         self.totalImagesLabel.setText(QCoreApplication.translate("DatasetExportWidget", u"\u5bfe\u8c61\u753b\u50cf\u6570: --", None))

--- a/src/lorairo/gui/widgets/dataset_export_widget.py
+++ b/src/lorairo/gui/widgets/dataset_export_widget.py
@@ -32,7 +32,6 @@ class DatasetExportWorker(QObject):
         resolution: int,
         export_format: str,
         merge_caption: bool = False,
-        latest_only: bool = False,
     ) -> None:
         """Initialize export worker.
 
@@ -43,7 +42,6 @@ class DatasetExportWorker(QObject):
             resolution: Image resolution (512, 768, 1024, 1536)
             export_format: Export format ("txt_separate", "txt_merged", "json")
             merge_caption: Whether to merge captions with tags
-            latest_only: Whether to use only latest annotations
         """
         super().__init__()
         self.export_service = export_service
@@ -52,7 +50,6 @@ class DatasetExportWorker(QObject):
         self.resolution = resolution
         self.export_format = export_format
         self.merge_caption = merge_caption
-        self.latest_only = latest_only
 
     def run(self) -> None:
         """Execute export processing with progress reporting."""
@@ -157,6 +154,33 @@ class DatasetExportWidget(QDialog):
         self.setWindowTitle("データセットエクスポート")
         self.resize(1200, 800)
 
+        # 互いに素な seam (Foundation #610): S5=解像度UI / S4=changed-since UI が各自実装する
+        self._setup_resolution_ui()
+        self._setup_changed_since_ui()
+
+    def _setup_resolution_ui(self) -> None:
+        """解像度関連 UI の初期化 seam（S5 #615 が実装）。
+
+        Foundation では no-op。S5 が解像度の意味明確化（resolutionHelpLabel の
+        補助文言/ツールチップ）と、選択時の対象/対象外件数の即時表示を実装する。
+        """
+
+    def _setup_changed_since_ui(self) -> None:
+        """changed-since フィルタ UI の初期化 seam（S4 #614 が実装）。
+
+        Foundation では no-op（changedSinceDateTimeEdit は .ui で無効状態）。
+        S4 が日時の既定値設定と、指定日時以降に変更があった画像への絞り込みを実装する。
+        """
+
+    def _on_changed_since_toggled(self, checked: bool) -> None:
+        """changed-since トグル: 日時入力の有効/無効を切り替え、検証結果を無効化する。
+
+        S4 #614 が日時を使った対象絞り込み（AI実行 created_at / 手動編集 updated_at）を
+        追加する seam。Foundation では旧 latestOnlyCheckBox 相当の「変更で再検証」挙動のみ。
+        """
+        self.ui.changedSinceDateTimeEdit.setEnabled(checked)
+        self._on_settings_changed()
+
     def _connect_signals(self) -> None:
         """Connect UI signals to appropriate slots."""
         # Button connections
@@ -168,7 +192,7 @@ class DatasetExportWidget(QDialog):
         # UI state change connections
         self.ui.comboBoxResolution.currentTextChanged.connect(self._on_settings_changed)
         self.format_button_group.idClicked.connect(self._on_settings_changed)
-        self.ui.latestOnlyCheckBox.toggled.connect(self._on_settings_changed)
+        self.ui.changedSinceCheckBox.toggled.connect(self._on_changed_since_toggled)
 
     def _update_initial_state(self) -> None:
         """Update UI to reflect initial state."""
@@ -263,7 +287,6 @@ class DatasetExportWidget(QDialog):
             resolution = self._get_selected_resolution()
             export_format = self._get_selected_format()
             merge_caption = export_format == "txt_merged"
-            latest_only = self.ui.latestOnlyCheckBox.isChecked()
 
             # Start async export
             self._start_export_worker(
@@ -271,7 +294,6 @@ class DatasetExportWidget(QDialog):
                 resolution=resolution,
                 export_format=export_format,
                 merge_caption=merge_caption,
-                latest_only=latest_only,
             )
 
         except Exception as e:
@@ -283,7 +305,6 @@ class DatasetExportWidget(QDialog):
         resolution: int,
         export_format: str,
         merge_caption: bool,
-        latest_only: bool,
     ) -> None:
         """Start async export worker."""
         # Update UI state
@@ -301,7 +322,6 @@ class DatasetExportWidget(QDialog):
             resolution=resolution,
             export_format=export_format,
             merge_caption=merge_caption,
-            latest_only=latest_only,
         )
 
         self.export_thread = QThread()

--- a/tests/unit/gui/widgets/test_dataset_export_widget.py
+++ b/tests/unit/gui/widgets/test_dataset_export_widget.py
@@ -274,6 +274,10 @@ class TestDatasetExportWidgetFoundation:
         """解像度補助ラベル枠 (S5 #615) が .ui に存在する"""
         assert hasattr(widget_with_images.ui, "resolutionHelpLabel")
 
+    def test_changed_since_checkbox_disabled_until_s4(self, widget_with_images):
+        """changed-since チェックボックスは S4 #614 実装まで無効（見えるが操作不可）"""
+        assert not widget_with_images.ui.changedSinceCheckBox.isEnabled()
+
     def test_changed_since_datetime_disabled_by_default(self, widget_with_images):
         """changed-since 日時入力は既定で無効"""
         assert not widget_with_images.ui.changedSinceDateTimeEdit.isEnabled()

--- a/tests/unit/gui/widgets/test_dataset_export_widget.py
+++ b/tests/unit/gui/widgets/test_dataset_export_widget.py
@@ -256,3 +256,31 @@ class TestDatasetExportWidgetFormats:
         """JSON ラジオボタン選択時"""
         widget_with_images.ui.radioJson.setChecked(True)
         assert widget_with_images._get_selected_format() == "json"
+
+
+class TestDatasetExportWidgetFoundation:
+    """Foundation (#610) で整地した seam の検証。S4/S5 はこの枠を埋める。"""
+
+    def test_latest_only_checkbox_removed(self, widget_with_images):
+        """死にコントロール latestOnlyCheckBox は撤去済み"""
+        assert not hasattr(widget_with_images.ui, "latestOnlyCheckBox")
+
+    def test_changed_since_widgets_exist(self, widget_with_images):
+        """changed-since フィルタ枠 (S4 #614) が .ui に存在する"""
+        assert hasattr(widget_with_images.ui, "changedSinceCheckBox")
+        assert hasattr(widget_with_images.ui, "changedSinceDateTimeEdit")
+
+    def test_resolution_help_label_exists(self, widget_with_images):
+        """解像度補助ラベル枠 (S5 #615) が .ui に存在する"""
+        assert hasattr(widget_with_images.ui, "resolutionHelpLabel")
+
+    def test_changed_since_datetime_disabled_by_default(self, widget_with_images):
+        """changed-since 日時入力は既定で無効"""
+        assert not widget_with_images.ui.changedSinceDateTimeEdit.isEnabled()
+
+    def test_changed_since_toggle_enables_datetime(self, widget_with_images):
+        """トグル ON で日時入力が有効化される (Foundation seam の挙動)"""
+        widget_with_images.ui.changedSinceCheckBox.setChecked(True)
+        assert widget_with_images.ui.changedSinceDateTimeEdit.isEnabled()
+        widget_with_images.ui.changedSinceCheckBox.setChecked(False)
+        assert not widget_with_images.ui.changedSinceDateTimeEdit.isEnabled()


### PR DESCRIPTION
epic #610 / Foundation（placeholder-swap の整地。S4 #614 / S5 #615 の前提）

## 目的
S4 と S5 が同じ `DatasetExportWidget.ui`/`_ui.py` を触ると `_ui.py` 全再生成が衝突する。これを避けるため、`.ui` の構造変更を Foundation が単独所有し、S4/S5 は互いに素な `.py` メソッド（stub）だけを実装できるようにする。

## 変更
- **死にコントロール撤去**: `latestOnlyCheckBox`（worker 止まりで未実装）を `.ui` から撤去し、`_on_export_clicked`/`_start_export_worker`/worker から `latest_only` の dead plumbing を除去。
- **S4枠追加**: `changedSinceCheckBox` + `changedSinceDateTimeEdit`（既定無効）。
- **S5枠追加**: `resolutionHelpLabel`（解像度の意味を補足）。
- **seam 配線**: `_setup_resolution_ui()`（S5実装）/ `_setup_changed_since_ui()`（S4実装）を no-op stub で `_setup_ui` から呼ぶ。`_on_changed_since_toggled` は日時の有効化＋再検証のみ（絞り込みは S4）。
- `_ui.py` 再生成。Foundation seam テスト5件追加（既存30 + 5 = 35 pass）。

## 占有契約
このPRが `DatasetExportWidget.ui`/`_ui.py` の唯一の所有者。マージ後 S4/S5 は `.ui`/`_ui.py` を触らず、それぞれ `_setup_changed_since_ui` 系 / `_setup_resolution_ui`・`_display_validation_results` のみ実装する。

Refs #610, #614, #615

🤖 Generated with [Claude Code](https://claude.com/claude-code)