### PR TITLE
feat: CLI JSONL emit/error 基盤 + 出力モード解決 (#640)

### DIFF
--- a/src/lorairo/cli/_emit.py
+++ b/src/lorairo/cli/_emit.py
@@ -1,0 +1,145 @@
+"""CLI 機械可読 (JSONL) 出力ヘルパー (ADR 0057 §1/§2)。
+
+stdout は機械可読 JSONL 専用。1 行 = 1 つの valid JSON object。ログ・進捗・装飾は
+stderr に出す (本モジュールは stdout のみ扱う)。``kind`` は ``item`` / ``result`` /
+``error`` の 3 種に閉じる (進捗用 ``event`` kind は採用しない、ADR 0057 §2)。
+
+シリアライズは単一の :func:`_emit` を経由し ``json.dumps(..., ensure_ascii=False,
+allow_nan=False, default=str)`` で行う:
+
+- ``ensure_ascii=False``: 日本語タグ等を UTF-8 のまま保持する。
+- ``allow_nan=False``: 非有限 float (``NaN`` / ``Infinity``) は標準 JSON で不正なため弾く。
+  混入しても stdout 行を壊さないよう :func:`_emit` が emit 前に ``None`` へ正規化する。
+- ``default=str``: ``Path`` / ``datetime`` 等の非自明値のフォールバック。
+
+``kind`` と エラー ``code`` は :class:`enum.StrEnum` で定義する。``StrEnum`` は ``str``
+派生のため ``json.dumps`` が ``"item"`` のような安定 wire 値へ直接シリアライズする
+(通常の ``Enum`` を ``default=str`` に頼ると ``"Kind.ITEM"`` のような不安定値になり、
+``code`` で分岐するエージェントが壊れるため使わない、ADR 0057 §1)。
+"""
+
+from __future__ import annotations
+
+import json
+import math
+from enum import StrEnum
+from typing import Any
+
+
+class Kind(StrEnum):
+    """stdout JSONL の ``kind``。3 種に閉じる (ADR 0057 §2)。"""
+
+    ITEM = "item"
+    RESULT = "result"
+    ERROR = "error"
+
+
+def _normalize_non_finite(value: Any) -> Any:
+    """``NaN`` / ``Infinity`` を ``None`` へ再帰的に正規化する。
+
+    非有限 float は標準 JSON で表現できない。score / metric に混入し得るため、
+    ``allow_nan=False`` で弾く前に ``None`` へ寄せて stdout 行の JSON 妥当性を守る。
+
+    Args:
+        value: 任意の JSON シリアライズ対象値。
+
+    Returns:
+        非有限 float を ``None`` に置換した同型の値。
+    """
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, float):
+        return value if math.isfinite(value) else None
+    if isinstance(value, dict):
+        return {key: _normalize_non_finite(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_normalize_non_finite(item) for item in value]
+    return value
+
+
+def _emit(line: dict[str, Any]) -> None:
+    """1 行 = 1 つの valid JSON object を stdout へ出力する (JSONL)。
+
+    Args:
+        line: stdout に 1 行で出力する JSON object。
+    """
+    safe = _normalize_non_finite(line)
+    print(json.dumps(safe, ensure_ascii=False, allow_nan=False, default=str))
+
+
+def _to_payload(record: object) -> Any:
+    """``item`` payload を取り出す。Pydantic モデルは ``model_dump(mode="json")``。
+
+    Args:
+        record: dict / Pydantic モデル / その他のスカラ。
+
+    Returns:
+        JSON シリアライズ可能な payload。
+    """
+    model_dump = getattr(record, "model_dump", None)
+    if callable(model_dump):
+        return model_dump(mode="json")
+    return record
+
+
+def emit_item(record: object) -> None:
+    """per-record 出力の 1 レコードを ``kind=item`` で 1 行出力する。
+
+    巨大配列を 1 行に詰めずレコードごとに改行する。dict は展開し、スカラは
+    ``value`` キーに包む。最終行のサマリは :func:`emit_result` で別途出す。
+
+    Args:
+        record: 出力する 1 レコード (dict / Pydantic モデル / スカラ)。
+    """
+    payload = _to_payload(record)
+    if isinstance(payload, dict):
+        _emit({"kind": Kind.ITEM, **payload})
+    else:
+        _emit({"kind": Kind.ITEM, "value": payload})
+
+
+def emit_result(message: str, **output: Any) -> None:
+    """成功時の最終行 ``kind=result`` を出力する。
+
+    Args:
+        message: 人間可読のサマリ文。
+        **output: 件数メタ等の追加フィールド (``count`` / ``total`` / ``processed`` 等)。
+    """
+    _emit({"kind": Kind.RESULT, "ok": True, "message": message, **output})
+
+
+def emit_error(
+    code: str,
+    message: str,
+    *,
+    retryable: bool,
+    user_action_required: bool,
+    hint: str | None = None,
+    details: dict[str, Any] | None = None,
+) -> None:
+    """失敗時の最終行 ``kind=error`` を出力する。
+
+    stderr の文字列パースに依存させず、stdout の JSONL 最終行に構造化エラーを出す。
+    エージェントは ``code`` / ``retryable`` / ``user_action_required`` で分岐する。
+
+    Args:
+        code: 安定エラーコード (:class:`lorairo.cli._errors.ErrorCode`)。
+        message: 人間可読のエラー文。
+        retryable: 同一/調整後の再試行で成功し得るか。
+        user_action_required: 入力/設定の変更が必要か。
+        hint: 任意の対処ヒント。
+        details: 任意の追加情報 (``{"limit": 500, "matched": 1234}`` 等)。
+    """
+    line: dict[str, Any] = {
+        "kind": Kind.ERROR,
+        "ok": False,
+        "code": code,
+        "message": message,
+        "retryable": retryable,
+        "user_action_required": user_action_required,
+    }
+    if hint:
+        line["hint"] = hint
+    if details:
+        line["details"] = details
+    _emit(line)

--- a/src/lorairo/cli/_errors.py
+++ b/src/lorairo/cli/_errors.py
@@ -1,0 +1,254 @@
+"""CLI 構造化エラー契約 (ADR 0057 §4/§5/§6)。
+
+任意の失敗を安定エラーコード集合と固定 exit code policy に写す。エージェントは
+stderr 文字列をパースせずコードとフラグで分岐でき、人間も理由を読める。失敗時の
+stdout 最終行は ``{"kind": "error", ...}`` (:func:`lorairo.cli._emit.emit_error`)。
+
+Exit code policy (ADR 0057 §6 / ADR 0060):
+    0 = 成功
+    2 = 入力・検証 (``INVALID_INPUT`` / ``VALIDATION_FAILED`` / ``RESULT_SET_TOO_LARGE``)
+    1 = 実行時 (上記以外すべて)
+
+例外 → コード分類 (:func:`classify_exception`) は 2 つの技法を使う:
+
+- **cause-chain walking**: ``__cause__`` / ``__context__`` を遡り ``raise X from e`` で
+  wrap された真因を拾う (LoRAIro は iam-lib 例外を多層 wrap するため必須)。
+- **module-prefix matching**: 例外クラスをモジュール名で判定し、分類のために ``torch`` /
+  推論 SDK を eager import しない (lazy import 制約、ADR 0010 系)。
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from enum import StrEnum
+
+
+class ErrorCode(StrEnum):
+    """安定 wire エラーコード (全 15 種、ADR 0057 §4)。"""
+
+    # 共有コア 11 種 (tag-db ADR 0003 と共有)
+    INVALID_INPUT = "INVALID_INPUT"
+    VALIDATION_FAILED = "VALIDATION_FAILED"
+    PRECONDITION_FAILED = "PRECONDITION_FAILED"
+    NOT_FOUND = "NOT_FOUND"
+    ALREADY_EXISTS = "ALREADY_EXISTS"
+    CONFLICT = "CONFLICT"
+    IO_ERROR = "IO_ERROR"
+    NETWORK_ERROR = "NETWORK_ERROR"
+    DB_ERROR = "DB_ERROR"
+    TIMEOUT = "TIMEOUT"
+    INTERNAL_ERROR = "INTERNAL_ERROR"
+    # AI 推論ドメイン拡張 3 種
+    RESOURCE_EXHAUSTED = "RESOURCE_EXHAUSTED"
+    AUTH_ERROR = "AUTH_ERROR"
+    RATE_LIMITED = "RATE_LIMITED"
+    # pagination ドメイン拡張 1 種 (ADR 0060)
+    RESULT_SET_TOO_LARGE = "RESULT_SET_TOO_LARGE"
+
+
+EXIT_SUCCESS = 0
+EXIT_RUNTIME_ERROR = 1
+EXIT_INPUT_ERROR = 2
+
+# 呼び出し側の不正リクエストを表すコード (exit 2)。
+_INPUT_CODES = frozenset(
+    {ErrorCode.INVALID_INPUT, ErrorCode.VALIDATION_FAILED, ErrorCode.RESULT_SET_TOO_LARGE}
+)
+
+# コードごとの短い対処ヒント (任意)。
+_HINTS: dict[ErrorCode, str] = {
+    ErrorCode.PRECONDITION_FAILED: "先に必要な前提操作 (プロジェクト作成 / 画像登録) を実行してください。",
+    ErrorCode.NETWORK_ERROR: "ネットワーク接続を確認して再試行してください。",
+    ErrorCode.AUTH_ERROR: "config/lorairo.toml に該当プロバイダの API キーを設定してください。",
+    ErrorCode.RESOURCE_EXHAUSTED: "batch_size を下げてから再実行してください (同一条件の再試行は再失敗します)。",
+    ErrorCode.RATE_LIMITED: "しばらく待ってから再試行してください。",
+    ErrorCode.RESULT_SET_TOO_LARGE: "検索条件を追加して 500 件以下に絞ってください。",
+}
+
+
+@dataclass(frozen=True)
+class ErrorInfo:
+    """raise された例外の分類結果。
+
+    Args:
+        code: 安定エラーコード。
+        retryable: 同一/調整後の再試行で成功し得るか (一時的障害か)。
+        user_action_required: 再試行前に入力/前提の変更が必要か。
+    """
+
+    code: ErrorCode
+    retryable: bool
+    user_action_required: bool
+
+    @property
+    def exit_code(self) -> int:
+        """固定 policy に従う process exit code を返す。"""
+        return EXIT_INPUT_ERROR if self.code in _INPUT_CODES else EXIT_RUNTIME_ERROR
+
+
+def hint_for(code: ErrorCode) -> str | None:
+    """コードに対する短い対処ヒントを返す (定義がなければ ``None``)。"""
+    return _HINTS.get(code)
+
+
+def _module_chain_matches(exc: BaseException, prefixes: tuple[str, ...]) -> bool:
+    """例外 MRO のいずれかが ``prefixes`` のモジュール由来なら ``True``。"""
+    return any(cls.__module__.startswith(prefixes) for cls in type(exc).__mro__)
+
+
+def _name_in_mro(exc: BaseException, names: frozenset[str]) -> bool:
+    """例外 MRO のいずれかのクラス名が ``names`` に含まれれば ``True``。"""
+    return any(cls.__name__ in names for cls in type(exc).__mro__)
+
+
+def _iter_cause_chain(exc: BaseException) -> list[BaseException]:
+    """``__cause__`` / ``__context__`` chain を遡る (``raise X from e`` 対応)。
+
+    LoRAIro は iam-lib 例外を ``typer.Exit`` 等で包む多層 wrap が多いため、真因を
+    辿らないと download 失敗を precondition と誤分類する。
+    """
+    chain: list[BaseException] = []
+    seen: set[int] = set()
+    current: BaseException | None = exc
+    while current is not None and id(current) not in seen:
+        seen.add(id(current))
+        chain.append(current)
+        current = current.__cause__ or current.__context__
+    return chain
+
+
+_NETWORK_MODULES = ("requests", "urllib3", "huggingface_hub", "http.client", "httpx")
+_NETWORK_NAMES = frozenset(
+    {
+        "HfHubHTTPError",
+        "LocalEntryNotFoundError",
+        "OfflineModeIsEnabled",
+        "ConnectionError",
+        "APIConnectionError",
+    }
+)
+_AUTH_SDK_MODULES = ("anthropic", "openai", "google", "litellm")
+_AUTH_NAMES = frozenset({"AuthenticationError", "PermissionDeniedError"})
+_RATE_NAMES = frozenset({"RateLimitError"})
+_OOM_NAMES = frozenset({"OutOfMemoryError", "ImageLoadMemoryError", "MemoryError"})
+_APIKEY_NAMES = frozenset({"APIKeyNotConfiguredError"})
+
+
+def _matches_network(exc: BaseException) -> bool:
+    if _module_chain_matches(exc, _NETWORK_MODULES):
+        return True
+    return _name_in_mro(exc, _NETWORK_NAMES)
+
+
+def _is_network_error(exc: BaseException) -> bool:
+    return any(_matches_network(item) for item in _iter_cause_chain(exc))
+
+
+def _is_db_error(exc: BaseException) -> bool:
+    return any(_module_chain_matches(item, ("sqlalchemy",)) for item in _iter_cause_chain(exc))
+
+
+def _is_auth_error(exc: BaseException) -> bool:
+    for item in _iter_cause_chain(exc):
+        # LoRAIro 独自の APIKeyNotConfiguredError (SDK 到達前にキー未設定で送出)
+        if _name_in_mro(item, _APIKEY_NAMES):
+            return True
+        # プロバイダ SDK の AuthenticationError / PermissionDeniedError
+        if _name_in_mro(item, _AUTH_NAMES) and _module_chain_matches(item, _AUTH_SDK_MODULES):
+            return True
+    return False
+
+
+def _is_rate_limited(exc: BaseException) -> bool:
+    return any(
+        _name_in_mro(item, _RATE_NAMES) and _module_chain_matches(item, _AUTH_SDK_MODULES)
+        for item in _iter_cause_chain(exc)
+    )
+
+
+def _is_resource_exhausted(exc: BaseException) -> bool:
+    for item in _iter_cause_chain(exc):
+        if _name_in_mro(item, _OOM_NAMES):
+            return True
+        if isinstance(item, RuntimeError) and "out of memory" in str(item).lower():
+            return True
+    return False
+
+
+def _classify_lorairo_exception(exc: BaseException) -> ErrorInfo | None:
+    """LoRAIro 独自例外を分類する (該当しなければ ``None``)。
+
+    自前の例外階層は ``lorairo.api.exceptions`` 由来 (純 ``Exception`` 派生、torch 等を
+    引かず import 安全) なので isinstance で判定する。
+    """
+    from lorairo.api import exceptions as app_exc
+
+    if isinstance(
+        exc, (app_exc.ProjectNotFoundError, app_exc.ImageNotFoundError, app_exc.TagNotFoundError)
+    ):
+        return ErrorInfo(ErrorCode.NOT_FOUND, retryable=False, user_action_required=True)
+    if isinstance(exc, (app_exc.ProjectAlreadyExistsError, app_exc.DuplicateImageError)):
+        return ErrorInfo(ErrorCode.ALREADY_EXISTS, retryable=False, user_action_required=True)
+    if isinstance(exc, app_exc.InvalidFormatError):
+        return ErrorInfo(ErrorCode.INVALID_INPUT, retryable=False, user_action_required=True)
+    if isinstance(exc, app_exc.ValidationError):
+        return ErrorInfo(ErrorCode.VALIDATION_FAILED, retryable=False, user_action_required=True)
+    if isinstance(exc, app_exc.DatabaseError):
+        return ErrorInfo(ErrorCode.DB_ERROR, retryable=False, user_action_required=False)
+    return None
+
+
+# cause-chain で真因を優先判定する分類器テーブル (順序が結果優先順位、上が勝つ)。
+# wrap された OOM / 認証 / ネットワークを真因として拾うため LoRAIro 独自例外より先に評価する。
+_CHAIN_CLASSIFIERS: tuple[tuple[Callable[[BaseException], bool], ErrorInfo], ...] = (
+    (
+        _is_resource_exhausted,
+        ErrorInfo(ErrorCode.RESOURCE_EXHAUSTED, retryable=True, user_action_required=True),
+    ),
+    (_is_auth_error, ErrorInfo(ErrorCode.AUTH_ERROR, retryable=False, user_action_required=True)),
+    (_is_rate_limited, ErrorInfo(ErrorCode.RATE_LIMITED, retryable=True, user_action_required=False)),
+    (_is_network_error, ErrorInfo(ErrorCode.NETWORK_ERROR, retryable=True, user_action_required=False)),
+    (_is_db_error, ErrorInfo(ErrorCode.DB_ERROR, retryable=False, user_action_required=False)),
+)
+
+
+def _classify_standard_exception(exc: BaseException) -> ErrorInfo:
+    """標準/Pydantic 例外をフォールバック分類する。
+
+    Pydantic ``ValidationError`` は ``ValueError`` の subclass、``FileNotFoundError`` は
+    ``OSError`` の subclass のため、いずれも基底クラスより先に判定する。
+    """
+    if type(exc).__name__ == "ValidationError" and _module_chain_matches(exc, ("pydantic",)):
+        return ErrorInfo(ErrorCode.VALIDATION_FAILED, retryable=False, user_action_required=True)
+    if isinstance(exc, TimeoutError):
+        return ErrorInfo(ErrorCode.TIMEOUT, retryable=True, user_action_required=False)
+    if isinstance(exc, FileNotFoundError):
+        return ErrorInfo(ErrorCode.IO_ERROR, retryable=False, user_action_required=True)
+    if isinstance(exc, ValueError):
+        return ErrorInfo(ErrorCode.INVALID_INPUT, retryable=False, user_action_required=True)
+    if isinstance(exc, OSError):
+        return ErrorInfo(ErrorCode.IO_ERROR, retryable=False, user_action_required=True)
+    return ErrorInfo(ErrorCode.INTERNAL_ERROR, retryable=False, user_action_required=False)
+
+
+def classify_exception(exc: BaseException) -> ErrorInfo:
+    """raise された例外を安定 :class:`ErrorInfo` に写す。
+
+    順序が重要: cause-chain ベースの判定 (:data:`_CHAIN_CLASSIFIERS`: resource / auth /
+    rate / network / db) を先に行い、真因が wrap されていても正しく拾う。次に LoRAIro
+    独自例外を isinstance で分類し、最後に標準例外をフォールバックする。
+
+    Args:
+        exc: 分類対象の例外。
+
+    Returns:
+        コードと再試行/ユーザー操作フラグを持つ :class:`ErrorInfo`。
+    """
+    for predicate, info in _CHAIN_CLASSIFIERS:
+        if predicate(exc):
+            return info
+    lorairo_info = _classify_lorairo_exception(exc)
+    if lorairo_info is not None:
+        return lorairo_info
+    return _classify_standard_exception(exc)

--- a/src/lorairo/cli/_output_mode.py
+++ b/src/lorairo/cli/_output_mode.py
@@ -1,0 +1,86 @@
+"""CLI 出力モード解決 (ADR 0058 §1)。
+
+出力モードは tri-state ``--json`` / ``--no-json`` グローバルフラグ + env
+``LORAIRO_CLI_JSON`` で決まる。解決順序は **明示フラグ > env > 既定 rich**:
+``--json`` / ``--no-json`` が指定されればそれが勝ち、未指定のときだけ env を見る。
+env が JSONL を有効化していても ``--no-json`` で rich に上書きできる。
+
+モードは中央エラー境界が raw ``sys.argv`` / env から **Click のパース前に** 解決する。
+Click は callback より前に context を構築・パースするため、``--json`` を callback
+option としてだけ扱うと parse 時 usage error がモード確定前に境界へ到達し JSONL で
+返せない。よって argv を先読み (prescan) してモードを確定する。
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from collections.abc import Mapping, Sequence
+
+_ENV_VAR = "LORAIRO_CLI_JSON"
+_JSON_FLAG = "--json"
+_NO_JSON_FLAG = "--no-json"
+_FALSEY_ENV = frozenset({"", "0", "false", "no", "off"})
+
+# 中央境界が解決したモードを保持する (コマンド本体が参照する)。
+_json_mode: bool = False
+
+
+def _scan_explicit_flag(argv: Sequence[str]) -> bool | None:
+    """argv を先読みして明示フラグを解決する (位置非依存、後勝ち)。
+
+    ``--json`` / ``--no-json`` はグローバル位置でもサブコマンド後でも受理する。
+    両方が現れた場合は後に現れた方を採用する。
+
+    Args:
+        argv: プログラム名を除いた引数列 (``sys.argv[1:]`` 相当)。
+
+    Returns:
+        ``--json`` なら ``True``、``--no-json`` なら ``False``、どちらも無ければ ``None``。
+    """
+    explicit: bool | None = None
+    for token in argv:
+        if token == _JSON_FLAG:
+            explicit = True
+        elif token == _NO_JSON_FLAG:
+            explicit = False
+        elif token == "--":
+            # ``--`` 以降は位置引数。フラグ走査を止める。
+            break
+    return explicit
+
+
+def _env_enables_json(env: Mapping[str, str]) -> bool:
+    """env ``LORAIRO_CLI_JSON`` が JSONL を有効化しているか。"""
+    return env.get(_ENV_VAR, "").strip().lower() not in _FALSEY_ENV
+
+
+def resolve_output_mode(argv: Sequence[str] | None = None, env: Mapping[str, str] | None = None) -> bool:
+    """JSONL 機械可読モードか判定する。
+
+    解決順序は「明示フラグ > env > 既定 rich」。
+
+    Args:
+        argv: 引数列 (省略時は ``sys.argv[1:]``)。
+        env: 環境変数 (省略時は ``os.environ``)。
+
+    Returns:
+        JSONL モードなら ``True``、rich 人間向けモードなら ``False``。
+    """
+    tokens = list(sys.argv[1:] if argv is None else argv)
+    environ = os.environ if env is None else env
+    explicit = _scan_explicit_flag(tokens)
+    if explicit is not None:
+        return explicit
+    return _env_enables_json(environ)
+
+
+def set_json_mode(value: bool) -> None:
+    """解決済みの出力モードを保存する (中央境界が呼ぶ)。"""
+    global _json_mode
+    _json_mode = value
+
+
+def is_json_mode() -> bool:
+    """現在の出力モードが JSONL かを返す (コマンド本体が参照する)。"""
+    return _json_mode

--- a/src/lorairo/cli/main.py
+++ b/src/lorairo/cli/main.py
@@ -13,14 +13,20 @@ from lorairo.cli._early_init import early_init
 
 early_init()
 
+import sys
+import traceback
 from enum import StrEnum
 from typing import TYPE_CHECKING, Any
 
+import click
 import typer
 from rich.table import Table
 
 from lorairo.cli._console import make_console
+from lorairo.cli._emit import emit_error
+from lorairo.cli._errors import ErrorCode, ErrorInfo, classify_exception, hint_for
 from lorairo.cli._glyphs import FAIL, OK
+from lorairo.cli._output_mode import resolve_output_mode, set_json_mode
 from lorairo.cli.commands import annotate, batch, export, images, models, project
 from lorairo.services.service_container import get_service_container
 from lorairo.utils.config import DEFAULT_CLI_LOG_PATH, DEFAULT_CONFIG_PATH
@@ -65,6 +71,8 @@ app = typer.Typer(
 
 # Rich console (Issue #254: Windows では safe_box=True で ASCII 罫線)
 console = make_console()
+# エラー/人間向け装飾は stderr へ (stdout は機械可読 JSONL 専用、ADR 0057 §1)
+console_err = make_console(stderr=True)
 
 # ===== サブコマンドグループ登録 =====
 app.add_typer(project.app, name="project", help="Project management commands")
@@ -172,15 +180,92 @@ def status() -> None:
         raise typer.Exit(code=1) from e
 
 
-def main() -> None:
-    """CLIメインエントリポイント。
+def _report_error(message: str, info: ErrorInfo, *, json_mode: bool) -> None:
+    """エラーを出力モードに応じて出す (JSONL or rich)。
+
+    Args:
+        message: 人間可読のエラー文。
+        info: 分類済みの :class:`ErrorInfo`。
+        json_mode: JSONL モードなら ``True``。
+    """
+    if json_mode:
+        emit_error(
+            info.code,
+            message,
+            retryable=info.retryable,
+            user_action_required=info.user_action_required,
+            hint=hint_for(info.code),
+        )
+    else:
+        console_err.print(f"[red]Error:[/red] {message}")
+
+
+def _handle_click_exception(exc: click.ClickException, *, json_mode: bool) -> int:
+    """Click の usage / parse error を ``INVALID_INPUT`` で処理する (ADR 0057 §7)。
+
+    Args:
+        exc: ``UsageError`` / ``BadParameter`` / ``NoSuchOption`` 等。
+        json_mode: JSONL モードなら ``True``。
+
+    Returns:
+        process exit code (2)。
+    """
+    message = exc.format_message() if hasattr(exc, "format_message") else str(exc)
+    info = ErrorInfo(ErrorCode.INVALID_INPUT, retryable=False, user_action_required=True)
+    _report_error(message, info, json_mode=json_mode)
+    return info.exit_code
+
+
+def _handle_cli_exception(exc: Exception, *, json_mode: bool) -> int:
+    """コマンドが伝播した例外を分類して構造化エラーに写す (ADR 0057 §5/§6/§7)。
+
+    Args:
+        exc: コマンド本体から伝播した例外。
+        json_mode: JSONL モードなら ``True``。
+
+    Returns:
+        分類コードから導出した process exit code。
+    """
+    info = classify_exception(exc)
+    message = str(exc) or type(exc).__name__
+    _report_error(message, info, json_mode=json_mode)
+    # stdout の JSONL 純度を保つため、traceback は INTERNAL_ERROR のときだけ stderr へ
+    if info.code == ErrorCode.INTERNAL_ERROR:
+        traceback.print_exc(file=sys.stderr)
+    return info.exit_code
+
+
+def main(argv: list[str] | None = None) -> None:
+    """CLIメインエントリポイント兼中央エラー境界 (ADR 0057 §7 / ADR 0058 §1)。
+
+    出力モード (``--json`` / ``--no-json`` / env) を Click のパース前に解決し、
+    ``standalone_mode=False`` で Typer/Click の自動 exit をバイパスして、
+    usage error も含む全失敗を 1 箇所で構造化エラー + exit code に写す。
 
     ``LORAIRO_CLI_MODE`` 設定とログ初期化は ``@app.callback()`` (``_configure``)
-    でサブコマンド実行時に行う (Issue #539 / #540)。``--help`` のみの呼び出しでは
-    callback が走らないため、不要なログ初期化・副作用を避けられる。
-    stdio 初期化は module top-level の ``early_init()`` で完了済。
+    でサブコマンド実行時に行う (Issue #539 / #540)。stdio 初期化は module top-level の
+    ``early_init()`` で完了済。
+
+    Args:
+        argv: 引数列 (省略時は ``sys.argv[1:]`` を Click が解決)。テスト用に注入可能。
     """
-    app()
+    json_mode = resolve_output_mode(argv)
+    set_json_mode(json_mode)
+    try:
+        # standalone_mode=False: ctx.exit() / --help は exit code を返し、
+        # ClickException / Abort / 一般例外は伝播する。
+        result = app(args=argv, standalone_mode=False)
+    except click.exceptions.Abort:
+        raise SystemExit(130) from None
+    except click.ClickException as exc:
+        raise SystemExit(_handle_click_exception(exc, json_mode=json_mode)) from exc
+    except SystemExit:
+        raise
+    except Exception as exc:  # CLI 最上位エラー境界 (ADR 0057 §7)
+        raise SystemExit(_handle_cli_exception(exc, json_mode=json_mode)) from exc
+    # ctx.exit(code) / --help は標準終了の exit code を int で返す。
+    if isinstance(result, int) and result != 0:
+        raise SystemExit(result)
 
 
 if __name__ == "__main__":

--- a/tests/unit/cli/test_emit.py
+++ b/tests/unit/cli/test_emit.py
@@ -1,0 +1,123 @@
+"""CLI JSONL emit ヘルパー (``lorairo.cli._emit``) の test (ADR 0057 §1/§2)。"""
+
+from __future__ import annotations
+
+import json
+import math
+
+import pytest
+
+from lorairo.cli._emit import Kind, emit_error, emit_item, emit_result
+
+
+def _last_json_line(captured: str) -> dict:
+    """capsys stdout の最終行を JSON として読む。"""
+    lines = [line for line in captured.splitlines() if line.strip()]
+    return json.loads(lines[-1])
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+def test_kind_serializes_to_stable_wire_value() -> None:
+    """StrEnum の kind は ``"item"`` 等の安定 wire 値にシリアライズされる。"""
+    assert json.dumps({"kind": Kind.ITEM}) == '{"kind": "item"}'
+    assert Kind.RESULT == "result"
+    assert Kind.ERROR == "error"
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+def test_emit_item_expands_dict(capsys: pytest.CaptureFixture[str]) -> None:
+    """dict レコードは ``kind=item`` 行に展開される。"""
+    emit_item({"image_id": 7, "file_path": "/a/b.png"})
+    line = _last_json_line(capsys.readouterr().out)
+    assert line == {"kind": "item", "image_id": 7, "file_path": "/a/b.png"}
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+def test_emit_item_uses_model_dump_json_mode(capsys: pytest.CaptureFixture[str]) -> None:
+    """Pydantic モデルは ``model_dump(mode="json")`` で展開される。"""
+
+    class _FakeModel:
+        def model_dump(self, *, mode: str = "python") -> dict:
+            assert mode == "json"
+            return {"name": "gpt4o", "score": 0.5}
+
+    emit_item(_FakeModel())
+    line = _last_json_line(capsys.readouterr().out)
+    assert line == {"kind": "item", "name": "gpt4o", "score": 0.5}
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+def test_emit_item_wraps_scalar(capsys: pytest.CaptureFixture[str]) -> None:
+    """スカラ値は ``value`` キーに包まれる。"""
+    emit_item("hello")
+    line = _last_json_line(capsys.readouterr().out)
+    assert line == {"kind": "item", "value": "hello"}
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+def test_emit_result_carries_meta(capsys: pytest.CaptureFixture[str]) -> None:
+    """``kind=result`` は ok/message + 件数メタを持つ。"""
+    emit_result("done", processed=480, total=480)
+    line = _last_json_line(capsys.readouterr().out)
+    assert line == {
+        "kind": "result",
+        "ok": True,
+        "message": "done",
+        "processed": 480,
+        "total": 480,
+    }
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+def test_emit_error_includes_flags_and_optional_fields(capsys: pytest.CaptureFixture[str]) -> None:
+    """``kind=error`` は code/flag を持ち、hint/details は任意。"""
+    emit_error(
+        "RESULT_SET_TOO_LARGE",
+        "too many",
+        retryable=False,
+        user_action_required=True,
+        hint="narrow it",
+        details={"limit": 500, "matched": 1234},
+    )
+    line = _last_json_line(capsys.readouterr().out)
+    assert line == {
+        "kind": "error",
+        "ok": False,
+        "code": "RESULT_SET_TOO_LARGE",
+        "message": "too many",
+        "retryable": False,
+        "user_action_required": True,
+        "hint": "narrow it",
+        "details": {"limit": 500, "matched": 1234},
+    }
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+def test_emit_error_omits_falsy_optional_fields(capsys: pytest.CaptureFixture[str]) -> None:
+    """hint/details が未指定なら error 行に含めない。"""
+    emit_error("INVALID_INPUT", "bad", retryable=False, user_action_required=True)
+    line = _last_json_line(capsys.readouterr().out)
+    assert "hint" not in line
+    assert "details" not in line
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+def test_emit_normalizes_non_finite_floats(capsys: pytest.CaptureFixture[str]) -> None:
+    """NaN / Infinity は None へ正規化され、行は valid JSON を保つ。"""
+    emit_item({"image_id": 1, "score": math.nan, "metric": math.inf})
+    raw = [line for line in capsys.readouterr().out.splitlines() if line.strip()][-1]
+    # 行が標準 JSON として読める (NaN/Infinity リテラルを含まない)
+    assert "NaN" not in raw
+    assert "Infinity" not in raw
+    parsed = json.loads(raw)
+    assert parsed["score"] is None
+    assert parsed["metric"] is None
+    assert parsed["image_id"] == 1

--- a/tests/unit/cli/test_errors.py
+++ b/tests/unit/cli/test_errors.py
@@ -1,0 +1,137 @@
+"""CLI 構造化エラー契約 (``lorairo.cli._errors``) の test (ADR 0057 §4/§5/§6)。"""
+
+from __future__ import annotations
+
+import pytest
+
+from lorairo.api import exceptions as app_exc
+from lorairo.cli._errors import ErrorCode, classify_exception, hint_for
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+def test_error_code_set_has_15_members() -> None:
+    """エラーコードは全 15 種 (ADR 0057 §4)。"""
+    assert len(list(ErrorCode)) == 15
+    assert ErrorCode.RESULT_SET_TOO_LARGE in set(ErrorCode)
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+@pytest.mark.parametrize(
+    ("code", "expected_exit"),
+    [
+        (ErrorCode.INVALID_INPUT, 2),
+        (ErrorCode.VALIDATION_FAILED, 2),
+        (ErrorCode.RESULT_SET_TOO_LARGE, 2),
+        (ErrorCode.NETWORK_ERROR, 1),
+        (ErrorCode.INTERNAL_ERROR, 1),
+        (ErrorCode.AUTH_ERROR, 1),
+        (ErrorCode.NOT_FOUND, 1),
+    ],
+)
+def test_exit_code_policy(code: ErrorCode, expected_exit: int) -> None:
+    """exit code は入力系 (2) と実行時 (1) で導出される (ADR 0057 §6 / 0060)。"""
+    from lorairo.cli._errors import ErrorInfo
+
+    assert ErrorInfo(code, retryable=False, user_action_required=False).exit_code == expected_exit
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+@pytest.mark.parametrize(
+    ("exc", "expected"),
+    [
+        (ValueError("bad"), ErrorCode.INVALID_INPUT),
+        (TimeoutError(), ErrorCode.TIMEOUT),
+        (FileNotFoundError("missing"), ErrorCode.IO_ERROR),
+        (KeyError("x"), ErrorCode.INTERNAL_ERROR),
+        (ConnectionError("net"), ErrorCode.NETWORK_ERROR),
+    ],
+)
+def test_classify_standard_exceptions(exc: BaseException, expected: ErrorCode) -> None:
+    """標準例外が正しいコードに分類される。"""
+    assert classify_exception(exc).code == expected
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+@pytest.mark.parametrize(
+    ("exc", "expected"),
+    [
+        (app_exc.ProjectNotFoundError("p"), ErrorCode.NOT_FOUND),
+        (app_exc.ImageNotFoundError(7), ErrorCode.NOT_FOUND),
+        (app_exc.ProjectAlreadyExistsError("p"), ErrorCode.ALREADY_EXISTS),
+        (app_exc.DuplicateImageError("a.png", 3), ErrorCode.ALREADY_EXISTS),
+        (app_exc.APIKeyNotConfiguredError("openai"), ErrorCode.AUTH_ERROR),
+        (app_exc.InvalidInputError("name", "empty"), ErrorCode.VALIDATION_FAILED),
+        (app_exc.InvalidFormatError("xyz", ["txt", "json"]), ErrorCode.INVALID_INPUT),
+        (app_exc.DatabaseConnectionError("p", "locked"), ErrorCode.DB_ERROR),
+    ],
+)
+def test_classify_lorairo_exceptions(exc: BaseException, expected: ErrorCode) -> None:
+    """LoRAIro 独自例外が正しいコードに分類される。"""
+    assert classify_exception(exc).code == expected
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+def test_classify_resource_exhausted_by_name() -> None:
+    """OOM 系 (ImageLoadMemoryError / OutOfMemoryError) は RESOURCE_EXHAUSTED。"""
+    oom = type("ImageLoadMemoryError", (RuntimeError,), {})("fatal")
+    assert classify_exception(oom).code == ErrorCode.RESOURCE_EXHAUSTED
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+def test_classify_resource_exhausted_by_runtime_message() -> None:
+    """``RuntimeError('... out of memory ...')`` は RESOURCE_EXHAUSTED。"""
+    assert classify_exception(RuntimeError("CUDA out of memory")).code == ErrorCode.RESOURCE_EXHAUSTED
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+def test_classify_walks_cause_chain_for_true_cause() -> None:
+    """wrap された真因 (API キー未設定) を cause-chain で拾い AUTH_ERROR にする。"""
+    try:
+        try:
+            raise app_exc.APIKeyNotConfiguredError("claude")
+        except app_exc.APIKeyNotConfiguredError as cause:
+            raise app_exc.AnnotationFailedError("m", 5, "wrapped") from cause
+    except app_exc.AnnotationFailedError as exc:
+        assert classify_exception(exc).code == ErrorCode.AUTH_ERROR
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+def test_classify_sdk_auth_and_rate_by_module() -> None:
+    """プロバイダ SDK の AuthenticationError / RateLimitError を module で分類する。"""
+    auth = type("AuthenticationError", (Exception,), {"__module__": "openai"})("401")
+    rate = type("RateLimitError", (Exception,), {"__module__": "anthropic"})("429")
+    assert classify_exception(auth).code == ErrorCode.AUTH_ERROR
+    assert classify_exception(rate).code == ErrorCode.RATE_LIMITED
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+def test_classify_sqlalchemy_by_module() -> None:
+    """sqlalchemy 由来の例外は DB_ERROR (eager import せず module で判定)。"""
+    db = type("OperationalError", (Exception,), {"__module__": "sqlalchemy.exc"})("locked")
+    assert classify_exception(db).code == ErrorCode.DB_ERROR
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+def test_classify_pydantic_validation_before_value_error() -> None:
+    """Pydantic ValidationError は ValueError subclass だが VALIDATION_FAILED にする。"""
+    pyd = type("ValidationError", (ValueError,), {"__module__": "pydantic"})("invalid")
+    assert classify_exception(pyd).code == ErrorCode.VALIDATION_FAILED
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+def test_hint_for_known_codes() -> None:
+    """対処ヒントが定義済みコードに返り、未定義には None。"""
+    assert hint_for(ErrorCode.RESULT_SET_TOO_LARGE) is not None
+    assert hint_for(ErrorCode.AUTH_ERROR) is not None
+    assert hint_for(ErrorCode.INTERNAL_ERROR) is None

--- a/tests/unit/cli/test_main_error_boundary.py
+++ b/tests/unit/cli/test_main_error_boundary.py
@@ -1,0 +1,74 @@
+"""CLI 中央エラー境界 (``lorairo.cli.main``) の test (ADR 0057 §6/§7)。"""
+
+from __future__ import annotations
+
+import json
+
+import click
+import pytest
+
+from lorairo.api import exceptions as app_exc
+from lorairo.cli.main import _handle_cli_exception, _handle_click_exception
+
+
+def _stdout_error_line(captured: str) -> dict:
+    lines = [line for line in captured.splitlines() if line.strip()]
+    return json.loads(lines[-1])
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+def test_handle_cli_exception_value_error_json(capsys: pytest.CaptureFixture[str]) -> None:
+    """ValueError → INVALID_INPUT 行 + exit 2 (JSONL モード)。"""
+    exit_code = _handle_cli_exception(ValueError("bad arg"), json_mode=True)
+    line = _stdout_error_line(capsys.readouterr().out)
+    assert exit_code == 2
+    assert line["kind"] == "error"
+    assert line["code"] == "INVALID_INPUT"
+    assert line["ok"] is False
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+def test_handle_cli_exception_not_found_returns_exit_1(capsys: pytest.CaptureFixture[str]) -> None:
+    """ProjectNotFoundError → NOT_FOUND 行 + exit 1。"""
+    exit_code = _handle_cli_exception(app_exc.ProjectNotFoundError("p"), json_mode=True)
+    line = _stdout_error_line(capsys.readouterr().out)
+    assert exit_code == 1
+    assert line["code"] == "NOT_FOUND"
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+def test_handle_cli_exception_internal_writes_traceback(capsys: pytest.CaptureFixture[str]) -> None:
+    """INTERNAL_ERROR のみ stderr に traceback、stdout は JSONL 行のみ。"""
+    try:
+        raise KeyError("boom")
+    except KeyError as exc:
+        exit_code = _handle_cli_exception(exc, json_mode=True)
+    captured = capsys.readouterr()
+    line = _stdout_error_line(captured.out)
+    assert exit_code == 1
+    assert line["code"] == "INTERNAL_ERROR"
+    assert "Traceback" in captured.err
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+def test_handle_click_exception_maps_to_invalid_input(capsys: pytest.CaptureFixture[str]) -> None:
+    """Click usage error → INVALID_INPUT 行 + exit 2。"""
+    exit_code = _handle_click_exception(click.UsageError("no such option"), json_mode=True)
+    line = _stdout_error_line(capsys.readouterr().out)
+    assert exit_code == 2
+    assert line["code"] == "INVALID_INPUT"
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+def test_handle_cli_exception_rich_mode_keeps_stdout_clean(capsys: pytest.CaptureFixture[str]) -> None:
+    """rich モードでは stdout に JSON を出さず、エラーは stderr へ。"""
+    exit_code = _handle_cli_exception(ValueError("bad"), json_mode=False)
+    captured = capsys.readouterr()
+    assert exit_code == 2
+    assert captured.out.strip() == ""
+    assert "Error" in captured.err

--- a/tests/unit/cli/test_output_mode.py
+++ b/tests/unit/cli/test_output_mode.py
@@ -1,0 +1,49 @@
+"""CLI 出力モード解決 (``lorairo.cli._output_mode``) の test (ADR 0058 §1)。"""
+
+from __future__ import annotations
+
+import pytest
+
+from lorairo.cli._output_mode import is_json_mode, resolve_output_mode, set_json_mode
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+@pytest.mark.parametrize(
+    ("argv", "env", "expected"),
+    [
+        # 明示フラグ
+        (["--json"], {}, True),
+        (["--no-json"], {}, False),
+        # 既定 rich
+        ([], {}, False),
+        # env のみ
+        ([], {"LORAIRO_CLI_JSON": "1"}, True),
+        ([], {"LORAIRO_CLI_JSON": "0"}, False),
+        ([], {"LORAIRO_CLI_JSON": "false"}, False),
+        ([], {"LORAIRO_CLI_JSON": ""}, False),
+        # 明示フラグ > env
+        (["--no-json"], {"LORAIRO_CLI_JSON": "1"}, False),
+        (["--json"], {"LORAIRO_CLI_JSON": "0"}, True),
+        # 位置非依存 (サブコマンド後でも受理)
+        (["images", "list", "--json"], {}, True),
+        # 後勝ち
+        (["--json", "--no-json"], {}, False),
+        (["--no-json", "--json"], {}, True),
+        # ``--`` 以降は走査しない
+        (["--", "--json"], {}, False),
+    ],
+)
+def test_resolve_output_mode(argv: list[str], env: dict[str, str], expected: bool) -> None:
+    """解決順序は「明示フラグ > env > 既定 rich」。"""
+    assert resolve_output_mode(argv, env) is expected
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+def test_set_and_is_json_mode_roundtrip() -> None:
+    """解決済みモードの保存/参照が往復する。"""
+    set_json_mode(True)
+    assert is_json_mode() is True
+    set_json_mode(False)
+    assert is_json_mode() is False


### PR DESCRIPTION
## 概要

エピック #634 の実装フェーズ第一弾。ADR 0057 (JSONL/error 契約) / ADR 0058 (出力モード) が確定したので、CLI agent-friendly 契約の**共通基盤**を実装する。各コマンドの JSONL 移行・introspection・pagination 適用 (#641) が乗る emit / error / mode レイヤー。**本 PR は基盤のみで既存コマンドの出力は未変更**。

実装は sibling `genai-tag-db-tools` の動く参照実装 (`cli.py` / `errors.py`) を移植 + LoRAIro 固有差分。

## 変更

| ファイル | 内容 |
|---|---|
| `cli/_emit.py` (新規) | `Kind` StrEnum (`item`/`result`/`error` の3種、進捗 `event` 不採用)。単一 `_emit` (`ensure_ascii=False` / `allow_nan=False` + NaN・Infinity を None 正規化 / `default=str`)。`emit_item`(`model_dump(mode="json")`) / `emit_result` / `emit_error` |
| `cli/_errors.py` (新規) | `ErrorCode` StrEnum **全15種**、`ErrorInfo` (+ `exit_code` 0/2/1)、`classify_exception` (cause-chain walking + module-prefix matching で torch/推論SDK を eager import せず分類)。LoRAIro 独自例外 (`APIKeyNotConfiguredError`→`AUTH_ERROR` 等) と SDK auth/rate/OOM の拡張分類 |
| `cli/_output_mode.py` (新規) | tri-state `--json`/`--no-json` + `LORAIRO_CLI_JSON` env。Click パース前の位置非依存 prescan (解決順: 明示フラグ > env > 既定 rich) |
| `cli/main.py` (改修) | 中央エラー境界 (`standalone_mode=False`、usage error→`INVALID_INPUT` exit2、他例外→classify→emit_error→exit、`INTERNAL_ERROR` のみ stderr traceback、rich/JSONL 分岐をこの1箇所に集約) |
| `tests/unit/cli/test_{emit,errors,output_mode,main_error_boundary}.py` (新規) | 55 unit tests |

## ADR 準拠

- ADR 0057 §1 (stdout=JSONL/StrEnum wire値) / §2 (kind 3種) / §4 (15エラーコード+flag) / §5 (classify_exception) / §6 (exit 0/2/1) / §7 (中央境界)
- ADR 0058 §1 (出力モードトリガ + Click パース前解決)

## 検証

- 新規 **55 unit tests** pass
- CI-equivalent filter (`-m "not gui_show and not calls_real_webapi and not downloads_and_runs_model and not slow"`) を repo root から実行 → **3888 passed**
- `ruff format` / `ruff check` / `mypy` (新規モジュール) pass

### ⚠️ 既存 main 破損 (本PR起因ではない)

CI の `tests/unit/test_hook_pre_commands.py` (3件) と `tests/unit/scripts/test_run_runtime_webapi_tests.py` (1件) は **main HEAD `9550e427` 起因の既存失敗** (worktree 配置変更の tooling chore で hook テスト期待値が未追従)。main CI も `9550e427` で赤転 (直前の `9ba5117b`/`8a3f40a2` は緑)。本 PR (cli/ のみ) とは無関係で、pristine main checkout でも再現する。

Closes #640

🤖 Generated with [Claude Code](https://claude.com/claude-code)