### PR TITLE
fix: 赤い main を修復 — worktree パス + display_score テスト drift (8件)

### DIFF
--- a/tests/unit/scripts/test_run_runtime_webapi_tests.py
+++ b/tests/unit/scripts/test_run_runtime_webapi_tests.py
@@ -75,7 +75,7 @@ def test_build_child_env_uses_shared_venv_for_worktree() -> None:
     env = runner_script.build_child_env(
         {"openai": "", "anthropic": "", "google": "", "openrouter": ""},
         base_env={"PATH": "/usr/bin"},
-        repo_root=Path("/tmp/worktrees/issue-123"),
+        repo_root=Path("/workspaces/LoRAIro/.agents/worktree/issue-123"),
     )
 
     assert env["UV_PROJECT_ENVIRONMENT"] == "/workspaces/LoRAIro/.venv"

--- a/tests/unit/services/test_annotation_save_service.py
+++ b/tests/unit/services/test_annotation_save_service.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from lorairo.domain.score_scaler import calibrate_to_display
 from lorairo.services.annotation_save_service import AnnotationSaveResult, AnnotationSaveService
 
 
@@ -447,7 +448,12 @@ def test_save_canonical_scorer_persists_score_labels(
     # Issue #626: AI scorer は positive key (hq) 1 行だけ生値で保存し、complement
     # (lq) は保存しない。これにより DB で positive 判別が一意になる。
     assert annotations_arg["scores"] == [
-        {"model_id": 42, "score": 0.85, "is_edited_manually": False},
+        {
+            "model_id": 42,
+            "score": 0.85,
+            "display_score": calibrate_to_display("aesthetic_shadow_v2", 0.85),
+            "is_edited_manually": False,
+        },
     ]
 
 
@@ -475,7 +481,14 @@ def test_save_regression_scorer_no_score_labels(
 
     _image_id_arg, annotations_arg = _first_batch_save_args(mock_repository)
     assert annotations_arg["score_labels"] == []
-    assert annotations_arg["scores"] == [{"model_id": 7, "score": 7.5, "is_edited_manually": False}]
+    assert annotations_arg["scores"] == [
+        {
+            "model_id": 7,
+            "score": 7.5,
+            "display_score": calibrate_to_display("ImprovedAesthetic", 7.5),
+            "is_edited_manually": False,
+        }
+    ]
 
 
 # ===== Issue #626: AI scorer は positive key 1 行のみ保存 =====
@@ -505,7 +518,12 @@ def test_save_cafe_scorer_persists_only_positive_key(
 
     _image_id_arg, annotations_arg = _first_batch_save_args(mock_repository)
     assert annotations_arg["scores"] == [
-        {"model_id": 11, "score": 0.67, "is_edited_manually": False},
+        {
+            "model_id": 11,
+            "score": 0.67,
+            "display_score": calibrate_to_display("cafe_aesthetic", 0.67),
+            "is_edited_manually": False,
+        },
     ]
 
 
@@ -533,7 +551,12 @@ def test_save_shadow_scorer_persists_only_hq(
 
     _image_id_arg, annotations_arg = _first_batch_save_args(mock_repository)
     assert annotations_arg["scores"] == [
-        {"model_id": 21, "score": 0.9, "is_edited_manually": False},
+        {
+            "model_id": 21,
+            "score": 0.9,
+            "display_score": calibrate_to_display("aesthetic_shadow_v1", 0.9),
+            "is_edited_manually": False,
+        },
     ]
 
 

--- a/tests/unit/test_hook_pre_commands.py
+++ b/tests/unit/test_hook_pre_commands.py
@@ -56,7 +56,7 @@ def test_allows_ready_pr_create_command() -> None:
 
 
 def test_blocks_uv_without_shared_environment_in_worktree() -> None:
-    result = _run_hook("uv run pytest", cwd="/tmp/worktrees/issue-123")
+    result = _run_hook("uv run pytest", cwd="/workspaces/LoRAIro/.agents/worktree/issue-123")
 
     assert result.returncode == 2
     payload = json.loads(result.stdout)
@@ -68,7 +68,7 @@ def test_blocks_uv_without_shared_environment_in_worktree() -> None:
 def test_allows_uv_with_shared_environment_in_worktree() -> None:
     result = _run_hook(
         "UV_PROJECT_ENVIRONMENT=/workspaces/LoRAIro/.venv uv run pytest tests/unit/test_hook_pre_commands.py",
-        cwd="/tmp/worktrees/issue-123",
+        cwd="/workspaces/LoRAIro/.agents/worktree/issue-123",
     )
 
     assert result.returncode == 0
@@ -78,7 +78,7 @@ def test_allows_uv_with_shared_environment_in_worktree() -> None:
 def test_allows_uv_with_shared_environment_from_process_env_in_worktree() -> None:
     result = _run_hook(
         "uv run pytest tests/unit/test_hook_pre_commands.py",
-        cwd="/tmp/worktrees/issue-123",
+        cwd="/workspaces/LoRAIro/.agents/worktree/issue-123",
         env={"UV_PROJECT_ENVIRONMENT": "/workspaces/LoRAIro/.venv"},
     )
 
@@ -89,21 +89,21 @@ def test_allows_uv_with_shared_environment_from_process_env_in_worktree() -> Non
 def test_blocks_similar_but_different_uv_environment_in_worktree() -> None:
     result = _run_hook(
         "UV_PROJECT_ENVIRONMENT=/workspaces/LoRAIro/.venv2 uv run pytest",
-        cwd="/tmp/worktrees/issue-123",
+        cwd="/workspaces/LoRAIro/.agents/worktree/issue-123",
     )
 
     assert result.returncode == 2
 
 
 def test_allows_bare_uv_in_worktree() -> None:
-    result = _run_hook("uv", cwd="/tmp/worktrees/issue-123")
+    result = _run_hook("uv", cwd="/workspaces/LoRAIro/.agents/worktree/issue-123")
 
     assert result.returncode == 0
     assert result.stdout == ""
 
 
 def test_blocks_cd_worktree_uv_without_shared_environment() -> None:
-    result = _run_hook("cd /tmp/worktrees/issue-123 && uv sync --dev")
+    result = _run_hook("cd /workspaces/LoRAIro/.agents/worktree/issue-123 && uv sync --dev")
 
     assert result.returncode == 2
     payload = json.loads(result.stdout)


### PR DESCRIPTION
## 背景

main は本日 \`9550e427\` 以降 **CI が赤** で、`maxfail=1` のため最初の失敗 (`scripts/`) で停止していた。その結果、後続でマージされた PR (#654 display_score 等) の CI が `services/` まで到達せず、**maxfail の壁の裏に hidden failure が積み上がっていた**。

このため #656 / #634 (#657) を含む全 PR が緑にならない。本 PR は決定論的な **8 件のテスト drift** を修復し main を緑に戻す。

## 修正内容

### グループA: worktree 配置移行に伴う旧パス参照 (4件)
chore `9550e427` が worktree 配置を `/tmp/worktrees` → `/workspaces/LoRAIro/.agents/worktree` に移行したが、テスト側が旧パスを参照したまま放置されていた。
- `test_run_runtime_webapi_tests.py::test_build_child_env_uses_shared_venv_for_worktree`
- `test_hook_pre_commands.py` の worktree 系 3 テスト

### グループB: display_score テスト未更新 (4件)
display_score 機能 (#654) で `scores` 行に `display_score` フィールドが追加されたが、scorer テストの期待値が未更新だった。
- `test_annotation_save_service.py` の scorer 系 4 テスト
- 期待値は `calibrate_to_display` を import して算出し、brittle な浮動小数 hardcode を避けた

いずれも**テストのみの変更**。production code・schema・submodule は不変。

## 検証
- 該当 3 ファイル: 43 passed
- `ruff format` / `ruff check`: pass
- フィルタ: `not gui_show and not calls_real_webapi and not downloads_and_runs_model and not slow` で main checkout 上の実 failure は本 8 件のみと特定済み (worktree フル実行で見える model_sync 系はローカル cwd 依存 artifact で CI には出ない)

🤖 Generated with [Claude Code](https://claude.com/claude-code)