### PR TITLE
feat: 解像度ドロップダウンの意味明確化と対象/対象外件数表示 (#615)

### DIFF
--- a/src/lorairo/gui/widgets/dataset_export_widget.py
+++ b/src/lorairo/gui/widgets/dataset_export_widget.py
@@ -162,11 +162,18 @@ class DatasetExportWidget(QDialog):
         self._setup_changed_since_ui()
 
     def _setup_resolution_ui(self) -> None:
-        """解像度関連 UI の初期化 seam（S5 #615 が実装）。
+        """解像度 UI の意味を明確化する (#615)。
 
-        Foundation では no-op。S5 が解像度の意味明確化（resolutionHelpLabel の
-        補助文言/ツールチップ）と、選択時の対象/対象外件数の即時表示を実装する。
+        「処理済み画像解像度」は画像を変換するのではなく、その解像度の前処理済み
+        バリアントを持つ画像だけをエクスポート対象に絞るフィルタである。誤解を避ける
+        ためツールチップで明示する。対象/対象外の件数は検証結果に表示する。
         """
+        resolution_hint = (
+            "画像を変換するのではなく、選択した解像度の前処理済み版を持つ画像のみが\n"
+            "エクスポート対象になります。その解像度版が無い画像は「対象外」になります。"
+        )
+        self.ui.comboBoxResolution.setToolTip(resolution_hint)
+        self.ui.resolutionHelpLabel.setToolTip(resolution_hint)
 
     def _setup_changed_since_ui(self) -> None:
         """changed-since フィルタ UI を初期化する (#614)。
@@ -283,6 +290,13 @@ class DatasetExportWidget(QDialog):
 
         # Update detailed results
         details = []
+        # 解像度フィルタの効果（対象/対象外）を明示する (#615)
+        resolution = self._get_selected_resolution()
+        missing_processed = results.get("missing_processed", 0)
+        details.append(
+            f"📐 解像度 {resolution}px: 対象 {valid}件 / "
+            f"対象外（この解像度の前処理済み版なし）{missing_processed}件"
+        )
         if valid > 0:
             details.append(f"✅ {valid}件の画像がエクスポート可能です。")
 

--- a/tests/unit/gui/widgets/test_dataset_export_widget.py
+++ b/tests/unit/gui/widgets/test_dataset_export_widget.py
@@ -304,3 +304,31 @@ class TestDatasetExportWidgetFoundation:
         widget_with_images.ui.changedSinceCheckBox.setChecked(True)
         effective = widget_with_images._get_effective_image_ids()
         assert effective == list(widget_with_images.image_ids)[:1]
+
+
+class TestDatasetExportWidgetResolution:
+    """S5 #615: 解像度の意味明確化と対象/対象外件数の表示。"""
+
+    def test_resolution_tooltip_clarifies_filter_semantics(self, widget_with_images):
+        """解像度コンボ/補助ラベルに「変換でなく前処理済み版の有無」のツールチップが付く"""
+        combo_tip = widget_with_images.ui.comboBoxResolution.toolTip()
+        label_tip = widget_with_images.ui.resolutionHelpLabel.toolTip()
+        assert "変換するのではなく" in combo_tip
+        assert "前処理済み版" in combo_tip
+        assert combo_tip == label_tip
+
+    def test_validation_details_show_resolution_in_out_counts(self, widget_with_images):
+        """検証結果に解像度別の対象/対象外件数が表示される"""
+        widget_with_images.ui.comboBoxResolution.setCurrentText("768px")
+        results = {
+            "total_images": 5,
+            "valid_images": 3,
+            "missing_processed": 2,
+            "missing_metadata": 0,
+            "issues": [],
+        }
+        widget_with_images._display_validation_results(results)
+        text = widget_with_images.ui.validationDetailsText.toPlainText()
+        assert "768px" in text
+        assert "対象 3件" in text
+        assert "対象外（この解像度の前処理済み版なし）2件" in text


### PR DESCRIPTION
epic #610 / 第3段階 / S5（リードが直接実装。当初担当 teammate がスタックしたため引き取り）

## 目的
「処理済み画像解像度」が「変換」でなく「その解像度の前処理済み版を持つ画像のみを対象にするフィルタ」であることが直感に反する（問題D）。意味を明確化する。

## 実装
- **`_setup_resolution_ui()`**（Foundation stub を実装）: `comboBoxResolution` / `resolutionHelpLabel` にツールチップを設定し「変換でなく前処理済み版の有無で絞る」ことを明示。
- **`_display_validation_results()`**: 検証結果に解像度別の **対象 N件 / 対象外（この解像度の前処理済み版なし）M件** を明示し、解像度フィルタの効果を可視化。

## 制約遵守
- `.ui`/`_ui.py` 不可触（Foundation 所有の `resolutionHelpLabel` を利用）。
- S4 領域（`_setup_changed_since_ui`/worker）は非接触。rebase で S4 と別メソッドとして共存（衝突は test の末尾追加のみ、両者保持で解消）。

## テスト（40 pass）
- ツールチップ文言（変換でなく前処理済み版）。
- 検証結果の対象/対象外件数表示（768px で 対象3/対象外2）。

Closes #615

🤖 Generated with [Claude Code](https://claude.com/claude-code)