### PR TITLE
fix: WebAPI/Vision LLM スコアが10.0に張り付くバグを修正 (#644)

### DIFF
--- a/src/lorairo/database/repository/image.py
+++ b/src/lorairo/database/repository/image.py
@@ -44,7 +44,7 @@ from sqlalchemy.exc import IntegrityError, SQLAlchemyError
 from sqlalchemy.orm import Session, joinedload, selectinload
 
 from ...domain.quality_tier import compute_quality_summary
-from ...domain.score_scaler import calibrate_to_display
+from ...domain.score_scaler import calibrate_to_display, display_weight_for
 from ...utils.log import logger
 from ..filter_criteria import ImageFilterCriteria
 from ..schema import (
@@ -1771,14 +1771,18 @@ class ImageRepository(BaseRepository):
             if existing is None or score_row.created_at > existing.created_at:
                 latest_by_model[score_row.model_id] = score_row
 
-        display_values: list[float] = []
+        weighted_sum: float = 0.0
+        total_weight: float = 0.0
         for score_row in latest_by_model.values():
             model_name = score_row.model.name if score_row.model else ""
-            display_values.append(calibrate_to_display(model_name, float(score_row.score)))
+            value = calibrate_to_display(model_name, float(score_row.score))
+            weight = display_weight_for(model_name)
+            weighted_sum += value * weight
+            total_weight += weight
 
-        if not display_values:
+        if total_weight == 0.0:
             return 0.0
-        return sum(display_values) / len(display_values)
+        return weighted_sum / total_weight
 
     def _format_score_labels(self, image: Image, annotations: dict[str, Any]) -> None:
         """スコアラベル (canonical scorer の categorical 分類) をフォーマットする。

--- a/src/lorairo/domain/score_scaler.py
+++ b/src/lorairo/domain/score_scaler.py
@@ -32,7 +32,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from itertools import pairwise
 
-MAPPING_VERSION: str = "score-scaler-v1"
+MAPPING_VERSION: str = "score-scaler-v2"
 """calibration table の version 識別子。マッピングを変更する際に bump する。"""
 
 DISPLAY_MIN: float = 0.0

--- a/src/lorairo/domain/score_scaler.py
+++ b/src/lorairo/domain/score_scaler.py
@@ -41,6 +41,10 @@ DISPLAY_MIN: float = 0.0
 DISPLAY_MAX: float = 10.0
 """表示尺度の上限。手動スライダーと揃える。"""
 
+WEBAPI_VISION_SCORE_WEIGHT: float = 0.5
+"""WebAPI Vision LLM スコアの表示平均重み。
+aesthetic scorer (重み 1.0) より信頼度が低いため割り引く。"""
+
 
 @dataclass(frozen=True)
 class _AIScoreSpec:
@@ -103,18 +107,33 @@ _AI_SCORE_SPEC: dict[str, _AIScoreSpec] = {
 }
 
 
+def _is_webapi_vision_scorer(model: str) -> bool:
+    """LiteLLM ``provider/model`` 形式 (slash あり) を WebAPI Vision scorer と判定する。
+
+    Phase 1.10 以降に登録されたモデルは常に slash を持つ。旧形式名
+    (``claude-3-5-sonnet-20240620`` 等、slash なし) は識別対象外で
+    未知モデル fallback になる — これは許容された制限。
+    """
+    return "/" in model
+
+
 def is_ai_scored_model(model: str) -> bool:
     """``model`` が AI 数値スコア (表示尺度変換対象) を出すモデルか判定する。"""
-    return model in _AI_SCORE_SPEC
+    return model in _AI_SCORE_SPEC or _is_webapi_vision_scorer(model)
 
 
 def positive_key_for(model: str) -> str | None:
     """``model`` の positive key (``higher_is_better=True`` の scores key) を返す。
 
-    未知 model は ``None``。
+    WebAPI Vision LLM は常に ``"overall"`` キーで単一スコアを返す。
+    未知モデル (旧形式 slash なし等) は ``None``。
     """
     spec = _AI_SCORE_SPEC.get(model)
-    return spec.positive_key if spec is not None else None
+    if spec is not None:
+        return spec.positive_key
+    if _is_webapi_vision_scorer(model):
+        return "overall"
+    return None
 
 
 def select_positive_score(model: str, scores: dict[str, float]) -> float | None:
@@ -178,7 +197,10 @@ def calibrate_to_display(model: str, raw: float) -> float:
     """
     spec = _AI_SCORE_SPEC.get(model)
     if spec is None:
-        # 未知 model: range 不明のため 0-1 を仮定した線形 0-10 マッピング。
+        if _is_webapi_vision_scorer(model):
+            # WebAPI Vision LLM は BASE_PROMPT で 0-10 スケールを返す → identity + clamp
+            return _clamp_display(raw)
+        # 完全未知モデル: range 不明のため 0-1 を仮定した線形 0-10 マッピング。
         return _clamp_display(raw * DISPLAY_MAX)
 
     if spec.knots is not None:
@@ -190,6 +212,18 @@ def calibrate_to_display(model: str, raw: float) -> float:
         return DISPLAY_MIN
     ratio = (raw - low) / (high - low)
     return _clamp_display(ratio * DISPLAY_MAX)
+
+
+def display_weight_for(model: str) -> float:
+    """``model`` の表示スコア平均における重みを返す。
+
+    WebAPI Vision LLM は aesthetic scorer より判定信頼度が低いため
+    ``WEBAPI_VISION_SCORE_WEIGHT`` (< 1.0) で割り引く。
+    既知の aesthetic scorer および未知モデルは重み 1.0。
+    """
+    if _is_webapi_vision_scorer(model):
+        return WEBAPI_VISION_SCORE_WEIGHT
+    return 1.0
 
 
 def value_range_for(model: str) -> tuple[float, float] | None:

--- a/src/lorairo/domain/score_scaler.py
+++ b/src/lorairo/domain/score_scaler.py
@@ -185,8 +185,10 @@ def calibrate_to_display(model: str, raw: float) -> float:
     """scorer の生値 ``raw`` を 0.0-10.0 の連続表示スコアへ変換する。
 
     変換は連続・単調・区分線形。各モデルの knot は ``_AI_SCORE_SPEC`` を参照
-    (根拠は module / テーブル docstring に記載)。未知 model は ``value_range`` 不明の
-    ため 0-1 を仮定した線形マッピングをフォールバックとして行う。
+    (根拠は module / テーブル docstring に記載)。``_AI_SCORE_SPEC`` に未登録の
+    model は fallback を行う:LiteLLM ``provider/model`` 形式 (slash あり) は
+    0-10 スケール直接 identity + clamp、slash なし完全未知モデルは 0-1 を仮定した
+    線形 0-10 マッピング。
 
     Args:
         model: scorer model 名 (iam-lib registry key)。
@@ -219,7 +221,7 @@ def display_weight_for(model: str) -> float:
 
     WebAPI Vision LLM は aesthetic scorer より判定信頼度が低いため
     ``WEBAPI_VISION_SCORE_WEIGHT`` (< 1.0) で割り引く。
-    既知の aesthetic scorer および未知モデルは重み 1.0。
+    ``_AI_SCORE_SPEC`` に登録済みの aesthetic scorer は重み 1.0。slash なし完全未知モデルも重み 1.0 (fallback)。
     """
     if _is_webapi_vision_scorer(model):
         return WEBAPI_VISION_SCORE_WEIGHT

--- a/tests/integration/test_provider_batch_annotation_e2e.py
+++ b/tests/integration/test_provider_batch_annotation_e2e.py
@@ -106,7 +106,7 @@ def _make_succeeded_item(
         "capabilities": ["tags", "captions", "scores"],
         "tags": tags,
         "captions": captions,
-        "scores": {"score": score},
+        "scores": {"overall": score},
         "score_labels": [],
         "ratings": [],
     }

--- a/tests/unit/database/test_db_repository_annotations.py
+++ b/tests/unit/database/test_db_repository_annotations.py
@@ -626,3 +626,40 @@ class TestDeriveDisplayScore:
         ]
         # 最新行 0.5 のみを採用 → cafe 0.5 → 6.0
         assert ImageRepository._derive_display_score(image) == pytest.approx(6.0)
+
+    @pytest.mark.unit
+    def test_webapi_score_identity_and_weighted(self):
+        """WebAPI モデル (slash 形式) のスコアは identity 変換かつ重み 0.5 で組み込まれる。"""
+        image = Mock(spec=Image)
+        image.scores = [
+            # WebAPI モデル: 生値 7.5 → calibrate → 7.5 (identity), weight=0.5
+            _score_row(7.5, "openai/o1", is_manual=False, created_at=datetime(2025, 1, 1), model_id=10),
+        ]
+        assert ImageRepository._derive_display_score(image) == pytest.approx(7.5)
+
+    @pytest.mark.unit
+    def test_webapi_mixed_with_aesthetic_weighted_average(self):
+        """aesthetic scorer と WebAPI スコアが混在する場合は weighted average になる。
+
+        cafe_aesthetic: 0.5 → calibrate → 6.0, weight=1.0
+        openai/o1: 8.0 → calibrate → 8.0, weight=0.5
+        weighted avg = (6.0 * 1.0 + 8.0 * 0.5) / (1.0 + 0.5) = (6.0 + 4.0) / 1.5 = 10.0 / 1.5 ≈ 6.667
+        """
+        image = Mock(spec=Image)
+        image.scores = [
+            _score_row(0.5, "cafe_aesthetic", is_manual=False, created_at=datetime(2025, 1, 1), model_id=1),
+            _score_row(8.0, "openai/o1", is_manual=False, created_at=datetime(2025, 1, 1), model_id=10),
+        ]
+        expected = (6.0 * 1.0 + 8.0 * 0.5) / (1.0 + 0.5)
+        assert ImageRepository._derive_display_score(image) == pytest.approx(expected)
+
+    @pytest.mark.unit
+    def test_webapi_score_clamps_to_display_range(self):
+        """WebAPI スコアが 10 超でも clamp される。"""
+        image = Mock(spec=Image)
+        image.scores = [
+            _score_row(
+                12.0, "openai/gpt-4o", is_manual=False, created_at=datetime(2025, 1, 1), model_id=10
+            ),
+        ]
+        assert ImageRepository._derive_display_score(image) == pytest.approx(10.0)

--- a/tests/unit/domain/test_score_scaler.py
+++ b/tests/unit/domain/test_score_scaler.py
@@ -9,7 +9,9 @@ from lorairo.domain.score_scaler import (
     DISPLAY_MAX,
     DISPLAY_MIN,
     MAPPING_VERSION,
+    WEBAPI_VISION_SCORE_WEIGHT,
     calibrate_to_display,
+    display_weight_for,
     is_ai_scored_model,
     positive_key_for,
     select_positive_score,
@@ -302,8 +304,6 @@ def test_positive_key_for_webapi_is_overall() -> None:
 @pytest.mark.unit
 def test_display_weight_for_webapi() -> None:
     """WebAPI モデルの表示重みは WEBAPI_VISION_SCORE_WEIGHT (< 1.0)。"""
-    from lorairo.domain.score_scaler import WEBAPI_VISION_SCORE_WEIGHT, display_weight_for
-
     assert display_weight_for("openai/o1") == pytest.approx(WEBAPI_VISION_SCORE_WEIGHT)
     assert display_weight_for("anthropic/claude-3-5-sonnet-20241022") == pytest.approx(
         WEBAPI_VISION_SCORE_WEIGHT
@@ -313,8 +313,6 @@ def test_display_weight_for_webapi() -> None:
 @pytest.mark.unit
 def test_display_weight_for_local_scorer_is_one() -> None:
     """ローカル ML scorer (aesthetic 系) の重みは 1.0。"""
-    from lorairo.domain.score_scaler import display_weight_for
-
     assert display_weight_for("aesthetic_shadow_v1") == pytest.approx(1.0)
     assert display_weight_for("cafe_aesthetic") == pytest.approx(1.0)
     assert display_weight_for("WaifuAesthetic") == pytest.approx(1.0)

--- a/tests/unit/domain/test_score_scaler.py
+++ b/tests/unit/domain/test_score_scaler.py
@@ -256,3 +256,65 @@ def test_spec_matches_lib_score_scales() -> None:
         assert score_scaler.value_range_for(model) == lib_range, (
             f"{model}: LoRAIro range {score_scaler.value_range_for(model)} != lib {lib_range}"
         )
+
+
+# ===== WebAPI / Vision LLM scorer =====
+
+
+@pytest.mark.unit
+def test_webapi_slash_model_identity() -> None:
+    """WebAPI モデル (slash 形式) は 0-10 を identity で返す。"""
+    assert calibrate_to_display("openai/o1", 7.5) == pytest.approx(7.5)
+    assert calibrate_to_display("anthropic/claude-3-5-sonnet-20241022", 8.0) == pytest.approx(8.0)
+    assert calibrate_to_display("openai/gpt-4o", 0.0) == pytest.approx(0.0)
+    assert calibrate_to_display("openai/gpt-4o", 10.0) == pytest.approx(10.0)
+
+
+@pytest.mark.unit
+def test_webapi_slash_model_clamps() -> None:
+    """WebAPI モデルが 0-10 範囲外を返した場合はクランプする。"""
+    assert calibrate_to_display("openai/o1", -1.0) == pytest.approx(0.0)
+    assert calibrate_to_display("openai/o1", 11.0) == pytest.approx(10.0)
+
+
+@pytest.mark.unit
+def test_non_slash_unknown_model_still_uses_linear_fallback() -> None:
+    """スラッシュなし未知モデルは従来どおり 0-1 仮定の線形 fallback。"""
+    assert calibrate_to_display("some_local_model", 0.5) == pytest.approx(5.0)
+    assert calibrate_to_display("some_local_model", 1.0) == pytest.approx(10.0)
+
+
+@pytest.mark.unit
+def test_is_ai_scored_model_webapi() -> None:
+    """slash 形式の WebAPI モデルは is_ai_scored_model が True。"""
+    assert is_ai_scored_model("openai/o1") is True
+    assert is_ai_scored_model("anthropic/claude-3-haiku-20240307") is True
+    assert is_ai_scored_model("openai/gpt-5-nano") is True
+
+
+@pytest.mark.unit
+def test_positive_key_for_webapi_is_overall() -> None:
+    """WebAPI モデルの positive key は 'overall'。"""
+    assert positive_key_for("openai/o1") == "overall"
+    assert positive_key_for("anthropic/claude-3-5-sonnet-20241022") == "overall"
+
+
+@pytest.mark.unit
+def test_display_weight_for_webapi() -> None:
+    """WebAPI モデルの表示重みは WEBAPI_VISION_SCORE_WEIGHT (< 1.0)。"""
+    from lorairo.domain.score_scaler import WEBAPI_VISION_SCORE_WEIGHT, display_weight_for
+
+    assert display_weight_for("openai/o1") == pytest.approx(WEBAPI_VISION_SCORE_WEIGHT)
+    assert display_weight_for("anthropic/claude-3-5-sonnet-20241022") == pytest.approx(
+        WEBAPI_VISION_SCORE_WEIGHT
+    )
+
+
+@pytest.mark.unit
+def test_display_weight_for_local_scorer_is_one() -> None:
+    """ローカル ML scorer (aesthetic 系) の重みは 1.0。"""
+    from lorairo.domain.score_scaler import display_weight_for
+
+    assert display_weight_for("aesthetic_shadow_v1") == pytest.approx(1.0)
+    assert display_weight_for("cafe_aesthetic") == pytest.approx(1.0)
+    assert display_weight_for("WaifuAesthetic") == pytest.approx(1.0)

--- a/tests/unit/services/test_annotation_save_service.py
+++ b/tests/unit/services/test_annotation_save_service.py
@@ -742,3 +742,37 @@ def test_save_annotation_results_persists_mapped_rating(
             "confidence_score": 0.81,
         }
     ]
+
+
+# ===== Issue #644: WebAPI モデル (slash 形式) の _append_scores 経路 =====
+
+
+class TestAppendScoresWebApi:
+    """WebAPI モデル (slash 形式) の _append_scores 経路テスト。"""
+
+    @pytest.mark.unit
+    def test_webapi_saves_only_overall_key(self, service: AnnotationSaveService) -> None:
+        """WebAPI モデルは is_ai_scored_model=True 経路で 'overall' key のみ保存する。"""
+        result: dict = {"scores": [], "score_labels": [], "tags": [], "captions": [], "ratings": []}
+        service._append_scores(
+            model_id=99,
+            scores={"overall": 8.0},
+            model_name="openai/o1",
+            result=result,
+        )
+        assert len(result["scores"]) == 1
+        assert result["scores"][0]["score"] == pytest.approx(8.0)
+        assert result["scores"][0]["model_id"] == 99
+        assert result["scores"][0]["is_edited_manually"] is False
+
+    @pytest.mark.unit
+    def test_webapi_missing_overall_key_skips(self, service: AnnotationSaveService) -> None:
+        """WebAPI モデルで 'overall' key が scores に無い場合はスキップする。"""
+        result: dict = {"scores": [], "score_labels": [], "tags": [], "captions": [], "ratings": []}
+        service._append_scores(
+            model_id=99,
+            scores={"some_other_key": 5.0},
+            model_name="openai/o1",
+            result=result,
+        )
+        assert len(result["scores"]) == 0


### PR DESCRIPTION
## Summary

- `score_scaler.py`: `_is_webapi_vision_scorer()` を追加し、LiteLLM `provider/model` 形式 (slash あり) の WebAPI モデルを識別。`calibrate_to_display` の未知モデル fallback を WebAPI (identity + clamp) と旧形式 (0-1 → 線形 0-10) に分岐させ、`7.5 → 10.0` の張り付きバグを修正
- `score_scaler.py`: `WEBAPI_VISION_SCORE_WEIGHT = 0.5` と `display_weight_for()` を追加。WebAPI スコアは aesthetic scorer より信頼度が低いため weighted average で割り引く
- `image.py`: `_derive_display_score` を単純平均 → weighted average に変更（WebAPI: weight=0.5、aesthetic scorer: weight=1.0）
- `MAPPING_VERSION` を `score-scaler-v2` に bump

## Root Cause

WebAPI LLM (`openai/o1` 等) は `BASE_PROMPT` の指定により 0-10 スケールでスコアを返すが、未知モデル fallback が `raw * 10` を適用していたため `7.5 * 10 = 75 → clamp → 10.0` に張り付いていた。

## Known Limitation

Phase 1.10 以前に登録された旧形式モデル名 (`claude-3-5-sonnet-20240620` 等、slash なし) は識別不能で引き続き fallback。再アノテーションで正常化可能。

## Test plan

- [ ] `uv run pytest tests/unit/domain/test_score_scaler.py -v` — WebAPI identity/clamp/weight テスト 8 件含む全 49 件 PASS
- [ ] `uv run pytest tests/unit/database/test_db_repository_annotations.py::TestDeriveDisplayScore -v` — weighted average テスト 3 件含む全 9 件 PASS
- [ ] `uv run pytest tests/unit/services/test_annotation_save_service.py::TestAppendScoresWebApi -v` — WebAPI `_append_scores` 経路テスト 2 件 PASS
- [ ] CI-equivalent filter `not gui_show and not calls_real_webapi and not downloads_and_runs_model and not slow` — 3943 passed (4 failures は main 既存、本 PR と無関係)

Closes #644

🤖 Generated with [Claude Code](https://claude.com/claude-code)