### PR TITLE
test(cli/api): 陳腐化テスト修正 - ResultSetTooLargeError/JSONL/exit_code (fixes #676 #677 #682)

### DIFF
--- a/tests/unit/api/test_exceptions.py
+++ b/tests/unit/api/test_exceptions.py
@@ -18,8 +18,10 @@ from lorairo.api.exceptions import (
     ProjectAlreadyExistsError,
     ProjectNotFoundError,
     ProjectOperationError,
+    ResultSetTooLargeError,
     TagNotFoundError,
     TagRegistrationError,
+    ValidationError,
 )
 
 
@@ -147,3 +149,17 @@ class TestValidationExceptions:
         err = InvalidPathError("/bad/path", "存在しません")
         assert err.path == "/bad/path"
         assert "存在しません" in str(err)
+
+    def test_result_set_too_large_error_attributes(self):
+        err = ResultSetTooLargeError(501, 500)
+        assert err.matched == 501
+        assert err.limit == 500
+
+    def test_result_set_too_large_error_details(self):
+        err = ResultSetTooLargeError(501, 500)
+        assert err.details == {"limit": 500, "matched": 501}
+
+    def test_result_set_too_large_error_inherits_validation_error(self):
+        err = ResultSetTooLargeError(501, 500)
+        assert isinstance(err, ValidationError)
+        assert isinstance(err, LoRAIroException)

--- a/tests/unit/cli/test_annotate_import_batch.py
+++ b/tests/unit/cli/test_annotate_import_batch.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from typer.testing import CliRunner
 
+from lorairo.cli._output_mode import set_json_mode
 from lorairo.cli.main import app
 from lorairo.services.batch_import_service import BatchImportResult
 
@@ -146,3 +147,60 @@ class TestImportBatchCommand:
         assert result.exit_code == 0
         assert "Unmatched" in result.output
         assert "id_a" in result.output
+
+    @patch("lorairo.cli.commands.annotate.import_batch_annotations")
+    def test_json_mode_emits_result_with_all_fields(self, mock_import: MagicMock, tmp_path: Path) -> None:
+        """--json フラグで emit_result が全フィールドを含む JSONL を出力する。"""
+        jsonl_dir = tmp_path / "jsonl"
+        jsonl_dir.mkdir()
+        (jsonl_dir / "test.jsonl").write_text("{}", encoding="utf-8")
+
+        mock_import.return_value = _make_batch_result()
+
+        result = runner.invoke(
+            app,
+            ["--json", "annotate", "import-batch", str(jsonl_dir), "-p", "test_project"],
+        )
+
+        assert result.exit_code == 0
+        parsed = []
+        for line in result.output.splitlines():
+            line = line.strip()
+            if line.startswith("{"):
+                parsed.append(json.loads(line))
+        result_rows = [row for row in parsed if row.get("kind") == "result"]
+        assert len(result_rows) == 1
+        row = result_rows[0]
+        assert row["total_records"] == 100
+        assert row["parsed_ok"] == 98
+        assert row["parse_errors"] == 2
+        assert row["matched"] == 90
+        assert row["unmatched"] == 8
+        assert row["saved"] == 90
+        assert row["save_errors"] == 0
+        assert row["model_name"] == "gpt-4-turbo-2024-04-09"
+        assert row["dry_run"] is False
+
+    @patch("lorairo.cli.commands.annotate.import_batch_annotations")
+    def test_json_mode_dry_run_field_is_true(self, mock_import: MagicMock, tmp_path: Path) -> None:
+        """--json --dry-run では dry_run フィールドが true になる。"""
+        jsonl_dir = tmp_path / "jsonl"
+        jsonl_dir.mkdir()
+        (jsonl_dir / "test.jsonl").write_text("{}", encoding="utf-8")
+
+        mock_import.return_value = _make_batch_result(saved=0)
+
+        result = runner.invoke(
+            app,
+            ["--json", "annotate", "import-batch", str(jsonl_dir), "-p", "test_project", "--dry-run"],
+        )
+
+        assert result.exit_code == 0
+        parsed = []
+        for line in result.output.splitlines():
+            line = line.strip()
+            if line.startswith("{"):
+                parsed.append(json.loads(line))
+        result_rows = [row for row in parsed if row.get("kind") == "result"]
+        assert len(result_rows) == 1
+        assert result_rows[0]["dry_run"] is True

--- a/tests/unit/cli/test_commands_annotate.py
+++ b/tests/unit/cli/test_commands_annotate.py
@@ -8,6 +8,7 @@ import pytest
 from PIL import Image
 from typer.testing import CliRunner
 
+from lorairo.api.exceptions import AnnotationFailedError
 from lorairo.cli._output_mode import set_json_mode
 from lorairo.cli.commands.annotate import _annotation_score, _emit_annotation_items
 from lorairo.cli.main import app
@@ -897,6 +898,51 @@ def test_annotate_run_annotation_failure(
 
     assert result.exit_code == 1
     assert "Annotation failed" in result.stderr or "Error" in result.stderr
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+@patch("lorairo.cli.commands.annotate.get_service_container")
+def test_annotate_run_annotation_failed_error_exit_code(
+    mock_get_container,
+    test_project_with_images: tuple[Path, list[Path]],
+) -> None:
+    """Test: annotate run - AnnotationFailedError は exit_code=1 (PRECONDITION_FAILED)。"""
+    _project_dir, image_files = test_project_with_images
+
+    mock_container = MagicMock()
+    mock_annotator = MagicMock()
+    mock_config = MagicMock()
+
+    mock_config.get_setting.return_value = "test_key"
+    # AnnotationFailedError を直接 side_effect に設定して PRECONDITION_FAILED 経路を明示
+    mock_annotator.annotate.side_effect = AnnotationFailedError("gpt-4o-mini", 3, "upstream API error")
+
+    image_records = [
+        {"id": i + 1, "phash": f"phash{i:016d}", "stored_image_path": str(img_path)}
+        for i, img_path in enumerate(image_files)
+    ]
+    mock_container.db_manager.image_repo.get_images_by_filter.return_value = (
+        image_records,
+        len(image_records),
+    )
+    mock_container.annotator_library = mock_annotator
+    mock_container.config_service = mock_config
+    mock_get_container.return_value = mock_container
+
+    result = runner.invoke(
+        app,
+        [
+            "annotate",
+            "run",
+            "--project",
+            "test_dataset",
+            "--model",
+            "gpt-4o-mini",
+        ],
+    )
+
+    assert result.exit_code == 1
 
 
 @pytest.mark.unit

--- a/tests/unit/cli/test_commands_batch.py
+++ b/tests/unit/cli/test_commands_batch.py
@@ -560,6 +560,19 @@ def test_batch_status_with_items_json_emits_item_rows_then_result(mock_get_conta
     assert result_row["items_limit"] == 500
     assert result_row["items_offset"] == 0
     assert result_row["items_has_more"] is False
+    # _ITEM_DETAIL_FIELDS の全フィールドが item 行に含まれることを確認する。
+    for field in (
+        "id",
+        "job_id",
+        "custom_id",
+        "image_id",
+        "model_id",
+        "task_type",
+        "status",
+        "error_type",
+        "error_message",
+    ):
+        assert field in item_rows[0], f"item row is missing field: {field}"
 
 
 @pytest.mark.unit

--- a/tests/unit/cli/test_commands_images.py
+++ b/tests/unit/cli/test_commands_images.py
@@ -321,6 +321,27 @@ def test_images_list_fetch_total_over_cap_errors_before_items(mock_projects_dir:
 
 @pytest.mark.unit
 @pytest.mark.cli
+def test_images_list_fetch_total_over_cap_errors_non_json(mock_projects_dir: Path) -> None:
+    """Test: images list --fetch (non-JSON) - total 500 超は exit_code 2 でエラーを表示する。"""
+    runner.invoke(app, ["project", "create", "test-project"])
+
+    with patch("lorairo.cli.commands.images.get_service_container") as mock_get_container:
+        mock_container = MagicMock()
+        mock_container.db_manager.image_repo.get_images_count_only.return_value = 501
+        mock_get_container.return_value = mock_container
+
+        result = runner.invoke(app, ["images", "list", "--project", "test-project", "--fetch"])
+
+    assert result.exit_code == 2
+    # non-JSON モードではエラーメッセージが日本語で stderr に出る
+    combined = result.stdout + result.stderr
+    assert "501" in combined
+    assert "500" in combined
+    mock_container.db_manager.image_repo.get_image_list_page.assert_not_called()
+
+
+@pytest.mark.unit
+@pytest.mark.cli
 def test_images_list_reflects_update_tags(mock_projects_dir: Path, test_images_dir: Path) -> None:
     """Test: images update 後も images list の count が取得できる。"""
     runner.invoke(app, ["project", "create", "test-project"])

--- a/tests/unit/cli/test_errors.py
+++ b/tests/unit/cli/test_errors.py
@@ -67,6 +67,7 @@ def test_classify_standard_exceptions(exc: BaseException, expected: ErrorCode) -
         (app_exc.InvalidInputError("name", "empty"), ErrorCode.VALIDATION_FAILED),
         (app_exc.InvalidFormatError("xyz", ["txt", "json"]), ErrorCode.INVALID_INPUT),
         (app_exc.DatabaseConnectionError("p", "locked"), ErrorCode.DB_ERROR),
+        (app_exc.ResultSetTooLargeError(501, 500), ErrorCode.RESULT_SET_TOO_LARGE),
     ],
 )
 def test_classify_lorairo_exceptions(exc: BaseException, expected: ErrorCode) -> None:


### PR DESCRIPTION
## Summary
- #676: `ResultSetTooLargeError` のテストを `test_exceptions.py` に追加（属性・details・継承チェック）、`test_errors.py` の `test_classify_lorairo_exceptions` parametrize に `RESULT_SET_TOO_LARGE` 分岐を追加、`test_commands_images.py` に non-JSON モードでの `exit_code 2` テストを追加
- #677: `test_annotate_import_batch.py` に `--json` フラグ付き `import-batch` の全フィールド JSONL アサーション追加（`total_records`/`parsed_ok`/`parse_errors`/`matched`/`unmatched`/`saved`/`save_errors`/`model_name`/`dry_run`）、`test_commands_batch.py` の既存テストに `_ITEM_DETAIL_FIELDS` 全フィールド確認を追加
- #682: `test_commands_annotate.py` に `AnnotationFailedError` を直接 `side_effect` に使う新テストを追加して `PRECONDITION_FAILED → exit_code=1` 経路を明示的にカバー

## Test plan
- [ ] `uv run pytest tests/unit/api/test_exceptions.py tests/unit/cli/test_errors.py tests/unit/cli/test_commands_images.py tests/unit/cli/test_annotate_import_batch.py tests/unit/cli/test_commands_batch.py tests/unit/cli/test_commands_annotate.py -x --timeout=30` がパス（ローカル確認済み: 142 passed）

🤖 Generated with [Claude Code](https://claude.com/claude-code)