### PR TITLE
fix: JSONL emit の datetime を ISO 8601 に統一 (#669)

### DIFF
--- a/src/lorairo/cli/_emit.py
+++ b/src/lorairo/cli/_emit.py
@@ -10,7 +10,9 @@ allow_nan=False, default=str)`` で行う:
 - ``ensure_ascii=False``: 日本語タグ等を UTF-8 のまま保持する。
 - ``allow_nan=False``: 非有限 float (``NaN`` / ``Infinity``) は標準 JSON で不正なため弾く。
   混入しても stdout 行を壊さないよう :func:`_emit` が emit 前に ``None`` へ正規化する。
-- ``default=str``: ``Path`` / ``datetime`` 等の非自明値のフォールバック。
+- ``default=_json_default``: 非自明値のフォールバック。``datetime`` / ``date`` は ISO 8601
+  (``isoformat()``) で安定化し (#669)、``Path`` 等はそれ以外は ``str()`` に委ねる。``default=str``
+  だけだと ``datetime`` が ``str(datetime)`` (空白区切り・非 ISO) に劣化するため使わない。
 
 ``kind`` と エラー ``code`` は :class:`enum.StrEnum` で定義する。``StrEnum`` は ``str``
 派生のため ``json.dumps`` が ``"item"`` のような安定 wire 値へ直接シリアライズする
@@ -22,6 +24,7 @@ from __future__ import annotations
 
 import json
 import math
+from datetime import date, datetime
 from enum import StrEnum
 from typing import Any
 
@@ -57,6 +60,24 @@ def _normalize_non_finite(value: Any) -> Any:
     return value
 
 
+def _json_default(value: Any) -> str:
+    """``json.dumps`` の非自明値フォールバック (ADR 0057 §1、#669)。
+
+    ``datetime`` / ``date`` は ISO 8601 (``isoformat()``) へ正規化し、機械可読 JSONL の
+    日時を ``str(datetime)`` (空白区切り・タイムゾーンなし) へ劣化させない。それ以外
+    (``Path`` 等) は ``str()`` に委ねる。
+
+    Args:
+        value: ``json.dumps`` が直接シリアライズできなかった値。
+
+    Returns:
+        JSON 文字列としてそのまま埋め込めるシリアライズ結果。
+    """
+    if isinstance(value, (datetime, date)):
+        return value.isoformat()
+    return str(value)
+
+
 def _emit(line: dict[str, Any]) -> None:
     """1 行 = 1 つの valid JSON object を stdout へ出力する (JSONL)。
 
@@ -64,7 +85,7 @@ def _emit(line: dict[str, Any]) -> None:
         line: stdout に 1 行で出力する JSON object。
     """
     safe = _normalize_non_finite(line)
-    print(json.dumps(safe, ensure_ascii=False, allow_nan=False, default=str))
+    print(json.dumps(safe, ensure_ascii=False, allow_nan=False, default=_json_default))
 
 
 def _to_payload(record: object) -> Any:

--- a/src/lorairo/cli/commands/batch.py
+++ b/src/lorairo/cli/commands/batch.py
@@ -144,7 +144,11 @@ def _format_dt(value: Any) -> str:
 
 
 def _job_dict(job: Any) -> dict[str, Any]:
-    """job を JSONL item/result 用の dict に変換する (datetime は emit が文字列化)。"""
+    """job を JSONL item/result 用の dict に変換する。
+
+    datetime は raw のまま載せ、``_emit`` の ``_json_default`` が ISO 8601 (isoformat) へ
+    正規化する (#669)。rich 表示の ``_format_dt`` とは別経路だが双方 isoformat で一致する。
+    """
     return {field: _job_value(job, field) for field in _JOB_DETAIL_FIELDS}
 
 

--- a/tests/unit/cli/test_emit.py
+++ b/tests/unit/cli/test_emit.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import math
+from datetime import date, datetime
 
 import pytest
 
@@ -32,6 +33,29 @@ def test_emit_item_expands_dict(capsys: pytest.CaptureFixture[str]) -> None:
     emit_item({"image_id": 7, "file_path": "/a/b.png"})
     line = _last_json_line(capsys.readouterr().out)
     assert line == {"kind": "item", "image_id": 7, "file_path": "/a/b.png"}
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+def test_emit_serializes_datetime_as_iso8601(capsys: pytest.CaptureFixture[str]) -> None:
+    """raw datetime は ISO 8601 (T 区切り) で emit される (#669)。
+
+    ``str(datetime)`` の空白区切りへ劣化させない。``batch *`` の datetime フィールドが
+    ``_emit`` の ``default`` 経由で出力される経路を守る。
+    """
+    emit_item({"image_id": 1, "imported_at": datetime(2026, 6, 3, 12, 44, 24, 797734)})
+    line = _last_json_line(capsys.readouterr().out)
+    assert line["imported_at"] == "2026-06-03T12:44:24.797734"
+    assert " " not in line["imported_at"]  # 空白区切りの str(datetime) でないこと
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+def test_emit_serializes_date_as_iso8601(capsys: pytest.CaptureFixture[str]) -> None:
+    """raw date も ISO 8601 で emit される (#669)。"""
+    emit_result("ok", created=date(2026, 6, 3))
+    line = _last_json_line(capsys.readouterr().out)
+    assert line["created"] == "2026-06-03"
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## 概要

#669 (`batch *` の datetime が JSONL で非 ISO 8601) の修正。ダブルチェックで発見した
#661 の sub #5。

親 Issue: #661

## 背景

`batch *` の JSONL 出力で datetime フィールドが `str(datetime)` (空白区切り・TZ なし) の
非 ISO 8601 になっていた。

```diff
- "imported_at": "2026-06-03 12:44:24.797734"   # str(datetime)、非 ISO
+ "imported_at": "2026-06-03T12:44:24.797734"   # ISO 8601 (T 区切り)
```

rich 表示の `_format_dt` は `isoformat()` なのに、JSONL 経路の `_job_dict` は raw datetime を
`_emit` の `default=str` フォールバックに任せており、**人間向け = ISO / 機械向け = 非 ISO** という
逆転が起きていた (#635 ギャップ分析のシリアライズ障壁 #3)。影響: `batch list` / `batch status` /
`batch submit` / `batch fetch` / `batch import`。

## 修正 (系統的 / defense-in-depth)

- **`_emit.py`**: `json.dumps` の `default=str` を `_json_default` に差し替え。`datetime` / `date` を
  `isoformat()` で ISO 8601 化、それ以外 (`Path` 等) は `str()` に委ねる。**全 emit 経路で ISO 8601 を
  保証**し、将来 datetime を emit する別コマンドの劣化も防ぐ。
- **`batch.py`**: `_job_dict` の docstring を実挙動 (emit が isoformat 正規化) に更新。
- **tests**: raw `datetime` / `date` が ISO 8601 (`T` 区切り) で emit されることを検証。

## 補足 (本 PR の対象外)

`project list` の `created` (`"20260427_025640"`) は dir 名由来のコンパクト識別子で、batch の
datetime 劣化とは別物のため対象に含めない (sub-issue 本文参照)。

## テスト

cli unit 全体 328 passed (CI-equivalent filter、worktree PYTHONPATH override) / ruff / mypy クリーン。
実機 smoke で `batch list --json` の `imported_at` が `T` 区切りになることを確認。

Closes #669
