### PR TITLE
fix(cli): tags add/remove/replace の --schema json_schema で入力スキーマを出力

### DIFF
--- a/src/lorairo/cli/introspection.py
+++ b/src/lorairo/cli/introspection.py
@@ -324,6 +324,40 @@ class TagsReplaceResult(BaseModel):
     model_config = ConfigDict(title="TagsReplaceResult")
 
 
+class TagsAddInputSchema(BaseModel):
+    """Implemented options surface accepted by ``tags add``."""
+
+    project: str
+    image_ids: str = Field(description="Comma-separated image IDs, max 500.")
+    tags: str = Field(description="Comma-separated tags to add.")
+    apply: bool = False
+
+    model_config = ConfigDict(title="TagsAddInput")
+
+
+class TagsRemoveInputSchema(BaseModel):
+    """Implemented options surface accepted by ``tags remove``."""
+
+    project: str
+    image_ids: str = Field(description="Comma-separated image IDs, max 500.")
+    tags: str = Field(description="Comma-separated tags to remove.")
+    apply: bool = False
+
+    model_config = ConfigDict(title="TagsRemoveInput")
+
+
+class TagsReplaceInputSchema(BaseModel):
+    """Implemented options surface accepted by ``tags replace``."""
+
+    project: str
+    image_ids: str = Field(description="Comma-separated image IDs, max 500.")
+    from_tag: str = Field(description="Tag to replace.")
+    to_tag: str = Field(description="Replacement tag.")
+    apply: bool = False
+
+    model_config = ConfigDict(title="TagsReplaceInput")
+
+
 class ModelsRefreshResult(BaseModel):
     """JSONL result payload emitted by ``models refresh --json``."""
 
@@ -1083,6 +1117,7 @@ TOOL_SPECS: dict[str, ToolSpec] = {
                     _f("tags", "csv[str]", required=True, description="Comma-separated tags to add."),
                     _f("apply", "bool", default=False, description="Write to DB. Default is dry-run."),
                 ),
+                schema=TagsAddInputSchema,
             ),
         ),
         outputs=(
@@ -1129,6 +1164,7 @@ TOOL_SPECS: dict[str, ToolSpec] = {
                     _f("tags", "csv[str]", required=True, description="Comma-separated tags to remove."),
                     _f("apply", "bool", default=False, description="Write to DB. Default is dry-run."),
                 ),
+                schema=TagsRemoveInputSchema,
             ),
         ),
         outputs=(
@@ -1176,6 +1212,7 @@ TOOL_SPECS: dict[str, ToolSpec] = {
                     _f("to_tag", "str", required=True, description="Replacement tag."),
                     _f("apply", "bool", default=False, description="Write to DB. Default is dry-run."),
                 ),
+                schema=TagsReplaceInputSchema,
             ),
         ),
         outputs=(

--- a/tests/unit/cli/test_introspection.py
+++ b/tests/unit/cli/test_introspection.py
@@ -509,15 +509,52 @@ def test_describe_tags_replace_exposes_from_to_fields() -> None:
 
 
 def test_describe_tags_add_json_schema_includes_edit_item_and_result() -> None:
-    """tags add --schema json_schema が TagsEditItem / TagsAddResult スキーマを返す (Issue #702)。"""
+    """tags add --schema json_schema が TagsAddInput / TagsEditItem / TagsAddResult スキーマを返す (Issue #702)。"""
     result = runner.invoke(app, ["--json", "describe", "tags add", "--schema", "json_schema"])
 
     assert result.exit_code == 0
     rows = _jsonl(result.stdout)
     schema_names = {row["name"] for row in rows if row.get("type") == "schema"}
+    assert "TagsAddInput" in schema_names
     assert "TagsEditItem" in schema_names
     assert "TagsAddResult" in schema_names
+
+    input_schema = next(row for row in rows if row.get("name") == "TagsAddInput")
+    input_props = set(input_schema["schema"]["properties"])
+    assert {"project", "image_ids", "tags", "apply"} <= input_props
 
     result_schema = next(row for row in rows if row.get("name") == "TagsAddResult")
     props = set(result_schema["schema"]["properties"])
     assert {"target_images", "tags", "added", "dry_run"} <= props
+
+
+def test_describe_tags_remove_json_schema_includes_input_and_result() -> None:
+    """tags remove --schema json_schema が TagsRemoveInput / TagsEditItem / TagsRemoveResult スキーマを返す (Issue #702b)。"""
+    result = runner.invoke(app, ["--json", "describe", "tags remove", "--schema", "json_schema"])
+
+    assert result.exit_code == 0
+    rows = _jsonl(result.stdout)
+    schema_names = {row["name"] for row in rows if row.get("type") == "schema"}
+    assert "TagsRemoveInput" in schema_names
+    assert "TagsEditItem" in schema_names
+    assert "TagsRemoveResult" in schema_names
+
+    input_schema = next(row for row in rows if row.get("name") == "TagsRemoveInput")
+    input_props = set(input_schema["schema"]["properties"])
+    assert {"project", "image_ids", "tags", "apply"} <= input_props
+
+
+def test_describe_tags_replace_json_schema_includes_input_and_result() -> None:
+    """tags replace --schema json_schema が TagsReplaceInput / TagsEditItem / TagsReplaceResult スキーマを返す (Issue #702b)。"""
+    result = runner.invoke(app, ["--json", "describe", "tags replace", "--schema", "json_schema"])
+
+    assert result.exit_code == 0
+    rows = _jsonl(result.stdout)
+    schema_names = {row["name"] for row in rows if row.get("type") == "schema"}
+    assert "TagsReplaceInput" in schema_names
+    assert "TagsEditItem" in schema_names
+    assert "TagsReplaceResult" in schema_names
+
+    input_schema = next(row for row in rows if row.get("name") == "TagsReplaceInput")
+    input_props = set(input_schema["schema"]["properties"])
+    assert {"project", "image_ids", "from_tag", "to_tag", "apply"} <= input_props


### PR DESCRIPTION
## Summary

- `tags add` / `tags remove` / `tags replace` コマンドで `--schema json_schema` を使用すると入力スキーマが出力されなかった問題を修正
- `TagsAddInputSchema` / `TagsRemoveInputSchema` / `TagsReplaceInputSchema` の Pydantic モデルを `introspection.py` に追加し、`_input()` の `schema=` パラメータに渡す
- compact describe では入力モデルが表示されていたが `json_schema` モードでは `schema_model=None` のため `schema_payload()` が `None` を返しスキップされていた

## Test plan

- [ ] `uv run pytest tests/unit/cli/test_introspection.py` — 26 tests pass
- [ ] 新テスト: `test_describe_tags_add_json_schema_includes_edit_item_and_result` (TagsAddInput assertion 追加)
- [ ] 新テスト: `test_describe_tags_remove_json_schema_includes_input_and_result`
- [ ] 新テスト: `test_describe_tags_replace_json_schema_includes_input_and_result`
- [ ] CI-equivalent filter: 4040 passed (main checkout)

🤖 Generated with [Claude Code](https://claude.com/claude-code)