### PR TITLE
fix+test(gui/workers): スコアキー修正 + dead mock 除去 (fixes #678 #681)

### DIFF
--- a/src/lorairo/gui/services/image_db_write_service.py
+++ b/src/lorairo/gui/services/image_db_write_service.py
@@ -118,7 +118,7 @@ class ImageDBWriteService:
 
             # スコア情報取得（最新のもの）
             scores_data = annotations.get("scores", [])
-            aesthetic_score = scores_data[0].get("value") if scores_data else None
+            aesthetic_score = scores_data[0].get("score") if scores_data else None
 
             result = AnnotationData(
                 tags=tags,

--- a/tests/unit/gui/services/test_image_db_write_service.py
+++ b/tests/unit/gui/services/test_image_db_write_service.py
@@ -48,7 +48,7 @@ class TestImageDBWriteService:
         mock_annotation_data = {
             "tags": [{"content": "1girl"}, {"content": "long hair"}],
             "captions": [{"content": "A beautiful anime girl"}],
-            "scores": [{"value": 0.85}],
+            "scores": [{"score": 0.85, "id": 1, "model_id": 1, "is_edited_manually": False}],
             "score_labels": [{"model": "aesthetic_shadow_v1", "label": "aesthetic"}],
             "ratings": [
                 {
@@ -124,7 +124,7 @@ class TestImageDBWriteService:
         mock_annotations = {
             "tags": [{"content": "landscape"}, {"content": "nature"}],
             "captions": [{"content": "Beautiful mountain landscape"}],
-            "scores": [{"value": 0.92}],
+            "scores": [{"score": 0.92, "id": 2, "model_id": 1, "is_edited_manually": False}],
         }
 
         mock_db_manager.image_repo.get_image_annotations.return_value = mock_annotations
@@ -167,14 +167,23 @@ class TestImageDBWriteService:
         assert result is True
 
     def test_update_score_success(self, service, mock_db_manager):
-        """Score更新機能正常動作（プレースホルダー実装）"""
+        """Score更新機能正常動作"""
         image_id = 200
         score = 750  # 0-1000範囲
 
         result = service.update_score(image_id, score)
 
-        # プレースホルダー実装では常にTrueを返す
         assert result is True
+
+        # save_annotations が display_score を含む ScoreAnnotationData で呼ばれることを確認
+        mock_db_manager.annotation_repo.save_annotations.assert_called_once()
+        call_kwargs = mock_db_manager.annotation_repo.save_annotations.call_args
+        annotations = (
+            call_kwargs.kwargs["annotations"] if call_kwargs.kwargs else call_kwargs[1]["annotations"]
+        )
+        score_data = annotations["scores"][0]
+        assert "display_score" in score_data
+        assert score_data["score"] == 7.5  # 750 / 100.0
 
     def test_update_rating_invalid_image_id(self, service, mock_db_manager):
         """不正なimage_id指定時の適切な処理（プレースホルダー実装）"""
@@ -322,12 +331,12 @@ class TestImageDBWriteServiceIntegration:
                 1: {
                     "tags": [{"content": "photography"}, {"content": "landscape"}, {"content": "sunset"}],
                     "captions": [{"content": "A breathtaking sunset over the mountains"}],
-                    "scores": [{"value": 0.91}],
+                    "scores": [{"score": 0.91, "id": 3, "model_id": 1, "is_edited_manually": False}],
                 },
                 2: {
                     "tags": [{"content": "digital art"}, {"content": "anime"}, {"content": "character"}],
                     "captions": [{"content": "Anime character illustration"}],
-                    "scores": [{"value": 0.78}],
+                    "scores": [{"score": 0.78, "id": 4, "model_id": 1, "is_edited_manually": False}],
                 },
             }
             return annotations_map.get(image_id, {})

--- a/tests/unit/gui/services/test_result_handler_service.py
+++ b/tests/unit/gui/services/test_result_handler_service.py
@@ -61,6 +61,7 @@ class TestHandleBatchRegistrationFinished:
         result.skipped_count = 10
         result.error_count = 5
         result.total_processing_time = 12.5
+        result.variant_count = 0
 
         completion_signal = Mock()
         completion_signal.emit = Mock()
@@ -74,6 +75,7 @@ class TestHandleBatchRegistrationFinished:
         mock_status_bar.clearMessage.assert_called_once()
         mock_status_bar.showMessage.assert_called_once()
         assert "登録=100" in mock_status_bar.showMessage.call_args[0][0]
+        assert "別版=0" in mock_status_bar.showMessage.call_args[0][0]
         assert "スキップ=10" in mock_status_bar.showMessage.call_args[0][0]
         completion_signal.emit.assert_called_once_with(100)
 

--- a/tests/unit/workers/test_database_related_workers.py
+++ b/tests/unit/workers/test_database_related_workers.py
@@ -68,18 +68,16 @@ class TestDatabaseRegistrationWorker:
     def test_api_method_names_are_correct(self, temp_dir, real_db_manager, mock_fsm):
         """
         APIメソッド名が正しいことをテスト
-        - このテストは実際のregister_image → register_original_imageエラーを検出できる
+        - このテストは実際のregister_image → register_image_with_side_effectsエラーを検出できる
         """
         DatabaseRegistrationWorker(temp_dir, real_db_manager, mock_fsm)
 
-        # 実際のDatabaseManagerのメソッドが存在することを確認
-        assert hasattr(real_db_manager, "detect_duplicate_image")
-        assert hasattr(real_db_manager, "register_original_image")  # register_imageではない！
+        # 実際のDatabaseManagerのメソッドが存在することを確認 (#633: 統一エントリへ移行)
+        assert hasattr(real_db_manager, "register_image_with_side_effects")
         assert hasattr(real_db_manager, "get_image_metadata")  # get_image_by_idではない！
 
         # メソッドが呼び出し可能であることを確認
-        assert callable(real_db_manager.detect_duplicate_image)
-        assert callable(real_db_manager.register_original_image)
+        assert callable(real_db_manager.register_image_with_side_effects)
         assert callable(real_db_manager.get_image_metadata)
 
     def test_import_paths_are_correct(self):
@@ -139,14 +137,12 @@ class TestDatabaseRegistrationWorker:
 
         mock_fsm.get_image_files.return_value = [image_file]
 
-        # DB操作をMock化
+        # DB操作をMock化 (#633: detect_duplicate_image は統一エントリ内で処理されるため除去)
         with (
-            patch.object(real_db_manager, "detect_duplicate_image") as mock_detect,
             patch.object(real_db_manager, "register_original_image") as mock_register,
             patch.object(real_db_manager, "save_tags") as mock_save_tags,
             patch.object(real_db_manager, "save_captions") as mock_save_captions,
         ):
-            mock_detect.return_value = None
             mock_register.return_value = (1, {"id": 1})
 
             worker = DatabaseRegistrationWorker(temp_dir, real_db_manager, mock_fsm)
@@ -637,6 +633,7 @@ class TestBuildRegistrationResult:
             log_message = mock_logger.info.call_args[0][0]
             assert "データベース登録完了" in log_message
             assert "登録=5" in log_message
+            assert "別版=0" in log_message
             assert "スキップ=2" in log_message
             assert "エラー=1" in log_message
 
@@ -782,13 +779,11 @@ class TestRegistrationErrorHandling:
 
         worker = DatabaseRegistrationWorker(temp_dir, real_db_manager, mock_fsm)
 
-        # register_original_imageをMock化
+        # register_original_imageをMock化 (#633: detect_duplicate_image は統一エントリ内で処理されるため除去)
         with (
-            patch.object(real_db_manager, "detect_duplicate_image") as mock_detect,
             patch.object(real_db_manager, "register_original_image") as mock_register,
             patch.object(worker, "_check_cancellation") as mock_cancel,
         ):
-            mock_detect.return_value = None
             mock_register.return_value = (1, {})
 
             # 2回目のチェック時にキャンセル
@@ -802,13 +797,11 @@ class TestRegistrationErrorHandling:
                 worker.execute()
 
     def test_exception_in_db_registration(self, temp_dir, real_db_manager, mock_fsm):
-        """register_original_imageが例外を発生した場合の処理確認"""
+        """register_original_imageが例外を発生した場合の処理確認 (#633: 統一エントリ経由)"""
         with (
-            patch.object(real_db_manager, "detect_duplicate_image") as mock_detect,
             patch.object(real_db_manager, "register_original_image") as mock_register,
             patch.object(real_db_manager, "save_error_record") as mock_save_error,
         ):
-            mock_detect.return_value = None
             mock_register.side_effect = ValueError("登録エラー")
 
             worker = DatabaseRegistrationWorker(temp_dir, real_db_manager, mock_fsm)
@@ -820,14 +813,12 @@ class TestRegistrationErrorHandling:
             assert result.error_count == 3
 
     def test_secondary_error_in_save_error_record(self, temp_dir, real_db_manager, mock_fsm):
-        """save_error_record自体が例外を発生した場合の処理確認"""
+        """save_error_record自体が例外を発生した場合の処理確認 (#633: 統一エントリ経由)"""
         with (
-            patch.object(real_db_manager, "detect_duplicate_image") as mock_detect,
             patch.object(real_db_manager, "register_original_image") as mock_register,
             patch.object(real_db_manager, "save_error_record") as mock_save_error,
             patch("lorairo.gui.workers.registration_worker.logger") as mock_logger,
         ):
-            mock_detect.return_value = None
             mock_register.side_effect = ValueError("登録エラー")
             mock_save_error.side_effect = Exception("エラー保存失敗")
 
@@ -848,13 +839,11 @@ class TestRegistrationErrorHandling:
         worker = DatabaseRegistrationWorker(temp_dir, real_db_manager, mock_fsm)
 
         with (
-            patch.object(real_db_manager, "detect_duplicate_image") as mock_detect,
             patch.object(real_db_manager, "register_original_image") as mock_register,
             patch.object(worker, "_report_progress") as mock_progress,
             patch.object(worker, "_report_progress_throttled") as mock_progress_throttled,
             patch.object(worker, "_report_batch_progress_throttled") as mock_batch,
         ):
-            mock_detect.return_value = None
             mock_register.return_value = (1, {})
 
             worker.execute()
@@ -887,12 +876,10 @@ class TestRegistrationErrorHandling:
         assert len(result.processed_paths) == 0
 
     def test_integration_with_split_methods(self, temp_dir, real_db_manager, mock_fsm):
-        """分割メソッド（_register_single_image, _build_registration_result）の協調確認"""
+        """分割メソッド（_register_single_image, _build_registration_result）の協調確認 (#633: 統一エントリ経由)"""
         with (
-            patch.object(real_db_manager, "detect_duplicate_image") as mock_detect,
             patch.object(real_db_manager, "register_original_image") as mock_register,
         ):
-            mock_detect.return_value = None
             mock_register.return_value = (1, {"id": 1})
 
             worker = DatabaseRegistrationWorker(temp_dir, real_db_manager, mock_fsm)
@@ -988,10 +975,8 @@ class TestRegistrationErrorHandling:
         mock_fsm.get_image_files.return_value = image_files
 
         with (
-            patch.object(real_db_manager, "detect_duplicate_image") as mock_detect,
             patch.object(real_db_manager, "register_original_image") as mock_register,
         ):
-            mock_detect.return_value = None
             mock_register.return_value = (1, {})
 
             worker = DatabaseRegistrationWorker(temp_dir, real_db_manager, mock_fsm)
@@ -1007,13 +992,11 @@ class TestRegistrationErrorHandling:
         worker = DatabaseRegistrationWorker(temp_dir, real_db_manager, mock_fsm)
 
         with (
-            patch.object(real_db_manager, "detect_duplicate_image") as mock_detect,
             patch.object(real_db_manager, "register_original_image") as mock_register,
             patch.object(worker, "_report_progress") as mock_progress,
             patch.object(worker, "_report_progress_throttled") as mock_progress_throttled,
             patch.object(worker, "_report_batch_progress_throttled") as mock_batch,
         ):
-            mock_detect.return_value = None
             mock_register.return_value = (1, {})
 
             worker.execute()


### PR DESCRIPTION
## Summary
- **#681**: `image_db_write_service.py` の `scores_data[0].get('value')` を `.get('score')` に修正。`_format_score_annotation()` が `"score"` キーで返すため `"value"` は常に `None` を返す本番バグ。テストモックも全4箇所を正しいキー構造に修正し、`test_update_score_success` に `save_annotations` 呼び出しと `display_score` フィールドのアサーションを追加。
- **#678**: #633 の `register_image_with_side_effects` 統一エントリ化後に10箇所残った dead `detect_duplicate_image` モックを除去。`register_original_image` モックは統一エントリ内部で呼ばれるため保持。`test_build_registration_result_info_log_output` に `別版=0` アサーション追加。`test_result_handler_service.py` に `variant_count=0` と `別版=0` ステータスバー検証追加。

## Test plan
- [x] `uv run pytest tests/unit/workers/test_database_related_workers.py tests/unit/gui/services/ -x --timeout=30` 86 passed
- [x] `uv run pytest tests/unit/workers/ tests/unit/gui/ -m "not gui_show and not calls_real_webapi" --timeout=30` 1441 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)