### PR TITLE
feat: add bounded image list pagination

### DIFF
--- a/src/lorairo/api/exceptions.py
+++ b/src/lorairo/api/exceptions.py
@@ -275,3 +275,20 @@ class InvalidPathError(ValidationError):
     def __init__(self, path: str, reason: str) -> None:
         self.path = path
         super().__init__(f"パス '{path}' は無効です: {reason}")
+
+
+class ResultSetTooLargeError(ValidationError):
+    """検索結果が bounded pagination の取得上限を超えた場合に発生。
+
+    Args:
+        matched: フィルタ条件に一致した総件数。
+        limit: 取得可能な最大件数。
+    """
+
+    def __init__(self, matched: int, limit: int) -> None:
+        self.matched = matched
+        self.limit = limit
+        self.details = {"limit": limit, "matched": matched}
+        super().__init__(
+            f"{matched:,} 件が一致しました。検索条件を追加して {limit} 件以下に絞ってください。"
+        )

--- a/src/lorairo/cli/_boundary.py
+++ b/src/lorairo/cli/_boundary.py
@@ -31,7 +31,7 @@ from lorairo.cli._output_mode import is_json_mode
 _console_err = make_console(stderr=True)
 
 
-def _report(message: str, info: ErrorInfo) -> None:
+def _report(message: str, info: ErrorInfo, details: dict[str, object] | None = None) -> None:
     """分類結果を出力モードに応じて出す (JSONL or rich/stderr)。"""
     if is_json_mode():
         emit_error(
@@ -40,6 +40,7 @@ def _report(message: str, info: ErrorInfo) -> None:
             retryable=info.retryable,
             user_action_required=info.user_action_required,
             hint=hint_for(info.code),
+            details=details,
         )
     else:
         _console_err.print(f"[red]Error:[/red] {message}")
@@ -73,5 +74,5 @@ def command_boundary() -> Iterator[None]:
     except Exception as exc:
         info = classify_exception(exc)
         message = str(exc) or type(exc).__name__
-        _report(message, info)
+        _report(message, info, details=getattr(exc, "details", None))
         raise typer.Exit(code=info.exit_code) from exc

--- a/src/lorairo/cli/_errors.py
+++ b/src/lorairo/cli/_errors.py
@@ -190,6 +190,8 @@ def _classify_lorairo_exception(exc: BaseException) -> ErrorInfo | None:
         return ErrorInfo(ErrorCode.NOT_FOUND, retryable=False, user_action_required=True)
     if isinstance(exc, (app_exc.ProjectAlreadyExistsError, app_exc.DuplicateImageError)):
         return ErrorInfo(ErrorCode.ALREADY_EXISTS, retryable=False, user_action_required=True)
+    if isinstance(exc, app_exc.ResultSetTooLargeError):
+        return ErrorInfo(ErrorCode.RESULT_SET_TOO_LARGE, retryable=False, user_action_required=True)
     if isinstance(exc, app_exc.InvalidFormatError):
         return ErrorInfo(ErrorCode.INVALID_INPUT, retryable=False, user_action_required=True)
     if isinstance(exc, app_exc.ValidationError):

--- a/src/lorairo/cli/commands/images.py
+++ b/src/lorairo/cli/commands/images.py
@@ -14,7 +14,7 @@ import click
 import typer
 from rich.table import Table
 
-from lorairo.api.exceptions import ImageNotFoundError
+from lorairo.api.exceptions import ImageNotFoundError, ResultSetTooLargeError
 from lorairo.api.images import register_images as api_register_images
 from lorairo.api.project import get_project as api_get_project
 from lorairo.api.types import RegistrationResult
@@ -32,6 +32,8 @@ app = typer.Typer(help="Image management commands")
 
 # Rich console (Issue #254: Windows では safe_box=True で ASCII 罫線)
 console = make_console()
+
+MAX_IMAGE_LIST_FETCH = 500
 
 
 def _print_registration_summary(result: RegistrationResult, project: str) -> None:
@@ -187,12 +189,24 @@ def list_images(
         "-p",
         help="Project name",
     ),
-    limit: int | None = typer.Option(
-        None,
+    fetch: bool = typer.Option(
+        False,
+        "--fetch",
+        help="Fetch image_id and file_path rows. Without this flag only the matching count is shown.",
+    ),
+    limit: int = typer.Option(
+        MAX_IMAGE_LIST_FETCH,
         "--limit",
         "-l",
+        max=MAX_IMAGE_LIST_FETCH,
         min=1,
-        help="Maximum number of images to display (>= 1)",
+        help=f"Maximum number of image rows to fetch (1-{MAX_IMAGE_LIST_FETCH})",
+    ),
+    offset: int = typer.Option(
+        0,
+        "--offset",
+        min=0,
+        help="Number of matching images to skip before fetching rows.",
     ),
     unrated: bool = typer.Option(
         False,
@@ -211,63 +225,51 @@ def list_images(
         container.set_active_project(project)
 
         repository = container.db_manager.image_repo
-        criteria = ImageFilterCriteria(include_nsfw=True, only_unrated=unrated, limit=limit)
-        image_records, total_count = repository.get_images_by_filter(criteria)
+        count_criteria = ImageFilterCriteria(include_nsfw=True, only_unrated=unrated)
+        total_count = repository.get_images_count_only(count_criteria)
+
+        if not fetch:
+            suffix = " without ratings" if unrated else ""
+            message = f"{total_count} image(s){suffix} found in project: {project}"
+            if is_json_mode():
+                emit_result(message, count=total_count)
+            else:
+                console.print(message)
+            return
+
+        if total_count > MAX_IMAGE_LIST_FETCH:
+            raise ResultSetTooLargeError(matched=total_count, limit=MAX_IMAGE_LIST_FETCH)
+
+        fetch_criteria = ImageFilterCriteria(
+            include_nsfw=True,
+            only_unrated=unrated,
+            limit=limit,
+            offset=offset,
+        )
+        image_records, total_count = repository.get_image_list_page(fetch_criteria)
+        count = len(image_records)
+        has_more = offset + count < total_count
 
         if is_json_mode():
             for record in image_records:
-                filename = Path(record.get("stored_image_path", "")).name or str(record.get("filename", ""))
-                has_any_annotation = bool(
-                    record.get("tags")
-                    or record.get("captions")
-                    or record.get("scores")
-                    or record.get("ratings")
-                )
                 emit_item(
                     {
-                        "id": record.get("id"),
-                        "filename": filename,
-                        "tags": len(record.get("tags") or []),
-                        "annotated": has_any_annotation,
+                        "image_id": record.get("image_id"),
+                        "file_path": record.get("file_path"),
                     }
                 )
             emit_result(
-                f"{len(image_records)} image(s)",
-                count=len(image_records),
+                f"{count} image(s)",
+                count=count,
                 total=total_count,
+                limit=limit,
+                offset=offset,
+                has_more=has_more,
             )
             return
-
-        if not image_records:
-            suffix = " without ratings" if unrated else ""
-            console.print(f"No images{suffix} found in project: {project}")
-            return
-
-        heading_suffix = " (unrated only)" if unrated else ""
-        console.print(f"Images in project: {project}{heading_suffix}")
-        table = Table()
-        table.add_column("ID", style="cyan")
-        table.add_column("Filename")
-        table.add_column("Tags", style="green")
-        table.add_column("Annotated", style="yellow")
 
         for record in image_records:
-            image_id = str(record.get("id", ""))
-            filename = Path(record.get("stored_image_path", "")).name or str(record.get("filename", ""))
-            tag_count = len(record.get("tags") or [])
-            has_any_annotation = bool(
-                record.get("tags")
-                or record.get("captions")
-                or record.get("scores")
-                or record.get("ratings")
-            )
-            annotated = "Yes" if has_any_annotation else "No"
-            table.add_row(image_id, filename, str(tag_count), annotated)
-
-        console.print(table)
-
-        if limit and total_count > limit:
-            console.print(f"Showing {limit} of {total_count} images.")
+            print(f"{record.get('image_id')}\t{record.get('file_path')}")
 
 
 @app.command("update")

--- a/src/lorairo/database/repository/image.py
+++ b/src/lorairo/database/repository/image.py
@@ -2340,6 +2340,86 @@ class ImageRepository(BaseRepository):
                 logger.error(f"画像件数取得中にエラーが発生しました: {e}", exc_info=True)
                 raise
 
+    def get_image_list_page(
+        self,
+        criteria: ImageFilterCriteria | None = None,
+        **kwargs: Any,
+    ) -> tuple[list[dict[str, Any]], int]:
+        """画像一覧用の軽量 projection と総件数を取得する。
+
+        ``images list --fetch`` 用に ``image_id`` と ``file_path`` だけを返す。
+        フィルタ、stable ``Image.id`` 昇順、``limit``/``offset`` は DB クエリへ
+        pushdown し、タグ・キャプション等の重い annotation metadata は読み込まない。
+
+        Args:
+            criteria: ImageFilterCriteria形式のフィルター条件（推奨）
+            **kwargs: レガシー形式のキーワード引数（後方互換性用）
+
+        Returns:
+            (一覧行, フィルタ総件数)。一覧行は ``image_id`` / ``file_path`` のみ。
+        """
+        filter_criteria = criteria if criteria else ImageFilterCriteria.from_kwargs(**kwargs)
+
+        with self.session_factory() as session:
+            try:
+                filtered_query = self._build_image_filter_query(
+                    session=session,
+                    tags=filter_criteria.tags,
+                    excluded_tags=filter_criteria.excluded_tags,
+                    caption=filter_criteria.caption,
+                    use_and=filter_criteria.use_and,
+                    start_date=filter_criteria.start_date,
+                    end_date=filter_criteria.end_date,
+                    include_untagged=filter_criteria.include_untagged,
+                    include_nsfw=filter_criteria.include_nsfw,
+                    include_unrated=filter_criteria.include_unrated,
+                    only_unrated=filter_criteria.only_unrated,
+                    missing_model_litellm_id=filter_criteria.missing_model_litellm_id,
+                    manual_rating_filter=filter_criteria.manual_rating_filter,
+                    ai_rating_filter=filter_criteria.ai_rating_filter,
+                    manual_edit_filter=filter_criteria.manual_edit_filter,
+                    score_min=filter_criteria.score_min,
+                    score_max=filter_criteria.score_max,
+                    project_name=filter_criteria.project_name,
+                    project_id=filter_criteria.project_id,
+                )
+                filtered_query = self._apply_processed_resolution_filter(
+                    filtered_query, filter_criteria.resolution
+                )
+
+                count_query = select(func.count()).select_from(filtered_query.subquery())
+                total_count = session.execute(count_query).scalar_one()
+                if total_count == 0:
+                    return [], 0
+
+                ids_subquery = filtered_query.order_by(Image.id)
+                if filter_criteria.offset:
+                    ids_subquery = ids_subquery.offset(filter_criteria.offset)
+                if filter_criteria.limit is not None:
+                    ids_subquery = ids_subquery.limit(filter_criteria.limit)
+
+                image_ids = list(session.execute(ids_subquery).scalars().all())
+                if not image_ids:
+                    return [], total_count
+
+                rows = session.execute(
+                    select(Image.id, Image.stored_image_path, Image.filename)
+                    .where(Image.id.in_(image_ids))
+                    .order_by(Image.id)
+                ).all()
+                page = [
+                    {
+                        "image_id": row.id,
+                        "file_path": str(row.stored_image_path or row.filename or ""),
+                    }
+                    for row in rows
+                ]
+                return page, total_count
+
+            except SQLAlchemyError as e:
+                logger.error(f"画像一覧ページ取得中にエラーが発生しました: {e}", exc_info=True)
+                raise
+
     # --- Count ---
 
     def get_total_image_count(self) -> int:

--- a/tests/unit/cli/test_commands_images.py
+++ b/tests/unit/cli/test_commands_images.py
@@ -1,5 +1,6 @@
 """Image management commands テスト。"""
 
+import json
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -203,111 +204,101 @@ def test_images_list_help() -> None:
 @pytest.mark.unit
 @pytest.mark.cli
 def test_images_list_shows_registered_images(mock_projects_dir: Path, test_images_dir: Path) -> None:
-    """Test: images list - 登録済み画像をテーブル表示する。"""
+    """Test: images list - デフォルトは件数のみを表示する。"""
     runner.invoke(app, ["project", "create", "test-project"])
     runner.invoke(app, ["images", "register", str(test_images_dir), "--project", "test-project"])
 
     result = runner.invoke(app, ["images", "list", "--project", "test-project"])
 
     assert result.exit_code == 0
-    assert "Images in project: test-project" in result.stdout
-    assert "ID" in result.stdout
-    assert "Filename" in result.stdout
-    assert "Tags" in result.stdout
-    assert "Annotated" in result.stdout
+    assert "image(s) found in project: test-project" in result.stdout
+    assert "ID" not in result.stdout
+    assert "Filename" not in result.stdout
 
 
 @pytest.mark.unit
 @pytest.mark.cli
-def test_images_list_displays_tag_count_from_tags_list(mock_projects_dir: Path) -> None:
-    """Test: images list - tags リストの長さがそのまま Tag 列に出る。"""
+def test_images_list_fetch_outputs_plain_id_path_rows(mock_projects_dir: Path) -> None:
+    """Test: images list --fetch - human output は image_id<TAB>file_path の plain 行。"""
     runner.invoke(app, ["project", "create", "test-project"])
 
     fake_records = [
         {
-            "id": 1,
-            "stored_image_path": "/path/img.jpg",
-            "tags": [
-                {"id": 1, "tag": "cat"},
-                {"id": 2, "tag": "dog"},
-            ],
-            "captions": [],
-            "scores": [],
-            "ratings": [],
+            "image_id": 1,
+            "file_path": "/path/img.jpg",
         },
     ]
     with patch("lorairo.cli.commands.images.get_service_container") as mock_get_container:
         mock_container = MagicMock()
-        mock_container.db_manager.image_repo.get_images_by_filter.return_value = (fake_records, 1)
+        mock_container.db_manager.image_repo.get_images_count_only.return_value = 1
+        mock_container.db_manager.image_repo.get_image_list_page.return_value = (fake_records, 1)
         mock_get_container.return_value = mock_container
 
-        result = runner.invoke(app, ["images", "list", "--project", "test-project"])
+        result = runner.invoke(app, ["images", "list", "--project", "test-project", "--fetch"])
 
     assert result.exit_code == 0
-    assert "img.jpg" in result.stdout
-    # タグ件数 2 と Annotated=Yes が両方表示されることを検証
-    assert "2" in result.stdout
-    assert "Yes" in result.stdout
+    assert result.stdout == "1\t/path/img.jpg\n"
 
 
 @pytest.mark.unit
 @pytest.mark.cli
-def test_images_list_annotated_yes_when_only_captions(mock_projects_dir: Path) -> None:
-    """Test: images list - tags 空でも captions があれば Annotated=Yes。"""
+def test_images_list_fetch_json_outputs_items_and_result_meta(mock_projects_dir: Path) -> None:
+    """Test: images list --fetch --json - item 行と件数メタを出力する。"""
     runner.invoke(app, ["project", "create", "test-project"])
 
     fake_records = [
         {
-            "id": 1,
-            "stored_image_path": "/path/img.jpg",
-            "tags": [],
-            "captions": [{"id": 1, "caption": "a cat"}],
-            "scores": [],
-            "ratings": [],
+            "image_id": 1,
+            "file_path": "/path/img.jpg",
         },
     ]
     with patch("lorairo.cli.commands.images.get_service_container") as mock_get_container:
         mock_container = MagicMock()
-        mock_container.db_manager.image_repo.get_images_by_filter.return_value = (fake_records, 1)
+        mock_container.db_manager.image_repo.get_images_count_only.return_value = 1
+        mock_container.db_manager.image_repo.get_image_list_page.return_value = (fake_records, 1)
         mock_get_container.return_value = mock_container
 
-        result = runner.invoke(app, ["images", "list", "--project", "test-project"])
+        result = runner.invoke(
+            app, ["--json", "images", "list", "--project", "test-project", "--fetch", "--limit", "1"]
+        )
 
     assert result.exit_code == 0
-    assert "Yes" in result.stdout
+    lines = [json.loads(line) for line in result.stdout.splitlines()]
+    assert lines[0] == {"kind": "item", "image_id": 1, "file_path": "/path/img.jpg"}
+    assert lines[1]["kind"] == "result"
+    assert lines[1]["count"] == 1
+    assert lines[1]["total"] == 1
+    assert lines[1]["limit"] == 1
+    assert lines[1]["offset"] == 0
+    assert lines[1]["has_more"] is False
 
 
 @pytest.mark.unit
 @pytest.mark.cli
-def test_images_list_no_annotation_shows_no(mock_projects_dir: Path) -> None:
-    """Test: images list - 何のアノテーションも無いとき Annotated=No。"""
+def test_images_list_fetch_total_over_cap_errors_before_items(mock_projects_dir: Path) -> None:
+    """Test: images list --fetch - total 500 超は RESULT_SET_TOO_LARGE で item を出さない。"""
     runner.invoke(app, ["project", "create", "test-project"])
 
-    fake_records = [
-        {
-            "id": 1,
-            "stored_image_path": "/path/img.jpg",
-            "tags": [],
-            "captions": [],
-            "scores": [],
-            "ratings": [],
-        },
-    ]
     with patch("lorairo.cli.commands.images.get_service_container") as mock_get_container:
         mock_container = MagicMock()
-        mock_container.db_manager.image_repo.get_images_by_filter.return_value = (fake_records, 1)
+        mock_container.db_manager.image_repo.get_images_count_only.return_value = 501
         mock_get_container.return_value = mock_container
 
-        result = runner.invoke(app, ["images", "list", "--project", "test-project"])
+        result = runner.invoke(app, ["--json", "images", "list", "--project", "test-project", "--fetch"])
 
-    assert result.exit_code == 0
-    assert "No" in result.stdout
+    assert result.exit_code == 2
+    lines = [json.loads(line) for line in result.stdout.splitlines()]
+    assert len(lines) == 1
+    assert lines[0]["kind"] == "error"
+    assert lines[0]["code"] == "RESULT_SET_TOO_LARGE"
+    assert lines[0]["details"] == {"limit": 500, "matched": 501}
+    mock_container.db_manager.image_repo.get_image_list_page.assert_not_called()
 
 
 @pytest.mark.unit
 @pytest.mark.cli
 def test_images_list_reflects_update_tags(mock_projects_dir: Path, test_images_dir: Path) -> None:
-    """Test: images update でタグを追加した後、images list が件数を反映する。"""
+    """Test: images update 後も images list の count が取得できる。"""
     runner.invoke(app, ["project", "create", "test-project"])
     runner.invoke(app, ["images", "register", str(test_images_dir), "--project", "test-project"])
     runner.invoke(app, ["images", "update", "--project", "test-project", "--tags", "cat,dog"])
@@ -315,8 +306,7 @@ def test_images_list_reflects_update_tags(mock_projects_dir: Path, test_images_d
     result = runner.invoke(app, ["images", "list", "--project", "test-project"])
 
     assert result.exit_code == 0
-    # 直前に 2 タグを追加したので Annotated=Yes になっているはず
-    assert "Yes" in result.stdout
+    assert "image(s) found in project: test-project" in result.stdout
 
 
 @pytest.mark.unit
@@ -328,38 +318,37 @@ def test_images_list_no_images_shows_message(mock_projects_dir: Path) -> None:
     result = runner.invoke(app, ["images", "list", "--project", "test-project"])
 
     assert result.exit_code == 0
-    assert "No images found" in result.stdout
+    assert "0 image(s) found" in result.stdout
 
 
 @pytest.mark.unit
 @pytest.mark.cli
-def test_images_list_with_limit(mock_projects_dir: Path) -> None:
-    """Test: images list --limit - 件数を制限して表示する。"""
+def test_images_list_fetch_with_limit_and_offset(mock_projects_dir: Path) -> None:
+    """Test: images list --fetch --limit/--offset - criteria に pushdown する。"""
     runner.invoke(app, ["project", "create", "test-project"])
 
     fake_records = [
         {
-            "id": i,
-            "stored_image_path": f"/path/image{i}.jpg",
-            "tags": [],
-            "captions": [],
-            "scores": [],
-            "ratings": [],
+            "image_id": 2,
+            "file_path": "/path/image2.jpg",
         }
-        for i in range(1, 4)
     ]
     with patch("lorairo.cli.commands.images.get_service_container") as mock_get_container:
         mock_container = MagicMock()
-        mock_container.db_manager.image_repo.get_images_by_filter.return_value = (fake_records[:1], 3)
+        mock_container.db_manager.image_repo.get_images_count_only.return_value = 3
+        mock_container.db_manager.image_repo.get_image_list_page.return_value = (fake_records, 3)
         mock_get_container.return_value = mock_container
 
-        result = runner.invoke(app, ["images", "list", "--project", "test-project", "--limit", "1"])
+        result = runner.invoke(
+            app,
+            ["images", "list", "--project", "test-project", "--fetch", "--limit", "1", "--offset", "1"],
+        )
 
     assert result.exit_code == 0
-    criteria = mock_container.db_manager.image_repo.get_images_by_filter.call_args.args[0]
+    criteria = mock_container.db_manager.image_repo.get_image_list_page.call_args.args[0]
     assert criteria.limit == 1
-    assert "Images in project: test-project" in result.stdout
-    assert "Showing 1 of 3" in result.stdout
+    assert criteria.offset == 1
+    assert result.stdout == "2\t/path/image2.jpg\n"
 
 
 @pytest.mark.unit
@@ -368,28 +357,18 @@ def test_images_list_unrated_passes_only_unrated_criteria(mock_projects_dir: Pat
     """Test: images list --unrated は rating 未保存画像のみに絞る criteria を渡す。"""
     runner.invoke(app, ["project", "create", "test-project"])
 
-    fake_records = [
-        {
-            "id": 1,
-            "stored_image_path": "/path/image1.jpg",
-            "tags": [],
-            "captions": [],
-            "scores": [],
-            "ratings": [],
-        }
-    ]
     with patch("lorairo.cli.commands.images.get_service_container") as mock_get_container:
         mock_container = MagicMock()
-        mock_container.db_manager.image_repo.get_images_by_filter.return_value = (fake_records, 1)
+        mock_container.db_manager.image_repo.get_images_count_only.return_value = 1
         mock_get_container.return_value = mock_container
 
         result = runner.invoke(app, ["images", "list", "--project", "test-project", "--unrated"])
 
     assert result.exit_code == 0
-    criteria = mock_container.db_manager.image_repo.get_images_by_filter.call_args.args[0]
+    criteria = mock_container.db_manager.image_repo.get_images_count_only.call_args.args[0]
     assert criteria.include_nsfw is True
     assert criteria.only_unrated is True
-    assert "unrated only" in result.stdout
+    assert "without ratings" in result.stdout
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary
- Implements ADR 0060 count-first behavior for `images list`.
- Adds `--fetch`, limit/offset, stable lightweight `image_id` + `file_path` output, and total-based 500 cap.
- Adds reusable `ResultSetTooLargeError` classification with JSONL error details.

## Verification
- `UV_PROJECT_ENVIRONMENT=/workspaces/LoRAIro/.venv uv run --no-sync pytest tests/unit/cli/test_commands_images.py -q`
- `UV_PROJECT_ENVIRONMENT=/workspaces/LoRAIro/.venv uv run --no-sync ruff check src/lorairo/api/exceptions.py src/lorairo/cli/_boundary.py src/lorairo/cli/_errors.py src/lorairo/cli/commands/images.py src/lorairo/database/repository/image.py tests/unit/cli/test_commands_images.py`

Closes part of #641.