### PR TITLE
fix: version/status を --json 機械可読契約に対応 + introspection 登録 (#662)

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -788,3 +788,73 @@ Structured error payload emitted as kind=error by the CLI boundary.
 - `user_action_required`: `bool` (required)
 - `hint`: `str?` (optional)
 - `details`: `dict?` (optional)
+
+### `status`
+
+Show system status (config file and API key availability).
+
+- Read only: `true`
+- Side effects: `file_read`
+
+#### Compact Introspection
+
+```bash
+lorairo-cli --json describe "status"
+```
+
+#### Models
+
+**Output `StatusResult`**
+
+- `environment`: `str` (optional)
+- `phase`: `str` (optional)
+- `config_found`: `bool` (optional)
+- `api_keys`: `dict[str,bool]?` (optional)
+- `initialized_services`: `dict[str,bool]?` (optional)
+
+**Error `CliErrorResponse`**
+
+Structured error payload emitted as kind=error by the CLI boundary.
+
+- `kind`: `error` (required)
+- `ok`: `false` (required)
+- `code`: `str` (required)
+- `message`: `str` (required)
+- `retryable`: `bool` (required)
+- `user_action_required`: `bool` (required)
+- `hint`: `str?` (optional)
+- `details`: `dict?` (optional)
+
+### `version`
+
+Show version information.
+
+- Read only: `true`
+- Side effects: 
+
+#### Compact Introspection
+
+```bash
+lorairo-cli --json describe "version"
+```
+
+#### Models
+
+**Output `VersionResult`**
+
+- `name`: `str` (optional)
+- `version`: `str` (optional)
+- `description`: `str` (optional)
+
+**Error `CliErrorResponse`**
+
+Structured error payload emitted as kind=error by the CLI boundary.
+
+- `kind`: `error` (required)
+- `ok`: `false` (required)
+- `code`: `str` (required)
+- `message`: `str` (required)
+- `retryable`: `bool` (required)
+- `user_action_required`: `bool` (required)
+- `hint`: `str?` (optional)
+- `details`: `dict?` (optional)

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -66,10 +66,10 @@ LoRAIro のテスト設計 4 段階構成の最終層。自動化が困難な領
 
 ## E2. CLI JSON モード・introspection (エージェント駆動)
 
-- [ ] `lorairo-cli --json status` で stdout が純 JSONL (kind は `item` / `result` / `error`) になり、
-      ログ・進捗・装飾は stderr に分離される (ADR 0057 / 0058)
+- [ ] `lorairo-cli --json status` / `--json version` で stdout が純 JSONL の単一 `result` 行になり、
+      ログ・進捗・装飾は stderr に分離される (ADR 0057 / 0058 / Issue #662)
 - [ ] 環境変数 `LORAIRO_CLI_JSON=1` でも同じ JSONL モードに切り替わる
-- [ ] `lorairo-cli --json list-commands` が副作用なしで全コマンドを列挙する (ADR 0059)
+- [ ] `lorairo-cli --json list-commands` が副作用なしで全コマンド (version / status 含む) を列挙する (ADR 0059)
 - [ ] `lorairo-cli --json describe "annotate run"` (compact) / `--schema json_schema` が
       入力・出力・エラーのスキーマを返す (ADR 0059)
 

--- a/src/lorairo/cli/introspection.py
+++ b/src/lorairo/cli/introspection.py
@@ -160,6 +160,38 @@ class ProjectDeleteResult(BaseModel):
     model_config = ConfigDict(title="ProjectDeleteResult")
 
 
+class VersionResult(BaseModel):
+    """JSONL result payload emitted by ``version --json`` (Issue #662)."""
+
+    kind: Literal["result"] = "result"
+    ok: Literal[True] = True
+    message: str
+    name: str
+    version: str
+    description: str
+
+    model_config = ConfigDict(title="VersionResult")
+
+
+class StatusResult(BaseModel):
+    """JSONL result payload emitted by ``status --json`` (Issue #662).
+
+    CLI 経路は ``api_keys``、GUI 経路は ``initialized_services`` を伴う
+    (実行環境によりどちらか一方のみが存在する)。
+    """
+
+    kind: Literal["result"] = "result"
+    ok: Literal[True] = True
+    message: str
+    environment: str
+    phase: str
+    config_found: bool
+    api_keys: dict[str, bool] | None = None
+    initialized_services: dict[str, bool] | None = None
+
+    model_config = ConfigDict(title="StatusResult")
+
+
 class ImagesRegisterResult(BaseModel):
     """JSONL result payload emitted by ``images register --json``."""
 
@@ -565,6 +597,44 @@ def _search_input(name: str, fields: tuple[FieldSpec, ...], description: str = "
 
 
 TOOL_SPECS: dict[str, ToolSpec] = {
+    "version": ToolSpec(
+        name="version",
+        path="version",
+        summary="Show version information.",
+        read_only=True,
+        side_effects=(),
+        inputs=(),
+        outputs=(
+            _output(
+                "VersionResult",
+                (_f("name", "str"), _f("version", "str"), _f("description", "str")),
+                schema=VersionResult,
+            ),
+        ),
+        errors=(ERROR_MODEL,),
+    ),
+    "status": ToolSpec(
+        name="status",
+        path="status",
+        summary="Show system status (config file and API key availability).",
+        read_only=True,
+        side_effects=("file_read",),
+        inputs=(),
+        outputs=(
+            _output(
+                "StatusResult",
+                (
+                    _f("environment", "str"),
+                    _f("phase", "str"),
+                    _f("config_found", "bool"),
+                    _f("api_keys", "dict[str,bool]?"),
+                    _f("initialized_services", "dict[str,bool]?"),
+                ),
+                schema=StatusResult,
+            ),
+        ),
+        errors=(ERROR_MODEL,),
+    ),
     "project create": ToolSpec(
         name="project create",
         path="project create",

--- a/src/lorairo/cli/main.py
+++ b/src/lorairo/cli/main.py
@@ -24,11 +24,12 @@ from rich.table import Table
 
 from lorairo.cli._boundary import command_boundary
 from lorairo.cli._console import make_console
-from lorairo.cli._emit import emit_error
+from lorairo.cli._emit import emit_error, emit_result
 from lorairo.cli._errors import ErrorCode, ErrorInfo, classify_exception, hint_for
 from lorairo.cli._glyphs import FAIL, OK
 from lorairo.cli._output_mode import (
     has_prescanned_mode,
+    is_json_mode,
     resolve_output_mode,
     set_json_mode,
     strip_mode_flags,
@@ -133,12 +134,27 @@ def _configure(
     )
 
 
+# CLI のバージョン文字列 (pyproject.toml の version と一致させる)。
+_CLI_VERSION = "0.0.8"
+_CLI_DESCRIPTION = "AI-powered image annotation and dataset management"
+
+
 # ===== トップレベルコマンド =====
 @app.command()
 def version() -> None:
     """Show version information."""
-    console.print("[bold cyan]LoRAIro CLI[/bold cyan] v0.0.8")
-    console.print("[dim]AI-powered image annotation and dataset management[/dim]")
+    with command_boundary():
+        if is_json_mode():
+            # ADR 0057/0058: --json 時は stdout に JSONL の result 行のみを出す (Issue #662)。
+            emit_result(
+                f"LoRAIro CLI v{_CLI_VERSION}",
+                name="lorairo-cli",
+                version=_CLI_VERSION,
+                description=_CLI_DESCRIPTION,
+            )
+        else:
+            console.print(f"[bold cyan]LoRAIro CLI[/bold cyan] v{_CLI_VERSION}")
+            console.print(f"[dim]{_CLI_DESCRIPTION}[/dim]")
 
 
 @app.command("list-commands")
@@ -202,25 +218,51 @@ def _show_gui_status(summary: dict[str, Any]) -> None:
     console.print(table)
 
 
+def _collect_api_key_status(container: ServiceContainer) -> dict[str, bool]:
+    """設定済み API キーの有無を provider 別に返す (rich / JSONL 共通の収集ロジック)。"""
+    config = container.config_service
+    api_providers = {
+        "openai": config.get_setting("api", "openai_key", ""),
+        "anthropic": config.get_setting("api", "claude_key", ""),
+        "google": config.get_setting("api", "google_key", ""),
+    }
+    return {provider: bool(key and key.strip()) for provider, key in api_providers.items()}
+
+
+def _emit_status_json(
+    container: ServiceContainer, summary: dict[str, Any], environment: str, phase: str
+) -> None:
+    """status を単一の ``result`` 行で機械可読出力する (ADR 0057/0058、Issue #662)。"""
+    config_found = DEFAULT_CONFIG_PATH.exists()
+    output: dict[str, Any] = {"environment": environment, "phase": phase, "config_found": config_found}
+    if environment == "CLI":
+        # CLI 経路は設定ファイルと API キー設定状況を返す。
+        output["api_keys"] = _collect_api_key_status(container) if config_found else {}
+    else:
+        # GUI 経路はサービス初期化状況を返す。
+        output["initialized_services"] = summary.get("initialized_services", {})
+    emit_result("status ok", **output)
+
+
 @app.command()
 def status() -> None:
     """Show system status."""
-    try:
+    with command_boundary():
         container = get_service_container()
         summary = container.get_service_summary()
         environment = summary.get("environment", "Unknown")
+        phase = summary.get("phase", "Unknown")
+
+        if is_json_mode():
+            _emit_status_json(container, summary, environment, phase)
+            return
 
         console.print(f"[dim]Environment:[/dim] {environment}")
-        console.print(f"[dim]Phase:[/dim] {summary.get('phase', 'Unknown')}\n")
-
+        console.print(f"[dim]Phase:[/dim] {phase}\n")
         if environment == "CLI":
             _show_cli_status(container)
         else:
             _show_gui_status(summary)
-
-    except Exception as e:
-        console.print(f"[red]Error:[/red] {e}")
-        raise typer.Exit(code=1) from e
 
 
 def _report_error(message: str, info: ErrorInfo, *, json_mode: bool) -> None:

--- a/tests/unit/cli/test_introspection.py
+++ b/tests/unit/cli/test_introspection.py
@@ -36,6 +36,35 @@ def test_list_commands_emits_tool_items_and_result() -> None:
     assert "db_write" in images_update["side_effects"]
 
 
+def test_list_commands_includes_version_and_status() -> None:
+    """version / status も introspection に載る (Issue #662)。"""
+    result = runner.invoke(app, ["--json", "list-commands"])
+
+    assert result.exit_code == 0
+    items = [row for row in _jsonl(result.stdout) if row["kind"] == "item"]
+    by_path = {row["path"]: row for row in items}
+
+    assert "version" in by_path
+    assert by_path["version"]["read_only"] is True
+    assert by_path["version"]["side_effects"] == []
+
+    assert "status" in by_path
+    assert by_path["status"]["read_only"] is True
+    assert "file_read" in by_path["status"]["side_effects"]
+
+
+def test_describe_status_exposes_status_result_schema() -> None:
+    """describe status が StatusResult 出力スキーマを返す (Issue #662)。"""
+    result = runner.invoke(app, ["--json", "describe", "status", "--schema", "json_schema"])
+
+    assert result.exit_code == 0
+    rows = _jsonl(result.stdout)
+    schema_rows = [row for row in rows if row.get("type") == "schema"]
+    status_schema = next(row for row in schema_rows if row["name"] == "StatusResult")
+    properties = set(status_schema["schema"]["properties"])
+    assert {"environment", "phase", "config_found", "api_keys"} <= properties
+
+
 def test_describe_compact_emits_tool_model_items_and_result() -> None:
     result = runner.invoke(app, ["--json", "describe", "export create"])
 

--- a/tests/unit/cli/test_main.py
+++ b/tests/unit/cli/test_main.py
@@ -152,6 +152,91 @@ def test_cli_status_config_not_found(
 
 @pytest.mark.unit
 @pytest.mark.cli
+def test_version_json_emits_single_result_line() -> None:
+    """Test: version --json は stdout に result 行を1つだけ出す (Issue #662)。"""
+    result = runner.invoke(app, ["--json", "version"])
+
+    assert result.exit_code == 0
+    lines = [line for line in result.stdout.splitlines() if line.strip()]
+    assert len(lines) == 1
+    payload = json.loads(lines[0])
+    assert payload["kind"] == "result"
+    assert payload["ok"] is True
+    assert payload["name"] == "lorairo-cli"
+    assert payload["version"] == "0.0.8"
+    # rich 装飾 (cyan マークアップ) が stdout に混入しないこと。
+    assert "[bold cyan]" not in result.stdout
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+@patch("lorairo.cli.main.DEFAULT_CONFIG_PATH")
+@patch("lorairo.cli.main.get_service_container")
+def test_status_json_emits_pure_jsonl_result(
+    mock_get_container: MagicMock,
+    mock_config_path: MagicMock,
+) -> None:
+    """Test: status --json は stdout が純 JSONL の単一 result になる (Issue #662)。"""
+    mock_config_path.exists.return_value = True
+
+    mock_container = MagicMock()
+    mock_container.get_service_summary.return_value = {
+        "environment": "CLI",
+        "phase": "Phase 4 (Production Integration)",
+        "initialized_services": {},
+    }
+    mock_config = MagicMock()
+    mock_config.get_setting.side_effect = lambda section, key, default="": (
+        "sk-test-key" if key == "openai_key" else ""
+    )
+    mock_container.config_service = mock_config
+    mock_get_container.return_value = mock_container
+
+    result = runner.invoke(app, ["--json", "status"])
+
+    assert result.exit_code == 0
+    lines = [line for line in result.stdout.splitlines() if line.strip()]
+    assert len(lines) == 1
+    payload = json.loads(lines[0])
+    assert payload["kind"] == "result"
+    assert payload["ok"] is True
+    assert payload["environment"] == "CLI"
+    assert payload["config_found"] is True
+    assert payload["api_keys"] == {"openai": True, "anthropic": False, "google": False}
+    # rich テーブルの装飾が stdout に混入していないこと。
+    assert "LoRAIro CLI Status" not in result.stdout
+    assert "┏" not in result.stdout  # テーブル罫線 (┏)
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+@patch("lorairo.cli.main.DEFAULT_CONFIG_PATH")
+@patch("lorairo.cli.main.get_service_container")
+def test_status_json_omits_api_keys_when_config_missing(
+    mock_get_container: MagicMock,
+    mock_config_path: MagicMock,
+) -> None:
+    """Test: 設定ファイルが無い場合 status --json は api_keys を空にする (Issue #662)。"""
+    mock_config_path.exists.return_value = False
+
+    mock_container = MagicMock()
+    mock_container.get_service_summary.return_value = {
+        "environment": "CLI",
+        "phase": "Phase 4 (Production Integration)",
+        "initialized_services": {},
+    }
+    mock_get_container.return_value = mock_container
+
+    result = runner.invoke(app, ["--json", "status"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout.strip())
+    assert payload["config_found"] is False
+    assert payload["api_keys"] == {}
+
+
+@pytest.mark.unit
+@pytest.mark.cli
 def test_project_help() -> None:
     """Test: project subcommand help."""
     result = runner.invoke(app, ["project", "--help"])


### PR DESCRIPTION
## 概要

エージェント実使用で判明した契約違反 #662 の修正。`version` / `status` が
グローバル `--json` フラグを無視し stdout に rich/plain text を出していた問題を、
`project list` 等と同じ canonical パターン (`command_boundary()` + `is_json_mode()`
分岐 + emit) に揃えて解消する。あわせて introspection registry に登録する
(スコープ判断: Full)。

親 Issue: #661

## 背景 (契約違反)

```console
$ lorairo-cli --json status   # 修正前: stdout に rich テーブル / JSON 0 行
$ lorairo-cli --json version  # 修正前: stdout に plain text / JSON 0 行
```

- ADR 0057 §1「stdout = JSONL 専用」違反
- ADR 0057 不変条件「全コマンドは必ず 1 行の `result` または `error` で終端」違反
- `status` は ADR 0057 §7 が撤廃した `except Exception` + `console.print("[red]Error:]")`
  + `Exit(1)` の散在アンチパターンを残置

## 変更

- **`src/lorairo/cli/main.py`**: `version()` / `status()` を `command_boundary()` +
  `is_json_mode()` 分岐に載せ替え。`status` の手動 try/except を撤廃し中央境界へ委譲。
  状態収集 (`_collect_api_key_status` / `_emit_status_json`) と rich 描画を分離。
- **`src/lorairo/cli/introspection.py`**: `VersionResult` / `StatusResult` wire モデル
  追加、ToolSpec registry に `version` / `status` 登録 → `list-commands` / `describe`
  で発見可能に。
- **`docs/cli.md`**: 再生成 (version / status 項目追加)。
- **`docs/release-checklist.md`** (#665): E2 スモーク項目を status/version 対応後の
  単一 `result` 前提に更新。

## 修正後の挙動

```console
$ lorairo-cli --json version
{"kind":"result","ok":true,"message":"LoRAIro CLI v0.0.8","name":"lorairo-cli","version":"0.0.8","description":"..."}

$ lorairo-cli --json status
{"kind":"result","ok":true,"message":"status ok","environment":"CLI","phase":"...","config_found":true,"api_keys":{"openai":true,"anthropic":false,"google":false}}
```

rich モード (既定 / `--no-json`) の出力は従来通り維持。

## 設計判断

- **スコープ = Full**: emit 対応に加えて introspection 登録まで実施。`list-commands` で
  全コマンドが見えないと別の不整合 issue を生むため。
- **status の JSONL 構造 = 単一 `result`**: 固定少数項目なので agent が 1 パースで取れる。

## テスト

- `--json` での stdout 純度 (単一 result 行・rich 装飾の非混入)
- config 欠落時の `api_keys` 空
- introspection への version/status 登録 + describe スキーマ
- cli unit 全体 324 passed (CI-equivalent filter、worktree PYTHONPATH override)

## 関連 Issue

Closes #662, #665
