### PR TITLE
feat(cli): images search コマンドを追加 (Issue #697)

### DIFF
--- a/src/lorairo/cli/commands/images.py
+++ b/src/lorairo/cli/commands/images.py
@@ -8,10 +8,14 @@ API層（lorairo.api）を経由してService層を利用する。
 に集約する。
 """
 
+import json
+import sys
 from pathlib import Path
+from typing import Literal
 
 import click
 import typer
+from pydantic import BaseModel, Field, ValidationError
 from rich.table import Table
 
 from lorairo.api.exceptions import ImageNotFoundError, ResultSetTooLargeError
@@ -34,6 +38,32 @@ app = typer.Typer(help="Image management commands")
 console = make_console()
 
 MAX_IMAGE_LIST_FETCH = 500
+
+
+class _SortSpec(BaseModel):
+    """images search JSON スキーマのソート指定。"""
+
+    field: Literal["image_id", "file_path"] = "image_id"
+    direction: Literal["asc", "desc"] = "asc"
+
+
+class ImageSearchQuery(BaseModel):
+    """images search コマンドが受け付ける JSON 検索スキーマ。"""
+
+    image_ids: list[int] | None = None
+    tags: list[str] | None = None
+    excluded_tags: list[str] | None = None
+    caption: str | None = None
+    manual_rating: str | None = None
+    ai_rating: str | None = None
+    score_min: float | None = None
+    score_max: float | None = None
+    only_unrated: bool = False
+    missing_model: str | None = None
+    include_nsfw: bool = False
+    limit: int = Field(default=500, ge=1, le=500)
+    offset: int = Field(default=0, ge=0)
+    sort: list[_SortSpec] = Field(default_factory=lambda: [_SortSpec()])
 
 
 def _print_registration_summary(result: RegistrationResult, project: str) -> None:
@@ -356,3 +386,91 @@ def update(
         # 一部タグが失敗した場合は exit 1 (部分失敗を exit code で示す)。
         if failed_tags:
             raise typer.Exit(code=1)
+
+
+@app.command("search")
+def search_images(
+    project: str = typer.Option(..., "--project", "-p", help="Project name"),
+    query_file: str | None = typer.Option(None, "--query-file", help="Path to JSON search schema file"),
+    query: str | None = typer.Option(None, "--query", help="JSON search schema string or '-' for stdin"),
+) -> None:
+    """Search images using a JSON search schema (read-only).
+
+    JSON 検索スキーマを受け取り、条件に合う画像を返します（副作用なし）。
+
+    Examples:
+
+        lorairo-cli images search --project proj --query-file search.json --json
+
+        echo '{"tags":["cat"]}' | lorairo-cli images search --project proj --query - --json
+    """
+    with command_boundary():
+        if query_file is None and query is None:
+            raise click.UsageError("--query-file または --query - のいずれかを指定してください。")
+        if query_file is not None and query is not None:
+            raise click.UsageError("--query-file と --query は同時に指定できません。")
+
+        try:
+            if query_file is not None:
+                raw = Path(query_file).read_text(encoding="utf-8")
+            else:
+                raw = sys.stdin.read() if query == "-" else (query or "")
+            parsed = json.loads(raw)
+        except (OSError, json.JSONDecodeError) as e:
+            raise click.UsageError(f"JSON 読み込みエラー: {e}") from e
+
+        try:
+            q = ImageSearchQuery.model_validate(parsed)
+        except ValidationError as e:
+            raise click.UsageError(f"検索スキーマが無効です: {e}") from e
+
+        api_get_project(project)
+        container = get_service_container()
+        container.set_active_project(project)
+
+        sort_spec = q.sort[0] if q.sort else _SortSpec()
+        criteria = ImageFilterCriteria(
+            image_ids=q.image_ids,
+            tags=q.tags,
+            excluded_tags=q.excluded_tags,
+            caption=q.caption,
+            manual_rating_filter=q.manual_rating,
+            ai_rating_filter=q.ai_rating,
+            score_min=q.score_min,
+            score_max=q.score_max,
+            only_unrated=q.only_unrated,
+            missing_model_litellm_id=q.missing_model,
+            include_nsfw=q.include_nsfw,
+            limit=q.limit,
+            offset=q.offset,
+            sort_field=sort_spec.field,
+            sort_direction=sort_spec.direction,
+        )
+
+        total_count = container.db_manager.image_repo.get_images_count_only(criteria)
+        if total_count > MAX_IMAGE_LIST_FETCH and criteria.image_ids is None:
+            raise ResultSetTooLargeError(matched=total_count, limit=MAX_IMAGE_LIST_FETCH)
+
+        records, total = container.db_manager.image_repo.get_images_by_filter(criteria)
+        count = len(records)
+        has_more = q.offset + count < total
+
+        if is_json_mode():
+            for record in records:
+                emit_item(
+                    {
+                        "image_id": record.get("id") or record.get("image_id"),
+                        "file_path": record.get("file_path"),
+                    }
+                )
+            emit_result(
+                f"{count} image(s)",
+                count=count,
+                total=total,
+                limit=q.limit,
+                offset=q.offset,
+                has_more=has_more,
+            )
+        else:
+            for record in records:
+                print(f"{record.get('id') or record.get('image_id')}\t{record.get('file_path')}")

--- a/src/lorairo/database/filter_criteria.py
+++ b/src/lorairo/database/filter_criteria.py
@@ -45,6 +45,8 @@ class ImageFilterCriteria:
             ステージング集合を criteria 経由でエクスポートする際に使用する。
             最大 ImageRepository.EXACT_SET_MAX_IDS 件（= ステージング上限 500）。
             超過時は ValueError（ADR 0056）。
+        sort_field: ソートキー。"image_id"（デフォルト）または "file_path"。
+        sort_direction: ソート方向。"asc"（デフォルト）または "desc"。
     """
 
     tags: list[str] | None = None
@@ -71,6 +73,9 @@ class ImageFilterCriteria:
     offset: int = 0
     # ADR 0055: 指定時は他フィルタを bypass する exact-set selector
     image_ids: list[int] | None = None
+    # Issue #697: images search で使用するソート条件
+    sort_field: str = "image_id"  # "image_id" または "file_path"
+    sort_direction: str = "asc"  # "asc" または "desc"
 
     @classmethod
     def from_kwargs(cls, **kwargs: Any) -> ImageFilterCriteria:
@@ -129,4 +134,6 @@ class ImageFilterCriteria:
             "limit": self.limit,
             "offset": self.offset,
             "image_ids": self.image_ids,
+            "sort_field": self.sort_field,
+            "sort_direction": self.sort_direction,
         }

--- a/src/lorairo/database/repository/image.py
+++ b/src/lorairo/database/repository/image.py
@@ -2255,7 +2255,12 @@ class ImageRepository(BaseRepository):
                     logger.info("指定された条件に一致する画像が見つかりませんでした。")
                     return [], 0
 
-                paged_query = query.order_by(Image.id)
+                # sort_field / sort_direction に従って ORDER BY を動的に決定
+                _sort_col = Image.filename if filter_criteria.sort_field == "file_path" else Image.id
+                if filter_criteria.sort_direction == "desc":
+                    paged_query = query.order_by(_sort_col.desc())
+                else:
+                    paged_query = query.order_by(_sort_col.asc())
                 if filter_criteria.offset:
                     paged_query = paged_query.offset(filter_criteria.offset)
                 if filter_criteria.limit is not None:

--- a/tests/unit/cli/test_commands_images_search.py
+++ b/tests/unit/cli/test_commands_images_search.py
@@ -1,0 +1,156 @@
+"""images search コマンドのユニットテスト。"""
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+from typer.testing import CliRunner
+
+from lorairo.cli.main import app
+from lorairo.database.filter_criteria import ImageFilterCriteria
+
+runner = CliRunner()
+
+
+@pytest.mark.unit
+class TestImageFilterCriteriaSort:
+    def test_default_sort_is_image_id_asc(self) -> None:
+        criteria = ImageFilterCriteria()
+        assert criteria.sort_field == "image_id"
+        assert criteria.sort_direction == "asc"
+
+    def test_sort_fields_can_be_set(self) -> None:
+        criteria = ImageFilterCriteria(sort_field="file_path", sort_direction="desc")
+        assert criteria.sort_field == "file_path"
+        assert criteria.sort_direction == "desc"
+
+
+def _make_container(records: list[dict]) -> MagicMock:  # type: ignore[type-arg]
+    container = MagicMock()
+    container.db_manager.image_repo.get_images_by_filter.return_value = (records, len(records))
+    container.db_manager.image_repo.get_images_count_only.return_value = len(records)
+    return container
+
+
+@pytest.fixture
+def mock_search_context(tmp_path: pytest.FixtureDef, monkeypatch: pytest.MonkeyPatch):  # type: ignore[type-arg]
+    records = [
+        {"id": 1, "image_id": 1, "file_path": "a.webp"},
+        {"id": 2, "image_id": 2, "file_path": "b.webp"},
+    ]
+    container = _make_container(records)
+    monkeypatch.setattr("lorairo.cli.commands.images.api_get_project", MagicMock(return_value=MagicMock()))
+    monkeypatch.setattr(
+        "lorairo.cli.commands.images.get_service_container", MagicMock(return_value=container)
+    )
+    return container, tmp_path
+
+
+@pytest.mark.unit
+class TestImagesSearch:
+    def test_search_query_file(self, mock_search_context: tuple, tmp_path: pytest.FixtureDef) -> None:
+        container, _ = mock_search_context
+        query_file = tmp_path / "search.json"
+        query_file.write_text('{"tags": ["cat"], "limit": 10}')
+
+        result = runner.invoke(
+            app,
+            ["--json", "images", "search", "--project", "proj", "--query-file", str(query_file)],
+        )
+        assert result.exit_code == 0
+        # JSON 行のみを抽出 (loguru 等の非 JSON 出力を除外)
+        json_lines = [
+            json.loads(line) for line in result.output.strip().splitlines() if line.strip().startswith("{")
+        ]
+        items = [r for r in json_lines if r.get("kind") == "item"]
+        result_row = next(r for r in json_lines if r.get("kind") == "result")
+        assert len(items) == 2
+        assert result_row["ok"] is True
+        assert "image_id" in items[0]
+        assert "file_path" in items[0]
+
+    def test_search_stdin(self, mock_search_context: tuple) -> None:
+        result = runner.invoke(
+            app,
+            ["--json", "images", "search", "--project", "proj", "--query", "-"],
+            input='{"include_nsfw": true}',
+        )
+        assert result.exit_code == 0
+        json_lines = [
+            json.loads(line) for line in result.output.strip().splitlines() if line.strip().startswith("{")
+        ]
+        assert any(r.get("kind") == "result" for r in json_lines)
+
+    def test_search_invalid_json_returns_exit2(self, mock_search_context: tuple) -> None:
+        result = runner.invoke(
+            app,
+            ["--json", "images", "search", "--project", "proj", "--query", "-"],
+            input="not json",
+        )
+        assert result.exit_code == 2
+
+    def test_search_invalid_schema_returns_exit2(
+        self, mock_search_context: tuple, tmp_path: pytest.FixtureDef
+    ) -> None:
+        query_file = tmp_path / "bad.json"
+        # limit は 1-500 の範囲でないと ValidationError
+        query_file.write_text('{"limit": 999}')
+        result = runner.invoke(
+            app,
+            ["--json", "images", "search", "--project", "proj", "--query-file", str(query_file)],
+        )
+        assert result.exit_code == 2
+
+    def test_search_with_sort(self, mock_search_context: tuple, tmp_path: pytest.FixtureDef) -> None:
+        query_file = tmp_path / "sort.json"
+        query_file.write_text('{"sort": [{"field": "file_path", "direction": "desc"}]}')
+        result = runner.invoke(
+            app,
+            ["--json", "images", "search", "--project", "proj", "--query-file", str(query_file)],
+        )
+        assert result.exit_code == 0
+
+    def test_search_no_options_returns_exit2(self, mock_search_context: tuple) -> None:
+        """--query-file も --query も指定しない場合は UsageError (exit 2)。"""
+        result = runner.invoke(
+            app,
+            ["--json", "images", "search", "--project", "proj"],
+        )
+        assert result.exit_code == 2
+
+    def test_search_both_options_returns_exit2(
+        self, mock_search_context: tuple, tmp_path: pytest.FixtureDef
+    ) -> None:
+        """--query-file と --query を同時指定すると UsageError (exit 2)。"""
+        query_file = tmp_path / "q.json"
+        query_file.write_text("{}")
+        result = runner.invoke(
+            app,
+            [
+                "--json",
+                "images",
+                "search",
+                "--project",
+                "proj",
+                "--query-file",
+                str(query_file),
+                "--query",
+                "-",
+            ],
+            input="{}",
+        )
+        assert result.exit_code == 2
+
+    def test_search_human_output_tab_rows(
+        self, mock_search_context: tuple, tmp_path: pytest.FixtureDef
+    ) -> None:
+        """--json なし時は image_id TAB file_path の plain 行を出力する。"""
+        query_file = tmp_path / "q.json"
+        query_file.write_text("{}")
+        result = runner.invoke(
+            app,
+            ["images", "search", "--project", "proj", "--query-file", str(query_file)],
+        )
+        assert result.exit_code == 0
+        assert "1\ta.webp" in result.output
+        assert "2\tb.webp" in result.output

--- a/tests/unit/cli/test_commands_images_search.py
+++ b/tests/unit/cli/test_commands_images_search.py
@@ -49,7 +49,7 @@ def mock_search_context(tmp_path: pytest.FixtureDef, monkeypatch: pytest.MonkeyP
 @pytest.mark.unit
 class TestImagesSearch:
     def test_search_query_file(self, mock_search_context: tuple, tmp_path: pytest.FixtureDef) -> None:
-        container, _ = mock_search_context
+        _container, _ = mock_search_context
         query_file = tmp_path / "search.json"
         query_file.write_text('{"tags": ["cat"], "limit": 10}')
 


### PR DESCRIPTION
## Summary
- `lorairo-cli images search --query-file / --query -` コマンドを追加 (read-only)
- Pydantic `ImageSearchQuery` モデルで JSON 検索スキーマを定義・バリデーション
- `ImageFilterCriteria` に `sort_field` / `sort_direction` フィールドを追加
- `get_images_by_filter` の ORDER BY を動的化（image_id / file_path, asc/desc）

## Test plan
- [x] `uv run pytest tests/unit/cli/test_commands_images_search.py -v` — 10 tests passed
- [x] CI-equivalent filter: `4036 passed, 2 skipped` 全 PASS 確認

Closes #697