### PR TITLE
fix+test(services/bdd): update_score_batch display_score バグ修正 + 陳腐化テスト (fixes #675 #679 #680)

### DIFF
--- a/src/lorairo/database/repository/annotation_record.py
+++ b/src/lorairo/database/repository/annotation_record.py
@@ -1134,6 +1134,8 @@ class AnnotationRepository(BaseRepository):
                         # 既存レコードを UPDATE
                         existing_score = existing_score_map[image_id]
                         existing_score.score = score
+                        # 手動編集スコアは DB 値 (0-10) をそのまま表示スコアとして使う。
+                        existing_score.display_score = score
                         existing_score.model_id = model_id
                         existing_score.is_edited_manually = True
                         existing_score.updated_at = func.now()
@@ -1144,6 +1146,8 @@ class AnnotationRepository(BaseRepository):
                             image_id=image_id,
                             model_id=model_id,
                             score=score,
+                            # 手動編集スコアは DB 値 (0-10) をそのまま表示スコアとして使う。
+                            display_score=score,
                             is_edited_manually=True,
                         )
                         session.add(new_score)

--- a/tests/bdd/steps/test_annotation_result_save.py
+++ b/tests/bdd/steps/test_annotation_result_save.py
@@ -94,7 +94,6 @@ def given_save_service_initialized(ctx: SaveContext) -> None:
 @given("AnnotationSaveService がモックリポジトリで初期化されている", target_fixture="ctx")
 def given_save_service_mock_repo() -> SaveContext:
     repo = MagicMock()
-    repo.find_image_ids_by_phashes.return_value = {}
     repo.find_image_ids_by_phashes_multi.return_value = {}
     repo.get_models_by_litellm_ids.return_value = {}
     repo.batch_resolve_tag_ids.return_value = {}

--- a/tests/unit/services/test_annotation_save_service.py
+++ b/tests/unit/services/test_annotation_save_service.py
@@ -787,6 +787,7 @@ class TestAppendScoresWebApi:
         assert result["scores"][0]["score"] == pytest.approx(8.0)
         assert result["scores"][0]["model_id"] == 99
         assert result["scores"][0]["is_edited_manually"] is False
+        assert "display_score" in result["scores"][0]
 
     @pytest.mark.unit
     def test_webapi_missing_overall_key_skips(self, service: AnnotationSaveService) -> None:

--- a/tests/unit/services/test_batch_image_matcher.py
+++ b/tests/unit/services/test_batch_image_matcher.py
@@ -64,6 +64,7 @@ class TestBatchImageMatcher:
         assert result.matched["0263_1228"] == 2
         assert result.matched["0264_1229"] == 3
         assert result.unmatched == []
+        assert result.ambiguous == {}
 
     def test_all_unmatched(self, mock_repository: MagicMock) -> None:
         """全件アンマッチ。"""
@@ -74,6 +75,7 @@ class TestBatchImageMatcher:
         assert len(result.unmatched) == 2
         assert "unknown_001" in result.unmatched
         assert "unknown_002" in result.unmatched
+        assert result.ambiguous == {}
 
     def test_partial_match(self, mock_repository: MagicMock) -> None:
         """部分マッチ。"""
@@ -84,6 +86,7 @@ class TestBatchImageMatcher:
         assert result.matched["0262_1227"] == 1
         assert result.matched["0264_1229"] == 3
         assert result.unmatched == ["unknown_001"]
+        assert result.ambiguous == {}
 
     def test_windows_path_custom_ids(self, mock_repository: MagicMock) -> None:
         """Windowsパス形式のcustom_idが正しくマッチする。"""
@@ -97,6 +100,7 @@ class TestBatchImageMatcher:
 
         assert len(result.matched) == 2
         assert result.matched["H:\\lora\\images\\0262_1227"] == 1
+        assert result.ambiguous == {}
 
     def test_empty_custom_ids(self, mock_repository: MagicMock) -> None:
         """空リスト。"""
@@ -105,6 +109,7 @@ class TestBatchImageMatcher:
 
         assert result.matched == {}
         assert result.unmatched == []
+        assert result.ambiguous == {}
 
     def test_image_match_result_frozen(self) -> None:
         """ImageMatchResultはfrozen。"""


### PR DESCRIPTION
## Summary
- **#675**: `annotation_record.update_score_batch()` に `display_score` 設定を追加（本番バグ修正）。手動編集スコアは DB 値 (0-10) をそのまま表示スコアとして設定する。`TestAppendScoresWebApi` に `display_score` キー存在アサーションを追加。
- **#679**: `TestBatchImageMatcher` の `test_all_matched` / `test_all_unmatched` / `test_partial_match` / `test_windows_path_custom_ids` / `test_empty_custom_ids` に `ambiguous == {}` アサーション追加。stem 形式照合では ambiguous が常に空であることを明示化。
- **#680**: `test_annotation_result_save.py` の `given_save_service_mock_repo` から dead stub `repo.find_image_ids_by_phashes.return_value = {}` を除去。本番コードは `find_image_ids_by_phashes_multi` のみ使用。

## Test plan
- [x] `uv run pytest tests/unit/services/test_annotation_save_service.py tests/unit/services/test_batch_image_matcher.py tests/bdd/steps/test_annotation_result_save.py tests/integration/services/` がパス (55 + 17 件)
- [x] CI-equivalent filter `uv run pytest tests/ -m "not gui_show and not calls_real_webapi and not downloads_and_runs_model and not slow"` — 4020 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)