### PR TITLE
feat: unify batch submit image ids option

### DIFF
--- a/docs/cli-rating-preflight.md
+++ b/docs/cli-rating-preflight.md
@@ -65,9 +65,7 @@ lorairo-cli batch submit \
   --project main_dataset \
   --task-type rating_preflight \
   --model openai/omni-moderation-latest \
-  --image-id 2 \
-  --image-id 7 \
-  --image-id 11
+  --image-ids 2,7,11
 ```
 
 Check status, fetch normalized results if needed, then import:

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -384,7 +384,7 @@ lorairo-cli --json describe "batch submit"
 
 - `project`: `str` (required)
 - `model`: `str` (required)
-- `image_id`: `list[int]` (required)
+- `image_ids`: `csv[int]` (required) - Comma-separated image IDs, e.g. 2,7,11.
 - `provider`: `openai|anthropic?` (optional)
 - `endpoint`: `str?` (optional)
 - `prompt_profile`: `str` (optional, default `default`)

--- a/docs/decisions/0060-cli-bounded-pagination-contract.md
+++ b/docs/decisions/0060-cli-bounded-pagination-contract.md
@@ -80,13 +80,14 @@ ADR 0058 の出力モードに従い表現を分ける:
 - **人間 (rich 既定)**: **枠付き Table を使わず、1 行 1 件のプレーン出力 `image_id<TAB>file_path`**
   (id と path の 2 カラム)。500 行でも `ls -i` / `find` 感覚で読め、コピー / grep できる。装飾 (枠線 / 色) は
   ADR 0058 のとおり presentation として扱い、本質的にプレーン行であることを契約とする (大量行に枠付き Table は
-  不向き)。**`image_id` は必ず含める** (path のみにしない) — 後段で `--image-id` にパイプ/コピーする
+  不向き)。**`image_id` は必ず含める** (path のみにしない) — 後段のコマンドへパイプ/コピーする
   ステージング ID 集合がここで欠落しないため。
 - **エージェント (`--json`)**: `kind:"item"` の JSONL (`image_id` + `file_path`) を N 行 + 終端
   `kind:"result"` (件数メタ)。
 
-`--fetch` が返す `image_id` 集合は ADR 0055 のステージング集合に相当し、そのまま annotate / export /
-images update の `--image-id` に渡せる (検索 → ID 集合 → 各処理)。
+`--fetch` が返す `image_id` 集合は ADR 0055 のステージング集合に相当し、後段コマンドの
+ID selector (`batch submit --image-ids` や各処理の image ID option) に渡せる
+(検索 → ID 集合 → 各処理)。
 
 ### 3. 基本リミット = 500 (読み取り・処理 共通)。stable 順 / pushdown
 
@@ -176,9 +177,9 @@ flowchart TD
   コードを `INVALID_INPUT` から本コードへ統一する (本 ADR の Amendment 節参照)。**この 0057 本体への適用は
   本 ADR が Accepted になった時点で行い、それまで 0057 は無編集のまま (確定済み契約に未承認の変更を混ぜない)**。
 - count は軽量 COUNT(*) で実装し、fetch とは別経路にする (ADR 0056 count-only 方針の延長)。
-- `--fetch` の `image_id` 出力は ADR 0055 のステージング集合として annotate / export / images update の
-  `--image-id` にパイプできる。#638 で別 Issue に切り出した「検索 → ID 集合 → 各処理」の二段構えが、本 ADR の
-  count-first / fetch 出力で素直に成立する。
+- `--fetch` の `image_id` 出力は ADR 0055 のステージング集合として後段コマンドの ID selector に渡せる。
+  #638 で別 Issue に切り出した「検索 → ID 集合 → 各処理」の二段構えが、本 ADR の count-first / fetch
+  出力で素直に成立する。
 - 小さい固定 enumeration (`models list`) は count 既定の対象外とし、直接列挙を維持する。
 - 人間向け fetch 出力は枠付き Table でなくプレーン行とするため、既存の rich Table 表示 (該当箇所) を
   プレーン行へ変更する (#641)。

--- a/docs/decisions/0063-cli-batch-submit-image-ids-csv.md
+++ b/docs/decisions/0063-cli-batch-submit-image-ids-csv.md
@@ -1,0 +1,44 @@
+# ADR 0063: CLI Batch Submit Image IDs CSV Contract
+
+- **日付**: 2026-06-07
+- **ステータス**: Accepted
+- **関連 Issue**: #671
+- **関連 ADR**: [0057](0057-cli-jsonl-output-and-error-contract.md), [0059](0059-cli-command-introspection.md), [0060](0060-cli-bounded-pagination-contract.md)
+
+## Context
+
+`lorairo-cli batch submit` は対象画像を repeatable な `--image-id` で受け取っていた。
+この形は少数の手入力では動くが、`images list --fetch` で得た ID 集合を後続の batch submit
+に渡す導線では冗長になる。CLI の利用者は ID 集合を「リスト」として扱いたい一方、引数ごとに
+同じ option 名を繰り返す契約はその意図とずれる。
+
+## Decision
+
+`batch submit` の画像 ID 指定は、単一 option のカンマ区切り CSV に統一する。
+
+```bash
+lorairo-cli batch submit \
+  --project main_dataset \
+  --model openai/omni-moderation-latest \
+  --task-type rating_preflight \
+  --image-ids 2,7,11
+```
+
+旧 `--image-id` repeatable option は authoritative な経路ではなくなり、CLI help、
+introspection、docs から削除する。command 層は `--image-ids` を `list[int]` に正規化し、
+既存の `ProviderBatchWorkflowService.submit_images(image_ids=...)` へ渡す。
+
+## Rationale
+
+`batch submit` の責務は「対象画像集合を provider batch に投入する」ことであり、サービス層の
+canonical input は今後も `list[int]` のままでよい。変更すべきなのは CLI の入力表面である。
+互換追加として `--image-id` と `--image-ids` を併存させると、help / introspection / docs の
+導線が二重化し、利用者がどちらを使うべきか迷う。Issue #671 では導線を単純にするため、
+CSV の単一路線へ寄せる。
+
+## Consequences
+
+- `batch submit` 利用者は `--image-ids 2,7,11` を使う。
+- 旧 `--image-id` を使う既存スクリプトは更新が必要。
+- introspection の `BatchSubmitInput` は `image_ids: csv[int]` を公開する。
+- `images list --fetch` の `image_id` 出力は、後段で CSV 化して `--image-ids` に渡す ID 集合として扱う。

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -66,6 +66,7 @@ LoRAIro の重要な設計判断を記録するドキュメント群。
 | [0060](0060-cli-bounded-pagination-contract.md) | CLI Bounded Pagination and Count-First Contract | 2026-06-06 | Accepted |
 | [0061](0061-phash-duplicate-variant-classification.md) | 登録パイプライン再設計 — pHash 候補の重複/別版分類 | 2026-06-05 | Accepted |
 | [0062](0062-batch-custom-id-phash-long-edge.md) | Provider Batch custom_id を pHash + 長辺解像度基準へ統一 | 2026-06-05 | Accepted |
+| [0063](0063-cli-batch-submit-image-ids-csv.md) | CLI Batch Submit Image IDs CSV Contract | 2026-06-07 | Accepted |
 
 ## ADR テンプレート
 

--- a/src/lorairo/cli/commands/batch.py
+++ b/src/lorairo/cli/commands/batch.py
@@ -169,6 +169,38 @@ def _summarize_fetch_counts(result: Any) -> tuple[int, int]:
     return int(succeeded_count or 0), int(failed_count or 0)
 
 
+def _parse_image_ids_csv(value: str) -> list[int]:
+    """Parse the canonical ``--image-ids`` CSV option into integer IDs."""
+    image_ids: list[int] = []
+    invalid_tokens: list[str] = []
+    empty_tokens = 0
+
+    for token in value.split(","):
+        normalized = token.strip()
+        if not normalized:
+            empty_tokens += 1
+            continue
+        try:
+            image_ids.append(int(normalized))
+        except ValueError:
+            invalid_tokens.append(normalized)
+
+    if invalid_tokens or empty_tokens or not image_ids:
+        details: list[str] = []
+        if invalid_tokens:
+            details.append(f"invalid token(s): {', '.join(invalid_tokens)}")
+        if empty_tokens:
+            details.append("empty item(s)")
+        if not image_ids:
+            details.append("no image IDs")
+        raise click.UsageError(
+            "--image-ids must be a comma-separated list of integer image IDs "
+            f"(example: --image-ids 2,7,11): {'; '.join(details)}"
+        )
+
+    return image_ids
+
+
 def _print_jobs_table(jobs: list[Any]) -> None:
     table = Table(title="Provider Batch Jobs")
     table.add_column("ID", style="cyan", no_wrap=True)
@@ -237,7 +269,11 @@ def _artifact_dicts(fetch_result: Any) -> list[dict[str, Any]]:
 def submit(
     project: str = typer.Option(..., "--project", "-p", help="Project name"),
     model: str = typer.Option(..., "--model", "-m", help="LiteLLM model ID or unique display name"),
-    image_ids: list[int] = typer.Option(..., "--image-id", help="Image ID to submit; repeatable"),
+    image_ids_csv: str = typer.Option(
+        ...,
+        "--image-ids",
+        help="Comma-separated image IDs to submit (example: 2,7,11)",
+    ),
     provider: str | None = typer.Option(None, "--provider", help="Provider override: openai/anthropic"),
     endpoint: str | None = typer.Option(None, "--endpoint", help="Provider endpoint override"),
     prompt_profile: str = typer.Option("default", "--prompt-profile", help="Prompt profile name"),
@@ -253,6 +289,7 @@ def submit(
 ) -> None:
     """Submit registered images to a Provider Batch API job."""
     with command_boundary():
+        image_ids = _parse_image_ids_csv(image_ids_csv)
         container = _activate_project(project)
         model_repo = container.db_manager.model_repo
         provider_batch_repo = container.db_manager.provider_batch_repo

--- a/src/lorairo/cli/introspection.py
+++ b/src/lorairo/cli/introspection.py
@@ -1011,7 +1011,12 @@ TOOL_SPECS: dict[str, ToolSpec] = {
                 (
                     _f("project", "str", required=True),
                     _f("model", "str", required=True),
-                    _f("image_id", "list[int]", required=True),
+                    _f(
+                        "image_ids",
+                        "csv[int]",
+                        required=True,
+                        description="Comma-separated image IDs, e.g. 2,7,11.",
+                    ),
                     _f("provider", "openai|anthropic?"),
                     _f("endpoint", "str?"),
                     _f("prompt_profile", "str", default="default"),

--- a/src/lorairo/cli/main.py
+++ b/src/lorairo/cli/main.py
@@ -71,7 +71,7 @@ app = typer.Typer(
         "--model openai/omni-moderation-latest\n\n"
         "  Large sets: lorairo-cli images list --project <name> --unrated\n"
         "              lorairo-cli batch submit --project <name> --task-type rating_preflight "
-        "--model openai/omni-moderation-latest --image-id <id>"
+        "--model openai/omni-moderation-latest --image-ids <id,id,...>"
     ),
     add_completion=True,
     no_args_is_help=True,

--- a/tests/unit/cli/test_commands_batch.py
+++ b/tests/unit/cli/test_commands_batch.py
@@ -95,10 +95,8 @@ def test_batch_submit_calls_workflow_service(mock_get_container: MagicMock) -> N
             "demo",
             "--model",
             "anthropic/claude-3-5-haiku-latest",
-            "--image-id",
-            "1",
-            "--image-id",
-            "2",
+            "--image-ids",
+            "1,2",
             "--description",
             "nightly",
         ],
@@ -137,7 +135,7 @@ def test_batch_submit_accepts_openai_annotation(mock_get_container: MagicMock) -
             "demo",
             "--model",
             "openai/gpt-4.1-mini",
-            "--image-id",
+            "--image-ids",
             "1",
         ],
     )
@@ -179,7 +177,7 @@ def test_batch_submit_rating_preflight_calls_workflow_service(mock_get_container
             "openai/omni-moderation-latest",
             "--task-type",
             "rating_preflight",
-            "--image-id",
+            "--image-ids",
             "1",
         ],
     )
@@ -206,6 +204,8 @@ def test_batch_submit_help_documents_rating_preflight_constraints() -> None:
 
     assert result.exit_code == 0
     assert "rating_preflight" in result.stdout
+    assert "--image-ids" in result.stdout
+    assert "repeatable" not in result.stdout
     assert "requires direct openai" in result.stdout
     assert "/v1/moderations" in result.stdout
     assert "openai/omni-moderation-*" in result.stdout
@@ -240,7 +240,7 @@ def test_batch_submit_rating_preflight_normalizes_endpoint_override(
             "rating_preflight",
             "--endpoint",
             "v1/moderations/",
-            "--image-id",
+            "--image-ids",
             "1",
         ],
     )
@@ -279,7 +279,7 @@ def test_batch_submit_rating_preflight_rejects_non_moderations_endpoint(
             "rating_preflight",
             "--endpoint",
             "/v1/chat/completions",
-            "--image-id",
+            "--image-ids",
             "1",
         ],
     )
@@ -310,7 +310,7 @@ def test_batch_submit_rejects_google_until_phase3(mock_get_container: MagicMock)
             "demo",
             "--model",
             "google/gemini-2.5-pro",
-            "--image-id",
+            "--image-ids",
             "1",
         ],
     )
@@ -318,6 +318,34 @@ def test_batch_submit_rejects_google_until_phase3(mock_get_container: MagicMock)
     # click.UsageError → INVALID_INPUT → exit 2 (入力検証、ADR 0057 §6)。
     assert result.exit_code == 2
     assert "Google Provider Batch submit is disabled" in result.output
+    container.provider_batch_workflow_service.submit_images.assert_not_called()
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+@patch("lorairo.cli.commands.batch.get_service_container")
+def test_batch_submit_rejects_invalid_image_ids_csv(mock_get_container: MagicMock) -> None:
+    container = _container()
+    mock_get_container.return_value = container
+
+    result = runner.invoke(
+        app,
+        [
+            "batch",
+            "submit",
+            "--project",
+            "demo",
+            "--model",
+            "openai/gpt-4.1-mini",
+            "--image-ids",
+            "1,,x",
+        ],
+    )
+
+    assert result.exit_code == 2
+    assert "--image-ids must be a comma-separated list" in result.output
+    assert "invalid token(s): x" in result.output
+    assert "empty item(s)" in result.output
     container.provider_batch_workflow_service.submit_images.assert_not_called()
 
 

--- a/tests/unit/cli/test_introspection.py
+++ b/tests/unit/cli/test_introspection.py
@@ -214,6 +214,22 @@ def test_import_batch_describes_actual_argument_names() -> None:
     assert {"total_records", "matched", "saved", "dry_run"} <= {f["name"] for f in output_row["fields"]}
 
 
+def test_batch_submit_describes_csv_image_ids() -> None:
+    result = runner.invoke(app, ["--json", "describe", "batch submit"])
+
+    assert result.exit_code == 0
+    rows = _jsonl(result.stdout)
+    input_row = next(
+        row for row in rows if row.get("type") == "model" and row["name"] == "BatchSubmitInput"
+    )
+    fields = {field["name"]: field for field in input_row["fields"]}
+
+    assert "image_id" not in fields
+    assert fields["image_ids"]["type"] == "csv[int]"
+    assert fields["image_ids"]["required"] is True
+    assert "Comma-separated" in fields["image_ids"]["description"]
+
+
 def test_cli_specific_output_json_schemas_match_item_rows() -> None:
     images_result = runner.invoke(app, ["--json", "describe", "images list", "--schema", "json_schema"])
     models_result = runner.invoke(app, ["--json", "describe", "models list", "--schema", "json_schema"])


### PR DESCRIPTION
Fixes #671.

Branch: issue-671-batch-submit-image-ids
Worktree: .agents/worktree/issue-671-batch-submit-image-ids
ADR: docs/decisions/0063-cli-batch-submit-image-ids-csv.md

## Summary

- Changed `lorairo-cli batch submit` image selection from repeatable `--image-id` to a single CSV `--image-ids` option.
- Added command-layer CSV validation before passing normalized `list[int]` to `ProviderBatchWorkflowService.submit_images`.
- Updated CLI introspection, generated CLI docs, rating preflight docs, top-level help, and ADR references.

## Verification

- `uv run --no-sync ruff check src/lorairo/cli/commands/batch.py src/lorairo/cli/introspection.py src/lorairo/cli/main.py tests/unit/cli/test_commands_batch.py tests/unit/cli/test_introspection.py`
- `uv run --no-sync pytest tests/unit/cli/test_commands_batch.py tests/unit/cli/test_introspection.py -q`
- `PYTHONPATH=... uv run --no-sync lorairo-cli batch submit --help`
- `PYTHONPATH=... uv run --no-sync lorairo-cli --json describe "batch submit"`