### PR TITLE
fix(cli,db): パス正規化 + annotate run --resolution オプション追加 (Issue #706/#707)

### DIFF
--- a/src/lorairo/cli/commands/annotate.py
+++ b/src/lorairo/cli/commands/annotate.py
@@ -32,7 +32,6 @@ if TYPE_CHECKING:
 from lorairo.api.batch_import import import_batch_annotations
 from lorairo.api.exceptions import (
     AnnotationFailedError,
-    BatchImportError,
     ResultSetTooLargeError,
 )
 from lorairo.api.project import get_project as api_get_project
@@ -278,6 +277,7 @@ class _StreamAnnotateSummary:
     saved: int = 0
     skipped: int = 0
     preflight_skipped: int = 0
+    resolution_skipped: int = 0
     save_errors: int = 0
     any_success: bool = False
     error_models: set[str] = field(default_factory=set)
@@ -367,6 +367,7 @@ def _stream_annotate(
     save_service: Any,
     resolved_litellm_ids: list[str],
     moderation_preflight_service: ModerationPreflightService | None = None,
+    resolution_skipped: int = 0,
 ) -> _StreamAnnotateSummary:
     """レコードを chunk 単位でロード→アノテーション→DB 保存する (Issue #536 / #537)。
 
@@ -389,7 +390,7 @@ def _stream_annotate(
         ImageLoadMemoryError: メモリ/リソース枯渇による致命的ロード失敗時。
         typer.Exit: ``annotator.annotate`` が例外を投げた場合 (code=1)。
     """
-    summary = _StreamAnnotateSummary()
+    summary = _StreamAnnotateSummary(resolution_skipped=resolution_skipped)
 
     progress_context: Any
     if is_json_mode():
@@ -527,7 +528,7 @@ def _annotate_and_save_chunk(
     selected_image_ids = {int(record["id"]) for record in records_chunk if record.get("id") is not None}
     save_result = save_service.save_annotation_results(
         results,
-        allowed_image_ids=selected_image_ids if selected_image_ids else None,
+        allowed_image_ids=selected_image_ids or None,
     )
     summary.saved += save_result.success_count
     summary.skipped += save_result.skip_count
@@ -555,6 +556,11 @@ def _finalize_annotation_run(summary: _StreamAnnotateSummary, resolved_litellm_i
         return
 
     console.print(f"[green]Loaded {summary.total_loaded} image(s) ({summary.total_failed} failed)[/green]")
+    if summary.resolution_skipped:
+        console.print(
+            f"[yellow]Resolution filter skipped {summary.resolution_skipped} image(s)"
+            f" (no processed image at requested resolution)[/yellow]"
+        )
     if summary.preflight_skipped:
         console.print(f"[yellow]Moderation preflight skipped {summary.preflight_skipped} image(s)[/yellow]")
 
@@ -585,6 +591,8 @@ def _finalize_annotation_run(summary: _StreamAnnotateSummary, resolved_litellm_i
     summary_table.add_row("Saved to DB", str(summary.saved))
     summary_table.add_row("Skipped", str(summary.skipped))
     summary_table.add_row("Preflight Skipped", str(summary.preflight_skipped))
+    if summary.resolution_skipped:
+        summary_table.add_row("Resolution Skipped", str(summary.resolution_skipped))
 
     console.print(summary_table)
 
@@ -611,6 +619,7 @@ def _emit_annotation_result(summary: _StreamAnnotateSummary, resolved_litellm_id
         f"Annotated {summary.saved} image(s)",
         annotated=summary.saved,
         skipped=summary.skipped + summary.preflight_skipped + summary.total_failed,
+        resolution_skipped=summary.resolution_skipped,
         errors=summary.save_errors + len(summary.error_models),
         loaded=summary.total_loaded,
         results=summary.total_results,
@@ -860,6 +869,15 @@ def run(
         "--missing-model",
         help="Annotate only images without saved annotations from the given LiteLLM model ID.",
     ),
+    resolution: int | None = typer.Option(
+        None,
+        "--resolution",
+        min=1,
+        help=(
+            "Use processed images at this resolution (long side in pixels). "
+            "Images without a matching processed image are skipped."
+        ),
+    ),
 ) -> None:
     """Run annotation on project images.
 
@@ -916,7 +934,28 @@ def run(
         if not records_to_process:
             raise AnnotationSelectionError("No images selected for annotation")
 
-        reject_original_image_records(records_to_process, command_name="annotate run")
+        resolution_skipped_count = 0
+        if resolution is not None:
+            # 処理済み画像パスを一括取得してレコードに置換 (Issue #706)
+            record_ids = [r["id"] for r in records_to_process if r.get("id") is not None]
+            proc_paths = image_repo.get_processed_image_paths_by_resolution(record_ids, resolution)
+            filtered_records = []
+            for record in records_to_process:
+                image_id = record.get("id")
+                if image_id in proc_paths:
+                    updated = dict(record)
+                    updated["stored_image_path"] = proc_paths[image_id]
+                    filtered_records.append(updated)
+                else:
+                    resolution_skipped_count += 1
+            records_to_process = filtered_records
+            if not records_to_process:
+                raise AnnotationSelectionError(
+                    f"No processed images found at resolution {resolution}; "
+                    f"{resolution_skipped_count} image(s) skipped"
+                )
+        else:
+            reject_original_image_records(records_to_process, command_name="annotate run")
 
         if len(records_to_process) > MAX_ANNOTATE_IMAGES:
             raise ResultSetTooLargeError(len(records_to_process), MAX_ANNOTATE_IMAGES)
@@ -976,6 +1015,7 @@ def run(
             save_service=container.annotation_save_service,
             resolved_litellm_ids=resolved_litellm_ids,
             moderation_preflight_service=moderation_preflight_service,
+            resolution_skipped=resolution_skipped_count,
         )
 
         _finalize_annotation_run(summary, resolved_litellm_ids)

--- a/src/lorairo/cli/commands/annotate.py
+++ b/src/lorairo/cli/commands/annotate.py
@@ -798,6 +798,36 @@ def _handle_no_image_records(
     )
 
 
+def _apply_resolution_filter(
+    records: list[dict[str, Any]],
+    image_repo: Any,
+    resolution: int,
+) -> tuple[list[dict[str, Any]], int]:
+    """処理済み画像パスで records を差し替え、該当なしをスキップカウントする (Issue #706)。
+
+    Args:
+        records: 処理対象レコード。
+        image_repo: ImageRepository インスタンス。
+        resolution: 目標解像度 (長辺ピクセル数)。
+
+    Returns:
+        (更新済みレコードリスト, スキップ件数)
+    """
+    record_ids = [r["id"] for r in records if r.get("id") is not None]
+    proc_paths = image_repo.get_processed_image_paths_by_resolution(record_ids, resolution)
+    filtered: list[dict[str, Any]] = []
+    skipped = 0
+    for record in records:
+        image_id = record.get("id")
+        if image_id in proc_paths:
+            updated = dict(record)
+            updated["stored_image_path"] = proc_paths[image_id]
+            filtered.append(updated)
+        else:
+            skipped += 1
+    return filtered, skipped
+
+
 def _print_annotation_filter_summary(
     *,
     unrated: bool,
@@ -936,19 +966,9 @@ def run(
 
         resolution_skipped_count = 0
         if resolution is not None:
-            # 処理済み画像パスを一括取得してレコードに置換 (Issue #706)
-            record_ids = [r["id"] for r in records_to_process if r.get("id") is not None]
-            proc_paths = image_repo.get_processed_image_paths_by_resolution(record_ids, resolution)
-            filtered_records = []
-            for record in records_to_process:
-                image_id = record.get("id")
-                if image_id in proc_paths:
-                    updated = dict(record)
-                    updated["stored_image_path"] = proc_paths[image_id]
-                    filtered_records.append(updated)
-                else:
-                    resolution_skipped_count += 1
-            records_to_process = filtered_records
+            records_to_process, resolution_skipped_count = _apply_resolution_filter(
+                records_to_process, image_repo, resolution
+            )
             if not records_to_process:
                 raise AnnotationSelectionError(
                     f"No processed images found at resolution {resolution}; "

--- a/src/lorairo/database/repository/image.py
+++ b/src/lorairo/database/repository/image.py
@@ -543,8 +543,8 @@ class ImageRepository(BaseRepository):
         new_image = Image(
             uuid=info["uuid"],
             phash=phash,
-            original_image_path=str(info["original_image_path"]),  # Pathオブジェクトを文字列に
-            stored_image_path=str(info["stored_image_path"]),  # Pathオブジェクトを文字列に
+            original_image_path=str(info["original_image_path"]).replace("\\", "/"),
+            stored_image_path=str(info["stored_image_path"]).replace("\\", "/"),
             width=info["width"],
             height=info["height"],
             format=info["format"],
@@ -656,7 +656,7 @@ class ImageRepository(BaseRepository):
         # 新しい ProcessedImage オブジェクトを作成
         new_processed_image = ProcessedImage(
             image_id=image_id,
-            stored_image_path=str(info["stored_image_path"]),  # Pathオブジェクトを文字列に
+            stored_image_path=str(info["stored_image_path"]).replace("\\", "/"),
             width=width,
             height=height,
             mode=info.get("mode"),
@@ -911,6 +911,39 @@ class ImageRepository(BaseRepository):
                     exc_info=True,
                 )
                 raise
+
+    def get_processed_image_paths_by_resolution(
+        self, image_ids: list[int], resolution: int
+    ) -> dict[int, str]:
+        """指定解像度に最も近い処理済み画像パスを image_id ごとに一括取得する (Issue #706)。
+
+        Args:
+            image_ids: 対象画像 ID リスト。
+            resolution: 目標解像度 (長辺ピクセル数)。
+
+        Returns:
+            {image_id: stored_image_path} マッピング。該当解像度がない画像は含まない。
+
+        Raises:
+            SQLAlchemyError: データベース操作でエラーが発生した場合。
+        """
+        if not image_ids:
+            return {}
+        with self.session_factory() as session:
+            stmt = select(ProcessedImage).where(ProcessedImage.image_id.in_(image_ids))
+            all_proc = list(session.execute(stmt).scalars().all())
+
+        by_image: dict[int, list[dict[str, Any]]] = {}
+        for img in all_proc:
+            entry = {c.name: getattr(img, c.name) for c in img.__table__.columns}
+            by_image.setdefault(img.image_id, []).append(entry)
+
+        result: dict[int, str] = {}
+        for image_id, metadata_list in by_image.items():
+            selected = self._filter_by_resolution(metadata_list, resolution)
+            if selected:
+                result[image_id] = selected["stored_image_path"]
+        return result
 
     def _filter_by_resolution(
         self,
@@ -1700,7 +1733,7 @@ class ImageRepository(BaseRepository):
 
             latest_caption = max(
                 image.captions,
-                key=lambda c: c.created_at if c.created_at else datetime.min,
+                key=lambda c: c.created_at or datetime.min,
             )
             annotations["caption_text"] = latest_caption.caption
         else:
@@ -2201,7 +2234,7 @@ class ImageRepository(BaseRepository):
             条件にマッチした画像メタデータのリストとその総数。
         """
         # criteriaが指定されていればそれを使用、なければkwargsから生成
-        filter_criteria = criteria if criteria else ImageFilterCriteria.from_kwargs(**kwargs)
+        filter_criteria = criteria or ImageFilterCriteria.from_kwargs(**kwargs)
 
         # 型安全性チェック: resolution が文字列の場合は int に変換
         if isinstance(filter_criteria.resolution, str):
@@ -2299,7 +2332,7 @@ class ImageRepository(BaseRepository):
             条件に一致した画像件数。
 
         """
-        filter_criteria = criteria if criteria else ImageFilterCriteria.from_kwargs(**kwargs)
+        filter_criteria = criteria or ImageFilterCriteria.from_kwargs(**kwargs)
 
         # ADR 0055: image_ids 指定時は exact-set として他フィルタを bypass する。
         # get_images_by_filter と総件数を一致させるため同一 helper の総件数を返す
@@ -2364,7 +2397,7 @@ class ImageRepository(BaseRepository):
         Returns:
             (一覧行, フィルタ総件数)。一覧行は ``image_id`` / ``file_path`` のみ。
         """
-        filter_criteria = criteria if criteria else ImageFilterCriteria.from_kwargs(**kwargs)
+        filter_criteria = criteria or ImageFilterCriteria.from_kwargs(**kwargs)
 
         with self.session_factory() as session:
             try:


### PR DESCRIPTION
## Summary

### Issue #707 — Windows バックスラッシュパスを Linux で解決できない

- `add_image()` と `add_processed_image()` でパスを DB に保存する際、`str(path).replace("\\", "/")` でバックスラッシュをスラッシュに正規化
- 読み込み側 (`resolve_stored_path()`) は既に正規化済み。保存側のみの修正

### Issue #706 — `annotate run` に `--resolution` オプションを追加

- `--resolution <int>`: 指定解像度（長辺ピクセル）に最も近い処理済み画像を使ってアノテーション実行
- `ImageRepository.get_processed_image_paths_by_resolution(image_ids, resolution)` を新規追加（バッチ取得、内部で `_filter_by_resolution` を使用）
- `--resolution` 指定時はオリジナル画像チェック (`reject_original_image_records`) をスキップ
- 該当解像度の処理済み画像がない画像は `resolution_skipped` としてカウントしサマリー・JSON 出力に追加

## Test plan

- [x] `uv run pytest -m "not gui_show and not calls_real_webapi and not downloads_and_runs_model and not slow"` — 4042 passed
- [x] `make test-iam-lib` — 855 passed (無関係だが regression チェック)
- [ ] `lorairo-cli annotate run --project P --model M --resolution 1024` でエンドツーエンド確認 (ADR 0026 on-demand smoke)

Closes #706
Closes #707

🤖 Generated with [Claude Code](https://claude.com/claude-code)