### PR TITLE
feat: Score.display_score カラム追加でスコアフィルタを 0-10 表示スコアに修正 (#626)

### DIFF
--- a/src/lorairo/database/migrations/versions/d1e2f3a4b5c6_add_display_score_to_scores.py
+++ b/src/lorairo/database/migrations/versions/d1e2f3a4b5c6_add_display_score_to_scores.py
@@ -1,0 +1,117 @@
+"""add display_score to scores
+
+Revision ID: d1e2f3a4b5c6
+Revises: e1f2a3b4c5d6
+Create Date: 2026-06-06 00:00:00.000000
+
+Issue #626: Score.score は生値 (aesthetic_shadow は 0-1 確率など) だが、
+UI フィルタは 0-10 表示スコアで指定する。表示スコアを DB に永続化して
+フィルタの O(1) 比較を可能にする。
+
+バックフィル戦略:
+- is_edited_manually=True  → display_score = score (手動編集値は既に 0-10)
+- WebAPI モデル (model.name に "/" 含む) → identity + clamp (0-10 で来る)
+- aesthetic_shadow_v1/v2  → 区分線形補間 knots
+- cafe_aesthetic          → 区分線形補間 knots
+- WaifuAesthetic          → linear 0-1 → 0-10
+- ImprovedAesthetic        → identity clamp (AVA 1-10)
+- それ以外 (未知 model)   → raw * 10 clamp (0-1 仮定 fallback)
+"""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy import text
+
+# revision identifiers, used by Alembic.
+revision: str = "d1e2f3a4b5c6"
+down_revision: str | None = "e1f2a3b4c5d6"
+branch_labels: str | tuple[str, ...] | None = None
+depends_on: str | tuple[str, ...] | None = None
+
+
+# ---------------------------------------------------------------------------
+# 移行専用の calibration ロジック (score_scaler.py から独立コピー)
+# migration は将来のコード変更の影響を受けないよう inline で保持する。
+# ---------------------------------------------------------------------------
+
+_KNOTS: dict[str, tuple[tuple[float, float], ...]] = {
+    "aesthetic_shadow_v1": ((0.0, 0.0), (0.27, 3.0), (0.45, 8.0), (0.71, 9.0), (1.0, 10.0)),
+    "aesthetic_shadow_v2": ((0.0, 0.0), (0.27, 3.0), (0.45, 8.0), (0.71, 9.0), (1.0, 10.0)),
+    "cafe_aesthetic": ((0.0, 0.0), (0.5, 6.0), (1.0, 8.0)),
+    "WaifuAesthetic": ((0.0, 0.0), (1.0, 10.0)),
+    "ImprovedAesthetic": ((0.0, 0.0), (1.0, 1.0), (10.0, 10.0)),
+}
+
+
+def _clamp(v: float) -> float:
+    return max(0.0, min(10.0, v))
+
+
+def _piecewise(knots: tuple[tuple[float, float], ...], raw: float) -> float:
+    """区分線形補間。knots は raw 昇順・display 単調非減少を前提とする。"""
+    first_raw, first_disp = knots[0]
+    if raw <= first_raw:
+        return first_disp
+    last_raw, last_disp = knots[-1]
+    if raw >= last_raw:
+        return last_disp
+    for i in range(len(knots) - 1):
+        x0, y0 = knots[i]
+        x1, y1 = knots[i + 1]
+        if x0 <= raw <= x1:
+            if x1 == x0:
+                return y1
+            return y0 + (raw - x0) / (x1 - x0) * (y1 - y0)
+    return last_disp
+
+
+def _calibrate(model_name: str | None, raw: float, is_manually_edited: bool) -> float:
+    """raw スコアを 0-10 表示スコアへ変換する (migration 用 inline 実装)。"""
+    if is_manually_edited:
+        # 手動編集値は save 時に既に 0-10 スケールで格納されている
+        return _clamp(raw)
+
+    if model_name is None:
+        return _clamp(raw * 10.0)
+
+    knots = _KNOTS.get(model_name)
+    if knots is not None:
+        return _clamp(_piecewise(knots, raw))
+
+    # WebAPI Vision LLM: LiteLLM provider/model 形式 (slash あり) → identity + clamp
+    if "/" in model_name:
+        return _clamp(raw)
+
+    # 完全未知モデル: 0-1 仮定 fallback
+    return _clamp(raw * 10.0)
+
+
+# ---------------------------------------------------------------------------
+
+
+def upgrade() -> None:
+    op.add_column("scores", sa.Column("display_score", sa.Float(), nullable=True))
+
+    conn = op.get_bind()
+
+    # 既存行を取得してバックフィル
+    rows = conn.execute(
+        text(
+            "SELECT s.id, s.score, s.is_edited_manually, m.name"
+            " FROM scores s LEFT JOIN models m ON s.model_id = m.id"
+        )
+    ).fetchall()
+
+    for row in rows:
+        score_id, raw_score, is_edited, model_name = row
+        display = _calibrate(model_name, float(raw_score), bool(is_edited))
+        conn.execute(
+            text("UPDATE scores SET display_score = :ds WHERE id = :sid"),
+            {"ds": display, "sid": score_id},
+        )
+
+
+def downgrade() -> None:
+    op.drop_column("scores", "display_score")

--- a/src/lorairo/database/migrations/versions/d1e2f3a4b5c6_add_display_score_to_scores.py
+++ b/src/lorairo/database/migrations/versions/d1e2f3a4b5c6_add_display_score_to_scores.py
@@ -22,7 +22,7 @@ from __future__ import annotations
 
 from alembic import op
 import sqlalchemy as sa
-from sqlalchemy import text
+from sqlalchemy import inspect as _sa_inspect, text
 
 # revision identifiers, used by Alembic.
 revision: str = "d1e2f3a4b5c6"
@@ -92,9 +92,13 @@ def _calibrate(model_name: str | None, raw: float, is_manually_edited: bool) -> 
 
 
 def upgrade() -> None:
-    op.add_column("scores", sa.Column("display_score", sa.Float(), nullable=True))
-
     conn = op.get_bind()
+
+    # scores テーブルが存在しない最小スキーマ (一部マイグレーションテストの stale DB) は no-op
+    if "scores" not in _sa_inspect(conn).get_table_names():
+        return
+
+    op.add_column("scores", sa.Column("display_score", sa.Float(), nullable=True))
 
     # 既存行を取得してバックフィル
     rows = conn.execute(
@@ -114,4 +118,7 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
+    conn = op.get_bind()
+    if "scores" not in _sa_inspect(conn).get_table_names():
+        return
     op.drop_column("scores", "display_score")

--- a/src/lorairo/database/repository/annotation_record.py
+++ b/src/lorairo/database/repository/annotation_record.py
@@ -790,6 +790,7 @@ class AnnotationRepository(BaseRepository):
         for score_info in scores_data:
             model_id = score_info["model_id"]
             score_value = score_info["score"]
+            display_score = score_info.get("display_score")
             is_edited = score_info.get("is_edited_manually", False)
 
             existing_record = existing_scores_map.get(model_id)
@@ -798,6 +799,7 @@ class AnnotationRepository(BaseRepository):
                 # 更新
                 logger.debug(f"Updating existing score: id={existing_record.id}")
                 existing_record.score = score_value
+                existing_record.display_score = display_score
                 existing_record.is_edited_manually = is_edited or False  # None → False
             else:
                 # 新規作成
@@ -806,6 +808,7 @@ class AnnotationRepository(BaseRepository):
                     image_id=image_id,
                     model_id=model_id,
                     score=score_value,
+                    display_score=display_score,
                     is_edited_manually=is_edited,  # 渡された値を使用
                 )
                 session.add(new_score)

--- a/src/lorairo/database/repository/image.py
+++ b/src/lorairo/database/repository/image.py
@@ -1572,24 +1572,25 @@ class ImageRepository(BaseRepository):
         if score_min is None and score_max is None:
             return query
 
-        # DB値（0.0-10.0）で直接比較
+        # 0.0-10.0 表示スコアで比較 (Issue #626: display_score 使用)
         db_min = score_min if score_min is not None else 0.0
         db_max = score_max if score_max is not None else 10.0
 
-        # 指定範囲内のスコアを持つ画像のみを含める
+        # display_score が存在する行のみ対象にし、表示スコアで範囲フィルタ
         score_condition = (
             exists()
             .where(
                 Score.image_id == Image.id,
-                Score.score >= db_min,
-                Score.score <= db_max,
+                Score.display_score.isnot(None),
+                Score.display_score >= db_min,
+                Score.display_score <= db_max,
             )
             .correlate(Image)
         )
 
         query = query.where(score_condition)
         logger.debug(
-            f"Score filter applied: {db_min:.2f} - {db_max:.2f}",
+            f"Score filter applied (display_score): {db_min:.2f} - {db_max:.2f}",
         )
 
         return query

--- a/src/lorairo/database/schema.py
+++ b/src/lorairo/database/schema.py
@@ -352,6 +352,7 @@ class Score(Base):
     image_id: Mapped[int | None] = mapped_column(ForeignKey("images.id", ondelete="CASCADE"))
     model_id: Mapped[int | None] = mapped_column(ForeignKey("models.id", ondelete="SET NULL"))
     score: Mapped[float] = mapped_column(Float, nullable=False)
+    display_score: Mapped[float | None] = mapped_column(Float, nullable=True)
     is_edited_manually: Mapped[bool] = mapped_column(Boolean, default=False, nullable=True)
     created_at: Mapped[datetime.datetime] = mapped_column(
         TIMESTAMP(timezone=True), server_default=func.now()
@@ -712,6 +713,7 @@ class ScoreAnnotationData(TypedDict):
     image_id: NotRequired[int | None]  # Set by save_annotations
     model_id: int | None
     score: float
+    display_score: NotRequired[float | None]
     # is_edited_manually: bool # Default False, NOT NULL in schema (check migration)
     is_edited_manually: bool | None  # nullable=True に合わせた
     created_at: NotRequired[datetime.datetime]

--- a/src/lorairo/gui/services/image_db_write_service.py
+++ b/src/lorairo/gui/services/image_db_write_service.py
@@ -200,6 +200,7 @@ class ImageDBWriteService:
             score_data: ScoreAnnotationData = {
                 "model_id": self.db_manager.get_manual_edit_model_id(),
                 "score": db_score,
+                "display_score": db_score,  # 手動編集値は既に 0-10 スケール
                 "is_edited_manually": True,  # 手動編集フラグ
             }
 

--- a/src/lorairo/services/annotation_save_service.py
+++ b/src/lorairo/services/annotation_save_service.py
@@ -15,7 +15,7 @@ from lorairo.database.repository.error_record import ErrorRecordRepository
 from lorairo.database.repository.image import ImageRepository
 from lorairo.database.repository.model import ModelRepository
 from lorairo.domain.rating_mapper import map_rating
-from lorairo.domain.score_scaler import is_ai_scored_model, positive_key_for
+from lorairo.domain.score_scaler import calibrate_to_display, is_ai_scored_model, positive_key_for
 from lorairo.utils.log import logger
 
 if TYPE_CHECKING:
@@ -176,10 +176,12 @@ class AnnotationSaveService:
                     f"スコア保存をスキップ: keys={list(scores.keys())}"
                 )
                 return
+            raw = float(scores[positive_key])
             result["scores"].append(
                 {
                     "model_id": model_id,
-                    "score": float(scores[positive_key]),
+                    "score": raw,
+                    "display_score": calibrate_to_display(model_name, raw),
                     "is_edited_manually": False,
                 }
             )
@@ -187,8 +189,14 @@ class AnnotationSaveService:
 
         # 未知 scorer: 後方互換で全 key を保存する。
         for _name, value in scores.items():
+            raw = float(value)
             result["scores"].append(
-                {"model_id": model_id, "score": float(value), "is_edited_manually": False}
+                {
+                    "model_id": model_id,
+                    "score": raw,
+                    "display_score": calibrate_to_display(model_name, raw),
+                    "is_edited_manually": False,
+                }
             )
 
     def _append_rating_row(self, model_id: int, ratings: Any, result: AnnotationsDict) -> None:

--- a/tests/unit/database/test_migration_d1e2f3a4b5c6_display_score.py
+++ b/tests/unit/database/test_migration_d1e2f3a4b5c6_display_score.py
@@ -1,0 +1,236 @@
+"""Alembic migration `d1e2f3a4b5c6` display_score backfill checks."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from alembic import command
+from alembic.config import Config
+from alembic.script import ScriptDirectory
+from sqlalchemy import create_engine, inspect, text
+
+
+def _make_alembic_config(db_path: Path) -> Config:
+    project_root = Path(__file__).resolve().parents[3]
+    cfg = Config(str(project_root / "alembic.ini"))
+    cfg.set_main_option("script_location", str(project_root / "src/lorairo/database/migrations"))
+    cfg.set_main_option("sqlalchemy.url", f"sqlite:///{db_path}")
+    return cfg
+
+
+def _get_current_head(cfg: Config) -> str:
+    heads = ScriptDirectory.from_config(cfg).get_heads()
+    assert len(heads) == 1
+    return heads[0]
+
+
+def _create_schema_at_e1(db_path: Path) -> None:
+    """e1f2a3b4c5d6 (grayscale) 直後の最小スキーマを作る (display_score カラムはまだない)。"""
+    engine = create_engine(f"sqlite:///{db_path}")
+    with engine.begin() as conn:
+        conn.execute(
+            text(
+                """
+                CREATE TABLE models (
+                    id INTEGER NOT NULL PRIMARY KEY,
+                    name VARCHAR NOT NULL,
+                    provider VARCHAR,
+                    litellm_model_id VARCHAR NOT NULL,
+                    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
+                    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL
+                )
+                """
+            )
+        )
+        conn.execute(
+            text(
+                """
+                CREATE TABLE images (
+                    id INTEGER NOT NULL PRIMARY KEY,
+                    uuid VARCHAR NOT NULL,
+                    phash VARCHAR NOT NULL,
+                    original_image_path VARCHAR NOT NULL,
+                    stored_image_path VARCHAR NOT NULL,
+                    width INTEGER NOT NULL,
+                    height INTEGER NOT NULL,
+                    format VARCHAR NOT NULL,
+                    mode VARCHAR NOT NULL,
+                    has_alpha BOOLEAN NOT NULL,
+                    filename VARCHAR NOT NULL,
+                    extension VARCHAR NOT NULL,
+                    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
+                    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL
+                )
+                """
+            )
+        )
+        conn.execute(
+            text(
+                """
+                CREATE TABLE scores (
+                    id INTEGER NOT NULL PRIMARY KEY,
+                    image_id INTEGER,
+                    model_id INTEGER,
+                    score FLOAT NOT NULL,
+                    is_edited_manually BOOLEAN,
+                    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
+                    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
+                    FOREIGN KEY(image_id) REFERENCES images (id) ON DELETE CASCADE,
+                    FOREIGN KEY(model_id) REFERENCES models (id) ON DELETE SET NULL
+                )
+                """
+            )
+        )
+        conn.execute(text("CREATE INDEX ix_scores_image_id ON scores (image_id)"))
+        # モデル行を登録
+        conn.execute(
+            text(
+                "INSERT INTO models (id, name, litellm_model_id) VALUES "
+                "(1, 'aesthetic_shadow_v2', 'aesthetic_shadow_v2'), "
+                "(2, 'openai/gpt-4o-mini', 'openai/gpt-4o-mini'), "
+                "(3, 'MANUAL_EDIT', 'MANUAL_EDIT'), "
+                "(4, 'unknown_legacy_model', 'unknown_legacy_model')"
+            )
+        )
+        conn.execute(
+            text(
+                "INSERT INTO images (id, uuid, phash, original_image_path, stored_image_path,"
+                " width, height, format, mode, has_alpha, filename, extension) VALUES"
+                " (1, 'u1', 'p1', 'orig1', 'stored1', 512, 512, 'PNG', 'RGB', 0, 'img1', 'png')"
+            )
+        )
+        # aesthetic_shadow_v2: hq=0.45 → 区分線形補間 → 8.0
+        conn.execute(
+            text(
+                "INSERT INTO scores (id, image_id, model_id, score, is_edited_manually) VALUES (1, 1, 1, 0.45, 0)"
+            )
+        )
+        # WebAPI (openai/gpt-4o-mini): raw=7.5 → identity + clamp → 7.5
+        conn.execute(
+            text(
+                "INSERT INTO scores (id, image_id, model_id, score, is_edited_manually) VALUES (2, 1, 2, 7.5, 0)"
+            )
+        )
+        # MANUAL_EDIT: raw=6.5 (already 0-10) → display_score=6.5
+        conn.execute(
+            text(
+                "INSERT INTO scores (id, image_id, model_id, score, is_edited_manually) VALUES (3, 1, 3, 6.5, 1)"
+            )
+        )
+        # 未知モデル: raw=0.3 → 0.3 * 10 = 3.0
+        conn.execute(
+            text(
+                "INSERT INTO scores (id, image_id, model_id, score, is_edited_manually) VALUES (4, 1, 4, 0.3, 0)"
+            )
+        )
+        conn.execute(text("CREATE TABLE alembic_version (version_num VARCHAR(32) PRIMARY KEY)"))
+        conn.execute(text("INSERT INTO alembic_version (version_num) VALUES ('e1f2a3b4c5d6')"))
+    engine.dispose()
+
+
+@pytest.mark.unit
+def test_display_score_column_added(tmp_path: Path) -> None:
+    """upgrade 後に display_score カラムが追加されること。"""
+    db_path = tmp_path / "display-score.db"
+    _create_schema_at_e1(db_path)
+    cfg = _make_alembic_config(db_path)
+
+    command.upgrade(cfg, "head")
+
+    engine = create_engine(f"sqlite:///{db_path}")
+    with engine.connect() as conn:
+        version = conn.execute(text("SELECT version_num FROM alembic_version")).scalar_one()
+        columns = {c["name"] for c in inspect(engine).get_columns("scores")}
+    engine.dispose()
+
+    assert version == _get_current_head(cfg)
+    assert "display_score" in columns
+
+
+@pytest.mark.unit
+def test_display_score_backfill_aesthetic_shadow(tmp_path: Path) -> None:
+    """aesthetic_shadow_v2 の raw=0.45 は区分線形補間で display_score=8.0 になること。"""
+    db_path = tmp_path / "display-score.db"
+    _create_schema_at_e1(db_path)
+    cfg = _make_alembic_config(db_path)
+
+    command.upgrade(cfg, "head")
+
+    engine = create_engine(f"sqlite:///{db_path}")
+    with engine.connect() as conn:
+        display = conn.execute(text("SELECT display_score FROM scores WHERE id = 1")).scalar_one()
+    engine.dispose()
+
+    assert display == pytest.approx(8.0, abs=1e-6)
+
+
+@pytest.mark.unit
+def test_display_score_backfill_webapi(tmp_path: Path) -> None:
+    """WebAPI モデル (name に '/' 含む) の raw=7.5 は identity → display_score=7.5 になること。"""
+    db_path = tmp_path / "display-score.db"
+    _create_schema_at_e1(db_path)
+    cfg = _make_alembic_config(db_path)
+
+    command.upgrade(cfg, "head")
+
+    engine = create_engine(f"sqlite:///{db_path}")
+    with engine.connect() as conn:
+        display = conn.execute(text("SELECT display_score FROM scores WHERE id = 2")).scalar_one()
+    engine.dispose()
+
+    assert display == pytest.approx(7.5, abs=1e-6)
+
+
+@pytest.mark.unit
+def test_display_score_backfill_manual_edit(tmp_path: Path) -> None:
+    """is_edited_manually=True の行は raw をそのまま display_score に使うこと。"""
+    db_path = tmp_path / "display-score.db"
+    _create_schema_at_e1(db_path)
+    cfg = _make_alembic_config(db_path)
+
+    command.upgrade(cfg, "head")
+
+    engine = create_engine(f"sqlite:///{db_path}")
+    with engine.connect() as conn:
+        display = conn.execute(text("SELECT display_score FROM scores WHERE id = 3")).scalar_one()
+    engine.dispose()
+
+    assert display == pytest.approx(6.5, abs=1e-6)
+
+
+@pytest.mark.unit
+def test_display_score_backfill_unknown_model(tmp_path: Path) -> None:
+    """未知モデルは raw * 10 fallback で display_score が計算されること。"""
+    db_path = tmp_path / "display-score.db"
+    _create_schema_at_e1(db_path)
+    cfg = _make_alembic_config(db_path)
+
+    command.upgrade(cfg, "head")
+
+    engine = create_engine(f"sqlite:///{db_path}")
+    with engine.connect() as conn:
+        display = conn.execute(text("SELECT display_score FROM scores WHERE id = 4")).scalar_one()
+    engine.dispose()
+
+    assert display == pytest.approx(3.0, abs=1e-6)
+
+
+@pytest.mark.unit
+def test_downgrade_removes_column(tmp_path: Path) -> None:
+    """downgrade 後に display_score カラムが削除されること。"""
+    db_path = tmp_path / "display-score.db"
+    _create_schema_at_e1(db_path)
+    cfg = _make_alembic_config(db_path)
+
+    command.upgrade(cfg, "head")
+    command.downgrade(cfg, "e1f2a3b4c5d6")
+
+    engine = create_engine(f"sqlite:///{db_path}")
+    with engine.connect() as conn:
+        columns = {c["name"] for c in inspect(engine).get_columns("scores")}
+        version = conn.execute(text("SELECT version_num FROM alembic_version")).scalar_one()
+    engine.dispose()
+
+    assert "display_score" not in columns
+    assert version == "e1f2a3b4c5d6"


### PR DESCRIPTION
## Summary

- `Score` テーブルに `display_score` (Float, nullable) カラムを追加。生の raw スコアを calibrate_to_display() で変換した 0-10 表示スコアを永続化する
- Alembic migration `d1e2f3a4b5c6` で既存 DB をバックフィル（起動時の `alembic upgrade head` で Windows 環境でも自動適用）
- `_apply_score_filter` を `Score.score`（raw、モデルごとに尺度が異なる）から `Score.display_score`（常に 0-10）で比較するよう修正
- `annotation_save_service`・`image_db_write_service`・`annotation_record` のスコア保存経路に `display_score` 計算・書き込みを追加

## Root cause

`aesthetic_shadow_v2` の raw スコアは 0-1 の確率値だが、スコアフィルタは UI の 0-10 値と直接比較していた。例: `hq=0.71`（表示スコア 9.0）が `フィルタ min=5.0` で除外されてしまう。WebAPI モデル (`openai/o1`) は 0-10 で返すが、未知モデル fallback で `raw * 10` されて 10.0 にクランプされていた（Issue #644 で修正済み）。

## バックフィル戦略

| モデル種別 | 変換方法 |
|---|---|
| `aesthetic_shadow_v1/v2` | 区分線形補間 (knots: 0→0, 0.45→8, 0.71→9, 1→10) |
| `cafe_aesthetic` | 区分線形補間 (knots: 0→0, 0.5→6, 1→8) |
| `WaifuAesthetic` | linear 0-1 → 0-10 |
| `ImprovedAesthetic` | AVA 1-10 identity clamp |
| WebAPI (name に `/` 含む) | identity + clamp |
| 手動編集 (`is_edited_manually=True`) | そのまま (既に 0-10) |
| 未知モデル | `raw * 10` fallback (0-1 仮定) |

## Test plan

- [ ] `tests/unit/database/test_migration_d1e2f3a4b5c6_display_score.py` (6 tests) — カラム追加・各モデル種別 backfill・downgrade を検証
- [ ] CI-equivalent filter 全通過確認済み (pre-existing failure 1件: `test_build_child_env_uses_shared_venv_for_worktree` は main でも失敗)
- [ ] Windows 起動時は `alembic upgrade head` が既存 DB を自動 backfill

Closes #626

🤖 Generated with [Claude Code](https://claude.com/claude-code)