### PR TITLE
chore: git-workflow.md のブランチ規則と docs/tooling 例外の矛盾を解消

### DIFF
--- a/.claude/rules/git-workflow.md
+++ b/.claude/rules/git-workflow.md
@@ -37,13 +37,15 @@ git worktree add /tmp/worktrees/issue-123 -b fix/issue-123 origin/main
 
 ## ブランチ運用
 
-### mainブランチでの直接作業禁止
-- Issue解決・機能開発は必ず専用ブランチで行う
+このセクションは**アプリのソース（`src/`, `tests/`, `local_packages/*/src`）・schema/migration を触る実装作業**に適用する。docs/tooling chore は上の「worktree + PR を要さない例外」が優先され、専用ブランチを切らず main 直 push してよい。
+
+### mainブランチでの直接作業禁止（アプリコード作業）
+- アプリコードの Issue解決・機能開発は必ず専用ブランチ（かつ worktree）で行う
 - ブランチ命名: `fix/issue-{番号}`, `feat/issue-{番号}`, `refactor/issue-{番号}`
 
 ### ブランチ作成タイミング
 - Issueやタスクの実装開始時に作成
-- 単純なtypo修正や1行変更でも原則ブランチを切る
+- アプリコードに触れる変更は、単純なtypo修正や1行変更でも原則ブランチを切る（docs/tooling chore は例外節に従い不要）
 
 ## ワークツリー運用
 


### PR DESCRIPTION
## 概要

PR #627 への Codex review 指摘（P2「Reconcile the exception with the branch rules」）への follow-up。

新設した「docs/tooling chore は main 直 push 可」例外が、下部の「main 直接作業禁止 / typo でもブランチを切る」既存節と矛盾し、ファイル全体を読むエージェントが正反対の指示を受ける状態だった。

## 変更内容

- `## ブランチ運用` 節の冒頭に**適用範囲（アプリコード作業）**を明記し、docs/tooling chore は例外節が優先されると相互参照
- 「main 直接作業禁止」「typo でもブランチを切る」を**アプリコードに限定**するよう文言修正

`.claude/rules/` のみの chore。

🤖 Generated with [Claude Code](https://claude.com/claude-code)