### PR TITLE
fix(cli): introspection を新 API に同期 (fixes #702)

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -329,7 +329,7 @@ Structured error payload emitted as kind=error by the CLI boundary.
 
 ### `batch status`
 
-Show provider batch job status.
+Show provider batch job status. Pass --items to list per-image items (custom_id, image_id, model_id, task_type, status, error_type); useful for auditing duplicate rating_preflight submissions.
 
 - Read only: `false`
 - Side effects: `db_read`, `db_write`, `network`
@@ -347,10 +347,32 @@ lorairo-cli --json describe "batch status"
 - `job_id`: `int` (required)
 - `project`: `str` (required)
 - `refresh`: `bool` (optional, default `True`)
+- `items`: `bool` (optional, default `False`) - Emit ProviderBatchItemRecord item rows before the result. Use to inspect per-image item state or detect duplicate submissions.
+- `limit`: `int[1,500]` (optional, default `500`) - Page size for items query (only when --items is set).
+- `offset`: `int>=0` (optional, default `0`) - Rows to skip in items query (only when --items is set).
+- `item_status`: `str?` (optional) - Filter items by status when --items is set (e.g. succeeded, failed).
+
+**Output `ProviderBatchItemRecord`**
+
+Emitted per item when --items is set. Precedes the BatchStatusResult row.
+
+- `id`: `int` (optional)
+- `job_id`: `int` (optional)
+- `custom_id`: `str` (optional)
+- `image_id`: `int?` (optional)
+- `model_id`: `int?` (optional)
+- `task_type`: `str?` (optional)
+- `status`: `str` (optional)
+- `error_type`: `str?` (optional)
+- `error_message`: `str?` (optional)
 
 **Output `BatchStatusResult`**
 
 - `job`: `ProviderBatchJob` (optional)
+- `items_count`: `int?` (optional) - Number of item rows emitted (null when --items is not set).
+- `items_limit`: `int?` (optional)
+- `items_offset`: `int?` (optional)
+- `items_has_more`: `bool?` (optional)
 
 **Error `CliErrorResponse`**
 
@@ -411,7 +433,7 @@ Structured error payload emitted as kind=error by the CLI boundary.
 
 ### `export create`
 
-Export a filtered dataset from a project.
+Export a dataset from a list of image IDs. Use 'images search' to resolve IDs first.
 
 - Read only: `false`
 - Side effects: `db_read`, `file_read`, `file_write`
@@ -427,25 +449,16 @@ lorairo-cli --json describe "export create"
 **Input `ExportCreateInput`**
 
 - `project`: `str` (required)
+- `image_ids`: `csv[int]` (required) - Comma-separated image IDs, e.g. '1,2,3'. Use images search to resolve IDs.
 - `output`: `path` (required)
-- `format`: `txt|json` (optional, default `txt`)
 - `resolution`: `int` (optional, default `512`)
-- `tags`: `csv[str]?` (optional)
-- `excluded_tags`: `csv[str]?` (optional)
-- `caption`: `str?` (optional)
-- `manual_rating`: `rating?` (optional)
-- `ai_rating`: `rating?` (optional)
-- `include_nsfw`: `bool` (optional, default `False`)
-- `score_min`: `float[0,10]?` (optional)
-- `score_max`: `float[0,10]?` (optional)
 
 **Output `ExportCreateResult`**
 
 - `output_path`: `path?` (optional)
 - `total_images`: `int?` (optional)
-- `format`: `str?` (optional)
 - `resolution`: `int?` (optional)
-- `count`: `int?` (optional) - Set to 0 on the no-match success path.
+- `count`: `int?` (optional)
 
 **Error `CliErrorResponse`**
 
@@ -536,6 +549,73 @@ lorairo-cli --json describe "images register"
 - `registered`: `int` (optional)
 - `skipped`: `int` (optional)
 - `errors`: `int` (optional)
+
+**Error `CliErrorResponse`**
+
+Structured error payload emitted as kind=error by the CLI boundary.
+
+- `kind`: `error` (required)
+- `ok`: `false` (required)
+- `code`: `str` (required)
+- `message`: `str` (required)
+- `retryable`: `bool` (required)
+- `user_action_required`: `bool` (required)
+- `hint`: `str?` (optional)
+- `details`: `dict?` (optional)
+
+### `images search`
+
+Search images by JSON query. Returns image_ids for use with export create or tags commands.
+
+- Read only: `true`
+- Side effects: `db_read`
+
+#### Compact Introspection
+
+```bash
+lorairo-cli --json describe "images search"
+```
+
+#### Models
+
+**Input `ImagesSearchInput`**
+
+Pass exactly one of --query or --query-file.
+
+- `project`: `str` (required)
+- `query`: `json|'-'` (optional) - JSON search schema string, or '-' to read from stdin.
+- `query_file`: `path?` (optional) - Path to a JSON file containing the search schema.
+
+**Input `ImageSearchQuery`**
+
+JSON body schema passed via --query or --query-file.
+
+- `image_ids`: `list[int]?` (optional)
+- `tags`: `list[str]?` (optional)
+- `excluded_tags`: `list[str]?` (optional)
+- `caption`: `str?` (optional)
+- `manual_rating`: `str?` (optional)
+- `ai_rating`: `str?` (optional)
+- `score_min`: `float?` (optional)
+- `score_max`: `float?` (optional)
+- `only_unrated`: `bool` (optional, default `False`)
+- `missing_model`: `str?` (optional)
+- `include_nsfw`: `bool` (optional, default `False`)
+- `limit`: `int[1,500]` (optional, default `500`)
+- `offset`: `int>=0` (optional, default `0`)
+
+**Output `ImagesListItem`**
+
+- `image_id`: `int?` (optional)
+- `file_path`: `str?` (optional)
+
+**Output `ImagesListResult`**
+
+- `count`: `int` (optional)
+- `total`: `int?` (optional)
+- `limit`: `int?` (optional)
+- `offset`: `int?` (optional)
+- `has_more`: `bool?` (optional)
 
 **Error `CliErrorResponse`**
 
@@ -811,6 +891,156 @@ lorairo-cli --json describe "status"
 - `config_found`: `bool` (optional)
 - `api_keys`: `dict[str,bool]?` (optional)
 - `initialized_services`: `dict[str,bool]?` (optional)
+
+**Error `CliErrorResponse`**
+
+Structured error payload emitted as kind=error by the CLI boundary.
+
+- `kind`: `error` (required)
+- `ok`: `false` (required)
+- `code`: `str` (required)
+- `message`: `str` (required)
+- `retryable`: `bool` (required)
+- `user_action_required`: `bool` (required)
+- `hint`: `str?` (optional)
+- `details`: `dict?` (optional)
+
+### `tags add`
+
+Add tags to images. Default dry-run; use --apply to write.
+
+- Read only: `false`
+- Side effects: `db_read`, `db_write`
+
+#### Compact Introspection
+
+```bash
+lorairo-cli --json describe "tags add"
+```
+
+#### Models
+
+**Input `TagsAddInput`**
+
+- `project`: `str` (required)
+- `image_ids`: `csv[int]` (required) - Comma-separated image IDs, max 500.
+- `tags`: `csv[str]` (required) - Comma-separated tags to add.
+- `apply`: `bool` (optional, default `False`) - Write to DB. Default is dry-run.
+
+**Output `TagsEditItem`**
+
+- `image_id`: `int` (optional)
+- `action`: `add` (optional)
+- `tags`: `list[str]` (optional)
+- `status`: `str` (optional)
+
+**Output `TagsAddResult`**
+
+- `target_images`: `int` (optional)
+- `tags`: `list[str]` (optional)
+- `added`: `int` (optional)
+- `dry_run`: `bool` (optional)
+
+**Error `CliErrorResponse`**
+
+Structured error payload emitted as kind=error by the CLI boundary.
+
+- `kind`: `error` (required)
+- `ok`: `false` (required)
+- `code`: `str` (required)
+- `message`: `str` (required)
+- `retryable`: `bool` (required)
+- `user_action_required`: `bool` (required)
+- `hint`: `str?` (optional)
+- `details`: `dict?` (optional)
+
+### `tags remove`
+
+Remove tags from images. Default dry-run; use --apply to write.
+
+- Read only: `false`
+- Side effects: `db_read`, `db_write`
+
+#### Compact Introspection
+
+```bash
+lorairo-cli --json describe "tags remove"
+```
+
+#### Models
+
+**Input `TagsRemoveInput`**
+
+- `project`: `str` (required)
+- `image_ids`: `csv[int]` (required) - Comma-separated image IDs, max 500.
+- `tags`: `csv[str]` (required) - Comma-separated tags to remove.
+- `apply`: `bool` (optional, default `False`) - Write to DB. Default is dry-run.
+
+**Output `TagsEditItem`**
+
+- `image_id`: `int` (optional)
+- `action`: `remove` (optional)
+- `tags`: `list[str]` (optional)
+- `status`: `str` (optional)
+
+**Output `TagsRemoveResult`**
+
+- `target_images`: `int` (optional)
+- `tags`: `list[str]` (optional)
+- `removed`: `int` (optional)
+- `dry_run`: `bool` (optional)
+
+**Error `CliErrorResponse`**
+
+Structured error payload emitted as kind=error by the CLI boundary.
+
+- `kind`: `error` (required)
+- `ok`: `false` (required)
+- `code`: `str` (required)
+- `message`: `str` (required)
+- `retryable`: `bool` (required)
+- `user_action_required`: `bool` (required)
+- `hint`: `str?` (optional)
+- `details`: `dict?` (optional)
+
+### `tags replace`
+
+Replace a tag with another across images. Default dry-run; use --apply to write.
+
+- Read only: `false`
+- Side effects: `db_read`, `db_write`
+
+#### Compact Introspection
+
+```bash
+lorairo-cli --json describe "tags replace"
+```
+
+#### Models
+
+**Input `TagsReplaceInput`**
+
+- `project`: `str` (required)
+- `image_ids`: `csv[int]` (required) - Comma-separated image IDs, max 500.
+- `from_tag`: `str` (required) - Tag to replace.
+- `to_tag`: `str` (required) - Replacement tag.
+- `apply`: `bool` (optional, default `False`) - Write to DB. Default is dry-run.
+
+**Output `TagsEditItem`**
+
+- `image_id`: `int` (optional)
+- `action`: `replace` (optional)
+- `from`: `str` (optional)
+- `to`: `str` (optional)
+- `status`: `str` (optional)
+
+**Output `TagsReplaceResult`**
+
+- `target_images`: `int` (optional)
+- `changed`: `int` (optional)
+- `skipped`: `int` (optional)
+- `errors`: `int` (optional)
+- `dry_run`: `bool` (optional)
 
 **Error `CliErrorResponse`**
 

--- a/src/lorairo/cli/introspection.py
+++ b/src/lorairo/cli/introspection.py
@@ -13,6 +13,7 @@ from pydantic import BaseModel, ConfigDict, Field
 
 from lorairo.api.types import ProjectCreateRequest
 from lorairo.cli._emit import emit_item, emit_result
+from lorairo.cli.commands.images import ImageSearchQuery
 
 SideEffect = Literal["db_read", "db_write", "file_read", "file_write", "network"]
 SchemaMode = Literal["compact", "json_schema"]
@@ -230,80 +231,97 @@ class ImagesUpdateResult(BaseModel):
 
 
 class ExportCreateInputSchema(BaseModel):
-    """Implemented filter/options surface accepted by ``export create``."""
+    """Implemented options surface accepted by ``export create``.
+
+    export create requires --image-ids (comma-separated IDs).
+    Use ``images search`` to resolve IDs, then pass them here.
+    """
 
     project: str
+    image_ids: str = Field(description="Comma-separated image IDs to export, e.g. '1,2,3'.")
     output: str
-    format: Literal["txt", "json"] = "txt"
     resolution: int = 512
-    tags: str | None = None
-    excluded_tags: str | None = None
-    caption: str | None = None
-    # export create の _validate_rating が受理する正規化済み値 (VALID_RATINGS)。
-    manual_rating: Literal["PG", "PG-13", "R", "X", "XXX", "UNRATED"] | None = None
-    ai_rating: Literal["PG", "PG-13", "R", "X", "XXX", "UNRATED"] | None = None
-    include_nsfw: bool = False
-    score_min: float | None = Field(default=None, ge=0.0, le=10.0)
-    score_max: float | None = Field(default=None, ge=0.0, le=10.0)
 
-    # export create は最低 1 つの有効フィルタ (tags/excluded_tags/caption/manual_rating/
-    # ai_rating/score_min/score_max) を要求し、無指定は UsageError で弾く
-    # (_criteria_has_effective_filter)。include_nsfw は修飾子でフィルタとは扱わない。
-    #
-    # 各 anyOf ブランチは「キーの存在」だけでなく「正規化後に有効」も表現する (Issue #659):
-    # CLI 実体は正規化後に truthy 判定するため、schema 側もこれに揃える。
-    #   - CSV フィルタ (tags/excluded_tags): _normalize_csv がカンマ区切り→strip→非空
-    #     トークン抽出。"," や "  " は空集合になり無効なので、区切り(,)・空白以外の文字を
-    #     1つ以上含むことを pattern "[^\\s,]" で要求する。
-    #   - text フィルタ (caption): _normalize_text が strip→非空判定。"   " は無効なので
-    #     非空白文字を1つ以上含むことを pattern "\\S" で要求する (caption はカンマ可)。
-    #   - score フィルタ (score_min/score_max): number 型を明示し null を除外する。
-    #   - rating (manual_rating/ai_rating): Literal enum なので非null要求だけで有効値が保証。
-    # minLength=1 も併記し「非空」を明示する (pattern が正規化後の有効性を補強する)。
-    model_config = ConfigDict(
-        title="ExportCreateInput",
-        json_schema_extra={
-            "anyOf": [
-                {
-                    "required": ["tags"],
-                    "properties": {"tags": {"type": "string", "minLength": 1, "pattern": "[^\\s,]"}},
-                },
-                {
-                    "required": ["excluded_tags"],
-                    "properties": {
-                        "excluded_tags": {"type": "string", "minLength": 1, "pattern": "[^\\s,]"}
-                    },
-                },
-                {
-                    "required": ["caption"],
-                    "properties": {"caption": {"type": "string", "minLength": 1, "pattern": "\\S"}},
-                },
-                {"required": ["manual_rating"], "properties": {"manual_rating": {"type": "string"}}},
-                {"required": ["ai_rating"], "properties": {"ai_rating": {"type": "string"}}},
-                {"required": ["score_min"], "properties": {"score_min": {"type": "number"}}},
-                {"required": ["score_max"], "properties": {"score_max": {"type": "number"}}},
-            ]
-        },
-    )
+    model_config = ConfigDict(title="ExportCreateInput")
 
 
 class ExportCreateResult(BaseModel):
-    """JSONL result payload emitted by ``export create --json``.
-
-    A no-match export returns a success row containing only ``count=0``;
-    a completed export returns ``output_path`` plus the export metadata.
-    """
+    """JSONL result payload emitted by ``export create --json``."""
 
     kind: Literal["result"] = "result"
     ok: Literal[True] = True
     message: str
     output_path: str | None = None
     total_images: int | None = None
-    format: str | None = None
     resolution: int | None = None
     count: int | None = None
 
     model_config = ConfigDict(title="ExportCreateResult")
+
+
+class TagsEditItem(BaseModel):
+    """JSONL item payload emitted per image by ``tags add/remove/replace --json``."""
+
+    image_id: int
+    action: Literal["add", "remove", "replace"]
+    tags: list[str] | None = Field(default=None, description="Tags operated on (add/remove commands).")
+    from_tag: str | None = Field(
+        default=None,
+        alias="from",
+        description="Source tag (replace command only). Wire key is 'from'.",
+    )
+    to_tag: str | None = Field(
+        default=None,
+        alias="to",
+        description="Destination tag (replace command only). Wire key is 'to'.",
+    )
+    status: str
+    reason: str | None = None
+
+    model_config = ConfigDict(title="TagsEditItem", populate_by_name=True)
+
+
+class TagsAddResult(BaseModel):
+    """JSONL result payload emitted by ``tags add --json``."""
+
+    kind: Literal["result"] = "result"
+    ok: Literal[True] = True
+    message: str
+    target_images: int
+    tags: list[str]
+    added: int
+    dry_run: bool
+
+    model_config = ConfigDict(title="TagsAddResult")
+
+
+class TagsRemoveResult(BaseModel):
+    """JSONL result payload emitted by ``tags remove --json``."""
+
+    kind: Literal["result"] = "result"
+    ok: Literal[True] = True
+    message: str
+    target_images: int
+    tags: list[str]
+    removed: int
+    dry_run: bool
+
+    model_config = ConfigDict(title="TagsRemoveResult")
+
+
+class TagsReplaceResult(BaseModel):
+    """JSONL result payload emitted by ``tags replace --json``."""
+
+    kind: Literal["result"] = "result"
+    ok: Literal[True] = True
+    message: str
+    target_images: int
+    changed: int
+    skipped: int
+    errors: int
+    dry_run: bool
+
+    model_config = ConfigDict(title="TagsReplaceResult")
 
 
 class ModelsRefreshResult(BaseModel):
@@ -945,7 +963,7 @@ TOOL_SPECS: dict[str, ToolSpec] = {
     "export create": ToolSpec(
         name="export create",
         path="export create",
-        summary="Export a filtered dataset from a project.",
+        summary="Export a dataset from a list of image IDs. Use 'images search' to resolve IDs first.",
         read_only=False,
         side_effects=("db_read", "file_read", "file_write"),
         inputs=(
@@ -953,17 +971,14 @@ TOOL_SPECS: dict[str, ToolSpec] = {
                 "ExportCreateInput",
                 (
                     _f("project", "str", required=True),
+                    _f(
+                        "image_ids",
+                        "csv[int]",
+                        required=True,
+                        description="Comma-separated image IDs, e.g. '1,2,3'. Use images search to resolve IDs.",
+                    ),
                     _f("output", "path", required=True),
-                    _f("format", "txt|json", default="txt"),
                     _f("resolution", "int", default=512),
-                    _f("tags", "csv[str]?"),
-                    _f("excluded_tags", "csv[str]?"),
-                    _f("caption", "str?"),
-                    _f("manual_rating", "rating?"),
-                    _f("ai_rating", "rating?"),
-                    _f("include_nsfw", "bool", default=False),
-                    _f("score_min", "float[0,10]?"),
-                    _f("score_max", "float[0,10]?"),
                 ),
                 schema=ExportCreateInputSchema,
             ),
@@ -974,11 +989,217 @@ TOOL_SPECS: dict[str, ToolSpec] = {
                 (
                     _f("output_path", "path?"),
                     _f("total_images", "int?"),
-                    _f("format", "str?"),
                     _f("resolution", "int?"),
-                    _f("count", "int?", description="Set to 0 on the no-match success path."),
+                    _f("count", "int?"),
                 ),
                 schema=ExportCreateResult,
+            ),
+        ),
+        errors=(ERROR_MODEL,),
+    ),
+    "images search": ToolSpec(
+        name="images search",
+        path="images search",
+        summary="Search images by JSON query. Returns image_ids for use with export create or tags commands.",
+        read_only=True,
+        side_effects=("db_read",),
+        inputs=(
+            _input(
+                "ImagesSearchInput",
+                (
+                    _f("project", "str", required=True),
+                    _f(
+                        "query",
+                        "json|'-'",
+                        description="JSON search schema string, or '-' to read from stdin.",
+                    ),
+                    _f(
+                        "query_file",
+                        "path?",
+                        description="Path to a JSON file containing the search schema.",
+                    ),
+                ),
+                description="Pass exactly one of --query or --query-file.",
+            ),
+            ModelSpec(
+                name="ImageSearchQuery",
+                role="input",
+                description="JSON body schema passed via --query or --query-file.",
+                fields=(
+                    _f("image_ids", "list[int]?"),
+                    _f("tags", "list[str]?"),
+                    _f("excluded_tags", "list[str]?"),
+                    _f("caption", "str?"),
+                    _f("manual_rating", "str?"),
+                    _f("ai_rating", "str?"),
+                    _f("score_min", "float?"),
+                    _f("score_max", "float?"),
+                    _f("only_unrated", "bool", default=False),
+                    _f("missing_model", "str?"),
+                    _f("include_nsfw", "bool", default=False),
+                    _f("limit", "int[1,500]", default=500),
+                    _f("offset", "int>=0", default=0),
+                ),
+                schema_model=ImageSearchQuery,
+            ),
+        ),
+        outputs=(
+            _output(
+                "ImagesListItem",
+                (_f("image_id", "int?"), _f("file_path", "str?")),
+                schema=ImagesListItem,
+            ),
+            _output(
+                "ImagesListResult",
+                (
+                    _f("count", "int"),
+                    _f("total", "int?"),
+                    _f("limit", "int?"),
+                    _f("offset", "int?"),
+                    _f("has_more", "bool?"),
+                ),
+                schema=ImagesListResult,
+            ),
+        ),
+        errors=(ERROR_MODEL,),
+    ),
+    "tags add": ToolSpec(
+        name="tags add",
+        path="tags add",
+        summary="Add tags to images. Default dry-run; use --apply to write.",
+        read_only=False,
+        side_effects=("db_read", "db_write"),
+        inputs=(
+            _input(
+                "TagsAddInput",
+                (
+                    _f("project", "str", required=True),
+                    _f(
+                        "image_ids",
+                        "csv[int]",
+                        required=True,
+                        description="Comma-separated image IDs, max 500.",
+                    ),
+                    _f("tags", "csv[str]", required=True, description="Comma-separated tags to add."),
+                    _f("apply", "bool", default=False, description="Write to DB. Default is dry-run."),
+                ),
+            ),
+        ),
+        outputs=(
+            _output(
+                "TagsEditItem",
+                (
+                    _f("image_id", "int"),
+                    _f("action", "add"),
+                    _f("tags", "list[str]"),
+                    _f("status", "str"),
+                ),
+                schema=TagsEditItem,
+            ),
+            _output(
+                "TagsAddResult",
+                (
+                    _f("target_images", "int"),
+                    _f("tags", "list[str]"),
+                    _f("added", "int"),
+                    _f("dry_run", "bool"),
+                ),
+                schema=TagsAddResult,
+            ),
+        ),
+        errors=(ERROR_MODEL,),
+    ),
+    "tags remove": ToolSpec(
+        name="tags remove",
+        path="tags remove",
+        summary="Remove tags from images. Default dry-run; use --apply to write.",
+        read_only=False,
+        side_effects=("db_read", "db_write"),
+        inputs=(
+            _input(
+                "TagsRemoveInput",
+                (
+                    _f("project", "str", required=True),
+                    _f(
+                        "image_ids",
+                        "csv[int]",
+                        required=True,
+                        description="Comma-separated image IDs, max 500.",
+                    ),
+                    _f("tags", "csv[str]", required=True, description="Comma-separated tags to remove."),
+                    _f("apply", "bool", default=False, description="Write to DB. Default is dry-run."),
+                ),
+            ),
+        ),
+        outputs=(
+            _output(
+                "TagsEditItem",
+                (
+                    _f("image_id", "int"),
+                    _f("action", "remove"),
+                    _f("tags", "list[str]"),
+                    _f("status", "str"),
+                ),
+                schema=TagsEditItem,
+            ),
+            _output(
+                "TagsRemoveResult",
+                (
+                    _f("target_images", "int"),
+                    _f("tags", "list[str]"),
+                    _f("removed", "int"),
+                    _f("dry_run", "bool"),
+                ),
+                schema=TagsRemoveResult,
+            ),
+        ),
+        errors=(ERROR_MODEL,),
+    ),
+    "tags replace": ToolSpec(
+        name="tags replace",
+        path="tags replace",
+        summary="Replace a tag with another across images. Default dry-run; use --apply to write.",
+        read_only=False,
+        side_effects=("db_read", "db_write"),
+        inputs=(
+            _input(
+                "TagsReplaceInput",
+                (
+                    _f("project", "str", required=True),
+                    _f(
+                        "image_ids",
+                        "csv[int]",
+                        required=True,
+                        description="Comma-separated image IDs, max 500.",
+                    ),
+                    _f("from_tag", "str", required=True, description="Tag to replace."),
+                    _f("to_tag", "str", required=True, description="Replacement tag."),
+                    _f("apply", "bool", default=False, description="Write to DB. Default is dry-run."),
+                ),
+            ),
+        ),
+        outputs=(
+            _output(
+                "TagsEditItem",
+                (
+                    _f("image_id", "int"),
+                    _f("action", "replace"),
+                    _f("from", "str"),
+                    _f("to", "str"),
+                    _f("status", "str"),
+                ),
+                schema=TagsEditItem,
+            ),
+            _output(
+                "TagsReplaceResult",
+                (
+                    _f("target_images", "int"),
+                    _f("changed", "int"),
+                    _f("skipped", "int"),
+                    _f("errors", "int"),
+                    _f("dry_run", "bool"),
+                ),
+                schema=TagsReplaceResult,
             ),
         ),
         errors=(ERROR_MODEL,),

--- a/tests/unit/cli/test_introspection.py
+++ b/tests/unit/cli/test_introspection.py
@@ -436,20 +436,29 @@ def test_batch_status_result_schema_includes_items_pagination_fields() -> None:
 
 
 def test_describe_images_search_exposes_query_schema() -> None:
-    """describe images search が ImagesSearchInput と ImageSearchQuery スキーマを返す (Issue #702)。"""
+    """describe images search が ImageSearchQuery ボディスキーマを返す (Issue #702)。
+
+    ImagesSearchInput は schema_model を持たないため json_schema モードでは出力されない。
+    ImageSearchQuery (--query / --query-file で渡す JSON ボディ) は json_schema モードで出力される。
+    """
     result = runner.invoke(app, ["--json", "describe", "images search", "--schema", "json_schema"])
 
     assert result.exit_code == 0
     rows = _jsonl(result.stdout)
     schema_rows = [row for row in rows if row.get("type") == "schema"]
     names = {row["name"] for row in schema_rows}
-    assert "ImagesSearchInput" in names
     assert "ImageSearchQuery" in names
 
     query_schema = next(row for row in schema_rows if row["name"] == "ImageSearchQuery")
     props = set(query_schema["schema"]["properties"])
     assert {"tags", "excluded_tags", "limit", "offset"} <= props
     assert "image_ids" in props
+
+    # compact モードでは ImagesSearchInput が出力される
+    compact_result = runner.invoke(app, ["--json", "describe", "images search"])
+    assert compact_result.exit_code == 0
+    compact_rows = _jsonl(compact_result.stdout)
+    assert any(r.get("name") == "ImagesSearchInput" for r in compact_rows)
 
 
 def test_describe_tags_add_exposes_required_fields() -> None:

--- a/tests/unit/cli/test_introspection.py
+++ b/tests/unit/cli/test_introspection.py
@@ -35,6 +35,12 @@ def test_list_commands_emits_tool_items_and_result() -> None:
     assert images_update["read_only"] is False
     assert "db_write" in images_update["side_effects"]
 
+    paths = {row["path"] for row in items}
+    assert "images search" in paths
+    assert "tags add" in paths
+    assert "tags remove" in paths
+    assert "tags replace" in paths
+
 
 def test_list_commands_includes_version_and_status() -> None:
     """version / status も introspection に載る (Issue #662)。"""
@@ -81,6 +87,11 @@ def test_describe_compact_emits_tool_model_items_and_result() -> None:
     assert any(row["name"] == "ExportCreateInput" for row in model_rows)
     assert all(row["name"] != "ImageFilterCriteria" for row in model_rows)
 
+    input_row = next(row for row in model_rows if row["name"] == "ExportCreateInput")
+    field_names = {f["name"] for f in input_row["fields"]}
+    assert "image_ids" in field_names
+    assert "tags" not in field_names
+
 
 def test_images_update_describes_only_supported_input_fields() -> None:
     result = runner.invoke(app, ["--json", "describe", "images update"])
@@ -124,20 +135,18 @@ def test_describe_json_schema_wraps_cli_input_schema_in_item_payload() -> None:
 
     input_schema = next(row for row in schema_rows if row["name"] == "ExportCreateInput")
     assert "properties" in input_schema["schema"]
-    assert {"project", "output", "tags", "score_min", "score_max"} <= set(
-        input_schema["schema"]["properties"]
-    )
-    assert "image_ids" not in input_schema["schema"]["properties"]
+    assert {"project", "output", "image_ids", "resolution"} <= set(input_schema["schema"]["properties"])
+    # 旧フィルタ API は削除済み
+    for old_field in ("tags", "excluded_tags", "caption", "score_min", "score_max"):
+        assert old_field not in input_schema["schema"]["properties"]
     assert "missing_model_litellm_id" not in input_schema["schema"]["properties"]
     assert "sql" not in json.dumps(input_schema["schema"]).lower()
 
 
-def test_export_create_anyof_requires_non_null_non_empty_filter() -> None:
-    """export create の anyOf は「キー存在」だけでなく非null/非空も要求する (Issue #659)。
+def test_export_create_image_ids_is_required_and_no_filter_anyof() -> None:
+    """export create は --image-ids 必須、旧フィルタ anyOf は削除済み (Issue #702)。
 
-    CLI 実体は ``_criteria_has_effective_filter`` で正規化後に truthy 判定するため、
-    ``{tags: null}`` や ``--tags ""`` は UsageError で弾かれる。schema 側も string
-    フィルタは minLength=1、score フィルタは number 型でこの契約に揃える。
+    新 API は image_ids (CSV) を必須とし、tags/score/caption フィルタを受け付けない。
     """
     result = runner.invoke(app, ["--json", "describe", "export create", "--schema", "json_schema"])
     assert result.exit_code == 0
@@ -145,23 +154,15 @@ def test_export_create_anyof_requires_non_null_non_empty_filter() -> None:
     input_schema = next(
         row for row in rows if row.get("type") == "schema" and row["name"] == "ExportCreateInput"
     )
-    branches = {
-        tuple(branch["required"]): branch.get("properties", {})
-        for branch in input_schema["schema"]["anyOf"]
-    }
-    # string フィルタ: 非空 (minLength=1) かつ正規化後に有効 (pattern) を要求
-    for key in ("tags", "excluded_tags", "caption"):
-        constraint = branches[(key,)][key]
-        assert constraint["type"] == "string"
-        assert constraint["minLength"] == 1
-    # CSV フィルタは区切り(,)・空白以外の文字を要求し "," や "  " を弾く
-    for key in ("tags", "excluded_tags"):
-        assert branches[(key,)][key]["pattern"] == "[^\\s,]"
-    # text フィルタは非空白文字を要求し "   " を弾く (caption はカンマ可)
-    assert branches[("caption",)]["caption"]["pattern"] == "\\S"
-    # score フィルタ: number 型で null を除外
-    for key in ("score_min", "score_max"):
-        assert branches[(key,)][key]["type"] == "number"
+    schema = input_schema["schema"]
+    # image_ids は required に含まれる
+    assert "image_ids" in schema.get("required", [])
+    # 旧フィルタ anyOf は削除済み
+    assert "anyOf" not in schema
+    # 旧フィルタフィールドは存在しない
+    properties = schema.get("properties", {})
+    for old_field in ("tags", "excluded_tags", "caption", "score_min", "score_max"):
+        assert old_field not in properties
 
 
 def test_annotate_run_describes_only_supported_flags() -> None:
@@ -432,3 +433,82 @@ def test_batch_status_result_schema_includes_items_pagination_fields() -> None:
         "status",
         "error_type",
     } <= set(item_schema["schema"]["properties"])
+
+
+def test_describe_images_search_exposes_query_schema() -> None:
+    """describe images search が ImagesSearchInput と ImageSearchQuery スキーマを返す (Issue #702)。"""
+    result = runner.invoke(app, ["--json", "describe", "images search", "--schema", "json_schema"])
+
+    assert result.exit_code == 0
+    rows = _jsonl(result.stdout)
+    schema_rows = [row for row in rows if row.get("type") == "schema"]
+    names = {row["name"] for row in schema_rows}
+    assert "ImagesSearchInput" in names
+    assert "ImageSearchQuery" in names
+
+    query_schema = next(row for row in schema_rows if row["name"] == "ImageSearchQuery")
+    props = set(query_schema["schema"]["properties"])
+    assert {"tags", "excluded_tags", "limit", "offset"} <= props
+    assert "image_ids" in props
+
+
+def test_describe_tags_add_exposes_required_fields() -> None:
+    """describe tags add が image_ids / tags 必須フィールドを返す (Issue #702)。"""
+    result = runner.invoke(app, ["--json", "describe", "tags add"])
+
+    assert result.exit_code == 0
+    rows = _jsonl(result.stdout)
+    assert rows[0]["path"] == "tags add"
+
+    input_row = next(row for row in rows if row.get("type") == "model" and row["name"] == "TagsAddInput")
+    fields = {f["name"]: f for f in input_row["fields"]}
+    assert fields["project"]["required"] is True
+    assert fields["image_ids"]["required"] is True
+    assert fields["tags"]["required"] is True
+    assert fields["apply"]["default"] is False
+
+
+def test_describe_tags_remove_exposes_required_fields() -> None:
+    """describe tags remove が image_ids / tags 必須フィールドを返す (Issue #702)。"""
+    result = runner.invoke(app, ["--json", "describe", "tags remove"])
+
+    assert result.exit_code == 0
+    rows = _jsonl(result.stdout)
+    assert rows[0]["path"] == "tags remove"
+
+    input_row = next(row for row in rows if row.get("type") == "model" and row["name"] == "TagsRemoveInput")
+    fields = {f["name"]: f for f in input_row["fields"]}
+    assert fields["image_ids"]["required"] is True
+    assert fields["tags"]["required"] is True
+
+
+def test_describe_tags_replace_exposes_from_to_fields() -> None:
+    """describe tags replace が from_tag / to_tag 必須フィールドを返す (Issue #702)。"""
+    result = runner.invoke(app, ["--json", "describe", "tags replace"])
+
+    assert result.exit_code == 0
+    rows = _jsonl(result.stdout)
+    assert rows[0]["path"] == "tags replace"
+
+    input_row = next(
+        row for row in rows if row.get("type") == "model" and row["name"] == "TagsReplaceInput"
+    )
+    fields = {f["name"]: f for f in input_row["fields"]}
+    assert fields["from_tag"]["required"] is True
+    assert fields["to_tag"]["required"] is True
+    assert fields["apply"]["default"] is False
+
+
+def test_describe_tags_add_json_schema_includes_edit_item_and_result() -> None:
+    """tags add --schema json_schema が TagsEditItem / TagsAddResult スキーマを返す (Issue #702)。"""
+    result = runner.invoke(app, ["--json", "describe", "tags add", "--schema", "json_schema"])
+
+    assert result.exit_code == 0
+    rows = _jsonl(result.stdout)
+    schema_names = {row["name"] for row in rows if row.get("type") == "schema"}
+    assert "TagsEditItem" in schema_names
+    assert "TagsAddResult" in schema_names
+
+    result_schema = next(row for row in rows if row.get("name") == "TagsAddResult")
+    props = set(result_schema["schema"]["properties"])
+    assert {"target_images", "tags", "added", "dry_run"} <= props


### PR DESCRIPTION
## Summary

- `export create` の `ExportCreateInputSchema` を新 API（`--image-ids` 必須 CSV）へ更新、旧フィルタフィールド (`tags`, `excluded_tags`, `caption`, `score_min` 等) と `anyOf` 制約を削除
- `images search` / `tags add` / `tags remove` / `tags replace` を `TOOL_SPECS` へ新規追加 (describe / list-commands で返る)
- `TagsEditItem` / `TagsAddResult` / `TagsRemoveResult` / `TagsReplaceResult` Pydantic モデルを追加
- `test_introspection.py`: 旧 `anyOf` テストを新契約テストに置換、新コマンド 5 テストを追加
- `docs/cli.md` を `scripts/generate_cli_docs.py` で再生成

## Test plan

- [x] `tests/unit/cli/test_introspection.py` 全 19 テスト pass
- [x] CI-equivalent filter (4035 tests, 2 skipped) pass
- [x] `docs/cli.md` に `images search`, `tags add/remove/replace`, `export create` (新フィールド) が反映

Closes #702

🤖 Generated with [Claude Code](https://claude.com/claude-code)