### PR TITLE
feat: CLI 出力境界 + 5コマンドの JSONL 移行 (#641 PR-A)

### DIFF
--- a/src/lorairo/cli/_boundary.py
+++ b/src/lorairo/cli/_boundary.py
@@ -19,15 +19,30 @@ from __future__ import annotations
 from collections.abc import Iterator
 from contextlib import contextmanager
 
+import click
 import typer
 
 from lorairo.cli._console import make_console
 from lorairo.cli._emit import emit_error
-from lorairo.cli._errors import classify_exception, hint_for
+from lorairo.cli._errors import ErrorCode, ErrorInfo, classify_exception, hint_for
 from lorairo.cli._output_mode import is_json_mode
 
 # エラー/装飾は stderr へ (stdout は機械可読 JSONL 専用、ADR 0057 §1)。
 _console_err = make_console(stderr=True)
+
+
+def _report(message: str, info: ErrorInfo) -> None:
+    """分類結果を出力モードに応じて出す (JSONL or rich/stderr)。"""
+    if is_json_mode():
+        emit_error(
+            info.code,
+            message,
+            retryable=info.retryable,
+            user_action_required=info.user_action_required,
+            hint=hint_for(info.code),
+        )
+    else:
+        _console_err.print(f"[red]Error:[/red] {message}")
 
 
 @contextmanager
@@ -48,17 +63,15 @@ def command_boundary() -> Iterator[None]:
         yield
     except (typer.Exit, typer.Abort):
         raise
+    except click.ClickException as exc:
+        # コマンド本体内で送出された usage / parameter エラー (例: click.UsageError) は
+        # 入力エラーとして INVALID_INPUT + exit 2 に統一する (ADR 0057 §6/§7)。
+        info = ErrorInfo(ErrorCode.INVALID_INPUT, retryable=False, user_action_required=True)
+        message = exc.format_message() if hasattr(exc, "format_message") else str(exc)
+        _report(message, info)
+        raise typer.Exit(code=info.exit_code) from exc
     except Exception as exc:
         info = classify_exception(exc)
         message = str(exc) or type(exc).__name__
-        if is_json_mode():
-            emit_error(
-                info.code,
-                message,
-                retryable=info.retryable,
-                user_action_required=info.user_action_required,
-                hint=hint_for(info.code),
-            )
-        else:
-            _console_err.print(f"[red]Error:[/red] {message}")
+        _report(message, info)
         raise typer.Exit(code=info.exit_code) from exc

--- a/src/lorairo/cli/_boundary.py
+++ b/src/lorairo/cli/_boundary.py
@@ -1,0 +1,64 @@
+"""コマンド本体を包む構造化エラー境界 (ADR 0057 §5/§6/§7)。
+
+各コマンドに散在していた ``except ... -> console.print("[red]Error") -> typer.Exit``
+を撤廃し、エラー整形を単一の :func:`command_boundary` に集約する。コマンド本体は
+型付き例外を raise / 伝播するだけにし、本境界が:
+
+1. :func:`lorairo.cli._errors.classify_exception` で安定コードへ分類し、
+2. JSONL モードなら :func:`lorairo.cli._emit.emit_error`、rich モードなら stderr に
+   人間向けエラーを出し (stdout の JSONL 純度を保つ)、
+3. :class:`typer.Exit` を分類由来の exit code (0/2/1) で送出する。
+
+``main:main`` の最上位境界 (ADR 0057 §7) と整合する: ``main`` 経由でも CliRunner 経由
+でも同一の整形ロジックが 1 箇所で適用される (``main`` 境界は本境界をすり抜けた想定外
+例外の安全網として残る)。
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+
+import typer
+
+from lorairo.cli._console import make_console
+from lorairo.cli._emit import emit_error
+from lorairo.cli._errors import classify_exception, hint_for
+from lorairo.cli._output_mode import is_json_mode
+
+# エラー/装飾は stderr へ (stdout は機械可読 JSONL 専用、ADR 0057 §1)。
+_console_err = make_console(stderr=True)
+
+
+@contextmanager
+def command_boundary() -> Iterator[None]:
+    """コマンド本体を包み、伝播した例外を構造化エラー + exit code に写す。
+
+    ``typer.Exit`` / ``typer.Abort`` (コマンドが意図的に送出する正常な制御フロー) は
+    そのまま素通しする。それ以外の例外は分類し、出力モードに応じて整形してから
+    分類由来の exit code で ``typer.Exit`` を送出する。
+
+    Yields:
+        None: ``with`` ブロック内でコマンド本体を実行する。
+
+    Raises:
+        typer.Exit: 例外発生時、分類コードの exit code で送出する。
+    """
+    try:
+        yield
+    except (typer.Exit, typer.Abort):
+        raise
+    except Exception as exc:
+        info = classify_exception(exc)
+        message = str(exc) or type(exc).__name__
+        if is_json_mode():
+            emit_error(
+                info.code,
+                message,
+                retryable=info.retryable,
+                user_action_required=info.user_action_required,
+                hint=hint_for(info.code),
+            )
+        else:
+            _console_err.print(f"[red]Error:[/red] {message}")
+        raise typer.Exit(code=info.exit_code) from exc

--- a/src/lorairo/cli/_output_mode.py
+++ b/src/lorairo/cli/_output_mode.py
@@ -75,6 +75,33 @@ def resolve_output_mode(argv: Sequence[str] | None = None, env: Mapping[str, str
     return _env_enables_json(environ)
 
 
+def strip_mode_flags(argv: Sequence[str]) -> list[str]:
+    """argv から ``--json`` / ``--no-json`` を除去する (``--`` 以降は保持)。
+
+    モードは :func:`resolve_output_mode` が prescan 済みのため、Click パース前に
+    これらを取り除くことでサブコマンド後位置 (例: ``images list --json``) でも
+    "no such option" にならず受理できる (ADR 0058 §1 の位置非依存を実現)。
+
+    Args:
+        argv: プログラム名を除いた引数列。
+
+    Returns:
+        モードフラグを除いた引数列。
+    """
+    stripped: list[str] = []
+    passthrough = False
+    for token in argv:
+        if passthrough:
+            stripped.append(token)
+            continue
+        if token == "--":
+            passthrough = True
+            stripped.append(token)
+        elif token not in (_JSON_FLAG, _NO_JSON_FLAG):
+            stripped.append(token)
+    return stripped
+
+
 def set_json_mode(value: bool) -> None:
     """解決済みの出力モードを保存する (中央境界が呼ぶ)。"""
     global _json_mode

--- a/src/lorairo/cli/commands/batch.py
+++ b/src/lorairo/cli/commands/batch.py
@@ -1,4 +1,9 @@
-"""Provider Batch commands."""
+"""Provider Batch commands.
+
+出力は ADR 0057/0058 に従う: ``--json`` 時は stdout に JSONL (item/result)、
+それ以外は rich 人間向け。エラー整形は :func:`lorairo.cli._boundary.command_boundary`
+に集約し、検証エラーは ``click.UsageError`` (INVALID_INPUT / exit 2) で送出する。
+"""
 
 from __future__ import annotations
 
@@ -7,13 +12,15 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any
 
+import click
 import typer
 from rich.table import Table
 
+from lorairo.cli._boundary import command_boundary
 from lorairo.cli._console import make_console
-from lorairo.services.provider_batch_service import ProviderBatchError
+from lorairo.cli._emit import emit_item, emit_result
+from lorairo.cli._output_mode import is_json_mode
 from lorairo.services.service_container import get_service_container
-from lorairo.utils.log import logger
 
 app = typer.Typer(help="Provider Batch API job commands")
 console = make_console()
@@ -29,6 +36,27 @@ _TASK_TYPE_ENDPOINTS = {
         "openai": "/v1/moderations",
     },
 }
+
+# _print_job_detail / json 出力共通の job フィールド。
+_JOB_DETAIL_FIELDS = (
+    "id",
+    "provider",
+    "provider_job_id",
+    "status",
+    "provider_status",
+    "endpoint",
+    "model_id",
+    "request_count",
+    "succeeded_count",
+    "failed_count",
+    "canceled_count",
+    "expired_count",
+    "submitted_at",
+    "completed_at",
+    "canceled_at",
+    "expires_at",
+    "imported_at",
+)
 
 
 def _activate_project(project: str) -> Any:
@@ -49,14 +77,11 @@ def _resolve_model(repository: Any, identifier: str) -> Any:
         candidates = "\n".join(
             f"  - {model.litellm_model_id} (provider: {model.provider or 'unknown'})" for model in by_name
         )
-        console.print(
-            f"[red]Error:[/red] Ambiguous model '{identifier}':\n"
-            f"{candidates}\nUse the full LiteLLM model ID."
+        raise click.UsageError(
+            f"Ambiguous model '{identifier}':\n{candidates}\nUse the full LiteLLM model ID."
         )
-        raise typer.Exit(code=1)
 
-    console.print(f"[red]Error:[/red] Unknown model '{identifier}'. Run `lorairo-cli models list`.")
-    raise typer.Exit(code=1)
+    raise click.UsageError(f"Unknown model '{identifier}'. Run `lorairo-cli models list`.")
 
 
 def _infer_provider(model: Any, explicit_provider: str | None) -> str:
@@ -71,23 +96,19 @@ def _infer_provider(model: Any, explicit_provider: str | None) -> str:
     if provider in {"openai", "anthropic", "google"}:
         return provider
 
-    console.print(
-        f"[red]Error:[/red] Could not infer a direct Provider Batch provider for "
-        f"{litellm_model_id!r}. Use a direct openai/... or anthropic/... model."
+    raise click.UsageError(
+        f"Could not infer a direct Provider Batch provider for {litellm_model_id!r}. "
+        "Use a direct openai/... or anthropic/... model."
     )
-    raise typer.Exit(code=1)
 
 
 def _validate_submit_provider(provider: str) -> None:
     if provider == "google":
-        console.print("[red]Error:[/red] Google Provider Batch submit is disabled until Phase 3.")
-        raise typer.Exit(code=1)
+        raise click.UsageError("Google Provider Batch submit is disabled until Phase 3.")
     if provider not in _SUPPORTED_SUBMIT_PROVIDERS:
-        console.print(
-            f"[red]Error:[/red] Unsupported Provider Batch provider '{provider}'. "
-            "Supported providers: openai, anthropic."
+        raise click.UsageError(
+            f"Unsupported Provider Batch provider '{provider}'. Supported providers: openai, anthropic."
         )
-        raise typer.Exit(code=1)
 
 
 def _model_has_model_type(model: Any, model_type: str) -> bool:
@@ -99,17 +120,13 @@ def _resolve_submit_endpoint(provider: str, task_type: str, endpoint: str | None
     provider_endpoints = _TASK_TYPE_ENDPOINTS.get(task_type, _TASK_TYPE_ENDPOINTS["annotation"])
     expected_endpoint = provider_endpoints.get(provider)
     if expected_endpoint is None:
-        console.print(
-            f"[red]Error:[/red] Task type '{task_type}' is not supported for provider '{provider}'."
-        )
-        raise typer.Exit(code=1)
+        raise click.UsageError(f"Task type '{task_type}' is not supported for provider '{provider}'.")
     if endpoint is None:
         return expected_endpoint
     if task_type == "rating_preflight":
         normalized_endpoint = endpoint if endpoint.startswith("/") else f"/{endpoint}"
         if normalized_endpoint.rstrip("/") != expected_endpoint:
-            console.print("[red]Error:[/red] rating_preflight submit requires endpoint /v1/moderations.")
-            raise typer.Exit(code=1)
+            raise click.UsageError("rating_preflight submit requires endpoint /v1/moderations.")
         return expected_endpoint
     return endpoint
 
@@ -124,6 +141,11 @@ def _format_dt(value: Any) -> str:
     if isinstance(value, datetime):
         return value.isoformat()
     return "" if value is None else str(value)
+
+
+def _job_dict(job: Any) -> dict[str, Any]:
+    """job を JSONL item/result 用の dict に変換する (datetime は emit が文字列化)。"""
+    return {field: _job_value(job, field) for field in _JOB_DETAIL_FIELDS}
 
 
 def _result_item_status(item: Any) -> str:
@@ -170,25 +192,7 @@ def _print_job_detail(job: Any) -> None:
     table.add_column("Field", style="cyan")
     table.add_column("Value", style="green")
 
-    for field in (
-        "id",
-        "provider",
-        "provider_job_id",
-        "status",
-        "provider_status",
-        "endpoint",
-        "model_id",
-        "request_count",
-        "succeeded_count",
-        "failed_count",
-        "canceled_count",
-        "expired_count",
-        "submitted_at",
-        "completed_at",
-        "canceled_at",
-        "expires_at",
-        "imported_at",
-    ):
+    for field in _JOB_DETAIL_FIELDS:
         table.add_row(field, _format_dt(_job_value(job, field)))
     console.print(table)
 
@@ -212,6 +216,19 @@ def _print_artifacts(fetch_result: Any) -> None:
     console.print(table)
 
 
+def _artifact_dicts(fetch_result: Any) -> list[dict[str, Any]]:
+    """artifacts を JSONL result 用の dict リストに変換する。"""
+    artifacts = list(getattr(fetch_result, "artifacts", ()) or ())
+    return [
+        {
+            "artifact_type": str(getattr(artifact, "artifact_type", "")),
+            "local_path": str(getattr(artifact, "local_path", "")),
+            "provider_file_id": getattr(artifact, "provider_file_id", None),
+        }
+        for artifact in artifacts
+    ]
+
+
 @app.command("submit")
 def submit(
     project: str = typer.Option(..., "--project", "-p", help="Project name"),
@@ -231,7 +248,7 @@ def submit(
     ),
 ) -> None:
     """Submit registered images to a Provider Batch API job."""
-    try:
+    with command_boundary():
         container = _activate_project(project)
         model_repo = container.db_manager.model_repo
         provider_batch_repo = container.db_manager.provider_batch_repo
@@ -240,21 +257,17 @@ def submit(
         _validate_submit_provider(resolved_provider)
         normalized_task_type = task_type.strip().lower()
         if normalized_task_type not in _SUPPORTED_TASK_TYPES:
-            console.print(f"[red]Error:[/red] Unsupported task type '{task_type}'.")
-            raise typer.Exit(code=1)
+            raise click.UsageError(f"Unsupported task type '{task_type}'.")
         if normalized_task_type == "rating_preflight":
             if resolved_provider != "openai":
-                console.print(
-                    "[red]Error:[/red] rating_preflight submit is only supported for direct openai "
-                    "models such as openai/omni-moderation-latest."
+                raise click.UsageError(
+                    "rating_preflight submit is only supported for direct openai models "
+                    "such as openai/omni-moderation-latest."
                 )
-                raise typer.Exit(code=1)
             if not _model_has_model_type(db_model, "ratings"):
-                console.print(
-                    "[red]Error:[/red] rating_preflight submit requires a ratings model_type "
-                    "using openai/omni-moderation-*."
+                raise click.UsageError(
+                    "rating_preflight submit requires a ratings model_type using openai/omni-moderation-*."
                 )
-                raise typer.Exit(code=1)
 
         resolved_endpoint = _resolve_submit_endpoint(resolved_provider, normalized_task_type, endpoint)
 
@@ -269,18 +282,16 @@ def submit(
             task_type=normalized_task_type,
         )
         job = provider_batch_repo.get_provider_batch_job(job_id)
-        console.print(f"[green]Provider Batch job submitted:[/green] {job_id}")
-        if job is not None:
-            _print_job_detail(job)
-    except typer.Exit:
-        raise
-    except ProviderBatchError as e:
-        console.print(f"[red]Error:[/red] {e}")
-        raise typer.Exit(code=1) from e
-    except Exception as e:
-        console.print(f"[red]Error:[/red] {e}")
-        logger.error(f"Provider Batch submit failed: {e}", exc_info=True)
-        raise typer.Exit(code=2) from e
+        if is_json_mode():
+            emit_result(
+                f"Provider Batch job submitted: {job_id}",
+                job_id=job_id,
+                job=_job_dict(job) if job is not None else None,
+            )
+        else:
+            console.print(f"[green]Provider Batch job submitted:[/green] {job_id}")
+            if job is not None:
+                _print_job_detail(job)
 
 
 @app.command("list")
@@ -292,7 +303,7 @@ def list_jobs(
     offset: int = typer.Option(0, "--offset", min=0, help="Rows to skip"),
 ) -> None:
     """List persisted Provider Batch jobs."""
-    try:
+    with command_boundary():
         container = _activate_project(project)
         jobs = container.db_manager.provider_batch_repo.list_provider_batch_jobs(
             provider=provider,
@@ -300,11 +311,12 @@ def list_jobs(
             limit=limit,
             offset=offset,
         )
-        _print_jobs_table(jobs)
-    except Exception as e:
-        console.print(f"[red]Error:[/red] {e}")
-        logger.error(f"Provider Batch list failed: {e}", exc_info=True)
-        raise typer.Exit(code=2) from e
+        if is_json_mode():
+            for job in jobs:
+                emit_item(_job_dict(job))
+            emit_result(f"{len(jobs)} job(s)", count=len(jobs))
+        else:
+            _print_jobs_table(jobs)
 
 
 @app.command("status")
@@ -314,7 +326,7 @@ def status(
     refresh: bool = typer.Option(True, "--refresh/--no-refresh", help="Refresh provider status first"),
 ) -> None:
     """Show Provider Batch job status."""
-    try:
+    with command_boundary():
         container = _activate_project(project)
         job = (
             container.provider_batch_workflow_service.refresh(job_id)
@@ -322,18 +334,11 @@ def status(
             else container.db_manager.provider_batch_repo.get_provider_batch_job(job_id)
         )
         if job is None:
-            console.print(f"[red]Error:[/red] Provider Batch job not found: {job_id}")
-            raise typer.Exit(code=1)
-        _print_job_detail(job)
-    except typer.Exit:
-        raise
-    except ProviderBatchError as e:
-        console.print(f"[red]Error:[/red] {e}")
-        raise typer.Exit(code=1) from e
-    except Exception as e:
-        console.print(f"[red]Error:[/red] {e}")
-        logger.error(f"Provider Batch status failed: {e}", exc_info=True)
-        raise typer.Exit(code=2) from e
+            raise click.UsageError(f"Provider Batch job not found: {job_id}")
+        if is_json_mode():
+            emit_result(f"Provider Batch job {job_id}", job=_job_dict(job))
+        else:
+            _print_job_detail(job)
 
 
 @app.command("cancel")
@@ -342,18 +347,18 @@ def cancel(
     project: str = typer.Option(..., "--project", "-p", help="Project name"),
 ) -> None:
     """Cancel a Provider Batch job."""
-    try:
+    with command_boundary():
         container = _activate_project(project)
         job = container.provider_batch_workflow_service.cancel(job_id)
-        console.print(f"[green]Provider Batch job cancel requested:[/green] {job_id}")
-        _print_job_detail(job)
-    except ProviderBatchError as e:
-        console.print(f"[red]Error:[/red] {e}")
-        raise typer.Exit(code=1) from e
-    except Exception as e:
-        console.print(f"[red]Error:[/red] {e}")
-        logger.error(f"Provider Batch cancel failed: {e}", exc_info=True)
-        raise typer.Exit(code=2) from e
+        if is_json_mode():
+            emit_result(
+                f"Provider Batch job cancel requested: {job_id}",
+                job_id=job_id,
+                job=_job_dict(job) if job is not None else None,
+            )
+        else:
+            console.print(f"[green]Provider Batch job cancel requested:[/green] {job_id}")
+            _print_job_detail(job)
 
 
 @app.command("fetch")
@@ -363,23 +368,27 @@ def fetch(
     output_dir: Path | None = typer.Option(None, "--output-dir", "-o", help="Artifact output directory"),
 ) -> None:
     """Fetch normalized Provider Batch results and artifacts."""
-    try:
+    with command_boundary():
         container = _activate_project(project)
         result = container.provider_batch_workflow_service.fetch_results(job_id, output_dir)
         succeeded_count, failed_count = _summarize_fetch_counts(result)
-        console.print(f"[green]Provider Batch results fetched:[/green] {job_id}")
-        console.print(
-            f"[dim]provider_status={result.provider_status}, items={len(result.items)}, "
-            f"succeeded={succeeded_count}, failed={failed_count}[/dim]"
-        )
-        _print_artifacts(result)
-    except ProviderBatchError as e:
-        console.print(f"[red]Error:[/red] {e}")
-        raise typer.Exit(code=1) from e
-    except Exception as e:
-        console.print(f"[red]Error:[/red] {e}")
-        logger.error(f"Provider Batch fetch failed: {e}", exc_info=True)
-        raise typer.Exit(code=2) from e
+        if is_json_mode():
+            emit_result(
+                f"Provider Batch results fetched: {job_id}",
+                job_id=job_id,
+                provider_status=result.provider_status,
+                items=len(result.items),
+                succeeded=succeeded_count,
+                failed=failed_count,
+                artifacts=_artifact_dicts(result),
+            )
+        else:
+            console.print(f"[green]Provider Batch results fetched:[/green] {job_id}")
+            console.print(
+                f"[dim]provider_status={result.provider_status}, items={len(result.items)}, "
+                f"succeeded={succeeded_count}, failed={failed_count}[/dim]"
+            )
+            _print_artifacts(result)
 
 
 @app.command("import")
@@ -389,24 +398,28 @@ def import_results(
     output_dir: Path | None = typer.Option(None, "--output-dir", "-o", help="Artifact output directory"),
 ) -> None:
     """Fetch and import Provider Batch results into annotations."""
-    try:
+    with command_boundary():
         container = _activate_project(project)
         result = container.provider_batch_workflow_service.import_results(
             job_id, destination_dir=output_dir
         )
-        table = Table(title="Provider Batch Import Summary")
-        table.add_column("Metric", style="cyan")
-        table.add_column("Value", style="green")
-        table.add_row("Imported", str(result.imported_count))
-        table.add_row("Skipped", str(result.skipped_count))
-        table.add_row("Errors", str(result.error_count))
-        table.add_row("Total", str(result.total_count))
-        table.add_row("Job Imported", "yes" if result.job_imported else "no")
-        console.print(table)
-    except ProviderBatchError as e:
-        console.print(f"[red]Error:[/red] {e}")
-        raise typer.Exit(code=1) from e
-    except Exception as e:
-        console.print(f"[red]Error:[/red] {e}")
-        logger.error(f"Provider Batch import failed: {e}", exc_info=True)
-        raise typer.Exit(code=2) from e
+        if is_json_mode():
+            emit_result(
+                f"Provider Batch results imported: {job_id}",
+                job_id=job_id,
+                imported=result.imported_count,
+                skipped=result.skipped_count,
+                errors=result.error_count,
+                total=result.total_count,
+                job_imported=result.job_imported,
+            )
+        else:
+            table = Table(title="Provider Batch Import Summary")
+            table.add_column("Metric", style="cyan")
+            table.add_column("Value", style="green")
+            table.add_row("Imported", str(result.imported_count))
+            table.add_row("Skipped", str(result.skipped_count))
+            table.add_row("Errors", str(result.error_count))
+            table.add_row("Total", str(result.total_count))
+            table.add_row("Job Imported", "yes" if result.job_imported else "no")
+            console.print(table)

--- a/src/lorairo/cli/commands/export.py
+++ b/src/lorairo/cli/commands/export.py
@@ -8,17 +8,15 @@ from pathlib import Path
 
 import click
 import typer
-from rich.progress import BarColumn, Progress, SpinnerColumn, TextColumn, TimeRemainingColumn
 from rich.table import Table
 
-from lorairo.api.exceptions import (
-    ProjectNotFoundError,
-)
 from lorairo.api.project import get_project as api_get_project
+from lorairo.cli._boundary import command_boundary
 from lorairo.cli._console import make_console
+from lorairo.cli._emit import emit_result
+from lorairo.cli._output_mode import is_json_mode
 from lorairo.database.filter_criteria import ImageFilterCriteria
 from lorairo.services.service_container import get_service_container
-from lorairo.utils.log import logger
 
 # サブコマンドアプリ定義
 app = typer.Typer(help="Dataset export commands")
@@ -244,15 +242,11 @@ def create(
         lorairo-cli export create --project myproject --tags "cat,dog" --manual-rating PG --output /tmp/out
         lorairo-cli export create --project myproject --score-min 6.0 --output /tmp/out --format json
     """
-    try:
-        # API層経由でプロジェクト確認
-        try:
-            api_get_project(project)
-        except ProjectNotFoundError as e:
-            console.print(f"[red]Error:[/red] Project not found: {project}")
-            raise typer.Exit(code=1) from e
+    with command_boundary():
+        # API層経由でプロジェクト確認 (未存在は ProjectNotFoundError → NOT_FOUND で伝播)
+        api_get_project(project)
 
-        # スコア範囲・順序検証（_apply_score_filter に渡す前に拒否）
+        # スコア範囲・順序検証 (click.UsageError → 境界が INVALID_INPUT exit 2)
         _validate_score_bounds(score_min, score_max)
 
         # フィルタ条件を構築（CSV分割・空白除去・空要素除外を含む正規化はここで完結）
@@ -271,13 +265,11 @@ def create(
         # 正規化後のフィルタ条件で判定する（--tags "," や "   " が repository に
         # 到達する時点では空リスト/空値となるため、検証もこの段階で行う必要がある）
         if not _criteria_has_effective_filter(criteria):
-            console.print(
-                "[red]Error:[/red] At least one filter condition is required for export.\n"
-                "エクスポートには最低1つのフィルタ条件が必要です"
+            raise click.UsageError(
+                "At least one filter condition is required for export "
+                "(--tags / --caption / --manual-rating / --ai-rating / --score-min / --score-max).\n"
+                "エクスポートには最低1つのフィルタ条件が必要です。"
             )
-            console.print("Example: lorairo-cli export create --project foo --tags cat --output /tmp/out")
-            console.print("詳細: lorairo-cli export create --help")
-            raise typer.Exit(code=2)
 
         # ServiceContainer を取得してプロジェクト DB に切り替え
         container = get_service_container()
@@ -285,91 +277,59 @@ def create(
         repository = container.db_manager.image_repo
         export_service = container.dataset_export_service
 
-        console.print(f"[cyan]Loading project database: {project}[/cyan]")
+        rich = not is_json_mode()
+        if rich:
+            console.print(f"[cyan]Loading project database: {project}[/cyan]")
 
         # フィルタ条件を適用して画像を取得
-        with Progress(
-            SpinnerColumn(),
-            TextColumn("[progress.description]{task.description}"),
-            BarColumn(),
-            TextColumn("[progress.percentage]{task.percentage:>3.1f}%"),
-            TimeRemainingColumn(),
-            console=console,
-        ) as progress:
-            task = progress.add_task("Fetching images...", total=None)
-
-            all_images, _ = repository.get_images_by_filter(criteria)
-            image_ids = [img["id"] for img in all_images] if all_images else []
-
-            progress.update(task, completed=1)
+        all_images, _ = repository.get_images_by_filter(criteria)
+        image_ids = [img["id"] for img in all_images] if all_images else []
 
         if not image_ids:
-            console.print(f"[yellow]Warning:[/yellow] No images found in project: {project}")
-            raise typer.Exit(code=0)
+            # 該当なしは成功扱い (exit 0)
+            if is_json_mode():
+                emit_result(f"No images found in project: {project}", count=0)
+            else:
+                console.print(f"[yellow]Warning:[/yellow] No images found in project: {project}")
+            return
 
-        console.print(f"[cyan]Found {len(image_ids)} image(s)[/cyan]")
-        console.print(f"[cyan]Export format: {format}[/cyan]")
-        console.print(f"[cyan]Target resolution: {resolution}px[/cyan]")
+        if rich:
+            console.print(f"[cyan]Found {len(image_ids)} image(s)[/cyan]")
+            console.print(f"[cyan]Export format: {format}[/cyan]")
+            console.print(f"[cyan]Target resolution: {resolution}px[/cyan]")
 
         # 出力ディレクトリの作成
         output_path = Path(output)
         output_path.mkdir(parents=True, exist_ok=True)
 
-        # データセット エクスポート実行
-        console.print("[cyan]Starting export...[/cyan]")
+        if rich:
+            console.print("[cyan]Starting export...[/cyan]")
 
-        try:
-            with Progress(
-                SpinnerColumn(),
-                TextColumn("[progress.description]{task.description}"),
-                BarColumn(),
-                TextColumn("[progress.percentage]{task.percentage:>3.1f}%"),
-                TimeRemainingColumn(),
-                console=console,
-            ) as progress:
-                task = progress.add_task("Exporting...", total=len(image_ids))
+        # image_ids は上で解決済みのため、export_filtered_dataset に直接渡して
+        # 二重 DB クエリを回避する。不正フォーマット等は ValueError として境界へ伝播する。
+        result_path = export_service.export_filtered_dataset(
+            image_ids=image_ids,
+            output_path=output_path,
+            format_type=format.lower(),
+            resolution=resolution,
+        )
 
-                # image_ids は上の repository.get_images_by_filter で既に解決済みのため、
-                # export_with_criteria に criteria を渡すと同じ DB クエリを 2 回実行してしまう。
-                # 解決済みの image_ids を直接渡して二重クエリを回避する。
-                result_path = export_service.export_filtered_dataset(
-                    image_ids=image_ids,
-                    output_path=output_path,
-                    format_type=format.lower(),
-                    resolution=resolution,
-                )
-
-                # 完了時に進捗を100%に
-                progress.update(task, completed=len(image_ids))
-
-        except ValueError as e:
-            console.print(f"[red]Error:[/red] Invalid export format: {e}")
-            logger.error(f"Export format error: {e}", exc_info=True)
-            raise typer.Exit(code=1) from e
-        except Exception as e:
-            console.print(f"[red]Error:[/red] Export failed: {e}")
-            logger.error(f"Export error: {e}", exc_info=True)
-            raise typer.Exit(code=1) from e
-
-        # 結果サマリー表示
-        console.print("\n[bold cyan]Export Summary[/bold cyan]")
-
-        summary_table = Table()
-        summary_table.add_column("Metric", style="cyan")
-        summary_table.add_column("Value", style="green")
-
-        summary_table.add_row("Total Images", str(len(image_ids)))
-        summary_table.add_row("Export Format", format)
-        summary_table.add_row("Resolution", f"{resolution}px")
-        summary_table.add_row("Output Path", str(result_path))
-
-        console.print(summary_table)
-
-        console.print("\n[green]Export completed successfully![/green]")
-
-    except typer.Exit:
-        raise
-    except Exception as e:
-        console.print(f"[red]Error:[/red] {e}")
-        logger.error(f"Command error: {e}", exc_info=True)
-        raise typer.Exit(code=2) from e
+        if is_json_mode():
+            emit_result(
+                "Export completed successfully.",
+                output_path=str(result_path),
+                total_images=len(image_ids),
+                format=format,
+                resolution=resolution,
+            )
+        else:
+            console.print("\n[bold cyan]Export Summary[/bold cyan]")
+            summary_table = Table()
+            summary_table.add_column("Metric", style="cyan")
+            summary_table.add_column("Value", style="green")
+            summary_table.add_row("Total Images", str(len(image_ids)))
+            summary_table.add_row("Export Format", format)
+            summary_table.add_row("Resolution", f"{resolution}px")
+            summary_table.add_row("Output Path", str(result_path))
+            console.print(summary_table)
+            console.print("\n[green]Export completed successfully![/green]")

--- a/src/lorairo/cli/commands/images.py
+++ b/src/lorairo/cli/commands/images.py
@@ -2,19 +2,27 @@
 
 画像の登録、メタデータ更新などの画像管理コマンド。
 API層（lorairo.api）を経由してService層を利用する。
+
+出力は ADR 0057/0058 に従う: ``--json`` 時は stdout に JSONL (item/result)、
+それ以外は rich 人間向け。エラー整形は :func:`lorairo.cli._boundary.command_boundary`
+に集約する。
 """
 
 from pathlib import Path
 
+import click
 import typer
 from rich.table import Table
 
-from lorairo.api.exceptions import ImageRegistrationError, ProjectNotFoundError
+from lorairo.api.exceptions import ImageNotFoundError
 from lorairo.api.images import register_images as api_register_images
 from lorairo.api.project import get_project as api_get_project
 from lorairo.api.types import RegistrationResult
+from lorairo.cli._boundary import command_boundary
 from lorairo.cli._console import make_console
+from lorairo.cli._emit import emit_item, emit_result
 from lorairo.cli._glyphs import OK
+from lorairo.cli._output_mode import is_json_mode
 from lorairo.database.filter_criteria import ImageFilterCriteria
 from lorairo.database.repository.annotation_record import AnnotationRepository
 from lorairo.services.service_container import get_service_container
@@ -129,44 +137,46 @@ def register(
     画像ファイルまたはディレクトリからプロジェクトへ画像を登録します。
     pHashを計算して重複検出を行います。
     """
-    try:
+    with command_boundary():
         input_path = Path(path).resolve()
 
-        # パス存在確認
+        # パス存在確認 (FileNotFoundError → IO_ERROR exit 1)
         if not input_path.exists():
-            console.print(f"[red]Error:[/red] Path not found: {path}")
-            raise typer.Exit(code=1)
-
+            raise FileNotFoundError(f"Path not found: {path}")
         if not input_path.is_file() and not input_path.is_dir():
-            console.print(f"[red]Error:[/red] Not a file or directory: {path}")
-            raise typer.Exit(code=1)
+            raise FileNotFoundError(f"Not a file or directory: {path}")
 
-        # プロジェクト存在確認 & DB 接続切り替え
-        try:
-            api_get_project(project)
-        except ProjectNotFoundError as e:
-            console.print(f"[red]Error:[/red] Project not found: {project}")
-            raise typer.Exit(code=1) from e
-
+        # プロジェクト存在確認 (未存在は ProjectNotFoundError → NOT_FOUND で伝播)
+        api_get_project(project)
         get_service_container().set_active_project(project)
 
         # API層経由で画像登録（プロジェクトコンテキスト付き）
         result = api_register_images(input_path, skip_duplicates, project_name=project)
 
         if result.total == 0:
-            console.print(f"[yellow]Warning:[/yellow] No image files found in {path}")
-            raise typer.Exit(code=0)
+            if is_json_mode():
+                emit_result(
+                    f"No image files found in {path}",
+                    total=0,
+                    registered=0,
+                    skipped=0,
+                    errors=0,
+                )
+            else:
+                console.print(f"[yellow]Warning:[/yellow] No image files found in {path}")
+            return
 
-        _print_registration_summary(result, project)
-
-    except ImageRegistrationError as e:
-        console.print(f"[red]Error:[/red] {e}")
-        raise typer.Exit(code=1) from e
-    except typer.Exit:
-        raise
-    except Exception as e:
-        console.print(f"[red]Error:[/red] {e}")
-        raise typer.Exit(code=1) from e
+        if is_json_mode():
+            emit_result(
+                f"Registered {result.successful} image(s) to project: {project}",
+                total=result.total,
+                registered=result.successful,
+                skipped=result.skipped,
+                errors=result.failed,
+                error_details=list(result.error_details) if result.error_details else [],
+            )
+        else:
+            _print_registration_summary(result, project)
 
 
 @app.command("list")
@@ -192,14 +202,10 @@ def list_images(
 ) -> None:
     """List images in a project.
 
-    プロジェクトに登録されている画像の一覧をテーブル形式で表示します。
+    プロジェクトに登録されている画像の一覧を表示します (``--json`` で JSONL)。
     """
-    try:
-        try:
-            api_get_project(project)
-        except ProjectNotFoundError as e:
-            console.print(f"[red]Error:[/red] Project not found: {project}")
-            raise typer.Exit(code=1) from e
+    with command_boundary():
+        api_get_project(project)
 
         container = get_service_container()
         container.set_active_project(project)
@@ -207,6 +213,30 @@ def list_images(
         repository = container.db_manager.image_repo
         criteria = ImageFilterCriteria(include_nsfw=True, only_unrated=unrated, limit=limit)
         image_records, total_count = repository.get_images_by_filter(criteria)
+
+        if is_json_mode():
+            for record in image_records:
+                filename = Path(record.get("stored_image_path", "")).name or str(record.get("filename", ""))
+                has_any_annotation = bool(
+                    record.get("tags")
+                    or record.get("captions")
+                    or record.get("scores")
+                    or record.get("ratings")
+                )
+                emit_item(
+                    {
+                        "id": record.get("id"),
+                        "filename": filename,
+                        "tags": len(record.get("tags") or []),
+                        "annotated": has_any_annotation,
+                    }
+                )
+            emit_result(
+                f"{len(image_records)} image(s)",
+                count=len(image_records),
+                total=total_count,
+            )
+            return
 
         if not image_records:
             suffix = " without ratings" if unrated else ""
@@ -239,12 +269,6 @@ def list_images(
         if limit and total_count > limit:
             console.print(f"Showing {limit} of {total_count} images.")
 
-    except typer.Exit:
-        raise
-    except Exception as e:
-        console.print(f"[red]Error:[/red] {e}")
-        raise typer.Exit(code=1) from e
-
 
 @app.command("update")
 def update(
@@ -274,17 +298,11 @@ def update(
     Example:
         lorairo-cli images update --project myproject --tags "cat,dog"
     """
-    if not tags:
-        console.print("[red]Error:[/red] At least one update operation is required.")
-        console.print('Example: --tags "tag1,tag2"')
-        raise typer.Exit(code=2)
+    with command_boundary():
+        if not tags:
+            raise click.UsageError('At least one update operation is required. Example: --tags "tag1,tag2"')
 
-    try:
-        try:
-            api_get_project(project)
-        except ProjectNotFoundError as e:
-            console.print(f"[red]Error:[/red] Project not found: {project}")
-            raise typer.Exit(code=1) from e
+        api_get_project(project)
 
         container = get_service_container()
         container.set_active_project(project)
@@ -294,37 +312,43 @@ def update(
         if image_id is not None:
             metadata = image_repo.get_image_metadata(image_id)
             if metadata is None:
-                console.print(f"[red]Error:[/red] No image found with ID: {image_id}")
-                raise typer.Exit(code=1)
+                raise ImageNotFoundError(image_id)
             image_ids: list[int] = [image_id]
         else:
             criteria = ImageFilterCriteria(include_nsfw=True)
             image_records, _total = image_repo.get_images_by_filter(criteria)
             if not image_records:
-                console.print(f"[yellow]Warning:[/yellow] No images found in project: {project}")
+                if is_json_mode():
+                    emit_result(f"No images found in project: {project}", count=0)
+                else:
+                    console.print(f"[yellow]Warning:[/yellow] No images found in project: {project}")
                 return
             image_ids = [int(r["id"]) for r in image_records]
 
         tag_list = [t.strip() for t in tags.split(",") if t.strip()]
         if not tag_list:
-            console.print("[red]Error:[/red] No valid tags specified.")
-            raise typer.Exit(code=2)
+            raise click.UsageError("No valid tags specified.")
 
         total_added, failed_tags = _apply_tags_to_images(annotation_repo, image_ids, tag_list)
 
-        _print_update_summary(
-            project=project,
-            target_count=len(image_ids),
-            tag_list=tag_list,
-            total_added=total_added,
-            failed_tags=failed_tags,
-        )
+        if is_json_mode():
+            emit_result(
+                f"Updated {len(image_ids)} image(s) in project: {project}",
+                project=project,
+                target_images=len(image_ids),
+                tags=tag_list,
+                added=total_added,
+                failed_tags=failed_tags,
+            )
+        else:
+            _print_update_summary(
+                project=project,
+                target_count=len(image_ids),
+                tag_list=tag_list,
+                total_added=total_added,
+                failed_tags=failed_tags,
+            )
 
+        # 一部タグが失敗した場合は exit 1 (部分失敗を exit code で示す)。
         if failed_tags:
             raise typer.Exit(code=1)
-
-    except typer.Exit:
-        raise
-    except Exception as e:
-        console.print(f"[red]Error:[/red] {e}")
-        raise typer.Exit(code=1) from e

--- a/src/lorairo/cli/commands/models.py
+++ b/src/lorairo/cli/commands/models.py
@@ -9,7 +9,11 @@ from typing import TYPE_CHECKING, Any
 import typer
 from rich.table import Table
 
+from lorairo.cli._boundary import command_boundary
 from lorairo.cli._console import make_console
+from lorairo.cli._emit import emit_error, emit_item, emit_result
+from lorairo.cli._errors import ErrorCode
+from lorairo.cli._output_mode import is_json_mode
 
 if TYPE_CHECKING:
     from rich.console import Console
@@ -64,29 +68,42 @@ def refresh(
     ),
 ) -> None:
     """Refresh available WebAPI models."""
-    try:
+    with command_boundary():
         container = get_service_container()
         if project is not None:
             container.set_active_project(project)
-        console.print("[cyan]Refreshing model registry...[/cyan]")
+        if not is_json_mode():
+            console.print("[cyan]Refreshing model registry...[/cyan]")
         models = container.annotator_library.refresh_available_models()
         sync_result = container.model_sync_service.sync_available_models()
 
         if sync_result.errors:
-            console.print("[red]Error:[/red] Model registry refreshed but DB sync failed.")
-            console.print(sync_result.summary)
-            for error in sync_result.errors:
-                console.print(f"[red]Sync error:[/red] {error}")
+            # DB sync の部分失敗。json は構造化 error、rich は従来表示で exit 1。
+            message = "Model registry refreshed but DB sync failed."
+            if is_json_mode():
+                emit_error(
+                    ErrorCode.DB_ERROR,
+                    message,
+                    retryable=False,
+                    user_action_required=False,
+                    details={"summary": sync_result.summary, "errors": list(sync_result.errors)},
+                )
+            else:
+                console.print(f"[red]Error:[/red] {message}")
+                console.print(sync_result.summary)
+                for error in sync_result.errors:
+                    console.print(f"[red]Sync error:[/red] {error}")
             raise typer.Exit(code=1)
 
-        console.print(f"[green]Model registry refreshed.[/green] {len(models)} model(s) discovered.")
-        console.print(sync_result.summary)
-    except typer.Exit:
-        raise
-    except Exception as e:
-        console.print(f"[red]Error:[/red] Failed to refresh models: {e}")
-        logger.error(f"Model refresh command failed: {e}", exc_info=True)
-        raise typer.Exit(code=1) from e
+        if is_json_mode():
+            emit_result(
+                f"Model registry refreshed. {len(models)} model(s) discovered.",
+                discovered=len(models),
+                summary=sync_result.summary,
+            )
+        else:
+            console.print(f"[green]Model registry refreshed.[/green] {len(models)} model(s) discovered.")
+            console.print(sync_result.summary)
 
 
 @app.command("list")
@@ -139,7 +156,7 @@ def list_models(
     Issue #249: ``--route`` 未指定時は config の ``[model_selection].route_preference``
     を default として読み込み、``--show-unavailable`` で API key 未設定の行も表示する。
     """
-    try:
+    with command_boundary():
         container = get_service_container()
         annotator = container.annotator_library
         infos = annotator.list_annotator_info()
@@ -179,26 +196,10 @@ def list_models(
         else:
             display_rows = display_rows_pre_unavailable
 
-        table = _build_available_models_table(
-            display_rows=display_rows,
-            type_filter=type_filter,
-            category=category,
-            show_unavailable=show_unavailable,
-            include_deprecated=include_deprecated,
-        )
-        console.print(table)
-        if category is ModelCategoryFilter.all:
-            _print_rating_models_section(display_rows)
-        # Issue #249: preference の取得元と unavailable 件数も表示
+        # Issue #249: preference の取得元と unavailable 件数。
         unavailable_count = sum(1 for r in display_rows if not r.get("available", True))
-        unavailable_suffix = f", unavailable={unavailable_count}" if unavailable_count > 0 else ""
-        console.print(
-            f"[dim]{len(display_rows)} model(s) "
-            f"(preference={route.value} from {preference_source}{unavailable_suffix})[/dim]"
-        )
 
-        # Issue #253: silent 0 件問題の切り分けのため DEBUG 診断を出し、
-        # 0 件のときは原因に応じた hint を画面に表示する。
+        # Issue #253: silent 0 件問題の切り分けのため DEBUG 診断 (stderr、両モード共通)。
         _log_models_list_diagnostic(
             container=container,
             api_keys=api_keys,
@@ -210,16 +211,51 @@ def list_models(
             route=route,
             preference_source=preference_source,
         )
+
+        if is_json_mode():
+            for row in display_rows:
+                emit_item(
+                    {
+                        "provider": row["provider"],
+                        "route": row["route"],
+                        "litellm_id": row["litellm_id"],
+                        "type": row["type_label"],
+                        "category": row["category"],
+                        "available": row.get("available", True),
+                        "deprecated": row["deprecated"],
+                    }
+                )
+            emit_result(
+                f"{len(display_rows)} model(s)",
+                count=len(display_rows),
+                preference=route.value,
+                preference_source=preference_source,
+                unavailable=unavailable_count,
+            )
+            return
+
+        table = _build_available_models_table(
+            display_rows=display_rows,
+            type_filter=type_filter,
+            category=category,
+            show_unavailable=show_unavailable,
+            include_deprecated=include_deprecated,
+        )
+        console.print(table)
+        if category is ModelCategoryFilter.all:
+            _print_rating_models_section(display_rows)
+        unavailable_suffix = f", unavailable={unavailable_count}" if unavailable_count > 0 else ""
+        console.print(
+            f"[dim]{len(display_rows)} model(s) "
+            f"(preference={route.value} from {preference_source}{unavailable_suffix})[/dim]"
+        )
+        # Issue #253: 0 件のときは原因に応じた hint を表示する。
         if not display_rows:
             _emit_zero_count_hint(
                 console=console,
                 api_keys_configured=bool(available_providers),
                 show_unavailable=show_unavailable,
             )
-    except Exception as e:
-        console.print(f"[red]Error:[/red] Failed to list models: {e}")
-        logger.error(f"Model list command failed: {e}", exc_info=True)
-        raise typer.Exit(code=1) from e
 
 
 def _build_available_models_table(

--- a/src/lorairo/cli/commands/project.py
+++ b/src/lorairo/cli/commands/project.py
@@ -2,16 +2,17 @@
 
 プロジェクトの作成、一覧表示、削除などの管理コマンド。
 API層（lorairo.api）を経由してService層を利用する。
+
+出力は ADR 0057/0058 に従う: ``--json`` 時は stdout に JSONL (item/result)、
+それ以外は rich 人間向け。エラー整形は :func:`lorairo.cli._boundary.command_boundary`
+に集約し、本モジュールは型付き例外を伝播するだけにする。
 """
+
+import json
 
 import typer
 from rich.table import Table
 
-from lorairo.api.exceptions import (
-    ProjectAlreadyExistsError,
-    ProjectNotFoundError,
-    ProjectOperationError,
-)
 from lorairo.api.project import (
     create_project as api_create_project,
 )
@@ -22,8 +23,11 @@ from lorairo.api.project import (
     list_projects as api_list_projects,
 )
 from lorairo.api.types import ProjectCreateRequest
+from lorairo.cli._boundary import command_boundary
 from lorairo.cli._console import make_console
+from lorairo.cli._emit import emit_item, emit_result
 from lorairo.cli._glyphs import OK
+from lorairo.cli._output_mode import is_json_mode
 
 # サブコマンドアプリ定義
 app = typer.Typer(help="Project management commands")
@@ -38,18 +42,18 @@ def create(
     description: str = typer.Option("", "--description", "-d", help="Project description"),
 ) -> None:
     """Create a new project."""
-    try:
+    with command_boundary():
         request = ProjectCreateRequest(name=name, description=description or None)
         project = api_create_project(request)
-        console.print(f"[green]{OK}[/green] Project created: [bold]{project.name}[/bold]")
-        console.print(f"[dim]Location: {project.path}[/dim]")
-
-    except ProjectAlreadyExistsError as e:
-        console.print(f"[red]Error:[/red] Project already exists: {name}")
-        raise typer.Exit(code=1) from e
-    except (ProjectOperationError, ValueError) as e:
-        console.print(f"[red]Error:[/red] {e}")
-        raise typer.Exit(code=1) from e
+        if is_json_mode():
+            emit_result(
+                f"Project created: {project.name}",
+                name=project.name,
+                path=str(project.path),
+            )
+        else:
+            console.print(f"[green]{OK}[/green] Project created: [bold]{project.name}[/bold]")
+            console.print(f"[dim]Location: {project.path}[/dim]")
 
 
 @app.command("list")
@@ -58,16 +62,27 @@ def list_projects(
         "table",
         "--format",
         "-f",
-        help="Output format: table/json",
+        help="Output format: table/json (legacy; prefer global --json).",
     ),
 ) -> None:
     """List all projects."""
-    try:
-        import json
-
+    with command_boundary():
         projects = api_list_projects()
 
+        if is_json_mode():
+            for proj in projects:
+                emit_item(
+                    {
+                        "name": proj.name,
+                        "created": proj.created.strftime("%Y%m%d_%H%M%S") if proj.created else "",
+                        "path": str(proj.path),
+                    }
+                )
+            emit_result(f"{len(projects)} project(s) found", count=len(projects))
+            return
+
         if format == "json":
+            # legacy: ``project list --format json`` (global --json への移行を推奨)
             projects_data = [
                 {
                     "name": p.name,
@@ -77,25 +92,22 @@ def list_projects(
                 for p in projects
             ]
             console.print(json.dumps(projects_data, indent=2, ensure_ascii=False), soft_wrap=True)
-        else:
-            if not projects:
-                console.print("[yellow]No projects found[/yellow]")
-                return
+            return
 
-            table = Table(title="Projects")
-            table.add_column("Name", style="cyan")
-            table.add_column("Created", style="magenta")
-            table.add_column("Path", style="dim")
+        if not projects:
+            console.print("[yellow]No projects found[/yellow]")
+            return
 
-            for proj in projects:
-                created_str = proj.created.strftime("%Y%m%d_%H%M%S") if proj.created else ""
-                table.add_row(proj.name, created_str, str(proj.path))
+        table = Table(title="Projects")
+        table.add_column("Name", style="cyan")
+        table.add_column("Created", style="magenta")
+        table.add_column("Path", style="dim")
 
-            console.print(table)
+        for proj in projects:
+            created_str = proj.created.strftime("%Y%m%d_%H%M%S") if proj.created else ""
+            table.add_row(proj.name, created_str, str(proj.path))
 
-    except ProjectOperationError as e:
-        console.print(f"[red]Error:[/red] {e}")
-        raise typer.Exit(code=1) from e
+        console.print(table)
 
 
 @app.command("delete")
@@ -104,19 +116,18 @@ def delete(
     force: bool = typer.Option(False, "--force", "-f", help="Force delete without confirmation"),
 ) -> None:
     """Delete a project."""
-    try:
+    with command_boundary():
         if not force:
             confirm = typer.confirm(f"Delete project '{name}'? This cannot be undone.")
             if not confirm:
-                console.print("[yellow]Cancelled[/yellow]")
-                raise typer.Exit(code=0)
+                if is_json_mode():
+                    emit_result("Cancelled", cancelled=True)
+                else:
+                    console.print("[yellow]Cancelled[/yellow]")
+                return
 
         api_delete_project(name)
-        console.print(f"[green]{OK}[/green] Project deleted: [bold]{name}[/bold]")
-
-    except ProjectNotFoundError as e:
-        console.print(f"[red]Error:[/red] Project not found: {name}")
-        raise typer.Exit(code=1) from e
-    except ProjectOperationError as e:
-        console.print(f"[red]Error:[/red] {e}")
-        raise typer.Exit(code=1) from e
+        if is_json_mode():
+            emit_result(f"Project deleted: {name}", name=name)
+        else:
+            console.print(f"[green]{OK}[/green] Project deleted: [bold]{name}[/bold]")

--- a/src/lorairo/cli/main.py
+++ b/src/lorairo/cli/main.py
@@ -26,7 +26,7 @@ from lorairo.cli._console import make_console
 from lorairo.cli._emit import emit_error
 from lorairo.cli._errors import ErrorCode, ErrorInfo, classify_exception, hint_for
 from lorairo.cli._glyphs import FAIL, OK
-from lorairo.cli._output_mode import resolve_output_mode, set_json_mode
+from lorairo.cli._output_mode import resolve_output_mode, set_json_mode, strip_mode_flags
 from lorairo.cli.commands import annotate, batch, export, images, models, project
 from lorairo.services.service_container import get_service_container
 from lorairo.utils.config import DEFAULT_CLI_LOG_PATH, DEFAULT_CONFIG_PATH
@@ -91,6 +91,11 @@ def _configure(
         help="Logging verbosity (DEBUG/INFO/WARNING/ERROR/CRITICAL).",
         case_sensitive=False,
     ),
+    json_output: bool | None = typer.Option(
+        None,
+        "--json/--no-json",
+        help="Emit machine-readable JSONL on stdout (--json) or human-readable rich output (--no-json).",
+    ),
 ) -> None:
     """全サブコマンド共通の初期化フック。
 
@@ -98,8 +103,19 @@ def _configure(
     Issue #540: ``@app.callback()`` は ``--help`` 時には実行されないため、ここで
     ログ初期化を行うことで help 表示時の不要な副作用を避ける。callback は各
     サブコマンド実行時に必ず一度走る。
+
+    ADR 0058 §1: ``--json`` / ``--no-json`` で出力モードを切り替える。``main`` 経由では
+    prescan が先に解決済みだが、CliRunner 等 ``main`` をすり抜ける経路でも本 callback が
+    モードを確定できるよう、明示フラグが与えられたら反映する (未指定なら env を見る)。
     """
     import os
+
+    from lorairo.cli._output_mode import resolve_output_mode, set_json_mode
+
+    if json_output is not None:
+        set_json_mode(json_output)
+    else:
+        set_json_mode(resolve_output_mode([]))
 
     os.environ.setdefault("LORAIRO_CLI_MODE", "true")
     initialize_logging(
@@ -249,12 +265,16 @@ def main(argv: list[str] | None = None) -> None:
     Args:
         argv: 引数列 (省略時は ``sys.argv[1:]`` を Click が解決)。テスト用に注入可能。
     """
-    json_mode = resolve_output_mode(argv)
+    raw_argv = list(sys.argv[1:] if argv is None else argv)
+    json_mode = resolve_output_mode(raw_argv)
     set_json_mode(json_mode)
+    # モードフラグは prescan 済みなので Click パース前に除去する (サブコマンド後位置でも
+    # "no such option" にせず受理する、ADR 0058 §1)。
+    cli_argv = strip_mode_flags(raw_argv)
     try:
         # standalone_mode=False: ctx.exit() / --help は exit code を返し、
         # ClickException / Abort / 一般例外は伝播する。
-        result = app(args=argv, standalone_mode=False)
+        result = app(args=cli_argv, standalone_mode=False)
     except click.exceptions.Abort:
         raise SystemExit(130) from None
     except click.ClickException as exc:

--- a/tests/unit/cli/test_commands_batch.py
+++ b/tests/unit/cli/test_commands_batch.py
@@ -284,8 +284,9 @@ def test_batch_submit_rating_preflight_rejects_non_moderations_endpoint(
         ],
     )
 
-    assert result.exit_code == 1
-    assert "endpoint /v1/moderations" in result.stdout
+    # click.UsageError → INVALID_INPUT → exit 2 (入力検証、ADR 0057 §6)。
+    assert result.exit_code == 2
+    assert "endpoint /v1/moderations" in result.output
     container.provider_batch_workflow_service.submit_images.assert_not_called()
 
 
@@ -314,8 +315,9 @@ def test_batch_submit_rejects_google_until_phase3(mock_get_container: MagicMock)
         ],
     )
 
-    assert result.exit_code == 1
-    assert "Google Provider Batch submit is disabled" in result.stdout
+    # click.UsageError → INVALID_INPUT → exit 2 (入力検証、ADR 0057 §6)。
+    assert result.exit_code == 2
+    assert "Google Provider Batch submit is disabled" in result.output
     container.provider_batch_workflow_service.submit_images.assert_not_called()
 
 

--- a/tests/unit/cli/test_commands_export.py
+++ b/tests/unit/cli/test_commands_export.py
@@ -255,8 +255,9 @@ def test_export_create_nonexistent_project(
         ],
     )
 
+    # ADR 0057 §7: NOT_FOUND は exit 1、エラーは中央境界が stderr に出す (例外 str)。
     assert result.exit_code == 1
-    assert "Project not found" in result.stdout
+    assert "見つかりません" in result.output
 
 
 @pytest.mark.unit
@@ -335,8 +336,9 @@ def test_export_create_invalid_format(
         ],
     )
 
-    assert result.exit_code == 1
-    assert "Invalid export format" in result.stdout or "Error" in result.stdout
+    # ValueError → INVALID_INPUT → exit 2 (入力系、ADR 0057 §6)。エラーは stderr。
+    assert result.exit_code == 2
+    assert "Error" in result.output
 
 
 @pytest.mark.unit
@@ -468,7 +470,7 @@ def test_export_create_no_filter_exits_code_2(
     )
 
     assert result.exit_code == 2
-    assert "At least one filter condition is required for export" in result.stdout
+    assert "At least one filter condition is required for export" in result.output
 
 
 @pytest.mark.unit
@@ -500,7 +502,7 @@ def test_export_create_include_nsfw_alone_exits_code_2(
     )
 
     assert result.exit_code == 2
-    assert "At least one filter condition is required for export" in result.stdout
+    assert "At least one filter condition is required for export" in result.output
 
 
 @pytest.mark.unit
@@ -763,7 +765,7 @@ def test_export_create_empty_tags_string_exits_code_2(
     )
 
     assert result.exit_code == 2
-    assert "At least one filter condition is required for export" in result.stdout
+    assert "At least one filter condition is required for export" in result.output
 
 
 @pytest.mark.unit
@@ -796,7 +798,7 @@ def test_export_create_empty_caption_string_exits_code_2(
     )
 
     assert result.exit_code == 2
-    assert "At least one filter condition is required for export" in result.stdout
+    assert "At least one filter condition is required for export" in result.output
 
 
 @pytest.mark.unit
@@ -829,7 +831,7 @@ def test_export_create_comma_only_tags_exits_code_2(
     )
 
     assert result.exit_code == 2
-    assert "At least one filter condition is required for export" in result.stdout
+    assert "At least one filter condition is required for export" in result.output
 
 
 @pytest.mark.unit
@@ -862,7 +864,7 @@ def test_export_create_multiple_commas_tags_exits_code_2(
     )
 
     assert result.exit_code == 2
-    assert "At least one filter condition is required for export" in result.stdout
+    assert "At least one filter condition is required for export" in result.output
 
 
 @pytest.mark.unit
@@ -895,7 +897,7 @@ def test_export_create_whitespace_excluded_tags_exits_code_2(
     )
 
     assert result.exit_code == 2
-    assert "At least one filter condition is required for export" in result.stdout
+    assert "At least one filter condition is required for export" in result.output
 
 
 @pytest.mark.unit

--- a/tests/unit/cli/test_commands_images.py
+++ b/tests/unit/cli/test_commands_images.py
@@ -100,7 +100,7 @@ def test_images_register_nonexistent_directory(mock_projects_dir: Path) -> None:
     )
 
     assert result.exit_code == 1
-    assert "not found" in result.stdout or "Directory not found" in result.stdout
+    assert "not found" in result.output
 
 
 @pytest.mark.unit
@@ -113,7 +113,7 @@ def test_images_register_nonexistent_project(mock_projects_dir: Path, test_image
     )
 
     assert result.exit_code == 1
-    assert "Project not found" in result.stdout
+    assert "見つかりません" in result.output
 
 
 @pytest.mark.unit
@@ -399,7 +399,7 @@ def test_images_list_nonexistent_project(mock_projects_dir: Path) -> None:
     result = runner.invoke(app, ["images", "list", "--project", "nonexistent"])
 
     assert result.exit_code == 1
-    assert "Project not found" in result.stdout
+    assert "見つかりません" in result.output
 
 
 @pytest.mark.unit
@@ -419,7 +419,7 @@ def test_images_update_no_tags_exits_code2(mock_projects_dir: Path) -> None:
     runner.invoke(app, ["project", "create", "test-project"])
     result = runner.invoke(app, ["images", "update", "--project", "test-project"])
     assert result.exit_code == 2
-    assert "At least one update operation" in result.stdout
+    assert "At least one update operation" in result.output
 
 
 @pytest.mark.unit
@@ -428,7 +428,7 @@ def test_images_update_nonexistent_project(mock_projects_dir: Path) -> None:
     """Test: images update - 存在しないプロジェクトはエラー。"""
     result = runner.invoke(app, ["images", "update", "--project", "nonexistent", "--tags", "cat"])
     assert result.exit_code == 1
-    assert "Project not found" in result.stdout
+    assert "見つかりません" in result.output
 
 
 @pytest.mark.unit
@@ -518,8 +518,9 @@ def test_images_update_image_id_not_found(mock_projects_dir: Path) -> None:
                 "9999",
             ],
         )
+    # ImageNotFoundError → NOT_FOUND exit 1。メッセージは例外 str (stderr)。
     assert result.exit_code == 1
-    assert "No image found with ID: 9999" in result.stdout
+    assert "9999" in result.output
 
 
 @pytest.mark.unit

--- a/tests/unit/cli/test_commands_project.py
+++ b/tests/unit/cli/test_commands_project.py
@@ -148,8 +148,10 @@ def test_project_delete_nonexistent(mock_projects_dir: Path) -> None:
         ["project", "delete", "nonexistent", "--force"],
     )
 
+    # ADR 0057 §7: エラーは中央境界が stderr に整形出力する (stdout は機械可読専用)。
+    # NOT_FOUND は実行時系のため exit 1。
     assert result.exit_code == 1
-    assert "Project not found" in result.stdout
+    assert "見つかりません" in result.output
 
 
 @pytest.mark.unit
@@ -222,8 +224,9 @@ def test_project_create_too_long_name(mock_projects_dir: Path) -> None:
         ["project", "create", long_name],
     )
 
-    assert result.exit_code == 1
-    assert "Error" in result.stdout
+    # Pydantic ValidationError → VALIDATION_FAILED → exit 2 (入力系、ADR 0057 §6)。
+    assert result.exit_code == 2
+    assert "Error" in result.output
 
 
 @pytest.mark.unit
@@ -235,8 +238,9 @@ def test_project_create_invalid_name(mock_projects_dir: Path) -> None:
         ["project", "create", "test project!"],
     )
 
-    assert result.exit_code == 1
-    assert "Error" in result.stdout
+    # Pydantic ValidationError → VALIDATION_FAILED → exit 2 (入力系、ADR 0057 §6)。
+    assert result.exit_code == 2
+    assert "Error" in result.output
 
 
 @pytest.mark.unit
@@ -353,3 +357,53 @@ def test_project_list_format_invalid(mock_projects_dir: Path) -> None:
 
     # Invalid format は table または json のみ
     assert result.exit_code == 0 or result.exit_code == 2
+
+
+# ===== 機械可読 (--json) モード (ADR 0057/0058) =====
+
+
+def _json_lines(stdout: str) -> list[dict]:
+    """stdout の各行を JSON object として読む。"""
+    return [json.loads(line) for line in stdout.splitlines() if line.strip()]
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+def test_project_create_json_mode(mock_projects_dir: Path) -> None:
+    """Test: --json project create - 終端 result を JSONL で返す。"""
+    result = runner.invoke(app, ["--json", "project", "create", "json-mode"])
+
+    assert result.exit_code == 0
+    last = _json_lines(result.stdout)[-1]
+    assert last["kind"] == "result"
+    assert last["ok"] is True
+    assert last["name"] == "json-mode"
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+def test_project_list_json_mode(mock_projects_dir: Path) -> None:
+    """Test: --json project list - item 行 + 件数 result を JSONL で返す。"""
+    runner.invoke(app, ["project", "create", "jm1"])
+
+    result = runner.invoke(app, ["--json", "project", "list"])
+
+    assert result.exit_code == 0
+    lines = _json_lines(result.stdout)
+    items = [line for line in lines if line.get("kind") == "item"]
+    result_line = next(line for line in reversed(lines) if line.get("kind") == "result")
+    assert any(item["name"] == "jm1" for item in items)
+    assert result_line["count"] == len(items)
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+def test_project_delete_nonexistent_json_mode(mock_projects_dir: Path) -> None:
+    """Test: --json project delete - 失敗時は構造化 error 行 (code=NOT_FOUND)。"""
+    result = runner.invoke(app, ["--json", "project", "delete", "nonexistent", "--force"])
+
+    assert result.exit_code == 1
+    last = _json_lines(result.stdout)[-1]
+    assert last["kind"] == "error"
+    assert last["code"] == "NOT_FOUND"
+    assert last["ok"] is False


### PR DESCRIPTION
## 概要

エピック #634 / #641 (既存コマンドの JSONL 移行 + introspection) の **PR-A: 出力モード境界 + 既存コマンドの JSONL 化**。#640 の emit/error/mode 基盤の上に、コマンド本体を JSONL 契約へ移行する。

**本 PR の範囲: 出力境界インフラ + 5コマンド (project / models / export / images / batch)**。残る **annotate** はストリーミング per-image item という構造的に別物 + 973 行と重いため、集中レビューできるよう **follow-up PR (PR-A-annotate) に分離**する。introspection (ADR 0059) と pagination (ADR 0060) は PR-C / PR-B。

## 変更

### 出力境界インフラ (新規)
- **`cli/_boundary.py`**: `command_boundary` context manager。コマンドが伝播した型付き例外を `classify_exception` で分類し、JSONL (`emit_error`) or rich (stderr) で整形して `typer.Exit(exit_code)` を送出。`click.ClickException` (body 内 `click.UsageError` 等) は `INVALID_INPUT` (exit 2) に統一。整形を 1 箇所に集約 (ADR 0057 §7)。
- **`cli/_output_mode.py`**: `strip_mode_flags` 追加 — Click パース前に `--json`/`--no-json` を除去し、サブコマンド後位置 (`images list --json`) でも受理 (ADR 0058 §1)。
- **`cli/main.py`**: `_configure` callback に tri-state `--json/--no-json` 登録 (CliRunner でもモード確定)、`main()` で prescan 後に strip。

### コマンド移行 (project / models / export / images / batch)
各コマンドを `command_boundary` で包み、散在する `except → console.print("[red]Error") → typer.Exit` を**撤廃**して型付き例外を伝播。成功出力は `is_json_mode()` 分岐:
- **per-record** (project list / models list / images list / batch list): `emit_item` × N + 終端 `emit_result`
- **バッチ操作** (project create/delete / models refresh / export create / images register/update / batch submit/status/cancel/fetch/import): 終端 `emit_result` のみ
- rich モードは既存の Table / 装飾を維持

## 契約上の挙動変更 (ADR 準拠の修正)
- **エラーは stderr へ** (stdout は機械可読専用、ADR 0057 §1)。エラーメッセージはハードコード英語 → 例外の `str()`。
- **入力検証エラーは exit 2 に統一** (`INVALID_INPUT`/`VALIDATION_FAILED`、ADR 0057 §6)。従来 exit 1 だった一部 (export 不正フォーマット、batch provider/endpoint 検証、project 名検証) を exit 2 に修正。
- これに合わせ各コマンドの error 系テストを `result.output` / 正しい exit code に更新。project に `--json` モードの item/result/error JSONL テストを追加。

## 検証
- **全 CLI unit テスト 294 passed** (worktree cwd、信頼できる収集)。`ruff format`/`ruff check`/`mypy` 全 pass。
- 各コマンド移行を個別 commit + 個別検証 (project/models/export/images/batch)。

> ⚠️ CI の `tests/unit/test_hook_pre_commands.py` 等 4 件は main HEAD `9550e427` 由来の**既存 main 破損** (本 PR 非起因、#651 と同じ)。

## 残タスク
- [ ] **annotate コマンドの JSONL 移行** (follow-up PR-A-annotate): ストリーミング per-image `emit_item` + memory-bounded (ADR 0053)。
- [ ] PR-B: bounded pagination (ADR 0060)、PR-C: introspection (ADR 0059)。

Refs #641

🤖 Generated with [Claude Code](https://claude.com/claude-code)