### PR TITLE
feat(cli): batch status --items で per-image item 可視化 + rating upsert 明文化 (#673)

### DIFF
--- a/docs/cli-rating-preflight.md
+++ b/docs/cli-rating-preflight.md
@@ -79,6 +79,56 @@ lorairo-cli batch import 1 --project main_dataset
 `rating_preflight` requires direct OpenAI, endpoint `/v1/moderations`, an
 `openai/omni-moderation-*` model, and a model registered with `ratings` model type.
 
+## Duplicate Submit and Rating Upsert Behavior
+
+### Why duplicate submission can occur
+
+`images list --unrated` returns images that have no `ratings` row yet. If a batch job has been
+submitted but not imported yet, the same images still appear as "unrated" and can be submitted
+again in a new job. There is no hard error for this — re-submission is allowed (e.g., after a
+failed job).
+
+As a result, the same `image_id` may appear in multiple provider batch jobs.
+
+### How to detect duplicate submissions
+
+Use `batch status --items` to inspect per-image items of a job:
+
+```bash
+lorairo-cli batch status <job_id> --project <project> --items
+```
+
+In JSON mode each item is emitted as a `ProviderBatchItemRecord` row before the result row:
+
+```bash
+lorairo-cli --json batch status <job_id> --project <project> --items
+```
+
+Fields: `id`, `job_id`, `custom_id`, `image_id`, `model_id`, `task_type`, `status`,
+`error_type`. Compare items across jobs to identify images submitted more than once.
+
+Use `--item-status` to filter by status, and `--limit` / `--offset` for pagination:
+
+```bash
+lorairo-cli batch status <job_id> --project <project> --items --item-status failed
+```
+
+### Rating upsert semantics on import
+
+When `batch import` runs, ratings are stored in the `ratings` table using an upsert keyed on
+`(image_id, model_id)`:
+
+- If a rating row already exists for that image and model, it is **updated** (overwritten).
+- If no row exists, it is **inserted**.
+
+Importing a second job for the same image overwrites the rating from the first import.
+The **last-imported result wins** as the canonical current value.
+
+The raw moderation response for each job is preserved in `provider_batch_items.raw_response`
+for audit and debugging. The `batch import` summary (`imported` / `skipped` / `errors` /
+`total`) counts images, not insert/update operations individually. See ADR 0031 Amendment
+2026-06-07 for the design rationale.
+
 ## Known Limitation
 
 Batch submit image path resolution is tracked separately in issue #528. If that bug is present in

--- a/docs/decisions/0002-database-schema-decisions.md
+++ b/docs/decisions/0002-database-schema-decisions.md
@@ -34,3 +34,20 @@ src/lorairo/database/
 ├── db_core.py
 └── migrations/
 ```
+
+## Supplement: rating の upsert 方針 (2026-06-07, Issue #673)
+
+本 ADR は「`tags`, `captions`, `scores`, `ratings` テーブルで UNIQUE 制約を設けない」と定めているが、
+これは「DB スキーマが履歴保持を許容する」という宣言であり、Repository 実装が常に履歴を保持するという
+意味ではない。
+
+**rating は別レイヤーの判断として `(image_id, model_id)` キーの現在値 (latest win) で upsert する。**
+
+- `AnnotationRepository._save_ratings()` は、同一 `image_id + model_id` の既存 row を UPDATE、
+  なければ INSERT する。複数 row が積み重なる tags/captions とは異なり、rating は canonical な
+  現在値が SSoT として意味を持つ (ADR 0031 §6、Amendment 2026-06-07 §4)。
+- この方針は UNIQUE 制約なしのスキーマと矛盾しない。UNIQUE 制約がなければ重複 row も許容できるが、
+  Repository が応用として「最新値のみ保持」する設計を選んでいる。
+- tags/captions は引き続き履歴保持 (複数 row) が基本方針。rating だけの例外的 upsert 運用。
+
+重複 submit 時の挙動については ADR 0031 Amendment 2026-06-07 を参照。

--- a/docs/decisions/0031-ai-rating-mapping.md
+++ b/docs/decisions/0031-ai-rating-mapping.md
@@ -272,13 +272,53 @@ OpenAI Moderations preflight (Amendment 2026-05-27) は以下の PR で merged:
 LoRAIro 側 boundary 配線は `tests/integration/test_provider_batch_rating_preflight_e2e.py`
 で deterministic に CI 監視する。
 
+### Amendment 2026-06-07: 重複 submit 許容と rating upsert 方針の明記 (Issue #673)
+
+`rating_preflight` では、`images list --unrated` で取得した未 rating 画像を submit しても、
+import 前の同一画像を別 job で重複 submit してしまうことがある (submit 時点では rating が存在
+しないため、重複を事前に防ぐ手段がない)。この挙動と対処方法を以下に明記する。
+
+#### 重複 submit の許容
+
+1. **DB スキーマ上は重複 submit を許容する。** `UNIQUE(job_id, custom_id)` のため同一 job 内の
+   重複は防がれるが、別 job からの同一 `image_id` の submit は止めない。DB unique 制約も追加しない。
+   理由: `submit` 時点では provider から結果が返っておらず、重複を hard error にすると正常な
+   再試行 (job 失敗後の resubmit) も阻害する。
+
+2. **raw moderation 結果は `provider_batch_items.raw_response` に job ごとに保持される。**
+   重複 job ごとに別 row が作られるため、provider 側の raw response は全件監査可能。
+
+3. **重複 submit の確認は `batch status --items` で行う。**
+   ```bash
+   lorairo-cli batch status <job_id> --project <project> --items
+   ```
+   出力には `image_id`, `custom_id`, `model_id`, `task_type`, `status`, `error_type` が
+   含まれる。複数 job の items を横断確認することで重複 submit の有無を検出できる。
+
+#### rating upsert 方針
+
+4. **`ratings` テーブルの canonical rating は `(image_id, model_id)` キーの現在値 (latest win)
+   として upsert される。** `batch import` 時の `_save_ratings()` は、同一 `image_id + model_id`
+   の既存 row を UPDATE (上書き)、なければ INSERT する。
+
+5. **重複 import の結果は「最後に import した job の result が canonical rating になる」。**
+   ブレの履歴を保持したい場合は `provider_batch_items.raw_response` が監査/debug 用として残る。
+
+6. **`batch import --json` の summary (`imported` / `skipped` / `errors` / `total`) は
+   image 単位の集計であり、INSERT / UPDATE の内訳 (ratings_inserted / ratings_updated) は
+   現時点では出力しない。** 理由: `_save_ratings()` 内部の update / insert 区別カウンタを
+   返すには複数レイヤーの変更が必要なため、docs/CLI help でのセマンティクス明記を先行する。
+   将来の改善が必要な場合は別 Issue で対応する。
+
 ## 関連
 
 - Issue: NEXTAltair/LoRAIro#333
 - Issue: NEXTAltair/LoRAIro#471
+- Issue: NEXTAltair/LoRAIro#673
 - Issue (umbrella): NEXTAltair/LoRAIro#507
 - Upstream: NEXTAltair/image-annotator-lib#79 (parent) / #80 (rating 出力実装) /
   #81 (新規 rating model 候補) / #119 / #120
+- ADR 0002 (Database Schema Decisions) — UNIQUE なしの方針と rating upsert の層別判断
 - ADR 0015 (Manual Rating Storage Unification) — manual / AI rating の Rating テーブル統一
 - ADR 0026 (On-Demand Runtime Validation Strategy) — 実 OpenAI Moderations Batch 検証境界
 - ADR 0038 (Provider Batch API Integration Strategy) — OpenAI `/v1/moderations` Batch lifecycle

--- a/src/lorairo/cli/commands/batch.py
+++ b/src/lorairo/cli/commands/batch.py
@@ -58,6 +58,19 @@ _JOB_DETAIL_FIELDS = (
     "imported_at",
 )
 
+# _print_items_table / json 出力共通の item フィールド。
+_ITEM_DETAIL_FIELDS = (
+    "id",
+    "job_id",
+    "custom_id",
+    "image_id",
+    "model_id",
+    "task_type",
+    "status",
+    "error_type",
+    "error_message",
+)
+
 
 def _activate_project(project: str) -> Any:
     container = get_service_container()
@@ -137,6 +150,12 @@ def _job_value(job: Any, name: str, default: Any = None) -> Any:
     return getattr(job, name, default)
 
 
+def _item_value(item: Any, name: str, default: Any = None) -> Any:
+    if isinstance(item, dict):
+        return item.get(name, default)
+    return getattr(item, name, default)
+
+
 def _format_dt(value: Any) -> str:
     if isinstance(value, datetime):
         return value.isoformat()
@@ -150,6 +169,11 @@ def _job_dict(job: Any) -> dict[str, Any]:
     正規化する (#669)。rich 表示の ``_format_dt`` とは別経路だが双方 isoformat で一致する。
     """
     return {field: _job_value(job, field) for field in _JOB_DETAIL_FIELDS}
+
+
+def _item_dict(item: Any) -> dict[str, Any]:
+    """provider batch item を JSONL item 用の dict に変換する。"""
+    return {field: _item_value(item, field) for field in _ITEM_DETAIL_FIELDS}
 
 
 def _result_item_status(item: Any) -> str:
@@ -231,6 +255,30 @@ def _print_job_detail(job: Any) -> None:
     for field in _JOB_DETAIL_FIELDS:
         table.add_row(field, _format_dt(_job_value(job, field)))
     console.print(table)
+
+
+def _print_items_table(items: list[Any], job_id: int) -> None:
+    table = Table(title=f"Provider Batch Items (job {job_id})")
+    table.add_column("ID", style="cyan", no_wrap=True)
+    table.add_column("custom_id", style="dim")
+    table.add_column("image_id", justify="right")
+    table.add_column("model_id", justify="right")
+    table.add_column("task_type", style="magenta")
+    table.add_column("status", style="green")
+    table.add_column("error_type", style="red")
+
+    for item in items:
+        table.add_row(
+            str(_item_value(item, "id", "")),
+            str(_item_value(item, "custom_id", "")),
+            str(_item_value(item, "image_id", "") or ""),
+            str(_item_value(item, "model_id", "") or ""),
+            str(_item_value(item, "task_type", "") or ""),
+            str(_item_value(item, "status", "")),
+            str(_item_value(item, "error_type", "") or ""),
+        )
+    console.print(table)
+    console.print(f"[dim]{len(items)} item(s)[/dim]")
 
 
 def _print_artifacts(fetch_result: Any) -> None:
@@ -365,8 +413,25 @@ def status(
     job_id: int = typer.Argument(..., help="Provider Batch job ID"),
     project: str = typer.Option(..., "--project", "-p", help="Project name"),
     refresh: bool = typer.Option(True, "--refresh/--no-refresh", help="Refresh provider status first"),
+    show_items: bool = typer.Option(
+        False,
+        "--items/--no-items",
+        help=(
+            "Show provider batch items (custom_id, image_id, model_id, task_type, status, error_type). "
+            "rating_preflight の重複 submit 確認に使用できる。"
+        ),
+    ),
+    items_limit: int = typer.Option(500, "--limit", min=1, max=500, help="Item page size (--items 時)"),
+    items_offset: int = typer.Option(0, "--offset", min=0, help="Item rows to skip (--items 時)"),
+    item_status: str | None = typer.Option(
+        None, "--item-status", help="Filter items by status (--items 時)"
+    ),
 ) -> None:
-    """Show Provider Batch job status."""
+    """Show Provider Batch job status.
+
+    --items を付けると provider batch items (job 配下の per-image item) を表示する。
+    rating_preflight で同一 image_id が別 job に重複投入されていないかの確認にも使える。
+    """
     with command_boundary():
         container = _activate_project(project)
         job = (
@@ -376,10 +441,33 @@ def status(
         )
         if job is None:
             raise click.UsageError(f"Provider Batch job not found: {job_id}")
+
+        fetched_items: list[Any] = []
+        if show_items:
+            fetched_items = container.db_manager.provider_batch_repo.list_provider_batch_items(
+                job_id,
+                status=item_status,
+                limit=items_limit,
+                offset=items_offset,
+            )
+
         if is_json_mode():
-            emit_result(f"Provider Batch job {job_id}", job=_job_dict(job))
+            if show_items:
+                for item in fetched_items:
+                    emit_item(_item_dict(item))
+            has_more = len(fetched_items) >= items_limit if show_items else None
+            emit_result(
+                f"Provider Batch job {job_id}",
+                job=_job_dict(job),
+                items_count=len(fetched_items) if show_items else None,
+                items_limit=items_limit if show_items else None,
+                items_offset=items_offset if show_items else None,
+                items_has_more=has_more,
+            )
         else:
             _print_job_detail(job)
+            if show_items:
+                _print_items_table(fetched_items, job_id)
 
 
 @app.command("cancel")

--- a/src/lorairo/cli/introspection.py
+++ b/src/lorairo/cli/introspection.py
@@ -391,13 +391,48 @@ class ProviderBatchJob(BaseModel):
     model_config = ConfigDict(title="ProviderBatchJob")
 
 
+class ProviderBatchItemRecord(BaseModel):
+    """JSONL item payload for a provider batch item (``batch status --items --json``).
+
+    ``--items`` を付けた ``batch status --json`` で、job 配下の per-image item ごとに
+    1 行ずつ emit される。rating_preflight の重複 submit 確認・audit に使用できる。
+    """
+
+    id: int
+    job_id: int
+    custom_id: str
+    image_id: int | None = None
+    model_id: int | None = None
+    task_type: str | None = None
+    status: str
+    error_type: str | None = None
+    error_message: str | None = None
+
+    model_config = ConfigDict(title="ProviderBatchItemRecord")
+
+
 class BatchStatusResult(BaseModel):
-    """JSONL result payload emitted by ``batch status --json``."""
+    """JSONL result payload emitted by ``batch status --json``.
+
+    ``--items`` が指定された場合、result 行の前に ``ProviderBatchItemRecord`` item 行が
+    emit される。``items_count`` / ``items_limit`` / ``items_offset`` / ``items_has_more``
+    はいずれも ``--items`` 指定時のみ非 null になる。
+    """
 
     kind: Literal["result"] = "result"
     ok: Literal[True] = True
     message: str
     job: ProviderBatchJob | None = None
+    items_count: int | None = Field(
+        default=None,
+        description="Number of item rows emitted (only when --items is set).",
+    )
+    items_limit: int | None = Field(default=None, description="Page size used for items query.")
+    items_offset: int | None = Field(default=None, description="Rows skipped in items query.")
+    items_has_more: bool | None = Field(
+        default=None,
+        description="True when len(items) >= limit, indicating further pages may exist.",
+    )
 
     model_config = ConfigDict(title="BatchStatusResult")
 
@@ -1078,7 +1113,11 @@ TOOL_SPECS: dict[str, ToolSpec] = {
     "batch status": ToolSpec(
         name="batch status",
         path="batch status",
-        summary="Show provider batch job status.",
+        summary=(
+            "Show provider batch job status. Pass --items to list per-image items "
+            "(custom_id, image_id, model_id, task_type, status, error_type); "
+            "useful for auditing duplicate rating_preflight submissions."
+        ),
         read_only=False,
         side_effects=("db_read", "db_write", "network"),
         inputs=(
@@ -1088,13 +1127,65 @@ TOOL_SPECS: dict[str, ToolSpec] = {
                     _f("job_id", "int", required=True),
                     _f("project", "str", required=True),
                     _f("refresh", "bool", default=True),
+                    _f(
+                        "items",
+                        "bool",
+                        default=False,
+                        description=(
+                            "Emit ProviderBatchItemRecord item rows before the result. "
+                            "Use to inspect per-image item state or detect duplicate submissions."
+                        ),
+                    ),
+                    _f(
+                        "limit",
+                        "int[1,500]",
+                        default=500,
+                        description="Page size for items query (only when --items is set).",
+                    ),
+                    _f(
+                        "offset",
+                        "int>=0",
+                        default=0,
+                        description="Rows to skip in items query (only when --items is set).",
+                    ),
+                    _f(
+                        "item_status",
+                        "str?",
+                        description="Filter items by status when --items is set (e.g. succeeded, failed).",
+                    ),
                 ),
             ),
         ),
         outputs=(
             _output(
+                "ProviderBatchItemRecord",
+                (
+                    _f("id", "int"),
+                    _f("job_id", "int"),
+                    _f("custom_id", "str"),
+                    _f("image_id", "int?"),
+                    _f("model_id", "int?"),
+                    _f("task_type", "str?"),
+                    _f("status", "str"),
+                    _f("error_type", "str?"),
+                    _f("error_message", "str?"),
+                ),
+                description="Emitted per item when --items is set. Precedes the BatchStatusResult row.",
+                schema=ProviderBatchItemRecord,
+            ),
+            _output(
                 "BatchStatusResult",
-                (_f("job", "ProviderBatchJob"),),
+                (
+                    _f("job", "ProviderBatchJob"),
+                    _f(
+                        "items_count",
+                        "int?",
+                        description="Number of item rows emitted (null when --items is not set).",
+                    ),
+                    _f("items_limit", "int?"),
+                    _f("items_offset", "int?"),
+                    _f("items_has_more", "bool?"),
+                ),
                 schema=BatchStatusResult,
             ),
         ),

--- a/tests/unit/cli/test_commands_batch.py
+++ b/tests/unit/cli/test_commands_batch.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from datetime import UTC, datetime
 from pathlib import Path
 from types import SimpleNamespace
@@ -62,6 +63,22 @@ def _container() -> MagicMock:
     container.db_manager.provider_batch_repo.get_provider_batch_job.return_value = _job()
     container.provider_batch_workflow_service.submit_images.return_value = 42
     return container
+
+
+def _batch_item(**overrides: object) -> SimpleNamespace:
+    values: dict[str, object] = {
+        "id": 1,
+        "job_id": 42,
+        "custom_id": "img-1-mod-7",
+        "image_id": 1,
+        "model_id": 7,
+        "task_type": "rating_preflight",
+        "status": "succeeded",
+        "error_type": None,
+        "error_message": None,
+    }
+    values.update(overrides)
+    return SimpleNamespace(**values)
 
 
 @pytest.mark.unit
@@ -486,3 +503,162 @@ def test_batch_import_shows_summary(mock_get_container: MagicMock, tmp_path: Pat
     assert "Summary" in result.stdout
     assert "Imported" in result.stdout
     assert "yes" in result.stdout
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+@patch("lorairo.cli.commands.batch.get_service_container")
+def test_batch_status_with_items_shows_items_table(mock_get_container: MagicMock) -> None:
+    """--items で items テーブルが人間向けモードに表示される。"""
+    container = _container()
+    container.provider_batch_workflow_service.refresh.return_value = _job()
+    container.db_manager.provider_batch_repo.list_provider_batch_items.return_value = [
+        _batch_item(id=1, status="succeeded"),
+        _batch_item(id=2, custom_id="img-2-mod-7", image_id=2, status="failed", error_type="server_error"),
+    ]
+    mock_get_container.return_value = container
+
+    result = runner.invoke(app, ["batch", "status", "42", "--project", "demo", "--items"])
+
+    assert result.exit_code == 0
+    container.db_manager.provider_batch_repo.list_provider_batch_items.assert_called_once_with(
+        42, status=None, limit=500, offset=0
+    )
+    assert "Provider Batch Items" in result.stdout
+    assert "img-1-mod-7" in result.stdout
+    assert "succeeded" in result.stdout
+    assert "server_error" in result.stdout
+    assert "2 item(s)" in result.stdout
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+@patch("lorairo.cli.commands.batch.get_service_container")
+def test_batch_status_with_items_json_emits_item_rows_then_result(mock_get_container: MagicMock) -> None:
+    """--items --json で ProviderBatchItemRecord item 行の後に BatchStatusResult が来る。"""
+    container = _container()
+    container.provider_batch_workflow_service.refresh.return_value = _job()
+    container.db_manager.provider_batch_repo.list_provider_batch_items.return_value = [
+        _batch_item(id=1),
+        _batch_item(id=2, custom_id="img-2-mod-7", image_id=2),
+    ]
+    mock_get_container.return_value = container
+
+    result = runner.invoke(app, ["--json", "batch", "status", "42", "--project", "demo", "--items"])
+
+    assert result.exit_code == 0
+    rows = [json.loads(line) for line in result.stdout.splitlines() if line.strip()]
+    item_rows = [row for row in rows if row["kind"] == "item"]
+    result_row = next(row for row in rows if row["kind"] == "result")
+
+    assert len(item_rows) == 2
+    assert item_rows[0]["custom_id"] == "img-1-mod-7"
+    assert item_rows[0]["status"] == "succeeded"
+    assert item_rows[1]["custom_id"] == "img-2-mod-7"
+    assert result_row["ok"] is True
+    assert result_row["items_count"] == 2
+    assert result_row["items_limit"] == 500
+    assert result_row["items_offset"] == 0
+    assert result_row["items_has_more"] is False
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+@patch("lorairo.cli.commands.batch.get_service_container")
+def test_batch_status_without_items_does_not_call_list_items(mock_get_container: MagicMock) -> None:
+    """--no-items（デフォルト）では list_provider_batch_items が呼ばれない。"""
+    container = _container()
+    container.provider_batch_workflow_service.refresh.return_value = _job()
+    mock_get_container.return_value = container
+
+    result = runner.invoke(app, ["batch", "status", "42", "--project", "demo"])
+
+    assert result.exit_code == 0
+    container.db_manager.provider_batch_repo.list_provider_batch_items.assert_not_called()
+    assert "Provider Batch Items" not in result.stdout
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+@patch("lorairo.cli.commands.batch.get_service_container")
+def test_batch_status_items_passes_filter_options_to_repo(mock_get_container: MagicMock) -> None:
+    """--item-status / --limit / --offset が list_provider_batch_items に正しく渡る。"""
+    container = _container()
+    container.provider_batch_workflow_service.refresh.return_value = _job()
+    container.db_manager.provider_batch_repo.list_provider_batch_items.return_value = [
+        _batch_item(status="failed", error_type="server_error"),
+    ]
+    mock_get_container.return_value = container
+
+    result = runner.invoke(
+        app,
+        [
+            "batch",
+            "status",
+            "42",
+            "--project",
+            "demo",
+            "--items",
+            "--item-status",
+            "failed",
+            "--limit",
+            "10",
+            "--offset",
+            "5",
+        ],
+    )
+
+    assert result.exit_code == 0
+    container.db_manager.provider_batch_repo.list_provider_batch_items.assert_called_once_with(
+        42, status="failed", limit=10, offset=5
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+@patch("lorairo.cli.commands.batch.get_service_container")
+def test_batch_status_has_more_when_items_fill_limit(mock_get_container: MagicMock) -> None:
+    """items 数が limit に達したとき items_has_more=True になる（JSON mode）。"""
+    container = _container()
+    container.provider_batch_workflow_service.refresh.return_value = _job()
+    container.db_manager.provider_batch_repo.list_provider_batch_items.return_value = [
+        _batch_item(id=i, custom_id=f"img-{i}-mod-7", image_id=i) for i in range(1, 4)
+    ]
+    mock_get_container.return_value = container
+
+    result = runner.invoke(
+        app,
+        ["--json", "batch", "status", "42", "--project", "demo", "--items", "--limit", "3"],
+    )
+
+    assert result.exit_code == 0
+    rows = [json.loads(line) for line in result.stdout.splitlines() if line.strip()]
+    result_row = next(row for row in rows if row["kind"] == "result")
+    assert result_row["items_has_more"] is True
+    assert result_row["items_count"] == 3
+    assert result_row["items_limit"] == 3
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+@patch("lorairo.cli.commands.batch.get_service_container")
+def test_batch_status_has_more_false_when_items_below_limit(mock_get_container: MagicMock) -> None:
+    """items 数が limit 未満のとき items_has_more=False になる（JSON mode）。"""
+    container = _container()
+    container.provider_batch_workflow_service.refresh.return_value = _job()
+    container.db_manager.provider_batch_repo.list_provider_batch_items.return_value = [
+        _batch_item(id=1),
+    ]
+    mock_get_container.return_value = container
+
+    result = runner.invoke(
+        app,
+        ["--json", "batch", "status", "42", "--project", "demo", "--items", "--limit", "10"],
+    )
+
+    assert result.exit_code == 0
+    rows = [json.loads(line) for line in result.stdout.splitlines() if line.strip()]
+    result_row = next(row for row in rows if row["kind"] == "result")
+    assert result_row["items_has_more"] is False
+    assert result_row["items_count"] == 1
+    assert result_row["items_limit"] == 10

--- a/tests/unit/cli/test_introspection.py
+++ b/tests/unit/cli/test_introspection.py
@@ -386,3 +386,49 @@ def test_describe_unknown_command_uses_existing_error_kind() -> None:
     rows = _jsonl(result.stdout)
     assert rows[-1]["kind"] == "error"
     assert rows[-1]["code"] == "INVALID_INPUT"
+
+
+def test_batch_status_describes_items_option_and_outputs() -> None:
+    """batch status が --items / --limit / --offset / --item-status を describe する (Issue #673)。"""
+    result = runner.invoke(app, ["--json", "describe", "batch status"])
+
+    assert result.exit_code == 0
+    rows = _jsonl(result.stdout)
+    input_row = next(
+        row for row in rows if row.get("type") == "model" and row["name"] == "BatchStatusInput"
+    )
+    field_names = {f["name"] for f in input_row["fields"]}
+    assert {"job_id", "project", "refresh", "items", "limit", "offset", "item_status"} <= field_names
+
+    output_names = {
+        row["name"] for row in rows if row.get("type") == "model" and row.get("role") == "output"
+    }
+    assert "ProviderBatchItemRecord" in output_names
+    assert "BatchStatusResult" in output_names
+
+
+def test_batch_status_result_schema_includes_items_pagination_fields() -> None:
+    """BatchStatusResult / ProviderBatchItemRecord スキーマが items フィールドを持つ (Issue #673)。"""
+    result = runner.invoke(app, ["--json", "describe", "batch status", "--schema", "json_schema"])
+
+    assert result.exit_code == 0
+    rows = _jsonl(result.stdout)
+    result_schema = next(
+        row for row in rows if row.get("type") == "schema" and row.get("name") == "BatchStatusResult"
+    )
+    props = set(result_schema["schema"]["properties"])
+    assert {"items_count", "items_limit", "items_offset", "items_has_more"} <= props
+
+    item_schema = next(
+        row for row in rows if row.get("type") == "schema" and row.get("name") == "ProviderBatchItemRecord"
+    )
+    assert {
+        "id",
+        "job_id",
+        "custom_id",
+        "image_id",
+        "model_id",
+        "task_type",
+        "status",
+        "error_type",
+    } <= set(item_schema["schema"]["properties"])


### PR DESCRIPTION
## Summary

- `batch status --items` / `--no-items` オプションを追加。`--limit`（1-500）・`--offset`・`--item-status` でページング・フィルタ対応
- `ProviderBatchItemRecord` Pydantic モデルを `introspection.py` に追加、`BatchStatusResult` に `items_count` / `items_limit` / `items_offset` / `items_has_more` フィールドを追加
- `TOOL_SPECS["batch status"]` に新しい入力フィールドと出力モデルを登録
- ADR 0031 Amendment 2026-06-07: 重複 submit 許容・rating upsert 方針を明文化
- ADR 0002 Supplement 2026-06-07: UNIQUE なし ≠ 履歴保持を明文化
- `docs/cli-rating-preflight.md` に重複 submit 検出手順と rating upsert 語義を追記

## Test plan

- [ ] `test_batch_status_with_items_shows_items_table`: `--items` で人間向けテーブル表示
- [ ] `test_batch_status_with_items_json_emits_item_rows_then_result`: JSON モードで item 行→result 行の順序
- [ ] `test_batch_status_without_items_does_not_call_list_items`: デフォルト（`--no-items`）で `list_provider_batch_items` 未呼び出し
- [ ] `test_batch_status_items_passes_filter_options_to_repo`: `--item-status` / `--limit` / `--offset` が Repository に渡る
- [ ] `test_batch_status_has_more_when_items_fill_limit`: `items_has_more=True` の判定
- [ ] `test_batch_status_has_more_false_when_items_below_limit`: `items_has_more=False` の判定
- [ ] `test_batch_status_describes_items_option_and_outputs`: introspection が新オプション・出力モデルを含む
- [ ] `test_batch_status_result_schema_includes_items_pagination_fields`: JSON Schema に pagination フィールドが含まれる
- [ ] CI-equivalent filter（main checkout）: 4004 passed, 回帰なし確認済み

Closes #673

🤖 Generated with [Claude Code](https://claude.com/claude-code)