### PR TITLE
feat(cli): export create を --image-ids 専用に整理 (Issue #698)

### DIFF
--- a/src/lorairo/cli/commands/export.py
+++ b/src/lorairo/cli/commands/export.py
@@ -1,7 +1,8 @@
 """Dataset export commands.
 
 データセット エクスポート コマンド。
-API層（lorairo.api）を経由してService層を利用する。
+image_ids を受け取り、タグ txt / キャプション txt / JSON の全形式を出力する。
+検索責務は ``lorairo-cli images search`` に委譲する (Issue #698)。
 """
 
 from pathlib import Path
@@ -15,7 +16,6 @@ from lorairo.cli._boundary import command_boundary
 from lorairo.cli._console import make_console
 from lorairo.cli._emit import emit_result
 from lorairo.cli._output_mode import is_json_mode
-from lorairo.database.filter_criteria import ImageFilterCriteria
 from lorairo.services.service_container import get_service_container
 
 # サブコマンドアプリ定義
@@ -24,141 +24,23 @@ app = typer.Typer(help="Dataset export commands")
 # Rich console (Issue #254: Windows では safe_box=True で ASCII 罫線)
 console = make_console()
 
-# 手動・AI レーティング共通の有効値（Civitai 基準 + UNRATED）
-VALID_RATINGS = {"PG", "PG-13", "R", "X", "XXX", "UNRATED"}
 
-
-def _validate_rating(ctx: click.Context, param: click.Parameter, value: str | None) -> str | None:
-    """レーティング値を検証し正規化する。
+def _parse_image_ids(image_ids_csv: str) -> list[int]:
+    """カンマ区切り文字列を int リストに変換。不正値は UsageError。
 
     Args:
-        ctx: Click コンテキスト。
-        param: Click パラメーター。
-        value: 入力されたレーティング値。
+        image_ids_csv: カンマ区切りの画像 ID 文字列。
 
     Returns:
-        正規化されたレーティング値（大文字）。
+        int のリスト。
 
     Raises:
-        click.BadParameter: 無効なレーティング値が指定された場合（exit_code=2）。
+        click.UsageError: 整数に変換できない値が含まれる場合（exit_code=2）。
     """
-    if value is None:
-        return None
-    normalized = value.strip().upper()
-    if normalized not in VALID_RATINGS:
-        raise click.BadParameter(
-            f"Valid values: {', '.join(sorted(VALID_RATINGS))}\n"
-            f"有効な値: {', '.join(sorted(VALID_RATINGS))}",
-            ctx=ctx,
-            param=param,
-        )
-    return normalized
-
-
-def _validate_score_bounds(
-    score_min: float | None,
-    score_max: float | None,
-) -> None:
-    """score_min/score_max の範囲と順序を検証する。
-
-    Args:
-        score_min: 最小スコア値。
-        score_max: 最大スコア値。
-
-    Raises:
-        click.UsageError: 範囲外または逆転指定の場合（exit_code=2）。
-    """
-    for name, value in (("--score-min", score_min), ("--score-max", score_max)):
-        if value is not None and not (0.0 <= value <= 10.0):
-            raise click.UsageError(
-                f"{name} must be between 0.0 and 10.0 (given: {value})\n"
-                f"{name} は 0.0 以上 10.0 以下で指定してください (指定値: {value})"
-            )
-    if score_min is not None and score_max is not None and score_min > score_max:
-        raise click.UsageError(
-            f"--score-min ({score_min}) must be <= --score-max ({score_max})\n"
-            f"--score-min ({score_min}) は --score-max ({score_max}) 以下にする必要があります"
-        )
-
-
-def _build_filter_criteria(
-    project_name: str,
-    tags: str | None,
-    excluded_tags: str | None,
-    caption: str | None,
-    manual_rating: str | None,
-    ai_rating: str | None,
-    include_nsfw: bool,
-    score_min: float | None,
-    score_max: float | None,
-) -> ImageFilterCriteria:
-    """CLI引数から ImageFilterCriteria を生成する。
-
-    全テキスト/リスト系フィルタは同一ポリシーで正規化する:
-    - リスト: カンマで分割し各要素を strip、空要素は破棄。空リストは None 扱い
-    - 文字列: strip して空なら None 扱い
-
-    こうすることで、後段の has_any_filter 判定が
-    「正規化後の最終フィルタ値」をそのまま参照できる。
-
-    Args:
-        project_name: プロジェクト名（_apply_project_filter のスコープ用）。
-        tags: カンマ区切りのタグ文字列。
-        excluded_tags: カンマ区切りの除外タグ文字列。
-        caption: キャプションテキストフィルター。
-        manual_rating: 手動レーティングフィルター。
-        ai_rating: AI評価レーティングフィルター。
-        include_nsfw: NSFWコンテンツを含めるかどうか。
-        score_min: 最小スコア値。
-        score_max: 最大スコア値。
-
-    Returns:
-        構築した ImageFilterCriteria。
-    """
-
-    def _normalize_csv(value: str | None) -> list[str] | None:
-        if not value:
-            return None
-        items = [t.strip() for t in value.split(",") if t.strip()]
-        return items if items else None
-
-    def _normalize_text(value: str | None) -> str | None:
-        if value is None:
-            return None
-        stripped = value.strip()
-        return stripped if stripped else None
-
-    return ImageFilterCriteria(
-        project_name=project_name,
-        tags=_normalize_csv(tags),
-        excluded_tags=_normalize_csv(excluded_tags),
-        caption=_normalize_text(caption),
-        manual_rating_filter=manual_rating,
-        ai_rating_filter=ai_rating,
-        include_nsfw=include_nsfw,
-        score_min=score_min,
-        score_max=score_max,
-    )
-
-
-def _criteria_has_effective_filter(criteria: ImageFilterCriteria) -> bool:
-    """正規化済みの ImageFilterCriteria に有効なフィルタが1つ以上あるか判定する。
-
-    _build_filter_criteria で空要素・空白は既に None/空リストに正規化されている
-    前提。ここでは truthy 判定だけで済む。include_nsfw はフィルタ条件としては
-    扱わない（他フィルタの振る舞い修飾子）。
-    """
-    return any(
-        [
-            bool(criteria.tags),
-            bool(criteria.excluded_tags),
-            bool(criteria.caption),
-            bool(criteria.manual_rating_filter),
-            bool(criteria.ai_rating_filter),
-            criteria.score_min is not None,
-            criteria.score_max is not None,
-        ]
-    )
+    try:
+        return [int(x.strip()) for x in image_ids_csv.split(",") if x.strip()]
+    except ValueError as e:
+        raise click.UsageError(f"--image-ids には整数のみ指定可: {e}") from e
 
 
 @app.command("create")
@@ -169,17 +51,16 @@ def create(
         "-p",
         help="Project name",
     ),
+    image_ids_csv: str = typer.Option(
+        ...,
+        "--image-ids",
+        help="Comma-separated image IDs to export",
+    ),
     output: str = typer.Option(
         ...,
         "--output",
         "-o",
         help="Output directory for exported dataset",
-    ),
-    format: str = typer.Option(
-        "txt",
-        "--format",
-        "-f",
-        help="Export format: txt or json",
     ),
     resolution: int = typer.Option(
         512,
@@ -187,149 +68,61 @@ def create(
         "-r",
         help="Target resolution for processed images",
     ),
-    tags: str | None = typer.Option(
-        None,
-        "--tags",
-        help="Comma-separated tag filter (e.g. 'cat,dog')",
-    ),
-    excluded_tags: str | None = typer.Option(
-        None,
-        "--excluded-tags",
-        help="Comma-separated tags to exclude from results",
-    ),
-    caption: str | None = typer.Option(
-        None,
-        "--caption",
-        help="Caption text filter",
-    ),
-    manual_rating: str | None = typer.Option(
-        None,
-        "--manual-rating",
-        help="Manual rating filter: PG / PG-13 / R / X / XXX / UNRATED",
-        callback=_validate_rating,
-    ),
-    ai_rating: str | None = typer.Option(
-        None,
-        "--ai-rating",
-        help="AI rating filter: PG / PG-13 / R / X / XXX / UNRATED",
-        callback=_validate_rating,
-    ),
-    include_nsfw: bool = typer.Option(
-        False,
-        "--include-nsfw",
-        help="Include NSFW content in export",
-    ),
-    score_min: float | None = typer.Option(
-        None,
-        "--score-min",
-        help="Minimum score filter (0.0-10.0)",
-    ),
-    score_max: float | None = typer.Option(
-        None,
-        "--score-max",
-        help="Maximum score filter (0.0-10.0)",
-    ),
 ) -> None:
-    """Create a dataset export from project.
+    """Create a dataset export from a list of image IDs.
 
-    プロジェクトからデータセットをエクスポートします。
+    指定した image_ids からデータセットをエクスポートします。
+    タグ txt、キャプション txt、JSON の全形式を出力します。
 
-    [必須] --tags / --caption / --manual-rating / --ai-rating /
-           --score-min / --score-max のいずれかを最低1つ指定してください。
+    画像の検索には ``lorairo-cli images search`` を使用してください。
 
-    Examples:
-        lorairo-cli export create --project myproject --tags cat --output /tmp/out
-        lorairo-cli export create --project myproject --tags "cat,dog" --manual-rating PG --output /tmp/out
-        lorairo-cli export create --project myproject --score-min 6.0 --output /tmp/out --format json
+    Example:
+        # まず検索で image_ids を取得
+
+        lorairo-cli images search --project proj --json \\
+          | jq -r 'select(.kind=="item")|.image_id' | paste -sd, > ids.txt
+
+        # 取得した ids でエクスポート
+        lorairo-cli export create --project proj --image-ids $(cat ids.txt) --output /tmp/out
     """
     with command_boundary():
         # API層経由でプロジェクト確認 (未存在は ProjectNotFoundError → NOT_FOUND で伝播)
         api_get_project(project)
 
-        # スコア範囲・順序検証 (click.UsageError → 境界が INVALID_INPUT exit 2)
-        _validate_score_bounds(score_min, score_max)
-
-        # フィルタ条件を構築（CSV分割・空白除去・空要素除外を含む正規化はここで完結）
-        criteria = _build_filter_criteria(
-            project_name=project,
-            tags=tags,
-            excluded_tags=excluded_tags,
-            caption=caption,
-            manual_rating=manual_rating,
-            ai_rating=ai_rating,
-            include_nsfw=include_nsfw,
-            score_min=score_min,
-            score_max=score_max,
-        )
-
-        # 正規化後のフィルタ条件で判定する（--tags "," や "   " が repository に
-        # 到達する時点では空リスト/空値となるため、検証もこの段階で行う必要がある）
-        if not _criteria_has_effective_filter(criteria):
-            raise click.UsageError(
-                "At least one filter condition is required for export "
-                "(--tags / --caption / --manual-rating / --ai-rating / --score-min / --score-max).\n"
-                "エクスポートには最低1つのフィルタ条件が必要です。"
-            )
+        # image_ids パース・検証 (click.UsageError → 境界が INVALID_INPUT exit 2)
+        image_ids = _parse_image_ids(image_ids_csv)
+        if not image_ids:
+            raise click.UsageError("--image-ids に有効な値がありません。")
 
         # ServiceContainer を取得してプロジェクト DB に切り替え
         container = get_service_container()
         container.set_active_project(project)
-        repository = container.db_manager.image_repo
+
         export_service = container.dataset_export_service
-
-        rich = not is_json_mode()
-        if rich:
-            console.print(f"[cyan]Loading project database: {project}[/cyan]")
-
-        # フィルタ条件を適用して画像を取得
-        all_images, _ = repository.get_images_by_filter(criteria)
-        image_ids = [img["id"] for img in all_images] if all_images else []
-
-        if not image_ids:
-            # 該当なしは成功扱い (exit 0)
-            if is_json_mode():
-                emit_result(f"No images found in project: {project}", count=0)
-            else:
-                console.print(f"[yellow]Warning:[/yellow] No images found in project: {project}")
-            return
-
-        if rich:
-            console.print(f"[cyan]Found {len(image_ids)} image(s)[/cyan]")
-            console.print(f"[cyan]Export format: {format}[/cyan]")
-            console.print(f"[cyan]Target resolution: {resolution}px[/cyan]")
-
-        # 出力ディレクトリの作成
         output_path = Path(output)
         output_path.mkdir(parents=True, exist_ok=True)
 
-        if rich:
-            console.print("[cyan]Starting export...[/cyan]")
+        if not is_json_mode():
+            console.print(f"Exporting {len(image_ids)} image(s) to {output}")
 
-        # image_ids は上で解決済みのため、export_filtered_dataset に直接渡して
-        # 二重 DB クエリを回避する。不正フォーマット等は ValueError として境界へ伝播する。
-        result_path = export_service.export_filtered_dataset(
-            image_ids=image_ids,
-            output_path=output_path,
-            format_type=format.lower(),
-            resolution=resolution,
-        )
+        # タグ txt + キャプション txt
+        txt_path = export_service.export_dataset_txt_format(image_ids, output_path, resolution)
+        # JSON メタデータ
+        export_service.export_dataset_json_format(image_ids, output_path, resolution)
 
         if is_json_mode():
             emit_result(
                 "Export completed successfully.",
-                output_path=str(result_path),
+                output_path=str(txt_path),
                 total_images=len(image_ids),
-                format=format,
                 resolution=resolution,
             )
         else:
-            console.print("\n[bold cyan]Export Summary[/bold cyan]")
-            summary_table = Table()
-            summary_table.add_column("Metric", style="cyan")
-            summary_table.add_column("Value", style="green")
-            summary_table.add_row("Total Images", str(len(image_ids)))
-            summary_table.add_row("Export Format", format)
-            summary_table.add_row("Resolution", f"{resolution}px")
-            summary_table.add_row("Output Path", str(result_path))
-            console.print(summary_table)
-            console.print("\n[green]Export completed successfully![/green]")
+            table = Table()
+            table.add_column("Metric", style="cyan")
+            table.add_column("Value", style="green")
+            table.add_row("Total Images", str(len(image_ids)))
+            table.add_row("Resolution", f"{resolution}px")
+            table.add_row("Output Path", str(txt_path))
+            console.print(table)
+            console.print("\nExport completed successfully!")

--- a/tests/integration/cli/test_cli_workflow.py
+++ b/tests/integration/cli/test_cli_workflow.py
@@ -174,6 +174,10 @@ def test_cli_full_workflow_with_fake_annotator(
     assert annotate_result.exit_code == 0, annotate_result.stdout + annotate_result.stderr
     assert "Annotation completed successfully" in annotate_result.stdout
 
+    # 登録済み画像IDをDBから取得して --image-ids に渡す
+    with sqlite3.connect(project_dir / "image_database.db") as conn:
+        image_ids_csv = ",".join(str(row[0]) for row in conn.execute("SELECT id FROM images").fetchall())
+
     export_dir = tmp_path / "export"
     export_result = cli_runner.invoke(
         app,
@@ -182,8 +186,8 @@ def test_cli_full_workflow_with_fake_annotator(
             "create",
             "--project",
             project_name,
-            "--tags",
-            FAKE_TAG,
+            "--image-ids",
+            image_ids_csv,
             "--output",
             str(export_dir),
         ],

--- a/tests/integration/gui/test_export_e2e.py
+++ b/tests/integration/gui/test_export_e2e.py
@@ -1,6 +1,6 @@
 """Export E2E 統合テスト
 
-CLI / Service直接 / GUI の3経路が同一フィルタ条件から同一ファイルセットを
+Service直接 / GUI の2経路が同一フィルタ条件から同一ファイルセットを
 エクスポートすることを検証する。
 """
 
@@ -10,7 +10,6 @@ from unittest.mock import Mock, patch
 
 import pytest
 
-from lorairo.cli.commands.export import _build_filter_criteria
 from lorairo.database.filter_criteria import ImageFilterCriteria
 from lorairo.services.dataset_export_service import DatasetExportService
 from lorairo.storage.file_system import FileSystemManager
@@ -18,7 +17,7 @@ from lorairo.storage.file_system import FileSystemManager
 
 @pytest.mark.integration
 class TestExportE2E:
-    """GUI/CLI/Service 3経路の出力一致を検証するE2Eテスト"""
+    """Service直接/GUI 2経路の出力一致を検証するE2Eテスト"""
 
     @pytest.fixture
     def temp_project_dir(self):
@@ -131,41 +130,20 @@ class TestExportE2E:
             )
             yield service
 
-    def test_three_paths_produce_same_files(self, export_service, mock_db_manager):
-        """CLI/Service直接/GUI の3経路が同一ファイルセットを出力する。"""
+    def test_service_and_gui_paths_produce_same_files(self, export_service, mock_db_manager):
+        """Service直接/GUI の2経路が同一ファイルセットを出力する。"""
         criteria = ImageFilterCriteria(project_name="proj", tags=["cat"])
 
         with tempfile.TemporaryDirectory() as out_root:
             out1 = Path(out_root) / "path1"
-            out2 = Path(out_root) / "path2"
             out3 = Path(out_root) / "path3"
             out1.mkdir()
-            out2.mkdir()
             out3.mkdir()
 
             # Path 1: Service 直接
             export_service.export_with_criteria(
                 criteria=criteria,
                 output_path=out1,
-                format_type="txt",
-                resolution=512,
-            )
-
-            # Path 2: CLI _build_filter_criteria 経由
-            cli_criteria = _build_filter_criteria(
-                project_name="proj",
-                tags="cat",
-                excluded_tags=None,
-                caption=None,
-                manual_rating=None,
-                ai_rating=None,
-                include_nsfw=False,
-                score_min=None,
-                score_max=None,
-            )
-            export_service.export_with_criteria(
-                criteria=cli_criteria,
-                output_path=out2,
                 format_type="txt",
                 resolution=512,
             )
@@ -180,9 +158,8 @@ class TestExportE2E:
                 resolution=512,
             )
 
-            # 3経路の出力ファイル名セットが一致する
+            # 2経路の出力ファイル名セットが一致する
             files1 = {f.name for f in out1.iterdir()}
-            files2 = {f.name for f in out2.iterdir()}
             files3 = {f.name for f in out3.iterdir()}
-            assert files1 == files2 == files3
+            assert files1 == files3
             assert len(files1) > 0  # 少なくとも何かファイルが出力されている

--- a/tests/integration/test_dataset_export_integration.py
+++ b/tests/integration/test_dataset_export_integration.py
@@ -13,7 +13,6 @@ import pytest
 from sqlalchemy import create_engine, event
 from sqlalchemy.orm import sessionmaker
 
-from lorairo.cli.commands.export import _criteria_has_effective_filter
 from lorairo.database.filter_criteria import ImageFilterCriteria
 from lorairo.database.repository.image import ImageRepository
 from lorairo.database.schema import Base, ModelType
@@ -449,28 +448,3 @@ class TestExportFullScanGuard:
         # 空 DB なので 0 件が返る
         assert result_images == []
         assert count == 0
-
-    def test_empty_criteria_no_effective_filter(self):
-        """空の criteria では _criteria_has_effective_filter が False を返す。
-
-        _criteria_has_effective_filter は CLI の export.py に定義された関数であり、
-        有効なフィルタ条件が 1 つ以上あるかを判定する。空の criteria は有効フィルタなし。
-        """
-        # すべてデフォルト値の空 criteria
-        empty_criteria = ImageFilterCriteria()
-        assert _criteria_has_effective_filter(empty_criteria) is False
-
-    def test_criteria_with_tags_has_effective_filter(self):
-        """tags を指定した criteria では _criteria_has_effective_filter が True を返す。"""
-        criteria = ImageFilterCriteria(tags=["anime", "girl"])
-        assert _criteria_has_effective_filter(criteria) is True
-
-    def test_criteria_with_rating_has_effective_filter(self):
-        """manual_rating_filter を指定した criteria では _criteria_has_effective_filter が True を返す。"""
-        criteria = ImageFilterCriteria(manual_rating_filter="g")
-        assert _criteria_has_effective_filter(criteria) is True
-
-    def test_criteria_with_score_range_has_effective_filter(self):
-        """score_min を指定した criteria では _criteria_has_effective_filter が True を返す。"""
-        criteria = ImageFilterCriteria(score_min=5.0)
-        assert _criteria_has_effective_filter(criteria) is True

--- a/tests/unit/cli/test_commands_export.py
+++ b/tests/unit/cli/test_commands_export.py
@@ -1,1105 +1,146 @@
-"""Dataset export commands テスト。"""
+"""export create コマンドのユニットテスト。"""
 
+import json
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
 from typer.testing import CliRunner
 
 from lorairo.cli.main import app
-from lorairo.database.filter_criteria import ImageFilterCriteria
-from lorairo.services.project_management_service import ProjectManagementService
-from lorairo.services.service_container import ServiceContainer
 
 runner = CliRunner()
 
 
+def _make_export_container(tmp_path: Path) -> MagicMock:
+    """export テスト用 ServiceContainer モックを生成する。"""
+    container = MagicMock()
+    out_dir = tmp_path / "out"
+    out_dir.mkdir()
+    container.dataset_export_service.export_dataset_txt_format.return_value = out_dir
+    container.dataset_export_service.export_dataset_json_format.return_value = out_dir
+    return container
+
+
 @pytest.fixture
-def mock_projects_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
-    """ProjectManagementService のプロジェクトディレクトリをモック。
-
-    Args:
-        tmp_path: 一時ディレクトリ
-        monkeypatch: pytest monkeypatch フィクスチャ
-
-    Returns:
-        Path: モック後のプロジェクトディレクトリ
-    """
-    mock_dir = tmp_path / "projects"
-    mock_dir.mkdir()
-
-    # ServiceContainerシングルトンのキャッシュをクリア
-    container = ServiceContainer()
-    container._project_management_service = None
-
-    original_init = ProjectManagementService.__init__
-
-    def patched_init(self: ProjectManagementService, projects_base_dir: Path | None = None) -> None:
-        original_init(self, projects_base_dir=mock_dir)
-
-    monkeypatch.setattr(ProjectManagementService, "__init__", patched_init)
-
-    return mock_dir
-
-
-def create_mock_service_container() -> MagicMock:
-    """Create a mock ServiceContainer.
-
-    Returns:
-        MagicMock: Mocked service container
-    """
-    mock_container = MagicMock()
-
-    # mock image_repository
-    mock_image_repository = MagicMock()
-    mock_image_repository.get_images_by_filter.return_value = (
-        [
-            {"id": 1, "name": "image1.jpg"},
-            {"id": 2, "name": "image2.jpg"},
-            {"id": 3, "name": "image3.jpg"},
-        ],
-        3,
+def mock_export_context(tmp_path, monkeypatch):
+    """project 確認と ServiceContainer をモック。"""
+    container = _make_export_container(tmp_path)
+    monkeypatch.setattr("lorairo.cli.commands.export.api_get_project", MagicMock(return_value=MagicMock()))
+    monkeypatch.setattr(
+        "lorairo.cli.commands.export.get_service_container", MagicMock(return_value=container)
     )
-    mock_container.db_manager.image_repo = mock_image_repository
-
-    # mock export_service - return the output path
-    mock_export_service = MagicMock()
-
-    def export_filtered_dataset_side_effect(image_ids, output_path, **kwargs):
-        return output_path
-
-    mock_export_service.export_filtered_dataset.side_effect = export_filtered_dataset_side_effect
-    mock_container.dataset_export_service = mock_export_service
-
-    return mock_container
+    return container, tmp_path
 
 
 @pytest.mark.unit
-@pytest.mark.cli
-@patch("lorairo.cli.commands.export.get_service_container")
-def test_export_create_txt_format(
-    mock_get_container,
-    mock_projects_dir: Path,
-    tmp_path: Path,
-) -> None:
-    """Test: export create --format txt - TXT フォーマットでのエクスポート。"""
-    mock_container = create_mock_service_container()
-    mock_get_container.return_value = mock_container
-
-    # プロジェクト作成
-    runner.invoke(app, ["project", "create", "test-project"])
-
-    # エクスポート実行
-    output_dir = tmp_path / "export"
-    result = runner.invoke(
-        app,
-        [
-            "export",
-            "create",
-            "--project",
-            "test-project",
-            "--output",
-            str(output_dir),
-            "--format",
-            "txt",
-            "--tags",
-            "cat",
-        ],
-    )
-
-    assert result.exit_code == 0
-    assert "Found 3 image(s)" in result.stdout
-    assert "Export Summary" in result.stdout
-    assert "Export completed successfully" in result.stdout
-    assert "txt" in result.stdout.lower()
-
-
-@pytest.mark.unit
-@pytest.mark.cli
-@patch("lorairo.cli.commands.export.get_service_container")
-def test_export_create_json_format(
-    mock_get_container,
-    mock_projects_dir: Path,
-    tmp_path: Path,
-) -> None:
-    """Test: export create --format json - JSON フォーマットでのエクスポート。"""
-    mock_container = create_mock_service_container()
-    mock_get_container.return_value = mock_container
-
-    # プロジェクト作成
-    runner.invoke(app, ["project", "create", "test-project"])
-
-    # エクスポート実行
-    output_dir = tmp_path / "export"
-    result = runner.invoke(
-        app,
-        [
-            "export",
-            "create",
-            "--project",
-            "test-project",
-            "--output",
-            str(output_dir),
-            "--format",
-            "json",
-            "--tags",
-            "cat",
-        ],
-    )
-
-    assert result.exit_code == 0
-    assert "Found 3 image(s)" in result.stdout
-    assert "json" in result.stdout.lower()
-
-
-@pytest.mark.unit
-@pytest.mark.cli
-@patch("lorairo.cli.commands.export.get_service_container")
-def test_export_create_with_custom_resolution(
-    mock_get_container,
-    mock_projects_dir: Path,
-    tmp_path: Path,
-) -> None:
-    """Test: export create --resolution - カスタム解像度指定。"""
-    mock_container = create_mock_service_container()
-    mock_get_container.return_value = mock_container
-
-    # プロジェクト作成
-    runner.invoke(app, ["project", "create", "test-project"])
-
-    # エクスポート実行（解像度1024指定）
-    output_dir = tmp_path / "export"
-    result = runner.invoke(
-        app,
-        [
-            "export",
-            "create",
-            "--project",
-            "test-project",
-            "--output",
-            str(output_dir),
-            "--format",
-            "txt",
-            "--resolution",
-            "1024",
-            "--tags",
-            "cat",
-        ],
-    )
-
-    assert result.exit_code == 0
-    assert "1024" in result.stdout
-
-
-@pytest.mark.unit
-@pytest.mark.cli
-@patch("lorairo.cli.commands.export.get_service_container")
-def test_export_create_output_directory_auto_creation(
-    mock_get_container,
-    mock_projects_dir: Path,
-    tmp_path: Path,
-) -> None:
-    """Test: export create - 出力ディレクトリ自動作成。"""
-    mock_container = create_mock_service_container()
-    mock_get_container.return_value = mock_container
-
-    # プロジェクト作成
-    runner.invoke(app, ["project", "create", "test-project"])
-
-    # 存在しない出力ディレクトリを指定
-    output_dir = tmp_path / "nonexistent" / "export"
-    result = runner.invoke(
-        app,
-        [
-            "export",
-            "create",
-            "--project",
-            "test-project",
-            "--output",
-            str(output_dir),
-            "--format",
-            "txt",
-            "--tags",
-            "cat",
-        ],
-    )
-
-    assert result.exit_code == 0
-    assert "Export completed successfully" in result.stdout
-
-
-@pytest.mark.unit
-@pytest.mark.cli
-@patch("lorairo.cli.commands.export.get_service_container")
-def test_export_create_nonexistent_project(
-    mock_get_container,
-    mock_projects_dir: Path,
-    tmp_path: Path,
-) -> None:
-    """Test: export create - 無効なプロジェクト名。"""
-    mock_container = create_mock_service_container()
-    mock_get_container.return_value = mock_container
-
-    output_dir = tmp_path / "export"
-    result = runner.invoke(
-        app,
-        [
-            "export",
-            "create",
-            "--project",
-            "nonexistent-project",
-            "--output",
-            str(output_dir),
-            "--format",
-            "txt",
-        ],
-    )
-
-    # ADR 0057 §7: NOT_FOUND は exit 1、エラーは中央境界が stderr に出す (例外 str)。
-    assert result.exit_code == 1
-    assert "見つかりません" in result.output
-
-
-@pytest.mark.unit
-@pytest.mark.cli
-@patch("lorairo.cli.commands.export.get_service_container")
-def test_export_create_no_images(
-    mock_get_container,
-    mock_projects_dir: Path,
-    tmp_path: Path,
-) -> None:
-    """Test: export create - プロジェクトに画像がない場合。"""
-    # ServiceContainer をモック（画像が0件）
-    mock_container = MagicMock()
-    mock_image_repository = MagicMock()
-    mock_image_repository.get_images_by_filter.return_value = ([], 0)
-    mock_container.db_manager.image_repo = mock_image_repository
-    mock_container.dataset_export_service = MagicMock()
-    mock_get_container.return_value = mock_container
-
-    # プロジェクト作成
-    runner.invoke(app, ["project", "create", "test-project"])
-
-    output_dir = tmp_path / "export"
-    result = runner.invoke(
-        app,
-        [
-            "export",
-            "create",
-            "--project",
-            "test-project",
-            "--output",
-            str(output_dir),
-            "--format",
-            "txt",
-            "--tags",
-            "cat",
-        ],
-    )
-
-    assert result.exit_code == 0
-    assert "No images found" in result.stdout
-
-
-@pytest.mark.unit
-@pytest.mark.cli
-@patch("lorairo.cli.commands.export.get_service_container")
-def test_export_create_invalid_format(
-    mock_get_container,
-    mock_projects_dir: Path,
-    tmp_path: Path,
-) -> None:
-    """Test: export create - 無効なフォーマット。"""
-    mock_container = create_mock_service_container()
-    mock_container.dataset_export_service.export_filtered_dataset.side_effect = ValueError(
-        "Unsupported format_type: invalid"
-    )
-    mock_get_container.return_value = mock_container
-
-    # プロジェクト作成
-    runner.invoke(app, ["project", "create", "test-project"])
-
-    output_dir = tmp_path / "export"
-    result = runner.invoke(
-        app,
-        [
-            "export",
-            "create",
-            "--project",
-            "test-project",
-            "--output",
-            str(output_dir),
-            "--format",
-            "invalid",
-            "--tags",
-            "cat",
-        ],
-    )
-
-    # ValueError → INVALID_INPUT → exit 2 (入力系、ADR 0057 §6)。エラーは stderr。
-    assert result.exit_code == 2
-    assert "Error" in result.output
-
-
-@pytest.mark.unit
-@pytest.mark.cli
-def test_export_create_help() -> None:
-    """Test: export create --help - ヘルプ表示。"""
-    result = runner.invoke(app, ["export", "create", "--help"])
-
-    assert result.exit_code == 0
-    assert "--project" in result.stdout
-    assert "--output" in result.stdout
-    assert "--format" in result.stdout
-    assert "--resolution" in result.stdout
-    assert "--tags" in result.stdout
-    assert "--manual-rating" in result.stdout
-    assert "--ai-rating" in result.stdout
-    assert "--score-min" in result.stdout
-    assert "--score-max" in result.stdout
-
-
-@pytest.mark.unit
-@pytest.mark.cli
-def test_export_help() -> None:
-    """Test: export --help - エクスポートコマンドヘルプ。"""
-    result = runner.invoke(app, ["export", "--help"])
-
-    assert result.exit_code == 0
-    assert "Dataset export commands" in result.stdout
-
-
-@pytest.mark.unit
-@pytest.mark.cli
-@patch("lorairo.cli.commands.export.get_service_container")
-def test_export_create_default_format(
-    mock_get_container,
-    mock_projects_dir: Path,
-    tmp_path: Path,
-) -> None:
-    """Test: export create - デフォルトフォーマット (txt)。"""
-    mock_container = create_mock_service_container()
-    mock_get_container.return_value = mock_container
-
-    # プロジェクト作成
-    runner.invoke(app, ["project", "create", "test-project"])
-
-    # format オプションなしで実行（デフォルトはtxt）
-    output_dir = tmp_path / "export"
-    result = runner.invoke(
-        app,
-        [
-            "export",
-            "create",
-            "--project",
-            "test-project",
-            "--output",
-            str(output_dir),
-            "--tags",
-            "cat",
-        ],
-    )
-
-    assert result.exit_code == 0
-    assert "Export completed successfully" in result.stdout
-
-
-@pytest.mark.unit
-@pytest.mark.cli
-@patch("lorairo.cli.commands.export.get_service_container")
-def test_export_create_default_resolution(
-    mock_get_container,
-    mock_projects_dir: Path,
-    tmp_path: Path,
-) -> None:
-    """Test: export create - デフォルト解像度 (512)。"""
-    mock_container = create_mock_service_container()
-    mock_get_container.return_value = mock_container
-
-    # プロジェクト作成
-    runner.invoke(app, ["project", "create", "test-project"])
-
-    # resolution オプションなしで実行（デフォルトは512）
-    output_dir = tmp_path / "export"
-    result = runner.invoke(
-        app,
-        [
-            "export",
-            "create",
-            "--project",
-            "test-project",
-            "--output",
-            str(output_dir),
-            "--tags",
-            "cat",
-        ],
-    )
-
-    assert result.exit_code == 0
-    assert "512" in result.stdout
-
-
-# ==================== 新規テスト: フィルタ必須化バリデーション ====================
-
-
-@pytest.mark.unit
-@pytest.mark.cli
-@patch("lorairo.cli.commands.export.get_service_container")
-def test_export_create_no_filter_exits_code_2(
-    mock_get_container,
-    mock_projects_dir: Path,
-    tmp_path: Path,
-) -> None:
-    """Test: フィルタ条件なし → exit_code=2。"""
-    mock_container = create_mock_service_container()
-    mock_get_container.return_value = mock_container
-
-    runner.invoke(app, ["project", "create", "test-project"])
-
-    output_dir = tmp_path / "export"
-    result = runner.invoke(
-        app,
-        [
-            "export",
-            "create",
-            "--project",
-            "test-project",
-            "--output",
-            str(output_dir),
-        ],
-    )
-
-    assert result.exit_code == 2
-    assert "At least one filter condition is required for export" in result.output
-
-
-@pytest.mark.unit
-@pytest.mark.cli
-@patch("lorairo.cli.commands.export.get_service_container")
-def test_export_create_include_nsfw_alone_exits_code_2(
-    mock_get_container,
-    mock_projects_dir: Path,
-    tmp_path: Path,
-) -> None:
-    """Test: --include-nsfw 単独はフィルタとして不十分 → exit_code=2。"""
-    mock_container = create_mock_service_container()
-    mock_get_container.return_value = mock_container
-
-    runner.invoke(app, ["project", "create", "test-project"])
-
-    output_dir = tmp_path / "export"
-    result = runner.invoke(
-        app,
-        [
-            "export",
-            "create",
-            "--project",
-            "test-project",
-            "--output",
-            str(output_dir),
-            "--include-nsfw",
-        ],
-    )
-
-    assert result.exit_code == 2
-    assert "At least one filter condition is required for export" in result.output
-
-
-@pytest.mark.unit
-@pytest.mark.cli
-@patch("lorairo.cli.commands.export.get_service_container")
-def test_export_create_with_tags_filter(
-    mock_get_container,
-    mock_projects_dir: Path,
-    tmp_path: Path,
-) -> None:
-    """Test: --tags 指定 → 正常終了。"""
-    mock_container = create_mock_service_container()
-    mock_get_container.return_value = mock_container
-
-    runner.invoke(app, ["project", "create", "test-project"])
-
-    output_dir = tmp_path / "export"
-    result = runner.invoke(
-        app,
-        [
-            "export",
-            "create",
-            "--project",
-            "test-project",
-            "--output",
-            str(output_dir),
-            "--tags",
-            "cat,dog",
-        ],
-    )
-
-    assert result.exit_code == 0
-    assert "Found 3 image(s)" in result.stdout
-
-
-@pytest.mark.unit
-@pytest.mark.cli
-@patch("lorairo.cli.commands.export.get_service_container")
-def test_export_create_with_manual_rating_pg(
-    mock_get_container,
-    mock_projects_dir: Path,
-    tmp_path: Path,
-) -> None:
-    """Test: --manual-rating PG → 正常終了。"""
-    mock_container = create_mock_service_container()
-    mock_get_container.return_value = mock_container
-
-    runner.invoke(app, ["project", "create", "test-project"])
-
-    output_dir = tmp_path / "export"
-    result = runner.invoke(
-        app,
-        [
-            "export",
-            "create",
-            "--project",
-            "test-project",
-            "--output",
-            str(output_dir),
-            "--manual-rating",
-            "PG",
-        ],
-    )
-
-    assert result.exit_code == 0
-    assert "Found 3 image(s)" in result.stdout
-
-
-@pytest.mark.unit
-@pytest.mark.cli
-@patch("lorairo.cli.commands.export.get_service_container")
-def test_export_create_with_manual_rating_pg13(
-    mock_get_container,
-    mock_projects_dir: Path,
-    tmp_path: Path,
-) -> None:
-    """Test: --manual-rating PG-13 → 正常終了（AI と同一スケール）。"""
-    mock_container = create_mock_service_container()
-    mock_get_container.return_value = mock_container
-
-    runner.invoke(app, ["project", "create", "test-project"])
-
-    output_dir = tmp_path / "export"
-    result = runner.invoke(
-        app,
-        [
-            "export",
-            "create",
-            "--project",
-            "test-project",
-            "--output",
-            str(output_dir),
-            "--manual-rating",
-            "PG-13",
-        ],
-    )
-
-    assert result.exit_code == 0
-    assert "Found 3 image(s)" in result.stdout
-
-
-@pytest.mark.unit
-@pytest.mark.cli
-def test_export_create_with_invalid_manual_rating(
-    mock_projects_dir: Path,
-    tmp_path: Path,
-) -> None:
-    """Test: --manual-rating invalid → exit_code=2。"""
-    runner.invoke(app, ["project", "create", "test-project"])
-
-    output_dir = tmp_path / "export"
-    result = runner.invoke(
-        app,
-        [
-            "export",
-            "create",
-            "--project",
-            "test-project",
-            "--output",
-            str(output_dir),
-            "--manual-rating",
-            "invalid",
-        ],
-    )
-
-    assert result.exit_code == 2
-
-
-@pytest.mark.unit
-@pytest.mark.cli
-def test_export_create_with_invalid_ai_rating(
-    mock_projects_dir: Path,
-    tmp_path: Path,
-) -> None:
-    """Test: --ai-rating invalid → exit_code=2。"""
-    runner.invoke(app, ["project", "create", "test-project"])
-
-    output_dir = tmp_path / "export"
-    result = runner.invoke(
-        app,
-        [
-            "export",
-            "create",
-            "--project",
-            "test-project",
-            "--output",
-            str(output_dir),
-            "--ai-rating",
-            "invalid",
-        ],
-    )
-
-    assert result.exit_code == 2
-
-
-@pytest.mark.unit
-@pytest.mark.cli
-@patch("lorairo.cli.commands.export.get_service_container")
-def test_export_create_with_score_filter(
-    mock_get_container,
-    mock_projects_dir: Path,
-    tmp_path: Path,
-) -> None:
-    """Test: --score-min / --score-max フィルタ → 正常終了。"""
-    mock_container = create_mock_service_container()
-    mock_get_container.return_value = mock_container
-
-    runner.invoke(app, ["project", "create", "test-project"])
-
-    output_dir = tmp_path / "export"
-    result = runner.invoke(
-        app,
-        [
-            "export",
-            "create",
-            "--project",
-            "test-project",
-            "--output",
-            str(output_dir),
-            "--score-min",
-            "7.0",
-            "--score-max",
-            "10.0",
-        ],
-    )
-
-    assert result.exit_code == 0
-    assert "Found 3 image(s)" in result.stdout
-
-
-@pytest.mark.unit
-@pytest.mark.cli
-@patch("lorairo.cli.commands.export.get_service_container")
-def test_export_create_filter_passed_to_repository(
-    mock_get_container,
-    mock_projects_dir: Path,
-    tmp_path: Path,
-) -> None:
-    """Test: フィルタ条件が repository.get_images_by_filter に渡されることを確認。"""
-    from lorairo.database.filter_criteria import ImageFilterCriteria
-
-    mock_container = create_mock_service_container()
-    mock_get_container.return_value = mock_container
-
-    runner.invoke(app, ["project", "create", "test-project"])
-
-    output_dir = tmp_path / "export"
-    runner.invoke(
-        app,
-        [
-            "export",
-            "create",
-            "--project",
-            "test-project",
-            "--output",
-            str(output_dir),
-            "--tags",
-            "cat,dog",
-            "--manual-rating",
-            "PG",
-        ],
-    )
-
-    # get_images_by_filter が ImageFilterCriteria を引数として呼ばれたことを確認
-    call_args = mock_container.db_manager.image_repo.get_images_by_filter.call_args
-    assert call_args is not None
-    criteria_arg = call_args[0][0]
-    assert isinstance(criteria_arg, ImageFilterCriteria)
-    assert criteria_arg.tags == ["cat", "dog"]
-    assert criteria_arg.manual_rating_filter == "PG"
-
-
-@pytest.mark.unit
-@pytest.mark.cli
-@patch("lorairo.cli.commands.export.get_service_container")
-def test_export_create_empty_tags_string_exits_code_2(
-    mock_get_container,
-    mock_projects_dir: Path,
-    tmp_path: Path,
-) -> None:
-    """Test: --tags "" (空文字列) はフィルタとして無効 → exit_code=2。"""
-    mock_container = create_mock_service_container()
-    mock_get_container.return_value = mock_container
-
-    runner.invoke(app, ["project", "create", "test-project"])
-
-    output_dir = tmp_path / "export"
-    result = runner.invoke(
-        app,
-        [
-            "export",
-            "create",
-            "--project",
-            "test-project",
-            "--output",
-            str(output_dir),
-            "--tags",
-            "",
-        ],
-    )
-
-    assert result.exit_code == 2
-    assert "At least one filter condition is required for export" in result.output
-
-
-@pytest.mark.unit
-@pytest.mark.cli
-@patch("lorairo.cli.commands.export.get_service_container")
-def test_export_create_empty_caption_string_exits_code_2(
-    mock_get_container,
-    mock_projects_dir: Path,
-    tmp_path: Path,
-) -> None:
-    """Test: --caption "" (空文字列) はフィルタとして無効 → exit_code=2。"""
-    mock_container = create_mock_service_container()
-    mock_get_container.return_value = mock_container
-
-    runner.invoke(app, ["project", "create", "test-project"])
-
-    output_dir = tmp_path / "export"
-    result = runner.invoke(
-        app,
-        [
-            "export",
-            "create",
-            "--project",
-            "test-project",
-            "--output",
-            str(output_dir),
-            "--caption",
-            "   ",
-        ],
-    )
-
-    assert result.exit_code == 2
-    assert "At least one filter condition is required for export" in result.output
-
-
-@pytest.mark.unit
-@pytest.mark.cli
-@patch("lorairo.cli.commands.export.get_service_container")
-def test_export_create_comma_only_tags_exits_code_2(
-    mock_get_container,
-    mock_projects_dir: Path,
-    tmp_path: Path,
-) -> None:
-    """Test: --tags "," (カンマのみ) は正規化後に空リスト → exit_code=2。"""
-    mock_container = create_mock_service_container()
-    mock_get_container.return_value = mock_container
-
-    runner.invoke(app, ["project", "create", "test-project"])
-
-    output_dir = tmp_path / "export"
-    result = runner.invoke(
-        app,
-        [
-            "export",
-            "create",
-            "--project",
-            "test-project",
-            "--output",
-            str(output_dir),
-            "--tags",
-            ",",
-        ],
-    )
-
-    assert result.exit_code == 2
-    assert "At least one filter condition is required for export" in result.output
-
-
-@pytest.mark.unit
-@pytest.mark.cli
-@patch("lorairo.cli.commands.export.get_service_container")
-def test_export_create_multiple_commas_tags_exits_code_2(
-    mock_get_container,
-    mock_projects_dir: Path,
-    tmp_path: Path,
-) -> None:
-    """Test: --tags ",,," (カンマのみ) は正規化後に空リスト → exit_code=2。"""
-    mock_container = create_mock_service_container()
-    mock_get_container.return_value = mock_container
-
-    runner.invoke(app, ["project", "create", "test-project"])
-
-    output_dir = tmp_path / "export"
-    result = runner.invoke(
-        app,
-        [
-            "export",
-            "create",
-            "--project",
-            "test-project",
-            "--output",
-            str(output_dir),
-            "--tags",
-            ",,,",
-        ],
-    )
-
-    assert result.exit_code == 2
-    assert "At least one filter condition is required for export" in result.output
-
-
-@pytest.mark.unit
-@pytest.mark.cli
-@patch("lorairo.cli.commands.export.get_service_container")
-def test_export_create_whitespace_excluded_tags_exits_code_2(
-    mock_get_container,
-    mock_projects_dir: Path,
-    tmp_path: Path,
-) -> None:
-    """Test: --excluded-tags " , , " (空白・カンマのみ) は正規化後に空リスト → exit_code=2。"""
-    mock_container = create_mock_service_container()
-    mock_get_container.return_value = mock_container
-
-    runner.invoke(app, ["project", "create", "test-project"])
-
-    output_dir = tmp_path / "export"
-    result = runner.invoke(
-        app,
-        [
-            "export",
-            "create",
-            "--project",
-            "test-project",
-            "--output",
-            str(output_dir),
-            "--excluded-tags",
-            " , , ",
-        ],
-    )
-
-    assert result.exit_code == 2
-    assert "At least one filter condition is required for export" in result.output
-
-
-@pytest.mark.unit
-@pytest.mark.cli
-@patch("lorairo.cli.commands.export.get_service_container")
-def test_export_create_tags_with_blanks_and_valid_entries_passes(
-    mock_get_container,
-    mock_projects_dir: Path,
-    tmp_path: Path,
-) -> None:
-    """Test: --tags "cat,,dog" は空要素除外後も有効要素が残るため正常終了。"""
-    from lorairo.database.filter_criteria import ImageFilterCriteria
-
-    mock_container = create_mock_service_container()
-    mock_get_container.return_value = mock_container
-
-    runner.invoke(app, ["project", "create", "test-project"])
-
-    output_dir = tmp_path / "export"
-    result = runner.invoke(
-        app,
-        [
-            "export",
-            "create",
-            "--project",
-            "test-project",
-            "--output",
-            str(output_dir),
-            "--tags",
-            "cat,,dog",
-        ],
-    )
-
-    assert result.exit_code == 0
-    call_args = mock_container.db_manager.image_repo.get_images_by_filter.call_args
-    criteria_arg = call_args[0][0]
-    assert isinstance(criteria_arg, ImageFilterCriteria)
-    assert criteria_arg.tags == ["cat", "dog"]
-
-
-@pytest.mark.unit
-@pytest.mark.cli
-@patch("lorairo.cli.commands.export.get_service_container")
-def test_export_create_score_min_below_zero_exits_code_2(
-    mock_get_container,
-    mock_projects_dir: Path,
-    tmp_path: Path,
-) -> None:
-    """Test: --score-min が 0.0 未満は exit code 2。"""
-    mock_get_container.return_value = create_mock_service_container()
-    runner.invoke(app, ["project", "create", "test-project"])
-
-    result = runner.invoke(
-        app,
-        [
-            "export",
-            "create",
-            "--project",
-            "test-project",
-            "--output",
-            str(tmp_path / "export"),
-            "--score-min",
-            "-1.0",
-        ],
-    )
-
-    assert result.exit_code == 2
-
-
-@pytest.mark.unit
-@pytest.mark.cli
-@patch("lorairo.cli.commands.export.get_service_container")
-def test_export_create_score_max_above_ten_exits_code_2(
-    mock_get_container,
-    mock_projects_dir: Path,
-    tmp_path: Path,
-) -> None:
-    """Test: --score-max が 10.0 超は exit code 2。"""
-    mock_get_container.return_value = create_mock_service_container()
-    runner.invoke(app, ["project", "create", "test-project"])
-
-    result = runner.invoke(
-        app,
-        [
-            "export",
-            "create",
-            "--project",
-            "test-project",
-            "--output",
-            str(tmp_path / "export"),
-            "--score-max",
-            "99.0",
-        ],
-    )
-
-    assert result.exit_code == 2
-
-
-@pytest.mark.unit
-@pytest.mark.cli
-@patch("lorairo.cli.commands.export.get_service_container")
-def test_export_create_score_reversed_bounds_exits_code_2(
-    mock_get_container,
-    mock_projects_dir: Path,
-    tmp_path: Path,
-) -> None:
-    """Test: --score-min > --score-max は exit code 2（常に 0 件になる逆転指定を拒否）。"""
-    mock_get_container.return_value = create_mock_service_container()
-    runner.invoke(app, ["project", "create", "test-project"])
-
-    result = runner.invoke(
-        app,
-        [
-            "export",
-            "create",
-            "--project",
-            "test-project",
-            "--output",
-            str(tmp_path / "export"),
-            "--score-min",
-            "9.0",
-            "--score-max",
-            "1.0",
-        ],
-    )
-
-    assert result.exit_code == 2
-
-
-@pytest.mark.unit
-@pytest.mark.cli
-@patch("lorairo.cli.commands.export.get_service_container")
-def test_export_create_whitespace_tags_entry_stripped(
-    mock_get_container,
-    mock_projects_dir: Path,
-    tmp_path: Path,
-) -> None:
-    """Test: --tags " cat , , dog " は strip 後に有効要素として扱われる。"""
-    from lorairo.database.filter_criteria import ImageFilterCriteria
-
-    mock_container = create_mock_service_container()
-    mock_get_container.return_value = mock_container
-
-    runner.invoke(app, ["project", "create", "test-project"])
-
-    output_dir = tmp_path / "export"
-    result = runner.invoke(
-        app,
-        [
-            "export",
-            "create",
-            "--project",
-            "test-project",
-            "--output",
-            str(output_dir),
-            "--tags",
-            " cat , , dog ",
-        ],
-    )
-
-    assert result.exit_code == 0
-    call_args = mock_container.db_manager.image_repo.get_images_by_filter.call_args
-    criteria_arg = call_args[0][0]
-    assert isinstance(criteria_arg, ImageFilterCriteria)
-    assert criteria_arg.tags == ["cat", "dog"]
-
-
-@pytest.mark.unit
-@pytest.mark.cli
-@patch("lorairo.cli.commands.export.get_service_container")
-def test_export_create_project_name_passed_to_filter_criteria(
-    mock_get_container,
-    mock_projects_dir: Path,
-    tmp_path: Path,
-) -> None:
-    """--project に渡したプロジェクト名が ImageFilterCriteria.project_name として
-    get_images_by_filter に渡され、_apply_project_filter が有効になる。
-
-    _apply_project_filter は project_name を Image.project_id サブクエリに変換する。
-    None だとプロジェクト単位の絞り込みが機能しない。
-    """
-    mock_container = create_mock_service_container()
-    mock_get_container.return_value = mock_container
-
-    runner.invoke(app, ["project", "create", "my-project"])
-
-    output_dir = tmp_path / "export"
-    runner.invoke(
-        app,
-        [
-            "export",
-            "create",
-            "--project",
-            "my-project",
-            "--output",
-            str(output_dir),
-            "--tags",
-            "cat",
-        ],
-    )
-
-    call_args = mock_container.db_manager.image_repo.get_images_by_filter.call_args
-    criteria_arg = call_args[0][0]
-    assert isinstance(criteria_arg, ImageFilterCriteria)
-    assert criteria_arg.project_name == "my-project"
+class TestExportCreate:
+    def test_create_with_image_ids_calls_both_exporters(self, mock_export_context, tmp_path):
+        """--image-ids 指定時に txt と json 両エクスポーターが呼ばれる。"""
+        container, _ = mock_export_context
+        result = runner.invoke(
+            app,
+            [
+                "export",
+                "create",
+                "--project",
+                "proj",
+                "--image-ids",
+                "1,2,3",
+                "--output",
+                str(tmp_path / "out"),
+            ],
+        )
+        assert result.exit_code == 0
+        container.dataset_export_service.export_dataset_txt_format.assert_called_once()
+        container.dataset_export_service.export_dataset_json_format.assert_called_once()
+
+    def test_create_without_image_ids_fails(self, mock_export_context, tmp_path):
+        """--image-ids なしは exit 2 (INVALID_INPUT)。"""
+        result = runner.invoke(
+            app,
+            [
+                "export",
+                "create",
+                "--project",
+                "proj",
+                "--output",
+                str(tmp_path / "out"),
+            ],
+        )
+        assert result.exit_code == 2
+
+    def test_create_json_output_has_result_row(self, mock_export_context, tmp_path):
+        """--json 出力に kind=result 行が含まれる。"""
+        _container, _ = mock_export_context
+        result = runner.invoke(
+            app,
+            [
+                "--json",
+                "export",
+                "create",
+                "--project",
+                "proj",
+                "--image-ids",
+                "1,2,3",
+                "--output",
+                str(tmp_path / "out"),
+            ],
+        )
+        assert result.exit_code == 0
+        json_lines = []
+        for line in result.output.strip().splitlines():
+            if not line.strip():
+                continue
+            try:
+                json_lines.append(json.loads(line))
+            except json.JSONDecodeError:
+                pass  # loguru やその他の非 JSON 行はスキップ
+        result_row = next(r for r in json_lines if r.get("kind") == "result")
+        assert result_row["ok"] is True
+        assert result_row["total_images"] == 3
+
+    def test_create_invalid_image_ids_fails(self, mock_export_context, tmp_path):
+        """非整数の --image-ids は exit 2 (INVALID_INPUT)。"""
+        result = runner.invoke(
+            app,
+            [
+                "export",
+                "create",
+                "--project",
+                "proj",
+                "--image-ids",
+                "abc,def",
+                "--output",
+                str(tmp_path / "out"),
+            ],
+        )
+        assert result.exit_code == 2
+
+    def test_create_resolution_passed_to_exporters(self, mock_export_context, tmp_path):
+        """--resolution が両エクスポーターに渡される。"""
+        container, _ = mock_export_context
+        runner.invoke(
+            app,
+            [
+                "export",
+                "create",
+                "--project",
+                "proj",
+                "--image-ids",
+                "1",
+                "--output",
+                str(tmp_path / "out"),
+                "--resolution",
+                "1024",
+            ],
+        )
+        call_args_txt = container.dataset_export_service.export_dataset_txt_format.call_args
+        call_args_json = container.dataset_export_service.export_dataset_json_format.call_args
+        assert call_args_txt is not None
+        assert call_args_json is not None
+        # resolution は第3引数 (positional) または keyword "resolution" で渡される
+        txt_args = call_args_txt[0]
+        json_args = call_args_json[0]
+        assert 1024 in txt_args or call_args_txt[1].get("resolution") == 1024
+        assert 1024 in json_args or call_args_json[1].get("resolution") == 1024


### PR DESCRIPTION
## Summary
- `export create` から検索オプション（`--tags` / `--excluded-tags` / `--caption` / `--manual-rating` / `--ai-rating` / `--include-nsfw` / `--score-min` / `--score-max`）を完全削除
- `--format` を削除し常にタグ txt・キャプション txt・JSON の全形式を出力
- `--image-ids`（カンマ区切り整数リスト）を必須オプションとして追加
- 検索責務を `images search` コマンドに完全分離
- テストを新仕様に完全置き換え（5 tests）

## Test plan
- [x] `uv run pytest .agents/worktree/feat-issue-698/tests/unit/cli/test_commands_export.py -v` — 5 passed
- [x] CI-equivalent filter 全 PASS: `uv run pytest -m "not gui_show and not calls_real_webapi and not downloads_and_runs_model and not slow" --timeout=60` — 4036 passed, 2 skipped

Closes #698