### PR TITLE
feat: migrate annotate commands to JSONL

### DIFF
--- a/src/lorairo/api/exceptions.py
+++ b/src/lorairo/api/exceptions.py
@@ -275,3 +275,15 @@ class InvalidPathError(ValidationError):
     def __init__(self, path: str, reason: str) -> None:
         self.path = path
         super().__init__(f"パス '{path}' は無効です: {reason}")
+
+
+class ResultSetTooLargeError(ValidationError):
+    """検索結果または処理対象集合が CLI の 500 件上限を超えた場合に発生。"""
+
+    def __init__(self, matched: int, limit: int) -> None:
+        self.matched = matched
+        self.limit = limit
+        self.details = {"limit": limit, "matched": matched}
+        super().__init__(
+            f"{matched:,} 件が一致しました。検索条件を追加して {limit} 件以下に絞ってください。"
+        )

--- a/src/lorairo/cli/_boundary.py
+++ b/src/lorairo/cli/_boundary.py
@@ -24,14 +24,25 @@ import typer
 
 from lorairo.cli._console import make_console
 from lorairo.cli._emit import emit_error
-from lorairo.cli._errors import ErrorCode, ErrorInfo, classify_exception, hint_for
+from lorairo.cli._errors import (
+    ErrorCode,
+    ErrorInfo,
+    classify_exception,
+    hint_for,
+)
 from lorairo.cli._output_mode import is_json_mode
 
 # エラー/装飾は stderr へ (stdout は機械可読 JSONL 専用、ADR 0057 §1)。
 _console_err = make_console(stderr=True)
 
 
-def _report(message: str, info: ErrorInfo) -> None:
+def _error_details(exc: BaseException | None) -> dict[str, int] | None:
+    """Return structured error details for known CLI exceptions."""
+    details = getattr(exc, "details", None)
+    return details if isinstance(details, dict) else None
+
+
+def _report(message: str, info: ErrorInfo, exc: BaseException | None = None) -> None:
     """分類結果を出力モードに応じて出す (JSONL or rich/stderr)。"""
     if is_json_mode():
         emit_error(
@@ -40,6 +51,7 @@ def _report(message: str, info: ErrorInfo) -> None:
             retryable=info.retryable,
             user_action_required=info.user_action_required,
             hint=hint_for(info.code),
+            details=_error_details(exc),
         )
     else:
         _console_err.print(f"[red]Error:[/red] {message}")
@@ -68,10 +80,10 @@ def command_boundary() -> Iterator[None]:
         # 入力エラーとして INVALID_INPUT + exit 2 に統一する (ADR 0057 §6/§7)。
         info = ErrorInfo(ErrorCode.INVALID_INPUT, retryable=False, user_action_required=True)
         message = exc.format_message() if hasattr(exc, "format_message") else str(exc)
-        _report(message, info)
+        _report(message, info, exc)
         raise typer.Exit(code=info.exit_code) from exc
     except Exception as exc:
         info = classify_exception(exc)
         message = str(exc) or type(exc).__name__
-        _report(message, info)
+        _report(message, info, exc)
         raise typer.Exit(code=info.exit_code) from exc

--- a/src/lorairo/cli/_errors.py
+++ b/src/lorairo/cli/_errors.py
@@ -192,6 +192,8 @@ def _classify_lorairo_exception(exc: BaseException) -> ErrorInfo | None:
         return ErrorInfo(ErrorCode.ALREADY_EXISTS, retryable=False, user_action_required=True)
     if isinstance(exc, app_exc.ResultSetTooLargeError):
         return ErrorInfo(ErrorCode.RESULT_SET_TOO_LARGE, retryable=False, user_action_required=True)
+    if isinstance(exc, app_exc.BatchImportError):
+        return ErrorInfo(ErrorCode.VALIDATION_FAILED, retryable=False, user_action_required=True)
     if isinstance(exc, app_exc.InvalidFormatError):
         return ErrorInfo(ErrorCode.INVALID_INPUT, retryable=False, user_action_required=True)
     if isinstance(exc, app_exc.ValidationError):
@@ -227,6 +229,10 @@ def _classify_standard_exception(exc: BaseException) -> ErrorInfo:
         return ErrorInfo(ErrorCode.TIMEOUT, retryable=True, user_action_required=False)
     if isinstance(exc, FileNotFoundError):
         return ErrorInfo(ErrorCode.IO_ERROR, retryable=False, user_action_required=True)
+    if _name_in_mro(exc, frozenset({"AnnotationSelectionError"})):
+        return ErrorInfo(ErrorCode.PRECONDITION_FAILED, retryable=False, user_action_required=True)
+    if _name_in_mro(exc, frozenset({"AnnotationRunFailedError"})):
+        return ErrorInfo(ErrorCode.PRECONDITION_FAILED, retryable=False, user_action_required=True)
     if isinstance(exc, ValueError):
         return ErrorInfo(ErrorCode.INVALID_INPUT, retryable=False, user_action_required=True)
     if isinstance(exc, OSError):

--- a/src/lorairo/cli/_errors.py
+++ b/src/lorairo/cli/_errors.py
@@ -190,6 +190,8 @@ def _classify_lorairo_exception(exc: BaseException) -> ErrorInfo | None:
         return ErrorInfo(ErrorCode.NOT_FOUND, retryable=False, user_action_required=True)
     if isinstance(exc, (app_exc.ProjectAlreadyExistsError, app_exc.DuplicateImageError)):
         return ErrorInfo(ErrorCode.ALREADY_EXISTS, retryable=False, user_action_required=True)
+    if isinstance(exc, app_exc.ResultSetTooLargeError):
+        return ErrorInfo(ErrorCode.RESULT_SET_TOO_LARGE, retryable=False, user_action_required=True)
     if isinstance(exc, app_exc.InvalidFormatError):
         return ErrorInfo(ErrorCode.INVALID_INPUT, retryable=False, user_action_required=True)
     if isinstance(exc, app_exc.ValidationError):

--- a/src/lorairo/cli/_errors.py
+++ b/src/lorairo/cli/_errors.py
@@ -194,6 +194,8 @@ def _classify_lorairo_exception(exc: BaseException) -> ErrorInfo | None:
         return ErrorInfo(ErrorCode.RESULT_SET_TOO_LARGE, retryable=False, user_action_required=True)
     if isinstance(exc, app_exc.BatchImportError):
         return ErrorInfo(ErrorCode.VALIDATION_FAILED, retryable=False, user_action_required=True)
+    if isinstance(exc, app_exc.AnnotationFailedError):
+        return ErrorInfo(ErrorCode.PRECONDITION_FAILED, retryable=False, user_action_required=True)
     if isinstance(exc, app_exc.InvalidFormatError):
         return ErrorInfo(ErrorCode.INVALID_INPUT, retryable=False, user_action_required=True)
     if isinstance(exc, app_exc.ValidationError):

--- a/src/lorairo/cli/_output_mode.py
+++ b/src/lorairo/cli/_output_mode.py
@@ -24,6 +24,7 @@ _FALSEY_ENV = frozenset({"", "0", "false", "no", "off"})
 
 # 中央境界が解決したモードを保持する (コマンド本体が参照する)。
 _json_mode: bool = False
+_prescanned_mode: bool = False
 
 
 def _scan_explicit_flag(argv: Sequence[str]) -> bool | None:
@@ -102,12 +103,18 @@ def strip_mode_flags(argv: Sequence[str]) -> list[str]:
     return stripped
 
 
-def set_json_mode(value: bool) -> None:
+def set_json_mode(value: bool, *, prescanned: bool = False) -> None:
     """解決済みの出力モードを保存する (中央境界が呼ぶ)。"""
-    global _json_mode
+    global _json_mode, _prescanned_mode
     _json_mode = value
+    _prescanned_mode = prescanned
 
 
 def is_json_mode() -> bool:
     """現在の出力モードが JSONL かを返す (コマンド本体が参照する)。"""
     return _json_mode
+
+
+def has_prescanned_mode() -> bool:
+    """``main()`` が Click parse 前に出力モードを確定済みなら ``True``。"""
+    return _prescanned_mode

--- a/src/lorairo/cli/commands/annotate.py
+++ b/src/lorairo/cli/commands/annotate.py
@@ -13,6 +13,7 @@ from enum import Enum
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+import click
 import typer
 from PIL import Image
 from rich.progress import (
@@ -31,12 +32,14 @@ if TYPE_CHECKING:
 from lorairo.api.batch_import import import_batch_annotations
 from lorairo.api.exceptions import (
     AnnotationFailedError,
-    APIKeyNotConfiguredError,
     BatchImportError,
-    ProjectNotFoundError,
+    ResultSetTooLargeError,
 )
 from lorairo.api.project import get_project as api_get_project
+from lorairo.cli._boundary import command_boundary
 from lorairo.cli._console import make_console
+from lorairo.cli._emit import emit_item, emit_result
+from lorairo.cli._output_mode import is_json_mode
 from lorairo.database.db_core import resolve_stored_path
 from lorairo.database.filter_criteria import ImageFilterCriteria
 from lorairo.services.model_registry_protocol import selection_includes_webapi_model
@@ -53,6 +56,9 @@ app = typer.Typer(help="Annotation commands")
 
 # Rich console (Issue #254: Windows では safe_box=True で ASCII 罫線)
 console = make_console()
+console_err = make_console(stderr=True)
+
+MAX_ANNOTATE_IMAGES = 500
 
 
 class LoadFailureAction(Enum):
@@ -64,6 +70,14 @@ class LoadFailureAction(Enum):
 
 class ImageLoadMemoryError(RuntimeError):
     """メモリ/リソース枯渇による致命的ロード失敗 (Issue #537)。"""
+
+
+class AnnotationSelectionError(RuntimeError):
+    """No images can be selected for annotation."""
+
+
+class AnnotationRunFailedError(RuntimeError):
+    """Annotation run finished without usable results."""
 
 
 def _classify_load_failure(exc: BaseException) -> LoadFailureAction:
@@ -158,7 +172,7 @@ def _load_batch_images(
                     opened.close()
                 logger.error(f"Fatal image load failure on {image_path.name}: {exc}", exc_info=True)
                 raise ImageLoadMemoryError(str(exc)) from exc
-            console.print(f"[yellow]Warning:[/yellow] Failed to load {image_path.name}: {exc}")
+            _status_console().print(f"[yellow]Warning:[/yellow] Failed to load {image_path.name}: {exc}")
             failed_count += 1
             continue
 
@@ -244,6 +258,11 @@ def _check_annotation_errors(
     return success_detected, error_detected_models
 
 
+def _status_console() -> Any:
+    """Return stderr console in JSON mode so stdout stays JSONL-only."""
+    return console_err if is_json_mode() else console
+
+
 @dataclass
 class _StreamAnnotateSummary:
     """ストリーミングアノテーションの全チャンク通算結果 (Issue #536)。"""
@@ -257,6 +276,71 @@ class _StreamAnnotateSummary:
     save_errors: int = 0
     any_success: bool = False
     error_models: set[str] = field(default_factory=set)
+
+
+def _annotation_value(value: Any, key: str, default: Any = None) -> Any:
+    """Return annotation payload value from dict-like or object-like results."""
+    if isinstance(value, dict):
+        return value.get(key, default)
+    return getattr(value, key, default)
+
+
+def _annotation_tags(result: Any) -> list[str]:
+    """Extract a compact tags list from an annotation result."""
+    raw_tags = _annotation_value(result, "tags")
+    if raw_tags is None:
+        raw_tags = _annotation_value(result, "keywords")
+    if raw_tags is None:
+        return []
+    if isinstance(raw_tags, dict):
+        return [str(tag) for tag in raw_tags]
+    if isinstance(raw_tags, (list, tuple, set)):
+        return [str(tag) for tag in raw_tags]
+    return [str(raw_tags)]
+
+
+def _annotation_score(result: Any) -> float | int | None:
+    """Extract a compact score/rating value from an annotation result."""
+    for key in ("score", "rating_score", "aesthetic_score"):
+        value = _annotation_value(result, key)
+        if isinstance(value, (int, float)):
+            return value
+    return None
+
+
+def _emit_annotation_items(results: Any, records_chunk: list[dict[str, Any]]) -> None:
+    """Emit one curated JSONL item per annotated image in the chunk."""
+    if not is_json_mode() or not results:
+        return
+
+    records_by_phash = {str(record.get("phash")): record for record in records_chunk}
+    for phash, model_results in results.items():
+        record = records_by_phash.get(str(phash), {})
+        models: list[dict[str, Any]] = []
+        if isinstance(model_results, dict):
+            iterable = model_results.items()
+        else:
+            iterable = []
+        for model_name, model_result in iterable:
+            error = _annotation_value(model_result, "error")
+            models.append(
+                {
+                    "model": str(model_name),
+                    "tags": _annotation_tags(model_result),
+                    "score": _annotation_score(model_result),
+                    "error": str(error) if error is not None else None,
+                }
+            )
+
+        emit_item(
+            {
+                "type": "annotation",
+                "image_id": record.get("id"),
+                "phash": str(phash),
+                "file_path": record.get("stored_image_path"),
+                "models": models,
+            }
+        )
 
 
 def _stream_annotate(
@@ -291,15 +375,21 @@ def _stream_annotate(
     """
     summary = _StreamAnnotateSummary()
 
-    with Progress(
-        SpinnerColumn(),
-        TextColumn("[progress.description]{task.description}"),
-        BarColumn(),
-        TextColumn("[progress.percentage]{task.percentage:>3.1f}%"),
-        TimeRemainingColumn(),
-        console=console,
-    ) as progress:
-        task = progress.add_task("Running annotation...", total=len(records_to_process))
+    progress_context: Any
+    if is_json_mode():
+        progress_context = _NullProgress()
+    else:
+        progress_context = Progress(
+            SpinnerColumn(),
+            TextColumn("[progress.description]{task.description}"),
+            BarColumn(),
+            TextColumn("[progress.percentage]{task.percentage:>3.1f}%"),
+            TimeRemainingColumn(),
+            console=console,
+        )
+
+    with progress_context as active_progress:
+        task = active_progress.add_task("Running annotation...", total=len(records_to_process))
 
         for chunk in _iter_record_batches(records_to_process, batch_size):
             original_chunk_size = len(chunk)
@@ -310,7 +400,7 @@ def _stream_annotate(
                 )
                 summary.preflight_skipped += skipped_count
                 if not chunk:
-                    progress.advance(task, advance=original_chunk_size)
+                    active_progress.advance(task, advance=original_chunk_size)
                     continue
 
             # Issue #537: FATAL (メモリ枯渇) は ImageLoadMemoryError で送出される。
@@ -319,11 +409,12 @@ def _stream_annotate(
             summary.total_failed += failed
 
             if not images:
-                progress.advance(task, advance=original_chunk_size)
+                active_progress.advance(task, advance=original_chunk_size)
                 continue
 
             try:
                 _annotate_and_save_chunk(
+                    records_chunk=chunk,
                     images=images,
                     annotator=annotator,
                     save_service=save_service,
@@ -334,9 +425,25 @@ def _stream_annotate(
                 for img in images:
                     img.close()
 
-            progress.advance(task, advance=original_chunk_size)
+            active_progress.advance(task, advance=original_chunk_size)
 
     return summary
+
+
+class _NullProgress:
+    """No-op context manager used to keep JSON mode stdout free of Rich progress."""
+
+    def __enter__(self) -> _NullProgress:
+        return self
+
+    def __exit__(self, *_args: object) -> None:
+        return None
+
+    def add_task(self, *_args: object, **_kwargs: object) -> None:
+        return None
+
+    def advance(self, *_args: object, **_kwargs: object) -> None:
+        return None
 
 
 def _apply_moderation_preflight_to_records(
@@ -361,12 +468,13 @@ def _apply_moderation_preflight_to_records(
     allowed = [path_to_record[path] for path in result.allowed_paths if path in path_to_record]
     skipped_count = result.skipped_count
     if skipped_count:
-        console.print(f"[yellow]Moderation preflight skipped {skipped_count} image(s)[/yellow]")
+        _status_console().print(f"[yellow]Moderation preflight skipped {skipped_count} image(s)[/yellow]")
     return passthrough_records + allowed, skipped_count
 
 
 def _annotate_and_save_chunk(
     *,
+    records_chunk: list[dict[str, Any]],
     images: list[Image.Image],
     annotator: Any,
     save_service: Any,
@@ -389,9 +497,8 @@ def _annotate_and_save_chunk(
         # Issue #245: AnnotatorLibraryAdapter.annotate は kwarg `litellm_model_ids` を受け取る。
         results = annotator.annotate(images, litellm_model_ids=resolved_litellm_ids)
     except Exception as e:
-        console.print(f"[red]Error:[/red] Annotation failed: {e}")
         logger.error(f"Annotation error: {e}", exc_info=True)
-        raise typer.Exit(code=1) from e
+        raise AnnotationFailedError(", ".join(resolved_litellm_ids), len(images), str(e)) from e
 
     if not results:
         return
@@ -405,13 +512,14 @@ def _annotate_and_save_chunk(
     summary.saved += save_result.success_count
     summary.skipped += save_result.skip_count
     summary.save_errors += save_result.error_count
+    _emit_annotation_items(results, records_chunk)
 
 
 def _finalize_annotation_run(summary: _StreamAnnotateSummary, resolved_litellm_ids: list[str]) -> None:
     """ストリーミング結果を検証し、サマリーを表示する (Issue #536)。
 
     全チャンク通算の集計に基づき、ロード不可・結果ゼロ・全モデル失敗を致命扱い
-    (``typer.Exit(code=1)``) とし、部分失敗は warning を表示する。最後に Rich Table
+    とし、部分失敗は warning を表示する。最後に Rich Table
     で結果サマリーを出力する。
 
     Args:
@@ -419,32 +527,20 @@ def _finalize_annotation_run(summary: _StreamAnnotateSummary, resolved_litellm_i
         resolved_litellm_ids: 解決済み litellm_model_id リスト (サマリー表示用)。
 
     Raises:
-        typer.Exit: ロード不可・結果ゼロ・全モデル失敗の場合 (code=1)。
+        AnnotationRunFailedError: ロード不可・結果ゼロ・全モデル失敗の場合。
     """
+    _validate_annotation_summary(summary)
+    if is_json_mode():
+        _emit_annotation_result(summary, resolved_litellm_ids)
+        return
+
     console.print(f"[green]Loaded {summary.total_loaded} image(s) ({summary.total_failed} failed)[/green]")
     if summary.preflight_skipped:
         console.print(f"[yellow]Moderation preflight skipped {summary.preflight_skipped} image(s)[/yellow]")
 
-    if summary.total_loaded == 0:
-        if summary.preflight_skipped > 0 and summary.total_failed == 0:
-            console.print(
-                "[green]Annotation completed: all selected images were skipped by preflight[/green]"
-            )
-            return
-        console.print("[red]Error:[/red] No images could be loaded for annotation")
-        raise typer.Exit(code=1)
-
-    # 全失敗判定の通算化 (Issue #536): 全チャンク通算で 1 件も成功結果が無く、
-    # かつエラーモデルがある場合は致命扱い (旧 _handle_annotation_results 相当)。
-    if summary.total_results == 0:
-        console.print("[red]Error:[/red] Annotation produced no results")
-        raise typer.Exit(code=1)
-
-    if not summary.any_success and summary.error_models:
-        console.print(
-            f"[red]Error:[/red] All annotation models failed: {', '.join(sorted(summary.error_models))}"
-        )
-        raise typer.Exit(code=1)
+    if summary.total_loaded == 0 and summary.preflight_skipped > 0 and summary.total_failed == 0:
+        console.print("[green]Annotation completed: all selected images were skipped by preflight[/green]")
+        return
     if summary.error_models:
         console.print(
             f"[yellow]Warning:[/yellow] Some models encountered errors: "
@@ -475,6 +571,33 @@ def _finalize_annotation_run(summary: _StreamAnnotateSummary, resolved_litellm_i
     console.print(f"\n[green]Annotation completed successfully! ({summary.saved} saved to DB)[/green]")
 
 
+def _validate_annotation_summary(summary: _StreamAnnotateSummary) -> None:
+    """Raise if the completed annotation stream has no usable result."""
+    if summary.total_loaded == 0:
+        if summary.preflight_skipped > 0 and summary.total_failed == 0:
+            return
+        raise AnnotationRunFailedError("No images could be loaded for annotation")
+    if summary.total_results == 0:
+        raise AnnotationRunFailedError("Annotation produced no results")
+    if not summary.any_success and summary.error_models:
+        raise AnnotationRunFailedError(
+            f"All annotation models failed: {', '.join(sorted(summary.error_models))}"
+        )
+
+
+def _emit_annotation_result(summary: _StreamAnnotateSummary, resolved_litellm_ids: list[str]) -> None:
+    """Emit the terminal JSONL result for annotate run."""
+    emit_result(
+        f"Annotated {summary.saved} image(s)",
+        annotated=summary.saved,
+        skipped=summary.skipped + summary.preflight_skipped + summary.total_failed,
+        errors=summary.save_errors + len(summary.error_models),
+        loaded=summary.total_loaded,
+        results=summary.total_results,
+        models=resolved_litellm_ids,
+    )
+
+
 def _get_deprecated_models_best_effort(annotator: Any, model_names: list[str]) -> list[str]:
     """廃止モデル一覧をbest-effortで取得する。
 
@@ -487,7 +610,7 @@ def _get_deprecated_models_best_effort(annotator: Any, model_names: list[str]) -
         ]
     except Exception as e:
         logger.warning(f"Deprecated model check skipped: {e}")
-        console.print(
+        _status_console().print(
             "[yellow]Warning:[/yellow] Deprecated model metadata is unavailable; continuing annotation."
         )
         return []
@@ -504,12 +627,11 @@ def _abort_if_discontinued(model: Any) -> None:
         typer.Exit: モデルが discontinued (`available=False`) の場合 (code=1)。
     """
     if not getattr(model, "available", True):
-        console.print(
-            f"[red]Error:[/red] Model '{model.litellm_model_id}' is discontinued / no longer "
+        raise click.UsageError(
+            f"Model '{model.litellm_model_id}' is discontinued / no longer "
             "provided by the annotation library and cannot be used. "
             "Run `lorairo-cli models list` to see available IDs."
         )
-        raise typer.Exit(code=1)
 
 
 def _resolve_model_identifier(repository: ModelRepository, identifier: str) -> str:
@@ -551,18 +673,15 @@ def _resolve_model_identifier(repository: ModelRepository, identifier: str) -> s
         candidate_lines = "\n".join(
             f"  - {m.litellm_model_id} (provider: {m.provider or 'unknown'})" for m in by_name
         )
-        console.print(
-            f"[red]Error:[/red] Ambiguous model '{identifier}':\n"
+        raise click.UsageError(
+            f"Ambiguous model '{identifier}':\n"
             f"{candidate_lines}\n"
             "Use the full LiteLLM model ID. Run `lorairo-cli models list` to see available IDs."
         )
-        raise typer.Exit(code=1)
 
-    console.print(
-        f"[red]Error:[/red] Unknown model '{identifier}'. "
-        "Run `lorairo-cli models list` to see available IDs."
+    raise click.UsageError(
+        f"Unknown model '{identifier}'. Run `lorairo-cli models list` to see available IDs."
     )
-    raise typer.Exit(code=1)
 
 
 def _validate_required_api_keys(
@@ -604,16 +723,16 @@ def _validate_required_api_keys(
     if not missing:
         return
 
-    console.print("[red]Error:[/red] Missing API keys for selected models:")
-    for litellm_id, missing_provider in missing:
-        console.print(f"  - {missing_provider}: required for {litellm_id}")
-    # Rich console は `[api]` のような bracket を tag として解釈するので、開く側のみ `\[` で escape する。
-    console.print(
-        "\nConfigure the missing keys in config/lorairo.toml \\[api] section, "
+    missing_lines = "\n".join(
+        f"  - {provider}: required for {litellm_id}" for litellm_id, provider in missing
+    )
+    raise click.UsageError(
+        "Missing API keys for selected models:\n"
+        f"{missing_lines}\n\n"
+        "Configure the missing keys in config/lorairo.toml [api] section, "
         "or pick a different route (e.g. `--model openai/...` instead of "
         "`--model openrouter/openai/...`)."
     )
-    raise typer.Exit(code=1)
 
 
 def _build_annotation_filter_criteria(
@@ -643,14 +762,11 @@ def _handle_no_image_records(
 ) -> None:
     """DB検索結果0件時のCLIエラーを表示して終了する。"""
     if filters_applied:
-        console.print(f"[red]Error:[/red] No images matched annotation filters for project '{project}'.")
-        raise typer.Exit(code=1)
+        raise AnnotationSelectionError(f"No images matched annotation filters for project '{project}'.")
 
-    console.print(
-        f"[red]Error:[/red] No registered images found in project '{project}'. "
-        "Run 'lorairo-cli images register' first."
+    raise AnnotationSelectionError(
+        f"No registered images found in project '{project}'. Run 'lorairo-cli images register' first."
     )
-    raise typer.Exit(code=1)
 
 
 def _print_annotation_filter_summary(
@@ -660,9 +776,9 @@ def _print_annotation_filter_summary(
 ) -> None:
     """適用中のannotate runフィルタを表示する。"""
     if unrated:
-        console.print("[cyan]Filter: unrated images only[/cyan]")
+        _status_console().print("[cyan]Filter: unrated images only[/cyan]")
     if missing_model_litellm_id is not None:
-        console.print(f"[cyan]Filter: missing model {missing_model_litellm_id}[/cyan]")
+        _status_console().print(f"[cyan]Filter: missing model {missing_model_litellm_id}[/cyan]")
 
 
 @app.command("run")
@@ -740,13 +856,9 @@ def run(
         lorairo-cli annotate run --project myproject \\
             --model openrouter/openai/gpt-4o --model openrouter/anthropic/claude-3-5-sonnet
     """
-    try:
+    with command_boundary():
         # API層経由でプロジェクト確認 & DB 接続切り替え
-        try:
-            api_get_project(project)
-        except ProjectNotFoundError as e:
-            console.print(f"[red]Error:[/red] Project not found: {project}")
-            raise typer.Exit(code=1) from e
+        api_get_project(project)
 
         container = get_service_container()
         container.set_active_project(project)
@@ -782,11 +894,14 @@ def run(
         )
 
         if not records_to_process:
-            console.print("[red]Error:[/red] No images selected for annotation")
-            raise typer.Exit(code=1)
+            raise AnnotationSelectionError("No images selected for annotation")
 
-        console.print(f"[cyan]Found {total_in_db} image(s) in DB[/cyan]")
-        console.print(f"[cyan]Using model(s): {', '.join(resolved_litellm_ids)}[/cyan]")
+        if len(records_to_process) > MAX_ANNOTATE_IMAGES:
+            raise ResultSetTooLargeError(len(records_to_process), MAX_ANNOTATE_IMAGES)
+
+        target_console = _status_console()
+        target_console.print(f"[cyan]Found {total_in_db} image(s) in DB[/cyan]")
+        target_console.print(f"[cyan]Using model(s): {', '.join(resolved_litellm_ids)}[/cyan]")
         # #543 の DB レベルフィルタ (--unrated / --missing-model) のサマリー。
         # eager な "Loaded N" 行は streaming では _finalize_annotation_run が
         # summary.total_loaded から出力するため、ここでは出さない (Issue #536)。
@@ -800,7 +915,7 @@ def run(
 
         deprecated_models = _get_deprecated_models_best_effort(annotator, resolved_litellm_ids)
         for deprecated_model in deprecated_models:
-            console.print(f"[yellow]Warning: Model '{deprecated_model}' is deprecated[/yellow]")
+            target_console.print(f"[yellow]Warning: Model '{deprecated_model}' is deprecated[/yellow]")
 
         # Issue #241: 実行直前に LoRAIro 側で API key 不足を事前検出する。
         # 旧実装は「3 種類キー全部無いとき警告」だけで、片方の provider key だけ
@@ -809,7 +924,7 @@ def run(
         _validate_required_api_keys(model_repo, config, resolved_litellm_ids)
 
         # アノテーション実行 (Issue #536: チャンクストリーミング)
-        console.print("[cyan]Starting annotation...[/cyan]")
+        target_console.print("[cyan]Starting annotation...[/cyan]")
         try:
             should_preflight = selection_includes_webapi_model(resolved_litellm_ids, annotator)
         except Exception as e:
@@ -832,28 +947,16 @@ def run(
                 moderation_runner=build_annotation_logic_runner(moderation_logic.execute_annotation),
             )
 
-        try:
-            summary = _stream_annotate(
-                records_to_process=records_to_process,
-                batch_size=batch_size,
-                annotator=annotator,
-                save_service=container.annotation_save_service,
-                resolved_litellm_ids=resolved_litellm_ids,
-                moderation_preflight_service=moderation_preflight_service,
-            )
-        except ImageLoadMemoryError as e:
-            console.print(f"[red]Error:[/red] Memory/resource exhaustion during image load: {e}")
-            logger.error(f"Fatal image load failure: {e}", exc_info=True)
-            raise typer.Exit(code=1) from e
+        summary = _stream_annotate(
+            records_to_process=records_to_process,
+            batch_size=batch_size,
+            annotator=annotator,
+            save_service=container.annotation_save_service,
+            resolved_litellm_ids=resolved_litellm_ids,
+            moderation_preflight_service=moderation_preflight_service,
+        )
 
         _finalize_annotation_run(summary, resolved_litellm_ids)
-
-    except typer.Exit:
-        raise
-    except Exception as e:
-        console.print(f"[red]Error:[/red] {e}")
-        logger.error(f"Command error: {e}", exc_info=True)
-        raise typer.Exit(code=2) from e
 
 
 def _display_batch_import_result(result: BatchImportResult, *, dry_run: bool) -> None:
@@ -949,7 +1052,7 @@ def import_batch(
         lorairo-cli annotate import-batch jsonl/ -p main_dataset_20250707_001
         lorairo-cli annotate import-batch jsonl/ -p my_project --dry-run
     """
-    try:
+    with command_boundary():
         get_service_container().set_active_project(project)
         result = import_batch_annotations(
             jsonl_dir,
@@ -957,17 +1060,19 @@ def import_batch(
             dry_run=dry_run,
             model_name_override=model_name,
         )
-        _display_batch_import_result(result, dry_run=dry_run)
+        if is_json_mode():
+            emit_result(
+                f"Imported {result.saved} batch annotation(s)",
+                total_records=result.total_records,
+                parsed_ok=result.parsed_ok,
+                parse_errors=result.parse_errors,
+                matched=result.matched,
+                unmatched=result.unmatched,
+                saved=result.saved,
+                save_errors=result.save_errors,
+                model_name=result.model_name,
+                dry_run=dry_run,
+            )
+            return
 
-    except ProjectNotFoundError as e:
-        console.print(f"[red]Error:[/red] {e}")
-        raise typer.Exit(code=1) from e
-    except BatchImportError as e:
-        console.print(f"[red]Error:[/red] {e}")
-        raise typer.Exit(code=1) from e
-    except typer.Exit:
-        raise
-    except Exception as e:
-        console.print(f"[red]Error:[/red] {e}")
-        logger.error(f"Batch import error: {e}", exc_info=True)
-        raise typer.Exit(code=2) from e
+        _display_batch_import_result(result, dry_run=dry_run)

--- a/src/lorairo/cli/commands/annotate.py
+++ b/src/lorairo/cli/commands/annotate.py
@@ -219,7 +219,9 @@ def _select_image_records(
         missing_ids = [image_id for image_id in dict.fromkeys(image_ids) if image_id not in found_ids]
         if missing_ids:
             missing_str = ", ".join(str(image_id) for image_id in missing_ids)
-            console.print(f"[yellow]Warning:[/yellow] Image ID(s) not found in project: {missing_str}")
+            _status_console().print(
+                f"[yellow]Warning:[/yellow] Image ID(s) not found in project: {missing_str}"
+            )
 
     # sharding 決定性: get_images_by_filter() の SQL は ORDER BY を持たず
     # (ImageRepository._build_image_filter_query は distinct() のみ)、行順は
@@ -307,6 +309,15 @@ def _annotation_score(result: Any) -> float | int | None:
         value = _annotation_value(result, key)
         if isinstance(value, (int, float)):
             return value
+    scores = _annotation_value(result, "scores")
+    if isinstance(scores, dict):
+        for value in scores.values():
+            if isinstance(value, (int, float)):
+                return value
+    if isinstance(scores, (list, tuple)):
+        for value in scores:
+            if isinstance(value, (int, float)):
+                return value
     return None
 
 
@@ -315,9 +326,10 @@ def _emit_annotation_items(results: Any, records_chunk: list[dict[str, Any]]) ->
     if not is_json_mode() or not results:
         return
 
-    records_by_phash = {str(record.get("phash")): record for record in records_chunk}
+    records_by_phash: dict[str, list[dict[str, Any]]] = {}
+    for record in records_chunk:
+        records_by_phash.setdefault(str(record.get("phash")), []).append(record)
     for phash, model_results in results.items():
-        record = records_by_phash.get(str(phash), {})
         models: list[dict[str, Any]] = []
         if isinstance(model_results, dict):
             model_items = list(model_results.items())
@@ -334,15 +346,16 @@ def _emit_annotation_items(results: Any, records_chunk: list[dict[str, Any]]) ->
                 }
             )
 
-        emit_item(
-            {
-                "type": "annotation",
-                "image_id": record.get("id"),
-                "phash": str(phash),
-                "file_path": record.get("stored_image_path"),
-                "models": models,
-            }
-        )
+        for record in records_by_phash.get(str(phash), [{}]):
+            emit_item(
+                {
+                    "type": "annotation",
+                    "image_id": record.get("id"),
+                    "phash": str(phash),
+                    "file_path": record.get("stored_image_path"),
+                    "models": models,
+                }
+            )
 
 
 def _stream_annotate(

--- a/src/lorairo/cli/commands/annotate.py
+++ b/src/lorairo/cli/commands/annotate.py
@@ -523,7 +523,11 @@ def _annotate_and_save_chunk(
     summary.any_success = summary.any_success or chunk_success
     summary.error_models |= chunk_error_models
 
-    save_result = save_service.save_annotation_results(results)
+    selected_image_ids = {int(record["id"]) for record in records_chunk if record.get("id") is not None}
+    save_result = save_service.save_annotation_results(
+        results,
+        allowed_image_ids=selected_image_ids if selected_image_ids else None,
+    )
     summary.saved += save_result.success_count
     summary.skipped += save_result.skip_count
     summary.save_errors += save_result.error_count

--- a/src/lorairo/cli/commands/annotate.py
+++ b/src/lorairo/cli/commands/annotate.py
@@ -171,7 +171,9 @@ def _load_batch_images(
                 for opened in pil_images:
                     opened.close()
                 logger.error(f"Fatal image load failure on {image_path.name}: {exc}", exc_info=True)
-                raise ImageLoadMemoryError(str(exc)) from exc
+                raise ImageLoadMemoryError(
+                    f"Memory/resource exhaustion while loading {image_path.name}: {exc}"
+                ) from exc
             _status_console().print(f"[yellow]Warning:[/yellow] Failed to load {image_path.name}: {exc}")
             failed_count += 1
             continue

--- a/src/lorairo/cli/commands/annotate.py
+++ b/src/lorairo/cli/commands/annotate.py
@@ -318,10 +318,10 @@ def _emit_annotation_items(results: Any, records_chunk: list[dict[str, Any]]) ->
         record = records_by_phash.get(str(phash), {})
         models: list[dict[str, Any]] = []
         if isinstance(model_results, dict):
-            iterable = model_results.items()
+            model_items = list(model_results.items())
         else:
-            iterable = []
-        for model_name, model_result in iterable:
+            model_items = []
+        for model_name, model_result in model_items:
             error = _annotation_value(model_result, "error")
             models.append(
                 {

--- a/src/lorairo/cli/main.py
+++ b/src/lorairo/cli/main.py
@@ -26,7 +26,12 @@ from lorairo.cli._console import make_console
 from lorairo.cli._emit import emit_error
 from lorairo.cli._errors import ErrorCode, ErrorInfo, classify_exception, hint_for
 from lorairo.cli._glyphs import FAIL, OK
-from lorairo.cli._output_mode import resolve_output_mode, set_json_mode, strip_mode_flags
+from lorairo.cli._output_mode import (
+    has_prescanned_mode,
+    resolve_output_mode,
+    set_json_mode,
+    strip_mode_flags,
+)
 from lorairo.cli.commands import annotate, batch, export, images, models, project
 from lorairo.services.service_container import get_service_container
 from lorairo.utils.config import DEFAULT_CLI_LOG_PATH, DEFAULT_CONFIG_PATH
@@ -110,11 +115,9 @@ def _configure(
     """
     import os
 
-    from lorairo.cli._output_mode import resolve_output_mode, set_json_mode
-
     if json_output is not None:
         set_json_mode(json_output)
-    else:
+    elif not has_prescanned_mode():
         set_json_mode(resolve_output_mode([]))
 
     os.environ.setdefault("LORAIRO_CLI_MODE", "true")
@@ -267,7 +270,7 @@ def main(argv: list[str] | None = None) -> None:
     """
     raw_argv = list(sys.argv[1:] if argv is None else argv)
     json_mode = resolve_output_mode(raw_argv)
-    set_json_mode(json_mode)
+    set_json_mode(json_mode, prescanned=True)
     # モードフラグは prescan 済みなので Click パース前に除去する (サブコマンド後位置でも
     # "no such option" にせず受理する、ADR 0058 §1)。
     cli_argv = strip_mode_flags(raw_argv)

--- a/tests/integration/cli/test_cli_workflow.py
+++ b/tests/integration/cli/test_cli_workflow.py
@@ -201,6 +201,6 @@ def test_cli_unknown_model_exits_before_annotation(
         ["annotate", "run", "--project", project_name, "--model", "missing-model"],
     )
 
-    assert result.exit_code == 1
-    assert "Unknown model 'missing-model'" in result.stdout
+    assert result.exit_code == 2
+    assert "Unknown model 'missing-model'" in result.stderr
     assert getattr(fake, "annotate_calls", 0) == calls_before

--- a/tests/unit/cli/test_annotate_api_key_validation.py
+++ b/tests/unit/cli/test_annotate_api_key_validation.py
@@ -1,7 +1,7 @@
 """Issue #241: CLI annotate run の API key validation 単体テスト。
 
-`_validate_required_api_keys()` が provider 別の不足検出と Rich console 出力 +
-``typer.Exit(1)`` を正しく実行することを検証する。
+`_validate_required_api_keys()` が provider 別の不足検出を click.UsageError として
+送出することを検証する。
 """
 
 from __future__ import annotations
@@ -9,8 +9,8 @@ from __future__ import annotations
 from types import SimpleNamespace
 from unittest.mock import Mock
 
+import click
 import pytest
-import typer
 
 from lorairo.cli.commands.annotate import _validate_required_api_keys
 
@@ -45,20 +45,19 @@ class TestValidateRequiredApiKeys:
         _validate_required_api_keys(repository, config, ["openai/gpt-4o"])
         # 例外が出なければ OK
 
-    def test_missing_openrouter_exits_with_message(self, capsys: pytest.CaptureFixture[str]) -> None:
-        """Issue #241 主要シナリオ: openai key のみ環境で openrouter モデル選択 -> exit 1"""
+    def test_missing_openrouter_raises_usage_error_with_message(self) -> None:
+        """Issue #241 主要シナリオ: openai key のみ環境で openrouter モデル選択 -> input error"""
         repository = Mock()
         repository.get_model_by_litellm_id.return_value = _fake_model("openrouter")
         config = _fake_config({"openai_key": "sk-a"})
 
-        with pytest.raises(typer.Exit) as excinfo:
+        with pytest.raises(click.UsageError) as excinfo:
             _validate_required_api_keys(repository, config, ["openrouter/openai/gpt-4o"])
 
-        assert excinfo.value.exit_code == 1
-        out = capsys.readouterr().out
-        assert "Missing API keys" in out
-        assert "openrouter: required for openrouter/openai/gpt-4o" in out
-        assert "[api] section" in out
+        message = excinfo.value.message
+        assert "Missing API keys" in message
+        assert "openrouter: required for openrouter/openai/gpt-4o" in message
+        assert "[api] section" in message
 
     def test_local_model_passes(self) -> None:
         """ローカル ML モデルは API key 要求しない"""
@@ -85,7 +84,7 @@ class TestValidateRequiredApiKeys:
         _validate_required_api_keys(repository, config, ["openrouter/openai/gpt-4o"])
 
     def test_multiple_models_with_multiple_missing_providers(
-        self, capsys: pytest.CaptureFixture[str]
+        self,
     ) -> None:
         """複数モデルで複数 provider 不足のケースは全件列挙"""
         repository = Mock()
@@ -97,13 +96,12 @@ class TestValidateRequiredApiKeys:
         repository.get_model_by_litellm_id.side_effect = lambda lid: provider_map.get(lid)
         config = _fake_config({})  # 全 key 空
 
-        with pytest.raises(typer.Exit) as excinfo:
+        with pytest.raises(click.UsageError) as excinfo:
             _validate_required_api_keys(repository, config, ["openai/gpt-4o", "anthropic/claude-3-5"])
 
-        assert excinfo.value.exit_code == 1
-        out = capsys.readouterr().out
-        assert "openai: required for openai/gpt-4o" in out
-        assert "anthropic: required for anthropic/claude-3-5" in out
+        message = excinfo.value.message
+        assert "openai: required for openai/gpt-4o" in message
+        assert "anthropic: required for anthropic/claude-3-5" in message
 
     def test_handles_model_not_found_in_db(self) -> None:
         """DB に未登録の litellm_id でも prefix から required_provider を判定できる"""

--- a/tests/unit/cli/test_annotate_load_failure.py
+++ b/tests/unit/cli/test_annotate_load_failure.py
@@ -193,7 +193,7 @@ def test_run_memory_error_exits_nonzero(
     )
 
     assert result.exit_code == 1, result.stdout
-    assert "Memory/resource exhaustion" in result.stdout
+    assert "Memory/resource exhaustion" in result.stderr
     # 致命扱いなので annotate は呼ばれない。
     assert mock_container.annotator_library.annotate.call_count == 0
 
@@ -224,7 +224,7 @@ def test_run_enomem_oserror_exits_nonzero(
     )
 
     assert result.exit_code == 1, result.stdout
-    assert "Memory/resource exhaustion" in result.stdout
+    assert "Memory/resource exhaustion" in result.stderr
 
 
 @pytest.mark.unit

--- a/tests/unit/cli/test_annotate_load_failure.py
+++ b/tests/unit/cli/test_annotate_load_failure.py
@@ -100,7 +100,7 @@ def _build_container(image_files: list[Path]) -> MagicMock:
     )
     mock_container.annotator_library = mock_annotator
     mock_container.config_service = mock_config
-    mock_container.annotation_save_service.save_annotation_results.side_effect = lambda results: (
+    mock_container.annotation_save_service.save_annotation_results.side_effect = lambda results, **_kwargs: (
         AnnotationSaveResult(
             success_count=len(results),
             skip_count=0,

--- a/tests/unit/cli/test_annotate_model_resolution.py
+++ b/tests/unit/cli/test_annotate_model_resolution.py
@@ -9,8 +9,8 @@ from __future__ import annotations
 from types import SimpleNamespace
 from unittest.mock import Mock
 
+import click
 import pytest
-import typer
 
 from lorairo.cli.commands.annotate import _resolve_model_identifier
 
@@ -59,39 +59,33 @@ class TestResolveModelIdentifier:
 
         assert result == "openai/gpt-4o-mini"
 
-    def test_ambiguous_name_match_aborts_with_candidate_list(
-        self, repository: Mock, capsys: pytest.CaptureFixture[str]
-    ) -> None:
-        """同 name 複数 provider の曖昧マッチは typer.Exit(1) で abort し候補一覧を表示"""
+    def test_ambiguous_name_match_aborts_with_candidate_list(self, repository: Mock) -> None:
+        """同 name 複数 provider の曖昧マッチは UsageError で候補一覧を表示"""
         repository.get_model_by_litellm_id.return_value = None
         repository.get_models_by_name.return_value = [
             _fake_model("openai/gpt-4o", "openai/gpt-4o", "openai"),
             _fake_model("openrouter/openai/gpt-4o", "openai/gpt-4o", "openrouter"),
         ]
 
-        with pytest.raises(typer.Exit) as excinfo:
+        with pytest.raises(click.UsageError) as excinfo:
             _resolve_model_identifier(repository, "openai/gpt-4o")
 
-        assert excinfo.value.exit_code == 1
-        out = capsys.readouterr().out
+        out = excinfo.value.message
         assert "Ambiguous model 'openai/gpt-4o'" in out
         # 両方の候補が表示される
         assert "openai/gpt-4o (provider: openai)" in out
         assert "openrouter/openai/gpt-4o (provider: openrouter)" in out
         assert "lorairo-cli models list" in out
 
-    def test_unknown_identifier_aborts_with_help(
-        self, repository: Mock, capsys: pytest.CaptureFixture[str]
-    ) -> None:
-        """litellm_model_id / name どちらにも一致しない場合は typer.Exit(1) + help"""
+    def test_unknown_identifier_aborts_with_help(self, repository: Mock) -> None:
+        """litellm_model_id / name どちらにも一致しない場合は UsageError + help"""
         repository.get_model_by_litellm_id.return_value = None
         repository.get_models_by_name.return_value = []
 
-        with pytest.raises(typer.Exit) as excinfo:
+        with pytest.raises(click.UsageError) as excinfo:
             _resolve_model_identifier(repository, "totally-unknown-model")
 
-        assert excinfo.value.exit_code == 1
-        out = capsys.readouterr().out
+        out = excinfo.value.message
         assert "Unknown model 'totally-unknown-model'" in out
         assert "lorairo-cli models list" in out
 
@@ -104,9 +98,7 @@ class TestResolveModelIdentifier:
 
         repository.get_models_by_name.assert_not_called()
 
-    def test_discontinued_litellm_match_aborts(
-        self, repository: Mock, capsys: pytest.CaptureFixture[str]
-    ) -> None:
+    def test_discontinued_litellm_match_aborts(self, repository: Mock) -> None:
         """de-list 済 (available=False) モデルは litellm_model_id 一致でも abort する (PR #590 review P2)。"""
         target = _fake_model(
             "openai/o4-mini-deep-research-2025-06-26",
@@ -116,24 +108,21 @@ class TestResolveModelIdentifier:
         )
         repository.get_model_by_litellm_id.return_value = target
 
-        with pytest.raises(typer.Exit) as excinfo:
+        with pytest.raises(click.UsageError) as excinfo:
             _resolve_model_identifier(repository, "openai/o4-mini-deep-research-2025-06-26")
 
-        assert excinfo.value.exit_code == 1
-        out = capsys.readouterr().out
+        out = excinfo.value.message
         assert "openai/o4-mini-deep-research-2025-06-26" in out
         assert "discontinued" in out
 
-    def test_discontinued_name_match_aborts(
-        self, repository: Mock, capsys: pytest.CaptureFixture[str]
-    ) -> None:
+    def test_discontinued_name_match_aborts(self, repository: Mock) -> None:
         """name 一致でも de-list 済モデルは abort する (PR #590 review P2)。"""
         repository.get_model_by_litellm_id.return_value = None
         repository.get_models_by_name.return_value = [
             _fake_model("openai/removed", "removed", "openai", available=False),
         ]
 
-        with pytest.raises(typer.Exit) as excinfo:
+        with pytest.raises(click.UsageError) as excinfo:
             _resolve_model_identifier(repository, "removed")
 
-        assert excinfo.value.exit_code == 1
+        assert "discontinued" in excinfo.value.message

--- a/tests/unit/cli/test_annotate_streaming.py
+++ b/tests/unit/cli/test_annotate_streaming.py
@@ -104,8 +104,8 @@ def _build_container(image_files: list[Path]) -> MagicMock:
     )
     mock_container.annotator_library = mock_annotator
     mock_container.config_service = mock_config
-    mock_container.annotation_save_service.save_annotation_results.side_effect = lambda results: (
-        AnnotationSaveResult(
+    mock_container.annotation_save_service.save_annotation_results.side_effect = (
+        lambda results, *, allowed_image_ids=None: AnnotationSaveResult(
             success_count=len(results),
             skip_count=0,
             error_count=0,

--- a/tests/unit/cli/test_annotate_streaming.py
+++ b/tests/unit/cli/test_annotate_streaming.py
@@ -11,11 +11,11 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
-import typer
 from PIL import Image
 from typer.testing import CliRunner
 
 from lorairo.cli.commands.annotate import (
+    AnnotationRunFailedError,
     _apply_moderation_preflight_to_records,
     _finalize_annotation_run,
     _StreamAnnotateSummary,
@@ -301,5 +301,5 @@ def test_finalize_annotation_run_all_preflight_skipped_is_success() -> None:
 def test_finalize_annotation_run_preflight_skip_plus_load_failure_is_error() -> None:
     summary = _StreamAnnotateSummary(total_failed=1, preflight_skipped=1)
 
-    with pytest.raises(typer.Exit):
+    with pytest.raises(AnnotationRunFailedError):
         _finalize_annotation_run(summary, ["openai/gpt-4o-mini"])

--- a/tests/unit/cli/test_commands_annotate.py
+++ b/tests/unit/cli/test_commands_annotate.py
@@ -1,5 +1,6 @@
 """Annotation commands テスト。"""
 
+import json
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -126,7 +127,7 @@ def test_annotate_run_nonexistent_project(mock_projects_dir: Path) -> None:
     )
 
     assert result.exit_code == 1
-    assert "Project not found" in result.stdout
+    assert "nonexistent" in result.stderr
 
 
 @pytest.mark.unit
@@ -160,7 +161,7 @@ def test_annotate_run_no_images(
     )
 
     assert result.exit_code == 1
-    assert "No registered images found" in result.stdout
+    assert "No registered images found" in result.stderr
 
 
 @pytest.mark.unit
@@ -242,6 +243,97 @@ def test_annotate_run_with_single_model(
     assert "Found 3 image(s)" in result.stdout
     assert "gpt-4o-mini" in result.stdout
     assert "Loaded 3 image(s)" in result.stdout or "annotation completed successfully" in result.stdout
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+@patch("lorairo.cli.commands.annotate.get_service_container")
+def test_annotate_run_json_emits_items_and_result_only(
+    mock_get_container,
+    test_project_with_images: tuple[Path, list[Path]],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """--json は画像ごとの item と終端 result だけを stdout JSONL に出す。"""
+    monkeypatch.setenv("LORAIRO_CLI_JSON", "1")
+    _project_dir, image_files = test_project_with_images
+
+    mock_container = MagicMock()
+    mock_annotator = MagicMock()
+    mock_config = MagicMock()
+    mock_config.get_setting.return_value = "test_key"
+    mock_annotator.annotate.return_value = {
+        "phash0000000000000000": {"gpt-4o-mini": {"tags": ["cat"], "score": 0.8, "error": None}},
+        "phash0000000000000001": {"gpt-4o-mini": {"tags": ["dog"], "score": 0.7, "error": None}},
+    }
+
+    image_records = [
+        {"id": i + 1, "phash": f"phash{i:016d}", "stored_image_path": str(img_path)}
+        for i, img_path in enumerate(image_files[:2])
+    ]
+    mock_container.db_manager.image_repo.get_images_by_filter.return_value = (
+        image_records,
+        len(image_records),
+    )
+    mock_container.annotator_library = mock_annotator
+    mock_container.config_service = mock_config
+    mock_container.annotation_save_service.save_annotation_results.return_value = AnnotationSaveResult(
+        success_count=2,
+        skip_count=0,
+        error_count=0,
+        total_count=2,
+    )
+    mock_get_container.return_value = mock_container
+
+    result = runner.invoke(
+        app,
+        ["annotate", "run", "--project", "test_dataset", "--model", "gpt-4o-mini"],
+    )
+
+    assert result.exit_code == 0, result.output
+    lines = [json.loads(line) for line in result.stdout.splitlines()]
+    assert [line["kind"] for line in lines] == ["item", "item", "result"]
+    assert lines[0]["type"] == "annotation"
+    assert lines[0]["image_id"] == 1
+    assert lines[0]["models"][0]["tags"] == ["cat"]
+    assert lines[-1]["annotated"] == 2
+    assert lines[-1]["skipped"] == 0
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+@patch("lorairo.cli.commands.annotate.get_service_container")
+def test_annotate_run_json_rejects_more_than_500_before_items(
+    mock_get_container,
+    test_project_with_images: tuple[Path, list[Path]],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """annotate run の処理集合500超は item を出す前に RESULT_SET_TOO_LARGE。"""
+    monkeypatch.setenv("LORAIRO_CLI_JSON", "1")
+    _project_dir, image_files = test_project_with_images
+
+    mock_container = MagicMock()
+    mock_config = MagicMock()
+    mock_config.get_setting.return_value = "test_key"
+    records = [
+        {"id": i + 1, "phash": f"phash{i:016d}", "stored_image_path": str(image_files[0])}
+        for i in range(501)
+    ]
+    mock_container.db_manager.image_repo.get_images_by_filter.return_value = (records, len(records))
+    mock_container.config_service = mock_config
+    mock_get_container.return_value = mock_container
+
+    result = runner.invoke(
+        app,
+        ["annotate", "run", "--project", "test_dataset", "--model", "gpt-4o-mini"],
+    )
+
+    assert result.exit_code == 2
+    lines = [json.loads(line) for line in result.stdout.splitlines()]
+    assert len(lines) == 1
+    assert lines[0]["kind"] == "error"
+    assert lines[0]["code"] == "RESULT_SET_TOO_LARGE"
+    assert lines[0]["details"] == {"limit": 500, "matched": 501}
+    mock_container.annotator_library.annotate.assert_not_called()
 
 
 @pytest.mark.unit
@@ -462,10 +554,10 @@ def test_annotate_run_no_api_keys(
         ],
     )
 
-    # Issue #241: 不足検出で exit 1 + Missing API keys メッセージ
-    assert result.exit_code == 1
-    assert "Missing API keys" in result.stdout
-    assert "openai" in result.stdout
+    # Issue #241 / ADR 0057: 不足検出は INVALID_INPUT + exit 2。
+    assert result.exit_code == 2
+    assert "Missing API keys" in result.stderr
+    assert "openai" in result.stderr
 
 
 @pytest.mark.unit
@@ -690,7 +782,7 @@ def test_annotate_run_filter_matches_no_images_exits_before_loading(
     )
 
     assert result.exit_code == 1
-    assert "No images matched annotation filters" in result.stdout
+    assert "No images matched annotation filters" in result.stderr
     mock_container.annotator_library.annotate.assert_not_called()
 
 
@@ -739,7 +831,7 @@ def test_annotate_run_annotation_failure(
     )
 
     assert result.exit_code == 1
-    assert "Annotation failed" in result.stdout or "Error" in result.stdout
+    assert "Annotation failed" in result.stderr or "Error" in result.stderr
 
 
 @pytest.mark.unit
@@ -957,8 +1049,8 @@ def test_annotate_run_all_models_failed_exits_nonzero(
     )
 
     assert result.exit_code == 1
-    assert "Error" in result.stdout
-    assert "gpt-4o-mini" in result.stdout
+    assert "Error" in result.stderr
+    assert "gpt-4o-mini" in result.stderr
 
 
 @pytest.mark.unit

--- a/tests/unit/cli/test_commands_annotate.py
+++ b/tests/unit/cli/test_commands_annotate.py
@@ -8,12 +8,77 @@ import pytest
 from PIL import Image
 from typer.testing import CliRunner
 
+from lorairo.cli._output_mode import set_json_mode
+from lorairo.cli.commands.annotate import _annotation_score, _emit_annotation_items
 from lorairo.cli.main import app
 from lorairo.services.annotation_save_service import AnnotationSaveResult
 from lorairo.services.project_management_service import ProjectManagementService
 from lorairo.services.service_container import ServiceContainer
 
 runner = CliRunner()
+
+
+def _jsonl(stdout: str) -> list[dict]:
+    return [json.loads(line) for line in stdout.splitlines() if line.strip()]
+
+
+@pytest.fixture(autouse=True)
+def _reset_json_mode() -> None:
+    set_json_mode(False)
+    yield
+    set_json_mode(False)
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+def test_annotation_score_reads_scores_payload() -> None:
+    """Scorer-only annotation results expose the first numeric scores value."""
+    result = MagicMock(score=None, rating_score=None, aesthetic_score=None)
+    result.scores = {"aesthetic": 7.5}
+
+    assert _annotation_score(result) == 7.5
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+def test_emit_annotation_items_emits_duplicate_phash_records(capsys: pytest.CaptureFixture[str]) -> None:
+    """Duplicate pHash selections emit one JSONL item per selected record."""
+    set_json_mode(True)
+    records = [
+        {"id": 1, "phash": "same", "stored_image_path": "/tmp/a.jpg"},
+        {"id": 2, "phash": "same", "stored_image_path": "/tmp/b.jpg"},
+    ]
+    results = {"same": {"scorer": {"scores": {"aesthetic": 8.0}, "tags": []}}}
+
+    _emit_annotation_items(results, records)
+
+    rows = _jsonl(capsys.readouterr().out)
+    assert [row["image_id"] for row in rows] == [1, 2]
+    assert [row["file_path"] for row in rows] == ["/tmp/a.jpg", "/tmp/b.jpg"]
+    assert all(row["models"][0]["score"] == 8.0 for row in rows)
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+def test_select_image_records_missing_warning_uses_stderr_in_json(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Missing image-id warning does not pollute JSON stdout."""
+    from lorairo.cli.commands.annotate import _select_image_records
+
+    set_json_mode(True)
+
+    selected = _select_image_records(
+        [{"id": 1, "phash": "p", "stored_image_path": "/tmp/a.jpg"}],
+        limit=None,
+        offset=0,
+        image_ids=[1, 99],
+    )
+
+    captured = capsys.readouterr()
+    assert [record["id"] for record in selected] == [1]
+    assert captured.out == ""
+    assert "Image ID(s) not found" in captured.err
 
 
 @pytest.fixture(autouse=True)

--- a/tests/unit/cli/test_commands_annotate.py
+++ b/tests/unit/cli/test_commands_annotate.py
@@ -1222,7 +1222,10 @@ def test_annotate_run_saves_results_to_db(
 
     assert result.exit_code == 0
     # annotation_save_service.save_annotation_results が呼ばれたことを確認
-    assert mock_container.annotation_save_service.save_annotation_results.call_count == 1
+    mock_container.annotation_save_service.save_annotation_results.assert_called_once()
+    assert mock_container.annotation_save_service.save_annotation_results.call_args.kwargs[
+        "allowed_image_ids"
+    ] == {1, 2, 3}
     # サマリーに保存件数が表示される
     assert "Saved to DB" in result.stdout
     assert "2" in result.stdout

--- a/tests/unit/cli/test_main.py
+++ b/tests/unit/cli/test_main.py
@@ -1,12 +1,13 @@
 """CLI メインモジュール テスト。"""
 
+import json
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
 from typer.testing import CliRunner
 
-from lorairo.cli.main import app
+from lorairo.cli.main import app, main
 
 runner = CliRunner()
 
@@ -178,6 +179,28 @@ def test_callback_configures_logging_default_info(monkeypatch: pytest.MonkeyPatc
     assert log_path.name == "lorairo-cli.log"
     assert log_path.parent.name == "logs"
     assert config_arg["rotation"] == "25 MB"
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+def test_main_preserves_post_command_json_flag(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """main() の prescan 後も callback が明示 --json を env で上書きしない。"""
+    monkeypatch.delenv("LORAIRO_CLI_JSON", raising=False)
+    monkeypatch.setattr("lorairo.cli.main.initialize_logging", MagicMock())
+    monkeypatch.setattr("lorairo.cli.commands.project.api_list_projects", MagicMock(return_value=[]))
+
+    main(["project", "list", "--json"])
+
+    captured = capsys.readouterr()
+    assert json.loads(captured.out) == {
+        "kind": "result",
+        "ok": True,
+        "message": "0 project(s) found",
+        "count": 0,
+    }
 
 
 # Issue #254: stdio init / Windows console code page / loguru sink クリア の test は

--- a/tests/unit/cli/test_main_error_boundary.py
+++ b/tests/unit/cli/test_main_error_boundary.py
@@ -8,6 +8,8 @@ import click
 import pytest
 
 from lorairo.api import exceptions as app_exc
+from lorairo.cli._errors import ErrorCode, classify_exception
+from lorairo.cli.commands.annotate import AnnotationRunFailedError, AnnotationSelectionError
 from lorairo.cli.main import _handle_cli_exception, _handle_click_exception
 
 
@@ -72,3 +74,33 @@ def test_handle_cli_exception_rich_mode_keeps_stdout_clean(capsys: pytest.Captur
     assert exit_code == 2
     assert captured.out.strip() == ""
     assert "Error" in captured.err
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+def test_classify_annotation_selection_as_user_action_error() -> None:
+    """Annotation selection failures are user-action/precondition errors."""
+    info = classify_exception(AnnotationSelectionError("No images selected"))
+
+    assert info.code == ErrorCode.PRECONDITION_FAILED
+    assert info.user_action_required is True
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+def test_classify_annotation_run_failure_as_user_action_error() -> None:
+    """Annotation terminal run failures are not internal crashes."""
+    info = classify_exception(AnnotationRunFailedError("Annotation produced no results"))
+
+    assert info.code == ErrorCode.PRECONDITION_FAILED
+    assert info.user_action_required is True
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+def test_classify_batch_import_error_as_validation_error() -> None:
+    """Malformed batch import input is classified as user-fixable validation."""
+    info = classify_exception(app_exc.BatchImportError("bad JSONL"))
+
+    assert info.code == ErrorCode.VALIDATION_FAILED
+    assert info.user_action_required is True

--- a/tests/unit/cli/test_main_error_boundary.py
+++ b/tests/unit/cli/test_main_error_boundary.py
@@ -104,3 +104,13 @@ def test_classify_batch_import_error_as_validation_error() -> None:
 
     assert info.code == ErrorCode.VALIDATION_FAILED
     assert info.user_action_required is True
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+def test_classify_annotation_failed_as_user_action_error() -> None:
+    """Annotator-raised failures are surfaced as run/precondition errors."""
+    info = classify_exception(app_exc.AnnotationFailedError("model", 1, "bad response"))
+
+    assert info.code == ErrorCode.PRECONDITION_FAILED
+    assert info.user_action_required is True

--- a/tests/unit/cli/test_output_mode.py
+++ b/tests/unit/cli/test_output_mode.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import pytest
 
-from lorairo.cli._output_mode import is_json_mode, resolve_output_mode, set_json_mode
+from lorairo.cli._output_mode import has_prescanned_mode, is_json_mode, resolve_output_mode, set_json_mode
 
 
 @pytest.mark.unit
@@ -45,5 +45,19 @@ def test_set_and_is_json_mode_roundtrip() -> None:
     """解決済みモードの保存/参照が往復する。"""
     set_json_mode(True)
     assert is_json_mode() is True
+    assert has_prescanned_mode() is False
     set_json_mode(False)
     assert is_json_mode() is False
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+def test_set_json_mode_records_prescanned_state() -> None:
+    """main() prescan 済みモードを callback が識別できる。"""
+    set_json_mode(True, prescanned=True)
+
+    assert is_json_mode() is True
+    assert has_prescanned_mode() is True
+
+    set_json_mode(False)
+    assert has_prescanned_mode() is False


### PR DESCRIPTION
## Summary
- Moves `annotate run` and `annotate import-batch` onto the central command boundary.
- Emits JSONL `item` rows per annotated image and a terminal `result` for `annotate run`.
- Keeps human progress/status out of stdout in JSON mode and routes errors through structured `kind:error`.
- Applies the 500 processing cap via `RESULT_SET_TOO_LARGE`.

## Verification
- `UV_PROJECT_ENVIRONMENT=/workspaces/LoRAIro/.venv uv run --no-sync pytest tests/unit/cli/test_annotate_selection.py tests/unit/cli/test_annotate_streaming.py tests/unit/cli/test_commands_annotate.py tests/unit/cli/test_annotate_import_batch.py tests/unit/cli/test_errors.py tests/unit/cli/test_emit.py tests/unit/cli/test_main_error_boundary.py -q`
- `UV_PROJECT_ENVIRONMENT=/workspaces/LoRAIro/.venv uv run --no-sync ruff check src/lorairo/api/exceptions.py src/lorairo/cli/_boundary.py src/lorairo/cli/_errors.py src/lorairo/cli/commands/annotate.py tests/unit/cli/test_commands_annotate.py tests/unit/cli/test_annotate_streaming.py`

Closes part of #641.