### PR TITLE
feat(cli): tags add/remove/replace コマンドを追加 (fixes #695)

### DIFF
--- a/src/lorairo/cli/commands/tags.py
+++ b/src/lorairo/cli/commands/tags.py
@@ -19,7 +19,7 @@ from lorairo.cli._emit import emit_item, emit_result
 from lorairo.cli._glyphs import OK
 from lorairo.cli._output_mode import is_json_mode
 from lorairo.database.filter_criteria import ImageFilterCriteria
-from lorairo.services.service_container import get_service_container
+from lorairo.services.service_container import ServiceContainer, get_service_container
 
 app = typer.Typer(help="Tag editing commands (agent-friendly)")
 console = make_console()
@@ -45,7 +45,7 @@ def _parse_image_ids(image_ids_csv: str) -> list[int]:
         raise click.UsageError(f"--image-ids には整数のみ指定可: {e}") from e
 
 
-def _validate_image_ids_exist(container, image_ids: list[int]) -> None:
+def _validate_image_ids_exist(container: ServiceContainer, image_ids: list[int]) -> None:
     """全 image_id が DB に存在するか確認。存在しなければ ImageNotFoundError。
 
     Args:

--- a/src/lorairo/cli/commands/tags.py
+++ b/src/lorairo/cli/commands/tags.py
@@ -1,0 +1,282 @@
+"""Tag editing commands.
+
+カンマ区切り image_ids に対してタグを追加・削除・置換するコマンド群。
+エージェントが判断した操作を安全に実行するための CLI インターフェース。
+
+デフォルトは dry-run (DB 非更新)。--apply を付けた場合のみ書き込む。
+"""
+
+from __future__ import annotations
+
+import click
+import typer
+
+from lorairo.api.exceptions import ImageNotFoundError
+from lorairo.api.project import get_project as api_get_project
+from lorairo.cli._boundary import command_boundary
+from lorairo.cli._console import make_console
+from lorairo.cli._emit import emit_item, emit_result
+from lorairo.cli._glyphs import OK
+from lorairo.cli._output_mode import is_json_mode
+from lorairo.database.filter_criteria import ImageFilterCriteria
+from lorairo.services.service_container import get_service_container
+
+app = typer.Typer(help="Tag editing commands (agent-friendly)")
+console = make_console()
+
+MAX_IMAGE_IDS = 500
+
+
+def _parse_image_ids(image_ids_csv: str) -> list[int]:
+    """カンマ区切り文字列を int リストに変換。不正値は UsageError。
+
+    Args:
+        image_ids_csv: カンマ区切りの画像 ID 文字列。
+
+    Returns:
+        画像 ID の整数リスト。
+
+    Raises:
+        click.UsageError: 整数に変換できない値が含まれていた場合。
+    """
+    try:
+        return [int(x.strip()) for x in image_ids_csv.split(",") if x.strip()]
+    except ValueError as e:
+        raise click.UsageError(f"--image-ids には整数のみ指定可: {e}") from e
+
+
+def _validate_image_ids_exist(container, image_ids: list[int]) -> None:
+    """全 image_id が DB に存在するか確認。存在しなければ ImageNotFoundError。
+
+    Args:
+        container: サービスコンテナ。
+        image_ids: 存在確認する画像 ID のリスト。
+
+    Raises:
+        ImageNotFoundError: リスト内に存在しない画像 ID があった場合。
+    """
+    criteria = ImageFilterCriteria(image_ids=image_ids, include_nsfw=True)
+    records, _ = container.db_manager.image_repo.get_images_by_filter(criteria)
+    found_ids = {int(r["id"]) for r in records}
+    missing = [i for i in image_ids if i not in found_ids]
+    if missing:
+        raise ImageNotFoundError(missing[0])
+
+
+@app.command("add")
+def add(
+    project: str = typer.Option(..., "--project", "-p", help="Project name"),
+    image_ids_csv: str = typer.Option(..., "--image-ids", help="Comma-separated image IDs"),
+    tags_csv: str = typer.Option(..., "--tags", help="Comma-separated tags to add"),
+    apply: bool = typer.Option(False, "--apply", help="Write to DB (default: dry-run)"),
+) -> None:
+    """Add tags to images.
+
+    指定した image_ids に対してタグを追加します。
+    デフォルトは dry-run です。--apply を付けると DB に書き込みます。
+
+    Example:
+        lorairo-cli tags add --project proj --image-ids 1,2,3 --tags "cat,dog" --apply
+    """
+    with command_boundary():
+        api_get_project(project)
+        image_ids = _parse_image_ids(image_ids_csv)
+        if not image_ids:
+            raise click.UsageError("--image-ids に有効な値がありません。")
+        if len(image_ids) > MAX_IMAGE_IDS:
+            raise click.UsageError(f"--image-ids は最大 {MAX_IMAGE_IDS} 件まで。")
+
+        tag_list = [t.strip() for t in tags_csv.split(",") if t.strip()]
+        if not tag_list:
+            raise click.UsageError("--tags に有効な値がありません。")
+
+        container = get_service_container()
+        container.set_active_project(project)
+        _validate_image_ids_exist(container, image_ids)
+
+        dry_run = not apply
+        total_added = 0
+
+        if not dry_run:
+            for tag in tag_list:
+                _, added = container.db_manager.annotation_repo.add_tag_to_images_batch(
+                    image_ids, tag, None
+                )
+                total_added += added
+
+        if is_json_mode():
+            for image_id in image_ids:
+                emit_item(
+                    {
+                        "image_id": image_id,
+                        "action": "add",
+                        "tags": tag_list,
+                        "status": "dry_run" if dry_run else "changed",
+                    }
+                )
+            emit_result(
+                f"{'[dry-run] ' if dry_run else ''}Added tags to {len(image_ids)} image(s)",
+                target_images=len(image_ids),
+                tags=tag_list,
+                added=total_added,
+                dry_run=dry_run,
+            )
+        else:
+            prefix = "[dry-run] " if dry_run else ""
+            console.print(
+                f"{prefix}{OK} {len(image_ids)} 件の画像に {tag_list} を追加{'予定' if dry_run else '完了'}"
+            )
+
+
+@app.command("remove")
+def remove(
+    project: str = typer.Option(..., "--project", "-p", help="Project name"),
+    image_ids_csv: str = typer.Option(..., "--image-ids", help="Comma-separated image IDs"),
+    tags_csv: str = typer.Option(..., "--tags", help="Comma-separated tags to remove"),
+    apply: bool = typer.Option(False, "--apply", help="Write to DB (default: dry-run)"),
+) -> None:
+    """Remove tags from images.
+
+    指定した image_ids からタグを削除します。
+    対象タグが存在しない画像はスキップします（エラーにしません）。
+    デフォルトは dry-run です。--apply を付けると DB に書き込みます。
+
+    Example:
+        lorairo-cli tags remove --project proj --image-ids 1,2,3 --tags "bad_tag" --apply
+    """
+    with command_boundary():
+        api_get_project(project)
+        image_ids = _parse_image_ids(image_ids_csv)
+        if not image_ids:
+            raise click.UsageError("--image-ids に有効な値がありません。")
+        if len(image_ids) > MAX_IMAGE_IDS:
+            raise click.UsageError(f"--image-ids は最大 {MAX_IMAGE_IDS} 件まで。")
+
+        tag_list = [t.strip() for t in tags_csv.split(",") if t.strip()]
+        if not tag_list:
+            raise click.UsageError("--tags に有効な値がありません。")
+
+        container = get_service_container()
+        container.set_active_project(project)
+        _validate_image_ids_exist(container, image_ids)
+
+        dry_run = not apply
+        per_item_results: list[tuple[int, str]] = []
+        total_removed = 0
+
+        if not dry_run:
+            for tag in tag_list:
+                _, item_results = container.db_manager.annotation_repo.remove_tag_from_images_batch(
+                    image_ids, tag
+                )
+                per_item_results = item_results
+                total_removed += sum(1 for _, s in item_results if s == "changed")
+
+        if is_json_mode():
+            for image_id in image_ids:
+                status = (
+                    "dry_run"
+                    if dry_run
+                    else next((s for iid, s in per_item_results if iid == image_id), "unknown")
+                )
+                emit_item(
+                    {
+                        "image_id": image_id,
+                        "action": "remove",
+                        "tags": tag_list,
+                        "status": status,
+                    }
+                )
+            emit_result(
+                f"{'[dry-run] ' if dry_run else ''}Removed tags from {len(image_ids)} image(s)",
+                target_images=len(image_ids),
+                tags=tag_list,
+                removed=total_removed,
+                dry_run=dry_run,
+            )
+        else:
+            prefix = "[dry-run] " if dry_run else ""
+            console.print(
+                f"{prefix}{OK} {len(image_ids)} 件の画像から {tag_list} を削除"
+                f"{'予定' if dry_run else '完了'}"
+            )
+
+
+@app.command("replace")
+def replace(
+    project: str = typer.Option(..., "--project", "-p", help="Project name"),
+    image_ids_csv: str = typer.Option(..., "--image-ids", help="Comma-separated image IDs"),
+    from_tag: str = typer.Option(..., "--from", help="Tag to replace (変換元)"),
+    to_tag: str = typer.Option(..., "--to", help="Replacement tag (変換先)"),
+    apply: bool = typer.Option(False, "--apply", help="Write to DB (default: dry-run)"),
+) -> None:
+    """Replace a tag with another tag across images.
+
+    指定した image_ids の変換元タグを変換先タグに置換します。
+
+    - 変換元タグが存在しない画像はスキップします。
+    - 変換先タグが既に存在する場合は変換元のみ削除します（重複しません）。
+
+    デフォルトは dry-run です。--apply を付けると DB に書き込みます。
+
+    Example:
+        lorairo-cli tags replace --project proj --image-ids 1,2,3 --from "bad tag" --to "good_tag" --apply
+    """
+    with command_boundary():
+        api_get_project(project)
+        image_ids = _parse_image_ids(image_ids_csv)
+        if not image_ids:
+            raise click.UsageError("--image-ids に有効な値がありません。")
+        if len(image_ids) > MAX_IMAGE_IDS:
+            raise click.UsageError(f"--image-ids は最大 {MAX_IMAGE_IDS} 件まで。")
+        if not from_tag.strip():
+            raise click.UsageError("--from に有効な値がありません。")
+        if not to_tag.strip():
+            raise click.UsageError("--to に有効な値がありません。")
+
+        container = get_service_container()
+        container.set_active_project(project)
+        _validate_image_ids_exist(container, image_ids)
+
+        dry_run = not apply
+        per_item_results: list[tuple[int, str]] = []
+
+        if not dry_run:
+            _, per_item_results = container.db_manager.annotation_repo.replace_tag_for_images_batch(
+                image_ids, from_tag, to_tag
+            )
+
+        changed = sum(1 for _, s in per_item_results if s == "changed")
+        skipped = sum(1 for _, s in per_item_results if s == "skipped")
+
+        if is_json_mode():
+            for image_id in image_ids:
+                status = (
+                    "dry_run"
+                    if dry_run
+                    else next((s for iid, s in per_item_results if iid == image_id), "unknown")
+                )
+                item: dict[str, object] = {
+                    "image_id": image_id,
+                    "action": "replace",
+                    "from": from_tag.strip().lower(),
+                    "to": to_tag.strip().lower(),
+                    "status": status,
+                }
+                if status == "skipped":
+                    item["reason"] = "from_tag_not_found"
+                emit_item(item)
+            emit_result(
+                f"{'[dry-run] ' if dry_run else ''}Replaced tags in {len(image_ids)} image(s)",
+                target_images=len(image_ids),
+                changed=changed,
+                skipped=skipped,
+                errors=0,
+                dry_run=dry_run,
+            )
+        else:
+            prefix = "[dry-run] " if dry_run else ""
+            console.print(
+                f"{prefix}{OK} {len(image_ids)} 件対象: '{from_tag}' -> '{to_tag}' "
+                f"({'予定' if dry_run else f'変更={changed}, スキップ={skipped}'})"
+            )

--- a/src/lorairo/cli/main.py
+++ b/src/lorairo/cli/main.py
@@ -34,7 +34,7 @@ from lorairo.cli._output_mode import (
     set_json_mode,
     strip_mode_flags,
 )
-from lorairo.cli.commands import annotate, batch, export, images, models, project
+from lorairo.cli.commands import annotate, batch, export, images, models, project, tags
 from lorairo.cli.introspection import emit_describe, emit_list_commands
 from lorairo.services.service_container import get_service_container
 from lorairo.utils.config import DEFAULT_CLI_LOG_PATH, DEFAULT_CONFIG_PATH
@@ -89,6 +89,7 @@ app.add_typer(annotate.app, name="annotate", help="Annotation commands")
 app.add_typer(export.app, name="export", help="Dataset export commands")
 app.add_typer(models.app, name="models", help="Model registry commands")
 app.add_typer(batch.app, name="batch", help="Provider Batch API job commands")
+app.add_typer(tags.app, name="tags", help="Tag editing commands (agent-friendly)")
 
 
 @app.callback()

--- a/src/lorairo/database/repository/annotation_record.py
+++ b/src/lorairo/database/repository/annotation_record.py
@@ -401,6 +401,71 @@ class AnnotationRepository(BaseRepository):
                 logger.error(f"Atomic batch tag add failed, rolled back: {e}", exc_info=True)
                 raise
 
+    def remove_tag_from_images_batch(
+        self,
+        image_ids: list[int],
+        tag: str,
+    ) -> tuple[bool, list[tuple[int, str]]]:
+        """複数画像から1つのタグを原子的に削除する。
+
+        単一トランザクションで全画像を処理。全件成功 or 全件ロールバック。
+
+        Args:
+            image_ids: 対象画像のIDリスト
+            tag: 削除するタグ
+
+        Returns:
+            (成功フラグ, [(image_id, "changed"|"skipped"), ...])
+
+        Raises:
+            SQLAlchemyError: データベースエラー時(ロールバック後に再送出)
+
+        """
+        if not image_ids:
+            logger.warning("Empty image_ids list for batch tag remove")
+            return (False, [])
+
+        if not tag.strip():
+            logger.warning("Empty tag for batch remove")
+            return (False, [])
+
+        normalized_tag = tag.strip().lower()
+        per_item: list[tuple[int, str]] = []
+
+        with self.session_factory() as session:
+            try:
+                existing_tags_by_image = self._build_existing_tags_map(session, image_ids)
+
+                for image_id in image_ids:
+                    existing_tags = existing_tags_by_image.get(image_id, set())
+                    if normalized_tag not in existing_tags:
+                        logger.debug(
+                            f"Tag '{normalized_tag}' not found for image_id {image_id}, skipping",
+                        )
+                        per_item.append((image_id, "skipped"))
+                        continue
+
+                    session.execute(
+                        delete(Tag).where(
+                            Tag.image_id == image_id,
+                            Tag.tag == normalized_tag,
+                        )
+                    )
+                    per_item.append((image_id, "changed"))
+
+                session.commit()
+                changed = sum(1 for _, s in per_item if s == "changed")
+                logger.info(
+                    f"Atomic batch tag remove completed: tag='{normalized_tag}', "
+                    f"processed={len(image_ids)}, removed={changed}",
+                )
+                return (True, per_item)
+
+            except SQLAlchemyError as e:
+                session.rollback()
+                logger.error(f"Atomic batch tag remove failed, rolled back: {e}", exc_info=True)
+                raise
+
     # --- External tag_db: resolve / register ---
 
     def _get_or_create_tag_id_external(self, session: Session, tag_string: str) -> int | None:

--- a/src/lorairo/database/repository/annotation_record.py
+++ b/src/lorairo/database/repository/annotation_record.py
@@ -471,6 +471,97 @@ class AnnotationRepository(BaseRepository):
                 logger.error(f"Atomic batch tag remove failed, rolled back: {e}", exc_info=True)
                 raise
 
+    def replace_tag_for_images_batch(
+        self,
+        image_ids: list[int],
+        from_tag: str,
+        to_tag: str,
+    ) -> tuple[bool, list[tuple[int, str]]]:
+        """複数画像のタグを原子的に置換する。
+
+        変換元タグが存在する画像のみ処理。変換先タグが既に存在する場合は
+        変換元を削除のみ行い（重複させない）、ステータスは changed 扱い。
+
+        Args:
+            image_ids: 対象画像のIDリスト
+            from_tag: 置換元タグ
+            to_tag: 置換先タグ
+
+        Returns:
+            (成功フラグ, [(image_id, "changed"|"skipped"), ...])
+            per-item リストにより呼び出し元が再クエリ不要で結果を判別できる。
+
+        Raises:
+            SQLAlchemyError: データベースエラー時(ロールバック後に再送出)
+
+        """
+        if not image_ids:
+            logger.warning("Empty image_ids list for batch tag replace")
+            return (False, [])
+
+        if not from_tag.strip() or not to_tag.strip():
+            logger.warning("Empty from_tag or to_tag for batch replace")
+            return (False, [])
+
+        normalized_from = from_tag.strip().lower()
+        normalized_to = to_tag.strip().lower()
+        per_item: list[tuple[int, str]] = []
+
+        with self.session_factory() as session:
+            try:
+                existing_tags_by_image = self._build_existing_tags_map(session, image_ids)
+
+                # per-item 分類
+                for image_id in image_ids:
+                    existing_tags = existing_tags_by_image.get(image_id, set())
+                    if normalized_from not in existing_tags:
+                        per_item.append((image_id, "skipped"))
+                    else:
+                        per_item.append((image_id, "changed"))
+
+                # bulk DELETE: 変換元タグを持つ画像から一括削除
+                images_to_change = [iid for iid, s in per_item if s == "changed"]
+                if images_to_change:
+                    session.execute(
+                        delete(Tag).where(
+                            Tag.image_id.in_(images_to_change),
+                            Tag.tag == normalized_from,
+                        )
+                    )
+
+                    # 変換先タグを追加（各画像で既存チェックして重複回避）
+                    to_tag_external_id: int | None = None
+                    for image_id in images_to_change:
+                        existing_tags = existing_tags_by_image.get(image_id, set())
+                        if normalized_to not in existing_tags:
+                            if to_tag_external_id is None:
+                                to_tag_external_id = self._get_or_create_tag_id_external(
+                                    session, normalized_to
+                                )
+                            new_tag = Tag(
+                                image_id=image_id,
+                                model_id=None,
+                                tag=normalized_to,
+                                tag_id=to_tag_external_id,
+                                confidence_score=None,
+                                existing=False,
+                                is_edited_manually=True,
+                            )
+                            session.add(new_tag)
+
+                session.commit()
+                changed = len(images_to_change)
+                logger.info(
+                    f"Atomic batch tag replace completed: '{normalized_from}' -> '{normalized_to}', "
+                    f"processed={len(image_ids)}, changed={changed}",
+                )
+                return (True, per_item)
+
+            except SQLAlchemyError as e:
+                session.rollback()
+                logger.error(f"Atomic batch tag replace failed, rolled back: {e}", exc_info=True)
+                raise
+
     # --- External tag_db: resolve / register ---
 
     def _get_or_create_tag_id_external(self, session: Session, tag_string: str) -> int | None:

--- a/src/lorairo/database/repository/annotation_record.py
+++ b/src/lorairo/database/repository/annotation_record.py
@@ -101,6 +101,7 @@ class AnnotationRepository(BaseRepository):
         Note:
             外部 tag_db (`MergedTagReader` / `TagRegisterService`) は初期化失敗時に
             `None` に縮退する。LoRAIro は外部 tag_db 無しでも動作可能。
+
         """
         if session_factory is None:
             super().__init__()
@@ -262,7 +263,7 @@ class AnnotationRepository(BaseRepository):
                     saved_count += len(chunk)
                     logger.debug(
                         f"アノテーションをバッチ保存しました: "
-                        f"chunk={start // effective_chunk_size + 1}, saved={len(chunk)}"
+                        f"chunk={start // effective_chunk_size + 1}, saved={len(chunk)}",
                     )
                 except Exception as e:
                     session.rollback()
@@ -436,6 +437,7 @@ class AnnotationRepository(BaseRepository):
             try:
                 existing_tags_by_image = self._build_existing_tags_map(session, image_ids)
 
+                # per_item リストを先に構築
                 for image_id in image_ids:
                     existing_tags = existing_tags_by_image.get(image_id, set())
                     if normalized_tag not in existing_tags:
@@ -443,15 +445,18 @@ class AnnotationRepository(BaseRepository):
                             f"Tag '{normalized_tag}' not found for image_id {image_id}, skipping",
                         )
                         per_item.append((image_id, "skipped"))
-                        continue
+                    else:
+                        per_item.append((image_id, "changed"))
 
+                # bulk DELETE (1回のみ)
+                images_to_delete = [iid for iid, s in per_item if s == "changed"]
+                if images_to_delete:
                     session.execute(
                         delete(Tag).where(
-                            Tag.image_id == image_id,
+                            Tag.image_id.in_(images_to_delete),
                             Tag.tag == normalized_tag,
                         )
                     )
-                    per_item.append((image_id, "changed"))
 
                 session.commit()
                 changed = sum(1 for _, s in per_item if s == "changed")
@@ -885,7 +890,7 @@ class AnnotationRepository(BaseRepository):
         image_id: int,
         score_labels_data: list[ScoreLabelAnnotationData],
     ) -> None:
-        """canonical scorer の score_label を保存・更新 (Upsert by model_id).
+        """Canonical scorer の score_label を保存・更新 (Upsert by model_id).
 
         ADR 0027 / iam-lib ADR 0002: aesthetic_shadow / cafe_aesthetic 等の
         canonical scorer は ``(image, model)`` 単位で単一 label を返す契約のため、
@@ -998,7 +1003,7 @@ class AnnotationRepository(BaseRepository):
                     delete(Rating).where(
                         Rating.image_id == image_id,
                         Rating.model_id == manual_edit_model_id,
-                    )
+                    ),
                 )
                 if rating is not None:
                     session.add(
@@ -1008,7 +1013,7 @@ class AnnotationRepository(BaseRepository):
                             raw_rating_value=rating,
                             normalized_rating=rating,
                             confidence_score=None,
-                        )
+                        ),
                     )
 
                 session.commit()
@@ -1096,6 +1101,7 @@ class AnnotationRepository(BaseRepository):
 
         Raises:
             SQLAlchemyError: データベースエラー時（ロールバック後に再送出）
+
         """
         if not image_ids:
             logger.warning("Empty image_ids list for batch rating update")
@@ -1201,6 +1207,7 @@ class AnnotationRepository(BaseRepository):
 
         Raises:
             SQLAlchemyError: データベースエラー時（ロールバック後に再送出）
+
         """
         if not image_ids:
             logger.warning("Empty image_ids list for batch score update")

--- a/tests/unit/cli/test_commands_tags.py
+++ b/tests/unit/cli/test_commands_tags.py
@@ -1,0 +1,165 @@
+"""tags コマンド群のユニットテスト。"""
+
+import json
+from unittest.mock import MagicMock
+
+import pytest
+from typer.testing import CliRunner
+
+from lorairo.cli.main import app
+
+runner = CliRunner()
+
+
+def _make_container(*, image_exists: bool = True) -> MagicMock:
+    container = MagicMock()
+    mock_records = [{"id": 1}, {"id": 2}] if image_exists else []
+    container.db_manager.image_repo.get_images_by_filter.return_value = (mock_records, len(mock_records))
+    container.db_manager.annotation_repo.add_tag_to_images_batch.return_value = (True, 2)
+    container.db_manager.annotation_repo.remove_tag_from_images_batch.return_value = (
+        True,
+        [(1, "changed"), (2, "changed")],
+    )
+    container.db_manager.annotation_repo.replace_tag_for_images_batch.return_value = (
+        True,
+        [(1, "changed"), (2, "skipped")],
+    )
+    return container
+
+
+@pytest.fixture
+def mock_project_and_container(monkeypatch):
+    container = _make_container()
+    monkeypatch.setattr("lorairo.cli.commands.tags.api_get_project", MagicMock(return_value=MagicMock()))
+    monkeypatch.setattr(
+        "lorairo.cli.commands.tags.get_service_container", MagicMock(return_value=container)
+    )
+    return container
+
+
+@pytest.mark.unit
+class TestTagsAdd:
+    def test_add_dry_run_default_does_not_write(self, mock_project_and_container):
+        result = runner.invoke(
+            app,
+            ["tags", "add", "--project", "proj", "--image-ids", "1,2", "--tags", "cat"],
+        )
+        assert result.exit_code == 0
+        mock_project_and_container.db_manager.annotation_repo.add_tag_to_images_batch.assert_not_called()
+
+    def test_add_apply_writes_to_db(self, mock_project_and_container):
+        result = runner.invoke(
+            app,
+            ["tags", "add", "--project", "proj", "--image-ids", "1,2", "--tags", "cat", "--apply"],
+        )
+        assert result.exit_code == 0
+        mock_project_and_container.db_manager.annotation_repo.add_tag_to_images_batch.assert_called()
+
+    def test_add_json_output_has_result_row(self, mock_project_and_container):
+        result = runner.invoke(
+            app,
+            [
+                "--json",
+                "tags",
+                "add",
+                "--project",
+                "proj",
+                "--image-ids",
+                "1,2",
+                "--tags",
+                "cat",
+                "--apply",
+            ],
+        )
+        assert result.exit_code == 0
+        lines = [json.loads(line) for line in result.stdout.strip().splitlines() if line.strip()]
+        result_row = next(r for r in lines if r.get("kind") == "result")
+        assert result_row["ok"] is True
+        assert result_row["dry_run"] is False
+
+
+@pytest.mark.unit
+class TestTagsRemove:
+    def test_remove_dry_run_does_not_write(self, mock_project_and_container):
+        result = runner.invoke(
+            app,
+            ["tags", "remove", "--project", "proj", "--image-ids", "1,2", "--tags", "bad_tag"],
+        )
+        assert result.exit_code == 0
+        mock_project_and_container.db_manager.annotation_repo.remove_tag_from_images_batch.assert_not_called()
+
+    def test_remove_apply_writes(self, mock_project_and_container):
+        result = runner.invoke(
+            app,
+            ["tags", "remove", "--project", "proj", "--image-ids", "1,2", "--tags", "bad_tag", "--apply"],
+        )
+        assert result.exit_code == 0
+        mock_project_and_container.db_manager.annotation_repo.remove_tag_from_images_batch.assert_called()
+
+
+@pytest.mark.unit
+class TestTagsReplace:
+    def test_replace_dry_run_does_not_write(self, mock_project_and_container):
+        result = runner.invoke(
+            app,
+            [
+                "tags",
+                "replace",
+                "--project",
+                "proj",
+                "--image-ids",
+                "1,2",
+                "--from",
+                "bad",
+                "--to",
+                "good",
+            ],
+        )
+        assert result.exit_code == 0
+        mock_project_and_container.db_manager.annotation_repo.replace_tag_for_images_batch.assert_not_called()
+
+    def test_replace_apply_writes(self, mock_project_and_container):
+        result = runner.invoke(
+            app,
+            [
+                "tags",
+                "replace",
+                "--project",
+                "proj",
+                "--image-ids",
+                "1,2",
+                "--from",
+                "bad",
+                "--to",
+                "good",
+                "--apply",
+            ],
+        )
+        assert result.exit_code == 0
+        mock_project_and_container.db_manager.annotation_repo.replace_tag_for_images_batch.assert_called()
+
+    def test_replace_json_item_rows(self, mock_project_and_container):
+        result = runner.invoke(
+            app,
+            [
+                "--json",
+                "tags",
+                "replace",
+                "--project",
+                "proj",
+                "--image-ids",
+                "1,2",
+                "--from",
+                "bad",
+                "--to",
+                "good",
+                "--apply",
+            ],
+        )
+        assert result.exit_code == 0
+        lines = [json.loads(line) for line in result.stdout.strip().splitlines() if line.strip()]
+        items = [r for r in lines if r.get("kind") == "item"]
+        result_row = next(r for r in lines if r.get("kind") == "result")
+        assert len(items) == 2
+        assert result_row["ok"] is True
+        assert result_row["dry_run"] is False

--- a/tests/unit/database/repository/test_tags_batch_ops.py
+++ b/tests/unit/database/repository/test_tags_batch_ops.py
@@ -61,3 +61,60 @@ class TestRemoveTagFromImagesBatch:
         with pytest.raises(SQLAlchemyError):
             repo.remove_tag_from_images_batch([123], "bad_tag")
         mock_session.rollback.assert_called_once()
+
+
+@pytest.mark.unit
+class TestReplaceTagForImagesBatch:
+    def test_replaces_tag_changed(self, repo, mock_session):
+        """変換元あり・変換先なし → changed。"""
+        repo._build_existing_tags_map = MagicMock(return_value={123: {"bad_tag"}})
+        repo._get_or_create_tag_id_external = MagicMock(return_value=42)
+        mock_session.execute = MagicMock(return_value=MagicMock())
+        mock_session.add = MagicMock()
+
+        ok, results = repo.replace_tag_for_images_batch([123], "bad_tag", "good_tag")
+
+        assert ok is True
+        assert results == [(123, "changed")]
+        mock_session.commit.assert_called_once()
+
+    def test_replaces_tag_to_already_exists(self, repo, mock_session):
+        """変換元あり・変換先あり → 変換元削除のみ、changed。"""
+        repo._build_existing_tags_map = MagicMock(return_value={123: {"bad_tag", "good_tag"}})
+        repo._get_or_create_tag_id_external = MagicMock(return_value=42)
+        mock_session.execute = MagicMock(return_value=MagicMock())
+
+        ok, results = repo.replace_tag_for_images_batch([123], "bad_tag", "good_tag")
+
+        assert ok is True
+        assert results == [(123, "changed")]
+
+    def test_skips_when_from_tag_not_found(self, repo, mock_session):
+        """変換元なし → skipped。"""
+        repo._build_existing_tags_map = MagicMock(return_value={123: {"other_tag"}})
+
+        ok, results = repo.replace_tag_for_images_batch([123], "bad_tag", "good_tag")
+
+        assert ok is True
+        assert results == [(123, "skipped")]
+
+    def test_empty_image_ids_returns_false(self, repo, mock_session):
+        """空の image_ids → (False, [])。"""
+        ok, results = repo.replace_tag_for_images_batch([], "bad_tag", "good_tag")
+        assert ok is False
+        assert results == []
+
+    def test_empty_from_tag_returns_false(self, repo, mock_session):
+        """空の from_tag → (False, [])。"""
+        ok, results = repo.replace_tag_for_images_batch([123], "", "good_tag")
+        assert ok is False
+        assert results == []
+
+    def test_db_error_rolls_back_and_reraises(self, repo, mock_session):
+        """DB エラー時にロールバックして再送出。"""
+        from sqlalchemy.exc import SQLAlchemyError
+
+        repo._build_existing_tags_map = MagicMock(side_effect=SQLAlchemyError("db error"))
+        with pytest.raises(SQLAlchemyError):
+            repo.replace_tag_for_images_batch([123], "bad_tag", "good_tag")
+        mock_session.rollback.assert_called_once()

--- a/tests/unit/database/repository/test_tags_batch_ops.py
+++ b/tests/unit/database/repository/test_tags_batch_ops.py
@@ -1,0 +1,55 @@
+"""AnnotationRepository タグ削除・置換バッチ操作のユニットテスト。"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from lorairo.database.repository.annotation_record import AnnotationRepository
+
+
+@pytest.fixture
+def mock_session():
+    session = MagicMock()
+    session.__enter__ = MagicMock(return_value=session)
+    session.__exit__ = MagicMock(return_value=False)
+    return session
+
+
+@pytest.fixture
+def repo(mock_session):
+    repo = AnnotationRepository.__new__(AnnotationRepository)
+    repo.session_factory = MagicMock(return_value=mock_session)
+    return repo
+
+
+@pytest.mark.unit
+class TestRemoveTagFromImagesBatch:
+    def test_removes_existing_tag_returns_per_item_results(self, repo, mock_session):
+        repo._build_existing_tags_map = MagicMock(return_value={123: {"bad_tag"}, 456: {"bad_tag"}})
+        mock_session.execute = MagicMock(return_value=MagicMock())
+
+        ok, results = repo.remove_tag_from_images_batch([123, 456], "bad_tag")
+
+        assert ok is True
+        assert results == [(123, "changed"), (456, "changed")]
+        mock_session.commit.assert_called_once()
+
+    def test_skips_images_without_tag(self, repo, mock_session):
+        repo._build_existing_tags_map = MagicMock(return_value={123: {"other_tag"}, 456: {"bad_tag"}})
+        mock_session.execute = MagicMock(return_value=MagicMock())
+
+        ok, results = repo.remove_tag_from_images_batch([123, 456], "bad_tag")
+
+        assert ok is True
+        assert (123, "skipped") in results
+        assert (456, "changed") in results
+
+    def test_empty_image_ids_returns_false(self, repo, mock_session):
+        ok, results = repo.remove_tag_from_images_batch([], "bad_tag")
+        assert ok is False
+        assert results == []
+
+    def test_empty_tag_returns_false(self, repo, mock_session):
+        ok, results = repo.remove_tag_from_images_batch([123], "")
+        assert ok is False
+        assert results == []

--- a/tests/unit/database/repository/test_tags_batch_ops.py
+++ b/tests/unit/database/repository/test_tags_batch_ops.py
@@ -53,3 +53,11 @@ class TestRemoveTagFromImagesBatch:
         ok, results = repo.remove_tag_from_images_batch([123], "")
         assert ok is False
         assert results == []
+
+    def test_db_error_rolls_back_and_reraises(self, repo, mock_session):
+        from sqlalchemy.exc import SQLAlchemyError
+
+        repo._build_existing_tags_map = MagicMock(side_effect=SQLAlchemyError("db error"))
+        with pytest.raises(SQLAlchemyError):
+            repo.remove_tag_from_images_batch([123], "bad_tag")
+        mock_session.rollback.assert_called_once()


### PR DESCRIPTION
## Summary
- `lorairo-cli tags add/remove/replace` コマンドを追加（Issue #695）
- `AnnotationRepository` に `remove_tag_from_images_batch` / `replace_tag_for_images_batch` を追加（単一トランザクション、per-item 結果返却）
- デフォルト dry-run、`--apply` のみ DB に書き込み
- `--json` で image_id ごとの item 行 + result 行を出力（ADR 0057/0058 準拠）
- mypy 型アノテーション修正（`_validate_image_ids_exist` の `container` 引数に `ServiceContainer` 型を追加）

## Test plan
- [x] `pytest tests/unit/cli/test_commands_tags.py` — 8 tests PASSED
- [x] `pytest tests/unit/database/repository/test_tags_batch_ops.py` — 11 tests PASSED
- [x] CI-equivalent filter: `not gui_show and not calls_real_webapi and not downloads_and_runs_model and not slow` — 4036 passed, 0 failed

Closes #695