### PR TITLE
fix(cli): batch status で fetch/import 待ち hint を表示

### DIFF
--- a/src/lorairo/cli/commands/batch.py
+++ b/src/lorairo/cli/commands/batch.py
@@ -258,6 +258,37 @@ def _print_job_detail(job: Any) -> None:
     console.print(table)
 
 
+def _print_job_status_hint(job: Any, project: str) -> None:
+    """job ステータスに応じて次のアクション hint を人間向けに表示する。
+
+    Args:
+        job: Provider Batch job オブジェクト。
+        project: プロジェクト名 (next コマンドの hint 表示に使用)。
+    """
+    job_id = _job_value(job, "id")
+    job_status = str(_job_value(job, "status", "") or "").lower()
+    provider_status = str(_job_value(job, "provider_status", "") or "").lower()
+    request_count = _job_value(job, "request_count", 0) or 0
+    succeeded_count = _job_value(job, "succeeded_count", 0) or 0
+    imported_at = _job_value(job, "imported_at")
+
+    # job=completed かつ provider=completed だが未 fetch/import → fetch 待ち
+    if job_status == "completed" and provider_status == "completed" and imported_at is None:
+        console.print(
+            "[yellow]Provider job is completed. LoRAIro items are still running because"
+            " results have not been fetched/imported yet.[/yellow]"
+        )
+        if request_count and succeeded_count == request_count:
+            console.print(f"[green]Next:[/green] lorairo-cli batch fetch {job_id} --project {project}")
+    # fetch 済みだが未 import
+    elif job_status == "fetched" and imported_at is None:
+        console.print("[yellow]Results are fetched. Run import to save annotations.[/yellow]")
+        console.print(f"[green]Next:[/green] lorairo-cli batch import {job_id} --project {project}")
+    # 完全に import 済み
+    elif job_status == "imported":
+        console.print("[green]Job is fully imported.[/green]")
+
+
 def _print_items_table(items: list[Any], job_id: int) -> None:
     table = Table(title=f"Provider Batch Items (job {job_id})")
     table.add_column("ID", style="cyan", no_wrap=True)
@@ -265,7 +296,8 @@ def _print_items_table(items: list[Any], job_id: int) -> None:
     table.add_column("image_id", justify="right")
     table.add_column("model_id", justify="right")
     table.add_column("task_type", style="magenta")
-    table.add_column("status", style="green")
+    # status は LoRAIro 側の取り込み状態（fetch/import 前は running のまま）
+    table.add_column("status (LoRAIro)", style="green")
     table.add_column("error_type", style="red")
 
     for item in items:
@@ -472,6 +504,7 @@ def status(
             )
         else:
             _print_job_detail(job)
+            _print_job_status_hint(job, project)
             if show_items:
                 _print_items_table(fetched_items, job_id)
 

--- a/tests/unit/cli/test_commands_batch.py
+++ b/tests/unit/cli/test_commands_batch.py
@@ -712,3 +712,140 @@ def test_batch_status_has_more_false_when_items_below_limit(mock_get_container: 
     assert result_row["items_has_more"] is False
     assert result_row["items_count"] == 1
     assert result_row["items_limit"] == 10
+
+
+# --- _print_job_status_hint のテスト ---
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+@patch("lorairo.cli.commands.batch.get_service_container")
+def test_batch_status_hint_fetch_waiting_shows_hint_and_next_command(
+    mock_get_container: MagicMock,
+) -> None:
+    """job=completed/provider=completed/items=running の場合、fetch 待ち hint と Next コマンドを表示する。"""
+    container = _container()
+    container.provider_batch_workflow_service.refresh.return_value = _job(
+        status="completed",
+        provider_status="completed",
+        request_count=300,
+        succeeded_count=300,
+        imported_at=None,
+    )
+    mock_get_container.return_value = container
+
+    result = runner.invoke(app, ["batch", "status", "42", "--project", "demo"])
+
+    assert result.exit_code == 0
+    assert "Provider job is completed" in result.stdout
+    assert "results have not been fetched/imported yet" in result.stdout
+    assert "lorairo-cli batch fetch 42 --project demo" in result.stdout
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+@patch("lorairo.cli.commands.batch.get_service_container")
+def test_batch_status_hint_fetch_waiting_no_next_when_counts_mismatch(
+    mock_get_container: MagicMock,
+) -> None:
+    """succeeded_count != request_count の場合、fetch hint は表示されるが Next コマンドは表示しない。"""
+    container = _container()
+    container.provider_batch_workflow_service.refresh.return_value = _job(
+        status="completed",
+        provider_status="completed",
+        request_count=300,
+        succeeded_count=200,  # 一部失敗または処理中
+        imported_at=None,
+    )
+    mock_get_container.return_value = container
+
+    result = runner.invoke(app, ["batch", "status", "42", "--project", "demo"])
+
+    assert result.exit_code == 0
+    assert "Provider job is completed" in result.stdout
+    assert "results have not been fetched/imported yet" in result.stdout
+    # 件数が一致しないため Next コマンドは表示しない
+    assert "lorairo-cli batch fetch" not in result.stdout
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+@patch("lorairo.cli.commands.batch.get_service_container")
+def test_batch_status_hint_fetched_shows_import_hint(mock_get_container: MagicMock) -> None:
+    """job=fetched/imported_at=None の場合、import hint と Next コマンドを表示する。"""
+    container = _container()
+    container.provider_batch_workflow_service.refresh.return_value = _job(
+        status="fetched",
+        provider_status="completed",
+        imported_at=None,
+    )
+    mock_get_container.return_value = container
+
+    result = runner.invoke(app, ["batch", "status", "42", "--project", "demo"])
+
+    assert result.exit_code == 0
+    assert "Results are fetched" in result.stdout
+    assert "lorairo-cli batch import 42 --project demo" in result.stdout
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+@patch("lorairo.cli.commands.batch.get_service_container")
+def test_batch_status_hint_imported_shows_fully_imported(mock_get_container: MagicMock) -> None:
+    """job=imported の場合、"fully imported" を表示する。"""
+    container = _container()
+    container.provider_batch_workflow_service.refresh.return_value = _job(
+        status="imported",
+        provider_status="completed",
+        imported_at=datetime(2026, 1, 2, tzinfo=UTC),
+    )
+    mock_get_container.return_value = container
+
+    result = runner.invoke(app, ["batch", "status", "42", "--project", "demo"])
+
+    assert result.exit_code == 0
+    assert "fully imported" in result.stdout
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+@patch("lorairo.cli.commands.batch.get_service_container")
+def test_batch_status_hint_no_hint_in_json_mode(mock_get_container: MagicMock) -> None:
+    """--json モードでは hint を表示しない（JSON 出力に含まない）。"""
+    container = _container()
+    container.provider_batch_workflow_service.refresh.return_value = _job(
+        status="completed",
+        provider_status="completed",
+        request_count=300,
+        succeeded_count=300,
+        imported_at=None,
+    )
+    mock_get_container.return_value = container
+
+    result = runner.invoke(app, ["--json", "batch", "status", "42", "--project", "demo"])
+
+    assert result.exit_code == 0
+    rows = [json.loads(line) for line in result.stdout.splitlines() if line.strip()]
+    # JSON 出力は result 行のみ (hint テキストは含まない)
+    assert all(row["kind"] in {"item", "result"} for row in rows)
+    assert "Provider job is completed" not in result.stdout
+    assert "lorairo-cli batch fetch" not in result.stdout
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+@patch("lorairo.cli.commands.batch.get_service_container")
+def test_batch_status_items_table_header_shows_lorairo_status(mock_get_container: MagicMock) -> None:
+    """--items の items テーブルに LoRAIro 側ステータスであることを示すヘッダーが表示される。"""
+    container = _container()
+    container.provider_batch_workflow_service.refresh.return_value = _job()
+    container.db_manager.provider_batch_repo.list_provider_batch_items.return_value = [
+        _batch_item(id=1, status="running"),
+    ]
+    mock_get_container.return_value = container
+
+    result = runner.invoke(app, ["batch", "status", "42", "--project", "demo", "--items"])
+
+    assert result.exit_code == 0
+    # LoRAIro 側ステータスであることをヘッダーで示す
+    assert "LoRAIro" in result.stdout


### PR DESCRIPTION
## Summary

- `batch status` コマンドの人間向け出力に `_print_job_status_hint()` を追加
- job/provider ステータスの組み合わせに応じて次アクションを hint 表示:
  - `completed` + provider `completed` + 未 fetch/import → fetch 待ち警告 + `batch fetch <id>` コマンド提示
  - `fetched` + 未 import → import 待ち警告 + `batch import <id>` コマンド提示
  - `imported` → "fully imported" 完了メッセージ
- `--items` テーブルの status 列ヘッダーを `status (LoRAIro)` に変更し、fetch/import 前は `running` のままであることを明示
- `--json` モードでは hint を出力しない (ADR 0057/0058 準拠、JSON 出力は変更なし)

fixes #690

## Test plan

- [ ] `test_batch_status_hint_fetch_waiting_shows_hint_and_next_command` — fetch 待ち + Next コマンド表示
- [ ] `test_batch_status_hint_fetch_waiting_no_next_when_counts_mismatch` — 件数不一致時は Next コマンドを表示しない
- [ ] `test_batch_status_hint_fetched_shows_import_hint` — import 待ち表示
- [ ] `test_batch_status_hint_imported_shows_fully_imported` — 完了メッセージ
- [ ] `test_batch_status_hint_no_hint_in_json_mode` — JSON モードでは hint なし
- [ ] `test_batch_status_items_table_header_shows_lorairo_status` — LoRAIro ステータスのヘッダー確認
- [ ] 既存 22 テストが全て通ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)