### PR TITLE
fix(cli): block original image annotation routes

### DIFF
--- a/docs/decisions/0064-cli-original-image-annotation-guard.md
+++ b/docs/decisions/0064-cli-original-image-annotation-guard.md
@@ -1,0 +1,44 @@
+# ADR 0064: CLI Original Image Annotation Guard
+
+- **Date**: 2026-06-07
+- **Status**: Accepted
+- **Related Issue**: #686
+- **Related ADRs**: [0053](0053-cli-streaming-annotation-memory-bounded-contract.md), [0057](0057-cli-jsonl-output-and-error-contract.md), [0063](0063-cli-batch-submit-image-ids-csv.md)
+
+## Context
+
+The GUI route does not let users directly annotate original stored images. CLI routes still accepted image records whose
+`stored_image_path` points under `image_dataset/original_images/`, so `annotate run` and `batch submit` could bypass the
+GUI safety policy.
+
+This surfaced during a rating preflight batch: image IDs selected for OpenAI moderation were submitted from
+`image_dataset/original_images/...`, including very large originals. That is the wrong CLI surface. CLI should operate on
+the same processed/resized image records that the GUI workflow is designed to use.
+
+## Decision
+
+CLI annotation entry points reject image records whose `stored_image_path` is under `image_dataset/original_images/`.
+
+The guard is enforced before expensive or external work:
+
+- `annotate run` rejects after filter/image-id selection and before image loading, moderation preflight, or annotation.
+- `batch submit` resolves the supplied `--image-ids` to image records and rejects before provider batch submission.
+
+The failure is treated as input validation (`click.UsageError`), preserving the CLI JSONL error contract through
+`INVALID_INPUT` / exit code 2.
+
+## Rationale
+
+The storage path is the only stable discriminator currently present on the selected image records. Adding a new schema
+field would be heavier than this safety fix and would not change the immediate behavior needed at the CLI boundary.
+
+Mixed selections fail as a whole. Silently dropping originals would make the submitted set differ from the user's exact
+ID selection and could hide mistakes in automated agent workflows.
+
+## Consequences
+
+- CLI users must select processed/resized image records for annotation and provider batch submission.
+- Original image records selected by exact ID or filters produce a clear validation error that includes sample image IDs
+  and stored paths.
+- Future explicit override, if needed, must be designed as a separate policy change rather than falling through by
+  default.

--- a/src/lorairo/cli/_image_guard.py
+++ b/src/lorairo/cli/_image_guard.py
@@ -1,0 +1,81 @@
+"""CLI guards for image selection safety."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass
+from pathlib import PurePosixPath
+from typing import Any
+
+import click
+
+_ORIGINAL_IMAGE_PREFIX = PurePosixPath("image_dataset/original_images")
+
+
+@dataclass(frozen=True)
+class OriginalImageSelection:
+    image_id: int | None
+    stored_image_path: str
+
+
+def is_original_image_stored_path(stored_image_path: str | None) -> bool:
+    """Return whether a DB stored path points at the original image storage."""
+    if not stored_image_path:
+        return False
+
+    normalized = PurePosixPath(str(stored_image_path).replace("\\", "/"))
+    parts = normalized.parts
+    prefix_parts = _ORIGINAL_IMAGE_PREFIX.parts
+    for idx in range(0, len(parts) - len(prefix_parts) + 1):
+        if parts[idx : idx + len(prefix_parts)] == prefix_parts:
+            return True
+    return False
+
+
+def find_original_image_records(
+    image_records: Iterable[Mapping[str, Any]],
+) -> list[OriginalImageSelection]:
+    """Extract image records that still point to original image storage."""
+    original_records: list[OriginalImageSelection] = []
+    for record in image_records:
+        stored_path = record.get("stored_image_path")
+        if not is_original_image_stored_path(str(stored_path) if stored_path is not None else None):
+            continue
+
+        raw_image_id = record.get("id")
+        image_id = (
+            int(raw_image_id)
+            if isinstance(raw_image_id, int | str) and str(raw_image_id).isdigit()
+            else None
+        )
+        original_records.append(
+            OriginalImageSelection(
+                image_id=image_id,
+                stored_image_path=str(stored_path),
+            )
+        )
+    return original_records
+
+
+def reject_original_image_records(
+    image_records: Iterable[Mapping[str, Any]],
+    *,
+    command_name: str,
+) -> None:
+    """Reject CLI annotation routes that would operate on original images."""
+    original_records = find_original_image_records(image_records)
+    if not original_records:
+        return
+
+    samples = ", ".join(
+        f"{record.image_id}:{record.stored_image_path}"
+        if record.image_id is not None
+        else record.stored_image_path
+        for record in original_records[:5]
+    )
+    extra = "" if len(original_records) <= 5 else f", ... (+{len(original_records) - 5} more)"
+    raise click.UsageError(
+        f"{command_name} cannot operate directly on original images. "
+        "Select processed/resized image records instead. "
+        f"Rejected {len(original_records)} original image(s): {samples}{extra}"
+    )

--- a/src/lorairo/cli/commands/annotate.py
+++ b/src/lorairo/cli/commands/annotate.py
@@ -39,6 +39,7 @@ from lorairo.api.project import get_project as api_get_project
 from lorairo.cli._boundary import command_boundary
 from lorairo.cli._console import make_console
 from lorairo.cli._emit import emit_item, emit_result
+from lorairo.cli._image_guard import reject_original_image_records
 from lorairo.cli._output_mode import is_json_mode
 from lorairo.database.db_core import resolve_stored_path
 from lorairo.database.filter_criteria import ImageFilterCriteria
@@ -914,6 +915,8 @@ def run(
 
         if not records_to_process:
             raise AnnotationSelectionError("No images selected for annotation")
+
+        reject_original_image_records(records_to_process, command_name="annotate run")
 
         if len(records_to_process) > MAX_ANNOTATE_IMAGES:
             raise ResultSetTooLargeError(len(records_to_process), MAX_ANNOTATE_IMAGES)

--- a/src/lorairo/cli/commands/batch.py
+++ b/src/lorairo/cli/commands/batch.py
@@ -19,6 +19,7 @@ from rich.table import Table
 from lorairo.cli._boundary import command_boundary
 from lorairo.cli._console import make_console
 from lorairo.cli._emit import emit_item, emit_result
+from lorairo.cli._image_guard import reject_original_image_records
 from lorairo.cli._output_mode import is_json_mode
 from lorairo.services.service_container import get_service_container
 
@@ -359,6 +360,11 @@ def submit(
                 )
 
         resolved_endpoint = _resolve_submit_endpoint(resolved_provider, normalized_task_type, endpoint)
+        image_repo = container.db_manager.image_repo
+        reject_original_image_records(
+            image_repo.get_images_by_ids(image_ids),
+            command_name="batch submit",
+        )
 
         job_id = container.provider_batch_workflow_service.submit_images(
             provider=resolved_provider,

--- a/tests/integration/cli/test_cli_workflow.py
+++ b/tests/integration/cli/test_cli_workflow.py
@@ -6,13 +6,13 @@ fixtures can isolate project storage and inject a deterministic annotator.
 
 from __future__ import annotations
 
+import shutil
+import sqlite3
 from pathlib import Path
 from types import SimpleNamespace
 
 import imagehash
 import pytest
-from image_annotator_lib import AnnotatorInfo
-from image_annotator_lib.core.types import TaskCapability
 from PIL import Image
 from typer.testing import CliRunner
 
@@ -31,18 +31,19 @@ class FakeAnnotatorLibrary:
     def __init__(self) -> None:
         self.annotate_calls = 0
 
-    def list_annotator_info(self) -> list[AnnotatorInfo]:
+    def list_annotator_info(self) -> list[SimpleNamespace]:
         return [
-            AnnotatorInfo(
+            SimpleNamespace(
                 name=FAKE_MODEL_ID,
                 model_type="tagger",
-                capabilities=frozenset({TaskCapability.TAGS, TaskCapability.CAPTIONS}),
+                capabilities=frozenset(),
                 is_local=True,
                 is_api=False,
                 device=None,
                 provider="local",
                 litellm_model_id=FAKE_MODEL_ID,
                 estimated_size_gb=0.0,
+                discontinued_at=None,
             )
         ]
 
@@ -114,6 +115,25 @@ def _install_fake_annotator() -> None:
     container._model_sync_service = None
 
 
+def _switch_registered_images_to_processed_paths(project_dir: Path) -> None:
+    """Simulate the GUI-safe processed image path before CLI annotation."""
+    db_path = project_dir / "image_database.db"
+    processed_dir = project_dir / "image_dataset" / "processed_images"
+    processed_dir.mkdir(parents=True, exist_ok=True)
+
+    with sqlite3.connect(db_path) as conn:
+        rows = conn.execute("SELECT id, stored_image_path FROM images").fetchall()
+        for image_id, stored_image_path in rows:
+            source_path = project_dir / stored_image_path
+            processed_relative = Path("image_dataset") / "processed_images" / source_path.name
+            shutil.copy2(source_path, project_dir / processed_relative)
+            conn.execute(
+                "UPDATE images SET stored_image_path = ? WHERE id = ?",
+                (processed_relative.as_posix(), image_id),
+            )
+        conn.commit()
+
+
 @pytest.mark.integration
 @pytest.mark.cli
 @pytest.mark.e2e
@@ -142,12 +162,16 @@ def test_cli_full_workflow_with_fake_annotator(
     )
     assert register_result.exit_code == 0, register_result.stdout
     assert "Registered" in register_result.stdout
+    project_dir = next(
+        path for path in isolated_projects_dir.iterdir() if path.name.startswith(project_name)
+    )
+    _switch_registered_images_to_processed_paths(project_dir)
 
     annotate_result = cli_runner.invoke(
         app,
         ["annotate", "run", "--project", project_name, "--model", FAKE_MODEL_ID],
     )
-    assert annotate_result.exit_code == 0, annotate_result.stdout
+    assert annotate_result.exit_code == 0, annotate_result.stdout + annotate_result.stderr
     assert "Annotation completed successfully" in annotate_result.stdout
 
     export_dir = tmp_path / "export"

--- a/tests/unit/cli/test_annotate_load_failure.py
+++ b/tests/unit/cli/test_annotate_load_failure.py
@@ -66,7 +66,7 @@ def project_with_images(mock_projects_dir: Path) -> list[Path]:
     project_dirs = list(mock_projects_dir.iterdir())
     project_dir = next(d for d in project_dirs if d.name.startswith("fail_dataset_"))
 
-    image_dataset_dir = project_dir / "image_dataset" / "original_images"
+    image_dataset_dir = project_dir / "image_dataset" / "processed_images"
     image_dataset_dir.mkdir(parents=True, exist_ok=True)
 
     image_files: list[Path] = []

--- a/tests/unit/cli/test_annotate_selection.py
+++ b/tests/unit/cli/test_annotate_selection.py
@@ -6,8 +6,10 @@ CLI 起動を介さず `_select_image_records` を直接呼ぶ。レコードは
 
 from typing import Any
 
+import click
 import pytest
 
+from lorairo.cli._image_guard import is_original_image_stored_path, reject_original_image_records
 from lorairo.cli.commands import annotate
 from lorairo.cli.commands.annotate import _select_image_records
 
@@ -156,3 +158,27 @@ def test_unordered_input_is_sorted_by_id_for_stable_sharding() -> None:
     combined = [r["id"] for r in (*shard0, *shard1, *shard2)]
     assert sorted(combined) == [1, 2, 3, 4, 5]
     assert len(combined) == len(set(combined))
+
+
+@pytest.mark.unit
+def test_original_image_path_detection_matches_project_relative_and_absolute_paths() -> None:
+    assert is_original_image_stored_path("image_dataset/original_images/2026/06/a.jpg")
+    assert is_original_image_stored_path(
+        "/workspaces/LoRAIro/lorairo_data/demo/image_dataset/original_images/2026/06/a.jpg"
+    )
+    assert not is_original_image_stored_path("image_dataset/processed_images/2026/06/a.jpg")
+    assert not is_original_image_stored_path("image_dataset/original_images_backup/a.jpg")
+
+
+@pytest.mark.unit
+def test_reject_original_image_records_fails_mixed_selection_without_dropping() -> None:
+    records = [
+        {"id": 1, "stored_image_path": "image_dataset/processed_images/1.jpg"},
+        {"id": 2, "stored_image_path": "image_dataset/original_images/2.jpg"},
+    ]
+
+    with pytest.raises(click.UsageError) as exc_info:
+        reject_original_image_records(records, command_name="annotate run")
+
+    assert "annotate run cannot operate directly on original images" in str(exc_info.value)
+    assert "2:image_dataset/original_images/2.jpg" in str(exc_info.value)

--- a/tests/unit/cli/test_annotate_streaming.py
+++ b/tests/unit/cli/test_annotate_streaming.py
@@ -67,7 +67,7 @@ def project_with_n_images(mock_projects_dir: Path):
         project_dirs = list(mock_projects_dir.iterdir())
         project_dir = next(d for d in project_dirs if d.name.startswith("stream_dataset_"))
 
-        image_dataset_dir = project_dir / "image_dataset" / "original_images"
+        image_dataset_dir = project_dir / "image_dataset" / "processed_images"
         image_dataset_dir.mkdir(parents=True, exist_ok=True)
 
         image_files: list[Path] = []

--- a/tests/unit/cli/test_commands_annotate.py
+++ b/tests/unit/cli/test_commands_annotate.py
@@ -148,7 +148,7 @@ def test_project_with_images(mock_projects_dir: Path) -> tuple[Path, list[Path]]
     project_dir = next(d for d in project_dirs if d.name.startswith("test_dataset_"))
 
     # 画像ファイルを作成
-    image_dataset_dir = project_dir / "image_dataset" / "original_images"
+    image_dataset_dir = project_dir / "image_dataset" / "processed_images"
     image_dataset_dir.mkdir(parents=True, exist_ok=True)
 
     image_files = []
@@ -399,6 +399,48 @@ def test_annotate_run_json_rejects_more_than_500_before_items(
     assert lines[0]["kind"] == "error"
     assert lines[0]["code"] == "RESULT_SET_TOO_LARGE"
     assert lines[0]["details"] == {"limit": 500, "matched": 501}
+    mock_container.annotator_library.annotate.assert_not_called()
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+@patch("lorairo.cli.commands.annotate.get_service_container")
+def test_annotate_run_rejects_original_image_records(
+    mock_get_container,
+    mock_projects_dir: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("LORAIRO_CLI_JSON", "1")
+    runner.invoke(app, ["project", "create", "original_guard_dataset"])
+
+    mock_container = MagicMock()
+    mock_config = MagicMock()
+    mock_config.get_setting.return_value = "test_key"
+    mock_container.db_manager.image_repo.get_images_by_filter.return_value = (
+        [
+            {
+                "id": 12,
+                "phash": "phash0000000000012",
+                "stored_image_path": "image_dataset/original_images/2026/06/original.jpg",
+            }
+        ],
+        1,
+    )
+    mock_container.config_service = mock_config
+    mock_get_container.return_value = mock_container
+
+    result = runner.invoke(
+        app,
+        ["annotate", "run", "--project", "original_guard_dataset", "--model", "gpt-4o-mini"],
+    )
+
+    assert result.exit_code == 2
+    rows = [json.loads(line) for line in result.stdout.splitlines()]
+    assert len(rows) == 1
+    assert rows[0]["kind"] == "error"
+    assert rows[0]["code"] == "INVALID_INPUT"
+    assert "cannot operate directly on original images" in rows[0]["message"]
+    assert "12:image_dataset/original_images/2026/06/original.jpg" in rows[0]["message"]
     mock_container.annotator_library.annotate.assert_not_called()
 
 
@@ -1025,7 +1067,7 @@ def test_annotate_run_with_special_project_name(
     project_dir = next(d for d in project_dirs if "special-project" in d.name)
 
     # 画像ファイルを作成
-    image_dataset_dir = project_dir / "image_dataset" / "original_images"
+    image_dataset_dir = project_dir / "image_dataset" / "processed_images"
     image_dataset_dir.mkdir(parents=True, exist_ok=True)
 
     img = Image.new("RGB", (100, 100), color=(50, 50, 50))

--- a/tests/unit/cli/test_commands_batch.py
+++ b/tests/unit/cli/test_commands_batch.py
@@ -60,6 +60,10 @@ def _container() -> MagicMock:
     container = MagicMock()
     container.db_manager.model_repo.get_model_by_litellm_id.return_value = _model()
     container.db_manager.model_repo.get_models_by_name.return_value = []
+    container.db_manager.image_repo.get_images_by_ids.return_value = [
+        {"id": 1, "stored_image_path": "image_dataset/processed_images/1.jpg"},
+        {"id": 2, "stored_image_path": "image_dataset/processed_images/2.jpg"},
+    ]
     container.db_manager.provider_batch_repo.get_provider_batch_job.return_value = _job()
     container.provider_batch_workflow_service.submit_images.return_value = 42
     return container
@@ -363,6 +367,39 @@ def test_batch_submit_rejects_invalid_image_ids_csv(mock_get_container: MagicMoc
     assert "--image-ids must be a comma-separated list" in result.output
     assert "invalid token(s): x" in result.output
     assert "empty item(s)" in result.output
+    container.provider_batch_workflow_service.submit_images.assert_not_called()
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+@patch("lorairo.cli.commands.batch.get_service_container")
+def test_batch_submit_rejects_original_image_records(mock_get_container: MagicMock) -> None:
+    container = _container()
+    container.db_manager.image_repo.get_images_by_ids.return_value = [
+        {
+            "id": 1,
+            "stored_image_path": "image_dataset/original_images/2026/06/sample.jpg",
+        }
+    ]
+    mock_get_container.return_value = container
+
+    result = runner.invoke(
+        app,
+        [
+            "batch",
+            "submit",
+            "--project",
+            "demo",
+            "--model",
+            "openai/gpt-4.1-mini",
+            "--image-ids",
+            "1",
+        ],
+    )
+
+    assert result.exit_code == 2
+    assert "cannot operate directly on original images" in result.output
+    assert "1:image_dataset/original_images/2026/06/sample.jpg" in result.output
     container.provider_batch_workflow_service.submit_images.assert_not_called()
 
 


### PR DESCRIPTION
## Summary

- Fixes #686.
- Adds a shared CLI guard that rejects image records whose `stored_image_path` points under `image_dataset/original_images/`.
- Applies the guard to `annotate run` before image loading/API preflight and to `batch submit` before provider submission.
- Adds ADR 0064 documenting the CLI original-image guard policy.
- Updates CLI unit tests so normal annotation fixtures use processed-image paths, and adds explicit rejection coverage for `annotate run` and `batch submit`.

## Verification

- `uv run --no-sync ruff format src/lorairo/cli/_image_guard.py src/lorairo/cli/commands/annotate.py src/lorairo/cli/commands/batch.py tests/unit/cli/test_annotate_selection.py tests/unit/cli/test_commands_batch.py tests/unit/cli/test_annotate_streaming.py tests/unit/cli/test_annotate_load_failure.py tests/unit/cli/test_commands_annotate.py`
- `uv run --no-sync ruff check src/lorairo/cli/_image_guard.py src/lorairo/cli/commands/annotate.py src/lorairo/cli/commands/batch.py tests/unit/cli/test_annotate_selection.py tests/unit/cli/test_commands_batch.py tests/unit/cli/test_annotate_streaming.py tests/unit/cli/test_annotate_load_failure.py tests/unit/cli/test_commands_annotate.py`
- `uv run --no-sync pytest tests/unit/cli/test_annotate_selection.py tests/unit/cli/test_commands_batch.py tests/unit/cli/test_annotate_streaming.py tests/unit/cli/test_annotate_load_failure.py tests/unit/cli/test_commands_annotate.py`
- `uv run --no-sync mypy src/lorairo/cli`
- `git diff --check`

## Notes

A real-data CLI smoke against `main_dataset` was attempted from the issue worktree, but this checkout has no untracked `config/lorairo.toml` / `lorairo_data` copy, so the command resolved projects relative to the worktree and returned project-not-found. The behavior is covered by command-level tests that exercise the same CLI boundary and JSONL error contract without touching provider APIs.
