### PR TITLE
fix: images list の count-first gate を introspection で明示 (#663)

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -462,7 +462,7 @@ Structured error payload emitted as kind=error by the CLI boundary.
 
 ### `images list`
 
-List images in a project.
+List images in a project. Count-first (ADR 0060): default returns only the matching count; --fetch returns id+path rows but only when the total is <= 500.
 
 - Read only: `true`
 - Side effects: `db_read`, `file_read`
@@ -478,9 +478,9 @@ lorairo-cli --json describe "images list"
 **Input `ImagesListInput`**
 
 - `project`: `str` (required)
-- `fetch`: `bool` (optional, default `False`)
-- `limit`: `int[1,500]` (optional, default `500`)
-- `offset`: `int>=0` (optional, default `0`)
+- `fetch`: `bool` (optional, default `False`) - Fetch id+path rows instead of only the count. Succeeds only when total matches are <= 500; a larger result yields RESULT_SET_TOO_LARGE (narrow the filter). Omitted (default) returns the count only.
+- `limit`: `int[1,500]` (optional, default `500`) - Page size within a <= 500 match set (ADR 0060). Does NOT bypass the count-first gate: a total over 500 is rejected regardless of limit.
+- `offset`: `int>=0` (optional, default `0`) - Rows to skip within a <= 500 match set. Pagination is bounded to the working set; it is not a way to page through a result larger than 500.
 - `unrated`: `bool` (optional, default `False`)
 
 **Output `ImagesListItem`**

--- a/src/lorairo/cli/introspection.py
+++ b/src/lorairo/cli/introspection.py
@@ -727,7 +727,10 @@ TOOL_SPECS: dict[str, ToolSpec] = {
     "images list": ToolSpec(
         name="images list",
         path="images list",
-        summary="List images in a project.",
+        summary=(
+            "List images in a project. Count-first (ADR 0060): default returns only the matching "
+            "count; --fetch returns id+path rows but only when the total is <= 500."
+        ),
         read_only=True,
         side_effects=("db_read", "file_read"),
         inputs=(
@@ -735,9 +738,28 @@ TOOL_SPECS: dict[str, ToolSpec] = {
                 "ImagesListInput",
                 (
                     _f("project", "str", required=True),
-                    _f("fetch", "bool", default=False),
-                    _f("limit", "int[1,500]", default=500),
-                    _f("offset", "int>=0", default=0),
+                    _f(
+                        "fetch",
+                        "bool",
+                        default=False,
+                        description="Fetch id+path rows instead of only the count. Succeeds only when "
+                        "total matches are <= 500; a larger result yields RESULT_SET_TOO_LARGE "
+                        "(narrow the filter). Omitted (default) returns the count only.",
+                    ),
+                    _f(
+                        "limit",
+                        "int[1,500]",
+                        default=500,
+                        description="Page size within a <= 500 match set (ADR 0060). Does NOT bypass the "
+                        "count-first gate: a total over 500 is rejected regardless of limit.",
+                    ),
+                    _f(
+                        "offset",
+                        "int>=0",
+                        default=0,
+                        description="Rows to skip within a <= 500 match set. Pagination is bounded to the "
+                        "working set; it is not a way to page through a result larger than 500.",
+                    ),
                     _f("unrated", "bool", default=False),
                 ),
             ),

--- a/tests/unit/cli/test_introspection.py
+++ b/tests/unit/cli/test_introspection.py
@@ -92,6 +92,26 @@ def test_images_update_describes_only_supported_input_fields() -> None:
     assert {field["name"] for field in input_rows[0]["fields"]} == {"project", "tags", "image_id"}
 
 
+def test_describe_images_list_documents_count_first_gate() -> None:
+    """images list の fetch/limit/offset が count-first gate を説明する (Issue #663)。"""
+    result = runner.invoke(app, ["--json", "describe", "images list"])
+
+    assert result.exit_code == 0
+    rows = _jsonl(result.stdout)
+    input_model = next(
+        row for row in rows if row.get("type") == "model" and row["name"] == "ImagesListInput"
+    )
+    fields = {field["name"]: field.get("description", "") for field in input_model["fields"]}
+
+    # fetch は総数 <= 500 のときだけ成功し、超過時は RESULT_SET_TOO_LARGE になる旨を明示。
+    assert "RESULT_SET_TOO_LARGE" in fields["fetch"]
+    assert "500" in fields["fetch"]
+    # limit/offset は count-first gate を回避しないことを明示。
+    assert "500" in fields["limit"]
+    assert "bypass" in fields["limit"].lower()
+    assert "500" in fields["offset"]
+
+
 def test_describe_json_schema_wraps_cli_input_schema_in_item_payload() -> None:
     result = runner.invoke(app, ["--json", "describe", "export create", "--schema", "json_schema"])
 


### PR DESCRIPTION
## 概要

#663 (count-first `--fetch` の 500 gate と `describe` の乖離) の修正。
ADR 0060 の確定済み挙動は維持し、introspection の説明だけを補強して乖離を解消する
(**挙動変更なし**)。

親 Issue: #661

## 背景

`describe "images list"` が `limit int[1,500]` / `offset int>=0` を**説明なしで**広告し、
agent が「limit/offset でページングできる」と誤解していた。実際は `--fetch` の gate が
**総ヒット数 > 500** で判定する (ADR 0060 §4 の意図的設計) ため、`--limit 3` を明示しても
総数が 500 超なら `RESULT_SET_TOO_LARGE` で弾かれる。

```console
$ lorairo-cli --json images list -p main_dataset --fetch --limit 3
{"kind":"error","code":"RESULT_SET_TOO_LARGE","details":{"limit":500,"matched":21192}}
```

→ これは挙動バグではなく introspection の説明不足。ADR 0060 §3/§4 は「total 判定 /
offset 巡回を採らず絞り込みに倒す」と意図的に決めている。よって挙動は変えず説明を補う。

## 変更

- **`introspection.py`**: `images list` の summary に count-first 要約を追記。
  `fetch` / `limit` / `offset` に description を付与し、機械可読に明示:
  - `fetch`: 総数 `<= 500` のときのみ成功、超過は `RESULT_SET_TOO_LARGE`
  - `limit` / `offset`: count-first gate を回避せず、`<= 500` の作業集合内 pagination
- **`docs/cli.md`**: 再生成。
- **tests**: describe 出力が gate 説明を含むことを検証。

## 検証後の describe 出力

```console
$ lorairo-cli --json describe "images list"
... "fetch" -> "Fetch id+path rows ... Succeeds only when total matches are <= 500;
              a larger result yields RESULT_SET_TOO_LARGE (narrow the filter)..."
... "limit" -> "Page size within a <= 500 match set (ADR 0060). Does NOT bypass the
              count-first gate: a total over 500 is rejected regardless of limit."
```

## 検討した代替案 (不採用)

- **gate 緩和 (`--limit` で先頭 N 件返す)**: ADR 0060 §3/§4 の確定決定を覆し、count-first の
  誤 dump 防止保証を弱め、`limit` の意味を二義化するため不採用。
- **`--head` / `--sample` 追加**: 「確認用覗き見」の需要が現状確認できず YAGNI のため見送り。

## テスト

cli unit 全体 325 passed (CI-equivalent filter、worktree PYTHONPATH override) / ruff / mypy クリーン。

Closes #663
