### PR TITLE
fix: images list の count/total 語義を両モードで統一 (#664)

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -490,8 +490,8 @@ lorairo-cli --json describe "images list"
 
 **Output `ImagesListResult`**
 
-- `count`: `int` (optional)
-- `total`: `int?` (optional)
+- `count`: `int` (optional) - Item rows emitted in this response (0 in count-first mode). Use total for the match count.
+- `total`: `int?` (optional) - Total number of matching images.
 - `limit`: `int?` (optional)
 - `offset`: `int?` (optional)
 - `has_more`: `bool?` (optional)

--- a/docs/decisions/0060-cli-bounded-pagination-contract.md
+++ b/docs/decisions/0060-cli-bounded-pagination-contract.md
@@ -56,7 +56,9 @@ flag 名 (`--fetch` 等) や projection の最終フィールド確定、Reposit
 ```jsonc
 // 既定 (フラグ無し) = 件数だけ。軽量 COUNT(*)、item 行なし。
 // 下は --json (エージェント) 時の JSONL 形。
-{"kind": "result", "ok": true, "count": 1234, "message": "1,234 件が一致します。"}
+// count = この応答の item 行数 (count-first は item を出さないので 0)、
+// total = 総ヒット数。両モードで count/total の語義を一貫させる (#664 で統一)。
+{"kind": "result", "ok": true, "count": 0, "total": 1234, "message": "1,234 件が一致します。"}
 ```
 
 上記 JSONL は **`--json` (エージェント) 時の形**。**rich (人間既定) では JSONL を出さず、人間向けの 1 行**
@@ -129,8 +131,10 @@ images update の `--image-id` に渡せる (検索 → ID 集合 → 各処理)
  "limit": 500, "offset": 0, "has_more": false}
 ```
 
-- `count`: このページの件数、`total`: フィルタ全件 (ADR 0049 が subquery COUNT で安価に取得済み)、
-  `offset`/`limit`: echo、`has_more`: `offset + count < total`。
+- `count`: この応答で出した item 行数 (= このページの件数)、`total`: フィルタ全件 (ADR 0049 が
+  subquery COUNT で安価に取得済み)、`offset`/`limit`: echo、`has_more`: `offset + count < total`。
+  **count-first 既定 (§1) と語義が一貫する**: count は常に「この応答の item 行数」、total は常に総ヒット数
+  (count-first は item を出さないので count=0 + total=N、#664)。
 - 500 以下なら limit/offset で自由にページングできる (既定 limit=500 なので通常 1 回で全部取れる)。
 
 ### count-first フロー
@@ -202,6 +206,20 @@ flowchart TD
 
 上記 1〜5 (§2/§3/§4/§6) は本 ADR の Accept と同一コミットで 0057 本体へ適用済み。README の 0057 ステータスも
 「Accepted (amended by 0060)」に更新済み。
+
+## Post-Accept Revision (#664)
+
+Accept 後、§1 の count-first 例が `count` を総ヒット数として示しており (`count=1234`)、§5 の `--fetch` 例の
+`count` (このページの件数) と語義が二重化していた。CLI 改装は未だ実運用に入っておらず wire 形に依存する
+consumer がいないため、後方互換を考慮せず語義を一本化した:
+
+- **`count` = この応答で出した item 行数**、**`total` = 総ヒット数**。両モードで一貫させる。
+- count-first 既定は item を出さないため `count=0` + `total=N`。`--fetch` は `count=len(page)` + `total=N`。
+- §1 の例を `{"count": 0, "total": 1234}` に修正、§5 に語義一貫の明記を追記。`project list` / `models list`
+  (item を出すコマンドは元々 count=item 行数) と語義が揃う。
+
+実装: `images list` count-first の emit を `count=total_count` から `count=0, total=total_count` に変更
+(`introspection.py` の `ImagesListResult` も description で語義を明示)。
 
 ## 関連
 

--- a/src/lorairo/cli/commands/images.py
+++ b/src/lorairo/cli/commands/images.py
@@ -232,7 +232,9 @@ def list_images(
             suffix = " without ratings" if unrated else ""
             message = f"{total_count} image(s){suffix} found in project: {project}"
             if is_json_mode():
-                emit_result(message, count=total_count)
+                # count = この応答の item 行数、total = 総ヒット数 に語義を統一する (#664)。
+                # count-first は item を出さないため count=0、件数は total に載せる。
+                emit_result(message, count=0, total=total_count)
             else:
                 console.print(message)
             return

--- a/src/lorairo/cli/introspection.py
+++ b/src/lorairo/cli/introspection.py
@@ -93,15 +93,17 @@ class ImagesListItem(BaseModel):
 class ImagesListResult(BaseModel):
     """JSONL result payload emitted by ``images list --json``.
 
-    Without ``--fetch`` only ``count`` is populated (count-first default, #655).
-    With ``--fetch`` the fetched-page metadata fields are also present.
+    ``count`` / ``total`` の語義は両モードで一貫する (#664): ``count`` は **この応答で
+    出力した item 行数**、``total`` は **総ヒット数**。count-first 既定は item を
+    出さないため ``count=0`` + ``total=N``。``--fetch`` は ``count=len(page)`` +
+    ``total=N`` + ページングメタ (``limit`` / ``offset`` / ``has_more``)。
     """
 
     kind: Literal["result"] = "result"
     ok: Literal[True] = True
     message: str
-    count: int
-    total: int | None = None
+    count: int = Field(description="Number of item rows emitted in this response (0 in count-first mode).")
+    total: int | None = Field(default=None, description="Total number of matching images.")
     limit: int | None = None
     offset: int | None = None
     has_more: bool | None = None
@@ -773,8 +775,13 @@ TOOL_SPECS: dict[str, ToolSpec] = {
             _output(
                 "ImagesListResult",
                 (
-                    _f("count", "int"),
-                    _f("total", "int?"),
+                    _f(
+                        "count",
+                        "int",
+                        description="Item rows emitted in this response (0 in count-first mode). "
+                        "Use total for the match count.",
+                    ),
+                    _f("total", "int?", description="Total number of matching images."),
                     _f("limit", "int?"),
                     _f("offset", "int?"),
                     _f("has_more", "bool?"),

--- a/tests/unit/cli/test_commands_images.py
+++ b/tests/unit/cli/test_commands_images.py
@@ -275,6 +275,30 @@ def test_images_list_fetch_json_outputs_items_and_result_meta(mock_projects_dir:
 
 @pytest.mark.unit
 @pytest.mark.cli
+def test_images_list_count_first_json_uses_total_not_count(mock_projects_dir: Path) -> None:
+    """Test: count-first --json は count=0 + total=N に語義を統一する (#664)。"""
+    runner.invoke(app, ["project", "create", "test-project"])
+
+    with patch("lorairo.cli.commands.images.get_service_container") as mock_get_container:
+        mock_container = MagicMock()
+        mock_container.db_manager.image_repo.get_images_count_only.return_value = 42
+        mock_get_container.return_value = mock_container
+
+        result = runner.invoke(app, ["--json", "images", "list", "--project", "test-project"])
+
+    assert result.exit_code == 0
+    lines = [json.loads(line) for line in result.stdout.splitlines()]
+    assert len(lines) == 1
+    assert lines[0]["kind"] == "result"
+    # count はこの応答の item 行数 (0)、総ヒット数は total に載る。
+    assert lines[0]["count"] == 0
+    assert lines[0]["total"] == 42
+    # count-first は item を一切出さない。
+    mock_container.db_manager.image_repo.get_image_list_page.assert_not_called()
+
+
+@pytest.mark.unit
+@pytest.mark.cli
 def test_images_list_fetch_total_over_cap_errors_before_items(mock_projects_dir: Path) -> None:
     """Test: images list --fetch - total 500 超は RESULT_SET_TOO_LARGE で item を出さない。"""
     runner.invoke(app, ["project", "create", "test-project"])


### PR DESCRIPTION
## 概要

#664 (`result.count` の語義 overload) の修正。count-first 既定では `count` が総ヒット数、
`--fetch` では `count` が返却行数 (別に `total`) と、同じ `kind=result` で `count` の語義が
二義化していた。agent が `count` を一律「総数」と解釈すると fetch 時にズレる。

親 Issue: #661

## 方針 (後方互換は考慮しない)

CLI 改装 (epic #634) は**まだ実運用に入っておらず**、現状の JSONL wire 形に依存する consumer が
いない。よって後方互換を考慮せず語義を一本化する:

- **`count` = この応答で出した item 行数**、**`total` = 総ヒット数** (両モード一貫)
- count-first 既定は item を出さないので `count=0` + `total=N`
- `--fetch` は `count=len(page)` + `total=N` (従来通り、変更なし)
- `project list` / `models list` (item を出すコマンドは元々 count=item 行数) と語義が揃う

## 変更

- **`images.py`**: count-first emit を `count=total_count` → `count=0, total=total_count`
- **`introspection.py`**: `ImagesListResult` の `count`/`total` に語義を明示する description
- **`docs/decisions/0060`**: §1 の count-first 例を `{count:0, total:1234}` に修正、§5 に語義一貫を
  明記、Post-Accept Revision 節を追記
- **`docs/cli.md`**: 再生成
- **tests**: count-first `--json` が `count=0` + `total=N` になることを検証

## Before / After (count-first `--json`)

```diff
- {"kind":"result","ok":true,"count":21192,"message":"..."}
+ {"kind":"result","ok":true,"count":0,"total":21192,"message":"..."}
```

## テスト

cli unit 全体 326 passed (CI-equivalent filter、worktree PYTHONPATH override) / ruff / mypy クリーン。

Closes #664
