### PR TITLE
fix: CLI introspection 契約精度向上 (export フィルタ + project delete force) (#659)

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -732,7 +732,7 @@ lorairo-cli --json describe "project delete"
 **Input `ProjectDeleteInput`**
 
 - `name`: `str` (required)
-- `force`: `bool` (optional, default `False`)
+- `force`: `bool` (optional, default `False`) - Required in JSON mode (--json): omitting it yields INVALID_INPUT since interactive confirmation cannot be driven over stdout.
 
 **Output `ProjectDeleteResult`**
 

--- a/src/lorairo/cli/commands/project.py
+++ b/src/lorairo/cli/commands/project.py
@@ -10,6 +10,7 @@ API層（lorairo.api）を経由してService層を利用する。
 
 import json
 
+import click
 import typer
 from rich.table import Table
 
@@ -118,12 +119,14 @@ def delete(
     """Delete a project."""
     with command_boundary():
         if not force:
+            # JSON mode は対話 confirm のプロンプトを stdout に書けない (JSONL 純度を
+            # 破る、ADR 0057 §1)。stdin で応答できない agent driving 前提なので、JSON mode
+            # では --force を契約上必須とし、未指定は INVALID_INPUT で弾く (Issue #659)。
+            if is_json_mode():
+                raise click.UsageError("project delete requires --force in JSON mode")
             confirm = typer.confirm(f"Delete project '{name}'? This cannot be undone.")
             if not confirm:
-                if is_json_mode():
-                    emit_result("Cancelled", cancelled=True)
-                else:
-                    console.print("[yellow]Cancelled[/yellow]")
+                console.print("[yellow]Cancelled[/yellow]")
                 return
 
         api_delete_project(name)

--- a/src/lorairo/cli/introspection.py
+++ b/src/lorairo/cli/introspection.py
@@ -146,13 +146,16 @@ class ProjectCreateResult(BaseModel):
 
 
 class ProjectDeleteResult(BaseModel):
-    """JSONL result payload emitted by ``project delete --json``."""
+    """JSONL result payload emitted by ``project delete --json``.
+
+    JSON mode は ``--force`` 必須 (Issue #659) のため対話キャンセル経路を持たず、
+    成功時は常に ``name`` を伴う result 行を 1 つだけ emit する。
+    """
 
     kind: Literal["result"] = "result"
     ok: Literal[True] = True
     message: str
     name: str | None = None
-    cancelled: bool | None = None
 
     model_config = ConfigDict(title="ProjectDeleteResult")
 
@@ -212,17 +215,25 @@ class ExportCreateInputSchema(BaseModel):
     # export create は最低 1 つの有効フィルタ (tags/excluded_tags/caption/manual_rating/
     # ai_rating/score_min/score_max) を要求し、無指定は UsageError で弾く
     # (_criteria_has_effective_filter)。include_nsfw は修飾子でフィルタとは扱わない。
+    #
+    # 各 anyOf ブランチは「キーの存在」だけでなく「非null・非空」も表現する (Issue #659):
+    # CLI 実体は正規化後に truthy 判定するため、{tags: null} や --tags "" は schema 上も
+    # invalid とする。string フィルタは minLength=1、score フィルタは number 型を明示し
+    # null を除外する (rating は Literal enum なので非null要求だけで有効値が保証される)。
     model_config = ConfigDict(
         title="ExportCreateInput",
         json_schema_extra={
             "anyOf": [
-                {"required": ["tags"]},
-                {"required": ["excluded_tags"]},
-                {"required": ["caption"]},
-                {"required": ["manual_rating"]},
-                {"required": ["ai_rating"]},
-                {"required": ["score_min"]},
-                {"required": ["score_max"]},
+                {"required": ["tags"], "properties": {"tags": {"type": "string", "minLength": 1}}},
+                {
+                    "required": ["excluded_tags"],
+                    "properties": {"excluded_tags": {"type": "string", "minLength": 1}},
+                },
+                {"required": ["caption"], "properties": {"caption": {"type": "string", "minLength": 1}}},
+                {"required": ["manual_rating"], "properties": {"manual_rating": {"type": "string"}}},
+                {"required": ["ai_rating"], "properties": {"ai_rating": {"type": "string"}}},
+                {"required": ["score_min"], "properties": {"score_min": {"type": "number"}}},
+                {"required": ["score_max"], "properties": {"score_max": {"type": "number"}}},
             ]
         },
     )

--- a/src/lorairo/cli/introspection.py
+++ b/src/lorairo/cli/introspection.py
@@ -216,20 +216,34 @@ class ExportCreateInputSchema(BaseModel):
     # ai_rating/score_min/score_max) を要求し、無指定は UsageError で弾く
     # (_criteria_has_effective_filter)。include_nsfw は修飾子でフィルタとは扱わない。
     #
-    # 各 anyOf ブランチは「キーの存在」だけでなく「非null・非空」も表現する (Issue #659):
-    # CLI 実体は正規化後に truthy 判定するため、{tags: null} や --tags "" は schema 上も
-    # invalid とする。string フィルタは minLength=1、score フィルタは number 型を明示し
-    # null を除外する (rating は Literal enum なので非null要求だけで有効値が保証される)。
+    # 各 anyOf ブランチは「キーの存在」だけでなく「正規化後に有効」も表現する (Issue #659):
+    # CLI 実体は正規化後に truthy 判定するため、schema 側もこれに揃える。
+    #   - CSV フィルタ (tags/excluded_tags): _normalize_csv がカンマ区切り→strip→非空
+    #     トークン抽出。"," や "  " は空集合になり無効なので、区切り(,)・空白以外の文字を
+    #     1つ以上含むことを pattern "[^\\s,]" で要求する。
+    #   - text フィルタ (caption): _normalize_text が strip→非空判定。"   " は無効なので
+    #     非空白文字を1つ以上含むことを pattern "\\S" で要求する (caption はカンマ可)。
+    #   - score フィルタ (score_min/score_max): number 型を明示し null を除外する。
+    #   - rating (manual_rating/ai_rating): Literal enum なので非null要求だけで有効値が保証。
+    # minLength=1 も併記し「非空」を明示する (pattern が正規化後の有効性を補強する)。
     model_config = ConfigDict(
         title="ExportCreateInput",
         json_schema_extra={
             "anyOf": [
-                {"required": ["tags"], "properties": {"tags": {"type": "string", "minLength": 1}}},
+                {
+                    "required": ["tags"],
+                    "properties": {"tags": {"type": "string", "minLength": 1, "pattern": "[^\\s,]"}},
+                },
                 {
                     "required": ["excluded_tags"],
-                    "properties": {"excluded_tags": {"type": "string", "minLength": 1}},
+                    "properties": {
+                        "excluded_tags": {"type": "string", "minLength": 1, "pattern": "[^\\s,]"}
+                    },
                 },
-                {"required": ["caption"], "properties": {"caption": {"type": "string", "minLength": 1}}},
+                {
+                    "required": ["caption"],
+                    "properties": {"caption": {"type": "string", "minLength": 1, "pattern": "\\S"}},
+                },
                 {"required": ["manual_rating"], "properties": {"manual_rating": {"type": "string"}}},
                 {"required": ["ai_rating"], "properties": {"ai_rating": {"type": "string"}}},
                 {"required": ["score_min"], "properties": {"score_min": {"type": "number"}}},
@@ -597,7 +611,19 @@ TOOL_SPECS: dict[str, ToolSpec] = {
         side_effects=("file_write", "db_write"),
         inputs=(
             _input(
-                "ProjectDeleteInput", (_f("name", "str", required=True), _f("force", "bool", default=False))
+                "ProjectDeleteInput",
+                (
+                    _f("name", "str", required=True),
+                    # JSON mode は対話 confirm を stdout に書けないため --force 必須
+                    # (Issue #659)。introspection 契約上も agent に必須要件を明示する。
+                    _f(
+                        "force",
+                        "bool",
+                        default=False,
+                        description="Required in JSON mode (--json): omitting it yields INVALID_INPUT "
+                        "since interactive confirmation cannot be driven over stdout.",
+                    ),
+                ),
             ),
         ),
         outputs=(_output("ProjectDeleteResult", (_f("name", "str"),), schema=ProjectDeleteResult),),

--- a/tests/unit/cli/test_commands_project.py
+++ b/tests/unit/cli/test_commands_project.py
@@ -407,3 +407,25 @@ def test_project_delete_nonexistent_json_mode(mock_projects_dir: Path) -> None:
     assert last["kind"] == "error"
     assert last["code"] == "NOT_FOUND"
     assert last["ok"] is False
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+def test_project_delete_json_mode_requires_force(mock_projects_dir: Path) -> None:
+    """Test: --json project delete - --force 省略は構造化 error (Issue #659)。
+
+    JSON mode は対話 confirm を stdout に書けない (JSONL 純度を破る) ため --force 必須。
+    未指定は INVALID_INPUT (exit 2) で弾き、stdout は error 行のみ (削除は実行しない)。
+    """
+    runner.invoke(app, ["project", "create", "json-force-test"])
+
+    result = runner.invoke(app, ["--json", "project", "delete", "json-force-test"])
+
+    assert result.exit_code == 2
+    last = _json_lines(result.stdout)[-1]
+    assert last["kind"] == "error"
+    assert last["code"] == "INVALID_INPUT"
+    assert last["ok"] is False
+    # 削除は実行されず、プロジェクトは残る
+    projects = [d.name for d in mock_projects_dir.iterdir() if d.name.startswith("json-force-test_")]
+    assert len(projects) > 0

--- a/tests/unit/cli/test_introspection.py
+++ b/tests/unit/cli/test_introspection.py
@@ -83,6 +83,33 @@ def test_describe_json_schema_wraps_cli_input_schema_in_item_payload() -> None:
     assert "sql" not in json.dumps(input_schema["schema"]).lower()
 
 
+def test_export_create_anyof_requires_non_null_non_empty_filter() -> None:
+    """export create の anyOf は「キー存在」だけでなく非null/非空も要求する (Issue #659)。
+
+    CLI 実体は ``_criteria_has_effective_filter`` で正規化後に truthy 判定するため、
+    ``{tags: null}`` や ``--tags ""`` は UsageError で弾かれる。schema 側も string
+    フィルタは minLength=1、score フィルタは number 型でこの契約に揃える。
+    """
+    result = runner.invoke(app, ["--json", "describe", "export create", "--schema", "json_schema"])
+    assert result.exit_code == 0
+    rows = _jsonl(result.stdout)
+    input_schema = next(
+        row for row in rows if row.get("type") == "schema" and row["name"] == "ExportCreateInput"
+    )
+    branches = {
+        tuple(branch["required"]): branch.get("properties", {})
+        for branch in input_schema["schema"]["anyOf"]
+    }
+    # string フィルタ: 非空 (minLength=1) を要求
+    for key in ("tags", "excluded_tags", "caption"):
+        constraint = branches[(key,)][key]
+        assert constraint["type"] == "string"
+        assert constraint["minLength"] == 1
+    # score フィルタ: number 型で null を除外
+    for key in ("score_min", "score_max"):
+        assert branches[(key,)][key]["type"] == "number"
+
+
 def test_annotate_run_describes_only_supported_flags() -> None:
     result = runner.invoke(app, ["--json", "describe", "annotate run"])
 
@@ -213,7 +240,7 @@ def test_remaining_cli_result_schemas_do_not_reuse_api_dtos() -> None:
     commands = {
         "project create": ("input", "ProjectCreateInput", {"name", "description"}, {"created"}),
         "project create result": ("output", "ProjectCreateResult", {"name", "path"}, {"created"}),
-        "project delete": ("output", "ProjectDeleteResult", {"name", "cancelled"}, {"success", "data"}),
+        "project delete": ("output", "ProjectDeleteResult", {"name"}, {"success", "data", "cancelled"}),
         "images register": (
             "output",
             "ImagesRegisterResult",

--- a/tests/unit/cli/test_introspection.py
+++ b/tests/unit/cli/test_introspection.py
@@ -100,11 +100,16 @@ def test_export_create_anyof_requires_non_null_non_empty_filter() -> None:
         tuple(branch["required"]): branch.get("properties", {})
         for branch in input_schema["schema"]["anyOf"]
     }
-    # string フィルタ: 非空 (minLength=1) を要求
+    # string フィルタ: 非空 (minLength=1) かつ正規化後に有効 (pattern) を要求
     for key in ("tags", "excluded_tags", "caption"):
         constraint = branches[(key,)][key]
         assert constraint["type"] == "string"
         assert constraint["minLength"] == 1
+    # CSV フィルタは区切り(,)・空白以外の文字を要求し "," や "  " を弾く
+    for key in ("tags", "excluded_tags"):
+        assert branches[(key,)][key]["pattern"] == "[^\\s,]"
+    # text フィルタは非空白文字を要求し "   " を弾く (caption はカンマ可)
+    assert branches[("caption",)]["caption"]["pattern"] == "\\S"
     # score フィルタ: number 型で null を除外
     for key in ("score_min", "score_max"):
         assert branches[(key,)][key]["type"] == "number"
@@ -234,6 +239,24 @@ def test_cli_specific_output_json_schemas_match_item_rows() -> None:
     } <= set(update_schema["schema"]["properties"])
     assert export_schema["name"] == "ExportCreateResult"
     assert {"output_path"} <= set(export_schema["schema"]["properties"])
+
+
+def test_project_delete_input_advertises_json_mode_force_requirement() -> None:
+    """describe project delete の force フィールドは JSON mode 必須要件を明示する (Issue #659)。
+
+    JSON mode で --force 必須を強制 (INVALID_INPUT) する一方、introspection 契約で
+    force を optional/default のまま放置すると agent が {name} 単独を valid と誤認する。
+    field description で必須要件を contract として明示する。
+    """
+    result = runner.invoke(app, ["--json", "describe", "project delete"])
+    assert result.exit_code == 0
+    rows = _jsonl(result.stdout)
+    input_row = next(
+        row for row in rows if row.get("type") == "model" and row["name"] == "ProjectDeleteInput"
+    )
+    force_field = next(field for field in input_row["fields"] if field["name"] == "force")
+    assert "JSON mode" in force_field["description"]
+    assert "INVALID_INPUT" in force_field["description"]
 
 
 def test_remaining_cli_result_schemas_do_not_reuse_api_dtos() -> None:


### PR DESCRIPTION
## 概要

#657 (CLI introspection docs) の codex レビュー round 7 で挙がった P2 advisory 2件 (#659) を解消する。いずれも introspection schema と CLI 契約の精度向上で、振る舞いの破壊はない (JSON mode の project delete を除く、後述)。

## 変更内容

### L225 — export create フィルタ値の非null/非空要求
`ExportCreateInputSchema` の `anyOf` は従来「フィルタキーの存在」だけを要求し、`{tags: null}` / `--tags ""` も schema 上 valid だった。一方 CLI 実体は `_criteria_has_effective_filter` で正規化後に truthy 判定し、空フィルタは `UsageError` で弾く。

→ 各 `anyOf` ブランチを「存在 + 非null/非空」に絞る:
- string フィルタ (`tags`/`excluded_tags`/`caption`): `minLength: 1`
- score フィルタ (`score_min`/`score_max`): `type: number` で null 除外
- rating (`manual_rating`/`ai_rating`): Literal enum なので非null要求のみ

### L591 — project delete の非force キャンセル経路
`--force` 省略時の `typer.confirm` が **stdout** にプロンプトを書き、JSON mode で JSONL 契約を破っていた (さらに "no" 時に `{cancelled: true}` を emit)。

→ **JSON mode の delete を `--force` 必須に契約化** (stdin で応答できない agent driving 前提):
- JSON mode で `--force` 未指定 → `click.UsageError` (INVALID_INPUT / exit 2)、削除は実行しない
- human mode は従来通り対話 confirm
- `ProjectDeleteResult` から `cancelled` フィールドを削除

## テスト

リグレッションテスト追加:
- `test_export_create_anyof_requires_non_null_non_empty_filter`
- `test_project_delete_json_mode_requires_force`

検証 (worktree src を PYTHONPATH 先頭に、main checkout が CI SSoT):
- `tests/unit/cli/test_introspection.py` + `test_commands_project.py`: 37 passed
- CLI unit+integration (CI filter): 320 passed / 1 failed
  - 失敗は `test_cli_full_workflow_with_fake_annotator` の **worktree-PYTHONPATH cwd artifact** (model 解決が iam-lib submodule パス解決に依存)。変更を退避しても同条件で再現し、main checkout では pass。本変更とは無関係 (annotate 経路は未変更)。
- `ruff check` / `mypy -p lorairo.cli`: clean

## 関連
- Closes #659
- #657 codex review round 7: comment 3367708202 (L225) / 3367708210 (L591)
- ADR 0057 §1 (stdout=JSONL 純度) / ADR 0059 (introspection)

🤖 Generated with [Claude Code](https://claude.com/claude-code)