### PR TITLE
fix(cli): batch import 後に rating breakdown を表示 (fixes #691)

### DIFF
--- a/src/lorairo/cli/commands/batch.py
+++ b/src/lorairo/cli/commands/batch.py
@@ -543,7 +543,7 @@ def _get_rating_breakdown(container: Any, job_id: int) -> dict[str, int]:
     if not image_ids:
         return {}
 
-    return container.db_manager.annotation_repo.get_rating_breakdown_for_images(image_ids)
+    return dict(container.db_manager.annotation_repo.get_rating_breakdown_for_images(image_ids))
 
 
 def _print_rating_breakdown(breakdown: dict[str, int], total: int) -> None:

--- a/src/lorairo/cli/commands/batch.py
+++ b/src/lorairo/cli/commands/batch.py
@@ -526,6 +526,43 @@ def fetch(
             _print_artifacts(result)
 
 
+def _get_rating_breakdown(container: Any, job_id: int) -> dict[str, int]:
+    """rating_preflight job の image_id セットに対する normalized_rating 別件数を返す。
+
+    job の items を最大 500 件取得し、task_type が rating_preflight の image_id を抽出する。
+    500 件超の job では最初の 500 件で近似する（CLI 上限 = 500）。
+    """
+    items = container.db_manager.provider_batch_repo.list_provider_batch_items(job_id, limit=500)
+    task_types = {_item_value(item, "task_type") for item in items}
+    if "rating_preflight" not in task_types:
+        return {}
+
+    image_ids = [
+        _item_value(item, "image_id") for item in items if _item_value(item, "image_id") is not None
+    ]
+    if not image_ids:
+        return {}
+
+    return container.db_manager.annotation_repo.get_rating_breakdown_for_images(image_ids)
+
+
+def _print_rating_breakdown(breakdown: dict[str, int], total: int) -> None:
+    table = Table(title="Rating Breakdown")
+    table.add_column("Rating", style="cyan")
+    table.add_column("Count", justify="right", style="green")
+    rating_order = ["PG", "PG-13", "R", "X", "XXX"]
+    shown: set[str] = set()
+    for rating in rating_order:
+        if rating in breakdown:
+            table.add_row(rating, str(breakdown[rating]))
+            shown.add(rating)
+    for rating in sorted(breakdown):
+        if rating not in shown:
+            table.add_row(rating, str(breakdown[rating]))
+    console.print(table)
+    console.print(f"[dim]Ratings saved: {total}[/dim]")
+
+
 @app.command("import")
 def import_results(
     job_id: int = typer.Argument(..., help="Provider Batch job ID"),
@@ -538,6 +575,9 @@ def import_results(
         result = container.provider_batch_workflow_service.import_results(
             job_id, destination_dir=output_dir
         )
+        rating_breakdown = _get_rating_breakdown(container, job_id)
+        ratings_saved = sum(rating_breakdown.values())
+
         if is_json_mode():
             emit_result(
                 f"Provider Batch results imported: {job_id}",
@@ -547,6 +587,8 @@ def import_results(
                 errors=result.error_count,
                 total=result.total_count,
                 job_imported=result.job_imported,
+                ratings_saved=ratings_saved if rating_breakdown else None,
+                rating_breakdown=rating_breakdown if rating_breakdown else None,
             )
         else:
             table = Table(title="Provider Batch Import Summary")
@@ -558,3 +600,5 @@ def import_results(
             table.add_row("Total", str(result.total_count))
             table.add_row("Job Imported", "yes" if result.job_imported else "no")
             console.print(table)
+            if rating_breakdown:
+                _print_rating_breakdown(rating_breakdown, ratings_saved)

--- a/src/lorairo/database/repository/annotation_record.py
+++ b/src/lorairo/database/repository/annotation_record.py
@@ -1091,6 +1091,31 @@ class AnnotationRepository(BaseRepository):
                 )
                 raise
 
+    def get_rating_breakdown_for_images(self, image_ids: list[int]) -> dict[str, int]:
+        """指定画像IDセットの normalized_rating 別件数を返す。
+
+        Args:
+            image_ids: 対象画像IDのリスト。
+
+        Returns:
+            normalized_rating → 件数のdict (例: {"PG": 122, "PG-13": 19})。
+
+        Raises:
+            SQLAlchemyError: データベース操作でエラーが発生した場合。
+
+        """
+        if not image_ids:
+            return {}
+
+        with self.session_factory() as session:
+            stmt = (
+                select(Rating.normalized_rating, func.count(Rating.id))
+                .where(Rating.image_id.in_(image_ids))
+                .group_by(Rating.normalized_rating)
+            )
+            rows = session.execute(stmt).all()
+            return {row[0]: row[1] for row in rows if row[0] is not None}
+
     def update_score_batch(
         self,
         image_ids: list[int],

--- a/tests/unit/cli/test_commands_batch.py
+++ b/tests/unit/cli/test_commands_batch.py
@@ -545,6 +545,104 @@ def test_batch_import_shows_summary(mock_get_container: MagicMock, tmp_path: Pat
 @pytest.mark.unit
 @pytest.mark.cli
 @patch("lorairo.cli.commands.batch.get_service_container")
+def test_batch_import_shows_rating_breakdown_for_rating_preflight(
+    mock_get_container: MagicMock,
+) -> None:
+    """rating_preflight job の import 後に rating breakdown が表示される。"""
+    container = _container()
+    container.provider_batch_workflow_service.import_results.return_value = SimpleNamespace(
+        imported_count=300,
+        skipped_count=0,
+        error_count=0,
+        total_count=300,
+        job_imported=True,
+    )
+    container.db_manager.provider_batch_repo.list_provider_batch_items.return_value = [
+        _batch_item(id=i, image_id=i, task_type="rating_preflight") for i in range(1, 4)
+    ]
+    container.db_manager.annotation_repo.get_rating_breakdown_for_images.return_value = {
+        "PG": 122,
+        "PG-13": 19,
+        "R": 21,
+        "X": 85,
+        "XXX": 53,
+    }
+    mock_get_container.return_value = container
+
+    result = runner.invoke(app, ["batch", "import", "42", "--project", "demo"])
+
+    assert result.exit_code == 0
+    assert "Rating Breakdown" in result.stdout
+    assert "PG" in result.stdout
+    assert "122" in result.stdout
+    assert "Ratings saved: 300" in result.stdout
+    container.db_manager.provider_batch_repo.list_provider_batch_items.assert_called_once_with(
+        42, limit=500
+    )
+    container.db_manager.annotation_repo.get_rating_breakdown_for_images.assert_called_once()
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+@patch("lorairo.cli.commands.batch.get_service_container")
+def test_batch_import_json_includes_ratings_saved(mock_get_container: MagicMock) -> None:
+    """--json モードで ratings_saved と rating_breakdown が含まれる。"""
+    container = _container()
+    container.provider_batch_workflow_service.import_results.return_value = SimpleNamespace(
+        imported_count=5,
+        skipped_count=0,
+        error_count=0,
+        total_count=5,
+        job_imported=True,
+    )
+    container.db_manager.provider_batch_repo.list_provider_batch_items.return_value = [
+        _batch_item(id=1, image_id=1, task_type="rating_preflight"),
+        _batch_item(id=2, image_id=2, task_type="rating_preflight"),
+    ]
+    container.db_manager.annotation_repo.get_rating_breakdown_for_images.return_value = {
+        "PG": 3,
+        "R": 2,
+    }
+    mock_get_container.return_value = container
+
+    result = runner.invoke(app, ["--json", "batch", "import", "42", "--project", "demo"])
+
+    assert result.exit_code == 0
+    rows = [json.loads(line) for line in result.stdout.splitlines() if line.strip()]
+    result_row = next(row for row in rows if row["kind"] == "result")
+    assert result_row["ratings_saved"] == 5
+    assert result_row["rating_breakdown"] == {"PG": 3, "R": 2}
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+@patch("lorairo.cli.commands.batch.get_service_container")
+def test_batch_import_no_rating_breakdown_for_annotation(mock_get_container: MagicMock) -> None:
+    """annotation task_type では rating breakdown が表示されない。"""
+    container = _container()
+    container.provider_batch_workflow_service.import_results.return_value = SimpleNamespace(
+        imported_count=10,
+        skipped_count=0,
+        error_count=0,
+        total_count=10,
+        job_imported=True,
+    )
+    container.db_manager.provider_batch_repo.list_provider_batch_items.return_value = [
+        _batch_item(id=i, image_id=i, task_type="annotation") for i in range(1, 4)
+    ]
+    mock_get_container.return_value = container
+
+    result = runner.invoke(app, ["batch", "import", "42", "--project", "demo"])
+
+    assert result.exit_code == 0
+    assert "Rating Breakdown" not in result.stdout
+    assert "Ratings saved" not in result.stdout
+    container.db_manager.annotation_repo.get_rating_breakdown_for_images.assert_not_called()
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+@patch("lorairo.cli.commands.batch.get_service_container")
 def test_batch_status_with_items_shows_items_table(mock_get_container: MagicMock) -> None:
     """--items で items テーブルが人間向けモードに表示される。"""
     container = _container()


### PR DESCRIPTION
## Summary

- `batch import` 実行後に rating_preflight job の rating 保存件数と PG/PG-13/R/X/XXX 内訳を表示する
- `AnnotationRepository.get_rating_breakdown_for_images()` を追加 (normalized_rating 別 COUNT クエリ)
- annotation task_type では rating breakdown を表示しない
- `--json` モードで `ratings_saved` / `rating_breakdown` フィールドを result 行に追加

## Test plan

- [x] `test_batch_import_shows_rating_breakdown_for_rating_preflight` — rating_preflight で breakdown 表示
- [x] `test_batch_import_json_includes_ratings_saved` — --json で ratings_saved / rating_breakdown 含まれる
- [x] `test_batch_import_no_rating_breakdown_for_annotation` — annotation では表示なし
- [x] 全 25 テスト pass (batch CLI test file)
- [x] mypy — 変更 2 ファイルともエラーなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)