### PR TITLE
feat: ImageFilterCriteria.image_ids 追加と criteria 経由エクスポート統一 (#612)

### DIFF
--- a/src/lorairo/database/filter_criteria.py
+++ b/src/lorairo/database/filter_criteria.py
@@ -39,6 +39,10 @@ class ImageFilterCriteria:
         project_id: フィルタ対象プロジェクトID（Phase C完了後に高速路）
         limit: 取得件数上限。None の場合は無制限
         offset: 取得開始位置
+        image_ids: 明示的な画像IDリスト。指定時は exact-set selector として扱い、
+            他のフィルタ次元（tags / caption / include_nsfw / rating / score 等）を
+            すべてバイパスして指定IDをそのまま対象にする（ADR 0055）。GUI が
+            ステージング集合を criteria 経由でエクスポートする際に使用する。
     """
 
     tags: list[str] | None = None
@@ -63,6 +67,8 @@ class ImageFilterCriteria:
     project_id: int | None = None
     limit: int | None = None
     offset: int = 0
+    # ADR 0055: 指定時は他フィルタを bypass する exact-set selector
+    image_ids: list[int] | None = None
 
     @classmethod
     def from_kwargs(cls, **kwargs: Any) -> ImageFilterCriteria:
@@ -120,4 +126,5 @@ class ImageFilterCriteria:
             "project_id": self.project_id,
             "limit": self.limit,
             "offset": self.offset,
+            "image_ids": self.image_ids,
         }

--- a/src/lorairo/database/repository/image.py
+++ b/src/lorairo/database/repository/image.py
@@ -1864,16 +1864,38 @@ class ImageRepository(BaseRepository):
             return [], 0
         with self.session_factory() as session:
             try:
-                existing_ids = list(
-                    session.execute(select(Image.id).where(Image.id.in_(requested)).order_by(Image.id))
-                    .scalars()
-                    .all()
-                )
+                # SQLite の bind 変数上限を避けるため BATCH_CHUNK_SIZE で分割 (Codex #623)
+                existing_ids: list[int] = []
+                for i in range(0, len(requested), self.BATCH_CHUNK_SIZE):
+                    chunk = requested[i : i + self.BATCH_CHUNK_SIZE]
+                    existing_ids.extend(
+                        session.execute(select(Image.id).where(Image.id.in_(chunk))).scalars().all()
+                    )
+                existing_ids.sort()
+
+                if resolution != 0:
+                    # 解像度フィルタはページングより前に適用する。_fetch_filtered_metadata は
+                    # 指定解像度の処理済み版を持たない ID を落とすため、先に metadata を取得して
+                    # 解像度で絞ってからページングしないと総件数/ページが狂う (Codex #623)。
+                    resolved = sorted(
+                        self._fetch_filtered_metadata(session, existing_ids, resolution),
+                        key=lambda m: m["id"],
+                    )
+                    total_count = len(resolved)
+                    paged = resolved[offset:]
+                    if limit is not None:
+                        paged = paged[:limit]
+                    logger.info(
+                        f"image_ids exact-set: 指定 {len(requested)}件 → 存在 {len(existing_ids)}件 "
+                        f"→ 解像度{resolution}該当 {total_count}件 → 取得 {len(paged)}件 (ADR 0055)"
+                    )
+                    return paged, total_count
+
                 total_count = len(existing_ids)
                 paged_ids = existing_ids[offset:]
                 if limit is not None:
                     paged_ids = paged_ids[:limit]
-                metadata = self._fetch_filtered_metadata(session, paged_ids, resolution)
+                metadata = self._fetch_filtered_metadata(session, paged_ids, 0)
                 logger.info(
                     f"image_ids exact-set: 指定 {len(requested)}件 → 存在 {total_count}件 "
                     f"→ 取得 {len(metadata)}件 (フィルタ bypass, ADR 0055)"
@@ -2000,11 +2022,16 @@ class ImageRepository(BaseRepository):
                 return 0
             with self.session_factory() as session:
                 try:
-                    return int(
-                        session.execute(
-                            select(func.count()).select_from(Image).where(Image.id.in_(requested))
-                        ).scalar_one()
-                    )
+                    # bind 変数上限を避けるため BATCH_CHUNK_SIZE で分割集計 (Codex #623)
+                    total = 0
+                    for i in range(0, len(requested), self.BATCH_CHUNK_SIZE):
+                        chunk = requested[i : i + self.BATCH_CHUNK_SIZE]
+                        total += int(
+                            session.execute(
+                                select(func.count()).select_from(Image).where(Image.id.in_(chunk))
+                            ).scalar_one()
+                        )
+                    return total
                 except SQLAlchemyError as e:
                     logger.error(f"image_ids exact-set 件数取得エラー: {e}", exc_info=True)
                     raise

--- a/src/lorairo/database/repository/image.py
+++ b/src/lorairo/database/repository/image.py
@@ -1859,48 +1859,38 @@ class ImageRepository(BaseRepository):
         Raises:
             SQLAlchemyError: データベース操作でエラーが発生した場合。
         """
-        requested = list({i for i in image_ids if i is not None})
+        # 呼び出し元の順序 (ステージング順など) を保持して dedup する (Codex #623)
+        requested = list(dict.fromkeys(i for i in image_ids if i is not None))
         if not requested:
             return [], 0
         with self.session_factory() as session:
             try:
                 # SQLite の bind 変数上限を避けるため BATCH_CHUNK_SIZE で分割 (Codex #623)
-                existing_ids: list[int] = []
+                existing: set[int] = set()
                 for i in range(0, len(requested), self.BATCH_CHUNK_SIZE):
                     chunk = requested[i : i + self.BATCH_CHUNK_SIZE]
-                    existing_ids.extend(
+                    existing.update(
                         session.execute(select(Image.id).where(Image.id.in_(chunk))).scalars().all()
                     )
-                existing_ids.sort()
+                # 入力順を保持したまま存在する ID に絞る
+                existing_ids = [i for i in requested if i in existing]
 
-                if resolution != 0:
-                    # 解像度フィルタはページングより前に適用する。_fetch_filtered_metadata は
-                    # 指定解像度の処理済み版を持たない ID を落とすため、先に metadata を取得して
-                    # 解像度で絞ってからページングしないと総件数/ページが狂う (Codex #623)。
-                    resolved = sorted(
-                        self._fetch_filtered_metadata(session, existing_ids, resolution),
-                        key=lambda m: m["id"],
-                    )
-                    total_count = len(resolved)
-                    paged = resolved[offset:]
-                    if limit is not None:
-                        paged = paged[:limit]
-                    logger.info(
-                        f"image_ids exact-set: 指定 {len(requested)}件 → 存在 {len(existing_ids)}件 "
-                        f"→ 解像度{resolution}該当 {total_count}件 → 取得 {len(paged)}件 (ADR 0055)"
-                    )
-                    return paged, total_count
-
-                total_count = len(existing_ids)
-                paged_ids = existing_ids[offset:]
+                # 解像度フィルタはページングより前に適用する。_fetch_filtered_metadata は
+                # 指定解像度の処理済み版を持たない ID を落とすため、先に metadata を取得して
+                # 解像度で絞り、入力順で並べ直してからページングする (Codex #623)。
+                meta_by_id = {
+                    m["id"]: m for m in self._fetch_filtered_metadata(session, existing_ids, resolution)
+                }
+                ordered = [meta_by_id[i] for i in existing_ids if i in meta_by_id]
+                total_count = len(ordered)
+                paged = ordered[offset:]
                 if limit is not None:
-                    paged_ids = paged_ids[:limit]
-                metadata = self._fetch_filtered_metadata(session, paged_ids, 0)
+                    paged = paged[:limit]
                 logger.info(
-                    f"image_ids exact-set: 指定 {len(requested)}件 → 存在 {total_count}件 "
-                    f"→ 取得 {len(metadata)}件 (フィルタ bypass, ADR 0055)"
+                    f"image_ids exact-set: 指定 {len(requested)}件 → 存在 {len(existing_ids)}件 "
+                    f"→ 解像度{resolution}該当 {total_count}件 → 取得 {len(paged)}件 (ADR 0055)"
                 )
-                return metadata, total_count
+                return paged, total_count
             except SQLAlchemyError as e:
                 logger.error(f"image_ids exact-set 取得エラー: {e}", exc_info=True)
                 raise
@@ -2015,26 +2005,14 @@ class ImageRepository(BaseRepository):
         """
         filter_criteria = criteria if criteria else ImageFilterCriteria.from_kwargs(**kwargs)
 
-        # ADR 0055: image_ids 指定時は exact-set として他フィルタを bypass する (Codex #623)。
+        # ADR 0055: image_ids 指定時は exact-set として他フィルタを bypass する。
+        # get_images_by_filter と総件数を一致させるため同一 helper の総件数を返す
+        # (resolution 指定時は解像度該当のみ数える, Codex #623)。
         if filter_criteria.image_ids is not None:
-            requested = list({i for i in filter_criteria.image_ids if i is not None})
-            if not requested:
-                return 0
-            with self.session_factory() as session:
-                try:
-                    # bind 変数上限を避けるため BATCH_CHUNK_SIZE で分割集計 (Codex #623)
-                    total = 0
-                    for i in range(0, len(requested), self.BATCH_CHUNK_SIZE):
-                        chunk = requested[i : i + self.BATCH_CHUNK_SIZE]
-                        total += int(
-                            session.execute(
-                                select(func.count()).select_from(Image).where(Image.id.in_(chunk))
-                            ).scalar_one()
-                        )
-                    return total
-                except SQLAlchemyError as e:
-                    logger.error(f"image_ids exact-set 件数取得エラー: {e}", exc_info=True)
-                    raise
+            _, total_count = self._fetch_images_by_exact_ids(
+                filter_criteria.image_ids, filter_criteria.resolution
+            )
+            return total_count
 
         with self.session_factory() as session:
             try:

--- a/src/lorairo/database/repository/image.py
+++ b/src/lorairo/database/repository/image.py
@@ -1835,6 +1835,46 @@ class ImageRepository(BaseRepository):
 
         return query.distinct()
 
+    def _fetch_images_by_exact_ids(
+        self, image_ids: list[int], resolution: int
+    ) -> tuple[list[dict[str, Any]], int]:
+        """明示的な image_id リストをそのまま取得する exact-set selector (ADR 0055)。
+
+        他のフィルタ次元 (tags / caption / include_nsfw / rating / score 等) を一切
+        適用せず、DB に存在する指定 ID の metadata を返す。GUI がステージング集合を
+        criteria 経由でエクスポートする際に、明示選択した NSFW 画像等がフィルタで
+        黙って落ちるのを防ぐ。
+
+        Args:
+            image_ids: 取得対象の画像 ID リスト。
+            resolution: metadata 取得時の解像度 (0 はオリジナル)。
+
+        Returns:
+            (metadata リスト, 件数)。DB に存在しない ID は除外される。
+
+        Raises:
+            SQLAlchemyError: データベース操作でエラーが発生した場合。
+        """
+        requested = list({i for i in image_ids if i is not None})
+        if not requested:
+            return [], 0
+        with self.session_factory() as session:
+            try:
+                existing_ids = list(
+                    session.execute(select(Image.id).where(Image.id.in_(requested)).order_by(Image.id))
+                    .scalars()
+                    .all()
+                )
+                metadata = self._fetch_filtered_metadata(session, existing_ids, resolution)
+                logger.info(
+                    f"image_ids exact-set: 指定 {len(requested)}件 → 取得 {len(metadata)}件 "
+                    f"(フィルタ bypass, ADR 0055)"
+                )
+                return metadata, len(metadata)
+            except SQLAlchemyError as e:
+                logger.error(f"image_ids exact-set 取得エラー: {e}", exc_info=True)
+                raise
+
     def get_images_by_filter(
         self,
         criteria: ImageFilterCriteria | None = None,
@@ -1863,6 +1903,10 @@ class ImageRepository(BaseRepository):
             except ValueError:
                 logger.error(f"解像度パラメータの変換に失敗しました: '{filter_criteria.resolution}'")
                 return [], 0
+
+        # ADR 0055: image_ids 指定時は exact-set selector として他フィルタを bypass する。
+        if filter_criteria.image_ids is not None:
+            return self._fetch_images_by_exact_ids(filter_criteria.image_ids, filter_criteria.resolution)
 
         with self.session_factory() as session:
             try:

--- a/src/lorairo/database/repository/image.py
+++ b/src/lorairo/database/repository/image.py
@@ -1836,21 +1836,25 @@ class ImageRepository(BaseRepository):
         return query.distinct()
 
     def _fetch_images_by_exact_ids(
-        self, image_ids: list[int], resolution: int
+        self, image_ids: list[int], resolution: int, offset: int = 0, limit: int | None = None
     ) -> tuple[list[dict[str, Any]], int]:
         """明示的な image_id リストをそのまま取得する exact-set selector (ADR 0055)。
 
         他のフィルタ次元 (tags / caption / include_nsfw / rating / score 等) を一切
         適用せず、DB に存在する指定 ID の metadata を返す。GUI がステージング集合を
         criteria 経由でエクスポートする際に、明示選択した NSFW 画像等がフィルタで
-        黙って落ちるのを防ぐ。
+        黙って落ちるのを防ぐ。`offset` / `limit` は通常パスと同じくページングに用いる
+        (総件数はページング前の存在件数を返す, Codex #623)。
 
         Args:
             image_ids: 取得対象の画像 ID リスト。
             resolution: metadata 取得時の解像度 (0 はオリジナル)。
+            offset: ページング開始位置。
+            limit: 取得件数上限。None は無制限。
 
         Returns:
-            (metadata リスト, 件数)。DB に存在しない ID は除外される。
+            (metadata リスト, 総件数)。総件数は DB に存在する指定 ID 数 (ページング前)。
+            DB に存在しない ID は除外される。
 
         Raises:
             SQLAlchemyError: データベース操作でエラーが発生した場合。
@@ -1865,12 +1869,16 @@ class ImageRepository(BaseRepository):
                     .scalars()
                     .all()
                 )
-                metadata = self._fetch_filtered_metadata(session, existing_ids, resolution)
+                total_count = len(existing_ids)
+                paged_ids = existing_ids[offset:]
+                if limit is not None:
+                    paged_ids = paged_ids[:limit]
+                metadata = self._fetch_filtered_metadata(session, paged_ids, resolution)
                 logger.info(
-                    f"image_ids exact-set: 指定 {len(requested)}件 → 取得 {len(metadata)}件 "
-                    f"(フィルタ bypass, ADR 0055)"
+                    f"image_ids exact-set: 指定 {len(requested)}件 → 存在 {total_count}件 "
+                    f"→ 取得 {len(metadata)}件 (フィルタ bypass, ADR 0055)"
                 )
-                return metadata, len(metadata)
+                return metadata, total_count
             except SQLAlchemyError as e:
                 logger.error(f"image_ids exact-set 取得エラー: {e}", exc_info=True)
                 raise
@@ -1906,7 +1914,12 @@ class ImageRepository(BaseRepository):
 
         # ADR 0055: image_ids 指定時は exact-set selector として他フィルタを bypass する。
         if filter_criteria.image_ids is not None:
-            return self._fetch_images_by_exact_ids(filter_criteria.image_ids, filter_criteria.resolution)
+            return self._fetch_images_by_exact_ids(
+                filter_criteria.image_ids,
+                filter_criteria.resolution,
+                offset=filter_criteria.offset,
+                limit=filter_criteria.limit,
+            )
 
         with self.session_factory() as session:
             try:
@@ -1979,6 +1992,22 @@ class ImageRepository(BaseRepository):
 
         """
         filter_criteria = criteria if criteria else ImageFilterCriteria.from_kwargs(**kwargs)
+
+        # ADR 0055: image_ids 指定時は exact-set として他フィルタを bypass する (Codex #623)。
+        if filter_criteria.image_ids is not None:
+            requested = list({i for i in filter_criteria.image_ids if i is not None})
+            if not requested:
+                return 0
+            with self.session_factory() as session:
+                try:
+                    return int(
+                        session.execute(
+                            select(func.count()).select_from(Image).where(Image.id.in_(requested))
+                        ).scalar_one()
+                    )
+                except SQLAlchemyError as e:
+                    logger.error(f"image_ids exact-set 件数取得エラー: {e}", exc_info=True)
+                    raise
 
         with self.session_factory() as session:
             try:

--- a/src/lorairo/gui/widgets/dataset_export_widget.py
+++ b/src/lorairo/gui/widgets/dataset_export_widget.py
@@ -65,7 +65,9 @@ class DatasetExportWorker(QObject):
 
             # ADR 0055: 明示 ID は exact-set selector の criteria 経由で渡す
             # (非推奨の image_ids 直渡しを排除。他フィルタを bypass し NSFW 等も落とさない)。
-            criteria = ImageFilterCriteria(image_ids=self.image_ids)
+            # resolution を criteria に載せ、対象解決を「選択解像度の処理済み版を持つ画像」に
+            # 揃える (対象数と実エクスポート件数を一致させる, #612)。
+            criteria = ImageFilterCriteria(image_ids=self.image_ids, resolution=self.resolution)
             if self.export_format == "json":
                 result_path = self.export_service.export_with_criteria(
                     output_path=self.output_path,

--- a/src/lorairo/gui/widgets/dataset_export_widget.py
+++ b/src/lorairo/gui/widgets/dataset_export_widget.py
@@ -13,6 +13,7 @@ from PySide6.QtCore import QDateTime, QObject, QThread, QTime, Signal
 from PySide6.QtGui import QCloseEvent
 from PySide6.QtWidgets import QButtonGroup, QDialog, QFileDialog, QMessageBox, QWidget
 
+from ...database.filter_criteria import ImageFilterCriteria
 from ...services.service_container import ServiceContainer
 from ..designer.DatasetExportWidget_ui import Ui_DatasetExportWidget
 
@@ -62,13 +63,15 @@ class DatasetExportWorker(QObject):
 
             self.progress.emit(10, "エクスポート処理を開始しています...")
 
-            # export_with_criteria 経由で統一エントリポイントを使用（image_ids は deprecated パス）
+            # ADR 0055: 明示 ID は exact-set selector の criteria 経由で渡す
+            # (非推奨の image_ids 直渡しを排除。他フィルタを bypass し NSFW 等も落とさない)。
+            criteria = ImageFilterCriteria(image_ids=self.image_ids)
             if self.export_format == "json":
                 result_path = self.export_service.export_with_criteria(
                     output_path=self.output_path,
                     format_type="json",
                     resolution=self.resolution,
-                    image_ids=self.image_ids,
+                    criteria=criteria,
                 )
                 self.progress.emit(90, "JSON形式でエクスポート中...")
             else:
@@ -77,7 +80,7 @@ class DatasetExportWorker(QObject):
                     output_path=self.output_path,
                     format_type="txt",
                     resolution=self.resolution,
-                    image_ids=self.image_ids,
+                    criteria=criteria,
                     merge_caption=merge_option,
                 )
                 self.progress.emit(90, "TXT形式でエクスポート中...")

--- a/tests/unit/database/repository/test_image_repository.py
+++ b/tests/unit/database/repository/test_image_repository.py
@@ -36,6 +36,7 @@ from lorairo.database.schema import (
     Image,
     ImageFilenameAlias,
     ProcessedImage,
+    Rating,
     Tag,
 )
 from lorairo.services.configuration_service import ConfigurationService
@@ -488,3 +489,64 @@ class TestFilterImageIdsWithTagChangesSince:
         import datetime
 
         assert image_repository.filter_image_ids_with_tag_changes_since([], datetime.datetime.now()) == []
+
+
+@pytest.mark.unit
+class TestImageFilterCriteriaExactSet:
+    """ADR 0055: image_ids 指定時は他フィルタを bypass する exact-set selector。"""
+
+    def test_image_ids_bypass_tag_filter_and_drop_missing(
+        self, image_repository: ImageRepository, memory_session_factory
+    ) -> None:
+        img_cat = _insert_image(image_repository, uuid="u-c", phash="p-c", filename="c.png")
+        img_plain = _insert_image(image_repository, uuid="u-p", phash="p-p", filename="p.png")
+        _insert_tag(
+            memory_session_factory,
+            image_id=img_cat,
+            tag="cat",
+            model_id=1,
+            created_at=datetime.datetime(2026, 1, 1),
+            updated_at=datetime.datetime(2026, 1, 1),
+        )
+
+        # 通常フィルタ (tags=["cat"]) は cat タグ画像のみ
+        normal, _ = image_repository.get_images_by_filter(ImageFilterCriteria(tags=["cat"]))
+        assert {m["id"] for m in normal} == {img_cat}
+
+        # image_ids 指定時は tags フィルタを bypass し両方返す。存在しない ID は除外。
+        exact, count = image_repository.get_images_by_filter(
+            ImageFilterCriteria(image_ids=[img_cat, img_plain, 999999], tags=["cat"])
+        )
+        ids = {m["id"] for m in exact}
+        assert ids == {img_cat, img_plain}
+        assert count == 2
+
+    def test_image_ids_bypass_nsfw_exclusion(
+        self, image_repository: ImageRepository, memory_session_factory
+    ) -> None:
+        """明示ステージングした NSFW 画像が include_nsfw=False でも落ちない (Codex/ADR 0055)。"""
+        img_nsfw = _insert_image(image_repository, uuid="u-n", phash="p-n", filename="n.png")
+        with memory_session_factory() as session:
+            session.add(
+                Rating(
+                    image_id=img_nsfw,
+                    model_id=1,
+                    raw_rating_value="X",
+                    normalized_rating="X",
+                )
+            )
+            session.commit()
+
+        # 通常フィルタ (include_nsfw=False) は NSFW 画像を除外する (control)
+        normal, _ = image_repository.get_images_by_filter(ImageFilterCriteria(include_nsfw=False))
+        assert img_nsfw not in {m["id"] for m in normal}
+
+        # image_ids exact-set は include_nsfw=False でも NSFW 画像を返す
+        exact, count = image_repository.get_images_by_filter(
+            ImageFilterCriteria(image_ids=[img_nsfw], include_nsfw=False)
+        )
+        assert {m["id"] for m in exact} == {img_nsfw}
+        assert count == 1
+
+    def test_image_ids_in_to_dict(self) -> None:
+        assert ImageFilterCriteria(image_ids=[1, 2]).to_dict()["image_ids"] == [1, 2]

--- a/tests/unit/database/repository/test_image_repository.py
+++ b/tests/unit/database/repository/test_image_repository.py
@@ -550,3 +550,36 @@ class TestImageFilterCriteriaExactSet:
 
     def test_image_ids_in_to_dict(self) -> None:
         assert ImageFilterCriteria(image_ids=[1, 2]).to_dict()["image_ids"] == [1, 2]
+
+    def test_count_only_honors_image_ids(
+        self, image_repository: ImageRepository, memory_session_factory
+    ) -> None:
+        """get_images_count_only も image_ids exact-set を尊重する (Codex #623)。"""
+        img_cat = _insert_image(image_repository, uuid="u-c2", phash="p-c2", filename="c2.png")
+        img_plain = _insert_image(image_repository, uuid="u-p2", phash="p-p2", filename="p2.png")
+        _insert_tag(
+            memory_session_factory,
+            image_id=img_cat,
+            tag="cat",
+            model_id=1,
+            created_at=datetime.datetime(2026, 1, 1),
+            updated_at=datetime.datetime(2026, 1, 1),
+        )
+        # tags フィルタは無視され、指定した存在 ID の件数を返す
+        count = image_repository.get_images_count_only(
+            ImageFilterCriteria(image_ids=[img_cat, img_plain, 999999], tags=["cat"])
+        )
+        assert count == 2
+
+    def test_image_ids_respect_limit_and_offset(self, image_repository: ImageRepository) -> None:
+        """exact-set でも limit / offset のページングが効く (Codex #623)。"""
+        ids = [
+            _insert_image(image_repository, uuid=f"u-{n}", phash=f"p-{n}", filename=f"{n}.png")
+            for n in range(5)
+        ]
+        rows, total = image_repository.get_images_by_filter(
+            ImageFilterCriteria(image_ids=ids, limit=2, offset=1)
+        )
+        assert total == 5  # 総件数はページング前
+        assert len(rows) == 2  # limit 適用
+        assert [m["id"] for m in rows] == ids[1:3]  # offset=1 から 2 件

--- a/tests/unit/database/repository/test_image_repository.py
+++ b/tests/unit/database/repository/test_image_repository.py
@@ -583,3 +583,16 @@ class TestImageFilterCriteriaExactSet:
         assert total == 5  # 総件数はページング前
         assert len(rows) == 2  # limit 適用
         assert [m["id"] for m in rows] == ids[1:3]  # offset=1 から 2 件
+
+    def test_image_ids_apply_resolution_before_paging(self, image_repository: ImageRepository) -> None:
+        """resolution 指定時は解像度フィルタをページングより前に適用する (Codex #623)。"""
+        img_missing = _insert_image(image_repository, uuid="u-rm", phash="p-rm", filename="rm.png")
+        img_has = _insert_image(image_repository, uuid="u-rh", phash="p-rh", filename="rh.png")
+        _insert_processed_image(image_repository, image_id=img_has, filename="rh-512.png")
+
+        # img_missing は 512px の処理済み版なし。limit=1 でも空ページにならず has を返す。
+        rows, total = image_repository.get_images_by_filter(
+            ImageFilterCriteria(image_ids=[img_missing, img_has], resolution=512, limit=1)
+        )
+        assert total == 1  # 解像度該当は has のみ
+        assert [m["id"] for m in rows] == [img_has]

--- a/tests/unit/database/repository/test_image_repository.py
+++ b/tests/unit/database/repository/test_image_repository.py
@@ -596,3 +596,26 @@ class TestImageFilterCriteriaExactSet:
         )
         assert total == 1  # 解像度該当は has のみ
         assert [m["id"] for m in rows] == [img_has]
+
+    def test_image_ids_preserve_caller_order(self, image_repository: ImageRepository) -> None:
+        """呼び出し元の明示順 (ステージング順) を保持する (Codex #623)。"""
+        first = _insert_image(image_repository, uuid="u-o1", phash="p-o1", filename="o1.png")
+        second = _insert_image(image_repository, uuid="u-o2", phash="p-o2", filename="o2.png")
+        third = _insert_image(image_repository, uuid="u-o3", phash="p-o3", filename="o3.png")
+        # DB id 昇順ではなく caller の順 [third, first, second] を維持する
+        rows, _ = image_repository.get_images_by_filter(
+            ImageFilterCriteria(image_ids=[third, first, second])
+        )
+        assert [m["id"] for m in rows] == [third, first, second]
+
+    def test_count_only_matches_filter_total_with_resolution(
+        self, image_repository: ImageRepository
+    ) -> None:
+        """count_only も resolution 該当のみを数え、get_images_by_filter と一致する (Codex #623)。"""
+        img_missing = _insert_image(image_repository, uuid="u-cm", phash="p-cm", filename="cm.png")
+        img_has = _insert_image(image_repository, uuid="u-ch", phash="p-ch", filename="ch.png")
+        _insert_processed_image(image_repository, image_id=img_has, filename="ch-512.png")
+
+        criteria = ImageFilterCriteria(image_ids=[img_missing, img_has], resolution=512)
+        _, total = image_repository.get_images_by_filter(criteria)
+        assert image_repository.get_images_count_only(criteria) == total == 1


### PR DESCRIPTION
epic #610 / 第2段階 / S2（リードが直接実装。当初担当 teammate がスタックしたため引き取り）

## 目的（ADR 0055 §3）
GUI のエクスポートを非推奨の `image_ids` 直渡しから `export_with_criteria(criteria=)` に統一する。その際、明示選択（ステージング）した画像が NSFW 等のフィルタで黙って落ちないよう、`image_ids` を **exact-set selector** として扱う。

## 実装
- **filter_criteria**: `ImageFilterCriteria.image_ids: list[int] | None` を追加。指定時は他フィルタ次元（tags / caption / include_nsfw / rating / score 等）を**バイパス**する exact-set selector。
- **repository**: `get_images_by_filter` に exact-set bypass を追加（`_fetch_images_by_exact_ids`）。NSFW/rating/tag/score を適用せず明示 ID をそのまま返し、DB に存在しない ID は除外。
- **widget worker**: `export_with_criteria(image_ids=...)`（非推奨・DeprecationWarning）を `criteria=ImageFilterCriteria(image_ids=...)` に切替。S4 の changed-since 絞り込み済み `_effective_image_ids` をそのまま exact-set に載せる。

## テスト
- exact-set が tags フィルタを bypass・存在しない ID を除外。
- **明示ステージングした NSFW 画像が `include_nsfw=False` でも落ちない**（ADR 0055 / Codex 由来の本命回帰）。
- `to_dict` に image_ids 反映。
- 既存 export e2e / bdd / integration 回帰なし（141 + 18 pass）。

Closes #612

🤖 Generated with [Claude Code](https://claude.com/claude-code)