### PR TITLE
fix(cli/db): --resolution pHash不一致とWindowsパス解決の修正

### DIFF
--- a/src/lorairo/cli/commands/annotate.py
+++ b/src/lorairo/cli/commands/annotate.py
@@ -124,7 +124,7 @@ def _iter_record_batches(records: list[dict[str, Any]], batch_size: int) -> Iter
 
 def _load_batch_images(
     records_chunk: list[dict[str, Any]],
-) -> tuple[list[Image.Image], int, int]:
+) -> tuple[list[Image.Image], list[dict[str, Any]], int, int]:
     """1 チャンク分の画像のみ open/load する (Issue #536 / #537)。
 
     各レコードについて ``stored_image_path`` を解決し ``Image.open`` →

--- a/src/lorairo/cli/commands/annotate.py
+++ b/src/lorairo/cli/commands/annotate.py
@@ -141,7 +141,8 @@ def _load_batch_images(
         records_chunk: ``_iter_record_batches`` が返す 1 チャンク分のレコード。
 
     Returns:
-        tuple: (ロード済み PIL 画像リスト, ロード成功数, ロード失敗数)。
+        tuple: (ロード済み PIL 画像リスト, ロード成功レコードリスト, ロード成功数, ロード失敗数)。
+            images[i] と loaded_records[i] は同じ画像を指す (phash_list 構築用)。
 
     Raises:
         ImageLoadMemoryError: メモリ/リソース枯渇による致命的ロード失敗時。
@@ -149,6 +150,7 @@ def _load_batch_images(
     from lorairo.database.db_core import resolve_stored_path
 
     pil_images: list[Image.Image] = []
+    loaded_records: list[dict[str, Any]] = []
     loaded_count = 0
     failed_count = 0
 
@@ -179,9 +181,10 @@ def _load_batch_images(
             continue
 
         pil_images.append(img)
+        loaded_records.append(record)
         loaded_count += 1
 
-    return pil_images, loaded_count, failed_count
+    return pil_images, loaded_records, loaded_count, failed_count
 
 
 def _select_image_records(
@@ -421,7 +424,8 @@ def _stream_annotate(
                     continue
 
             # Issue #537: FATAL (メモリ枯渇) は ImageLoadMemoryError で送出される。
-            images, loaded, failed = _load_batch_images(chunk)
+            # loaded_records は images と 1:1 対応。失敗分は除外済み (phash_list 用)。
+            images, loaded_records, loaded, failed = _load_batch_images(chunk)
             summary.total_loaded += loaded
             summary.total_failed += failed
 
@@ -432,6 +436,7 @@ def _stream_annotate(
             try:
                 _annotate_and_save_chunk(
                     records_chunk=chunk,
+                    loaded_records=loaded_records,
                     images=images,
                     annotator=annotator,
                     save_service=save_service,
@@ -492,6 +497,7 @@ def _apply_moderation_preflight_to_records(
 def _annotate_and_save_chunk(
     *,
     records_chunk: list[dict[str, Any]],
+    loaded_records: list[dict[str, Any]],
     images: list[Image.Image],
     annotator: Any,
     save_service: Any,
@@ -501,6 +507,8 @@ def _annotate_and_save_chunk(
     """1 チャンク分の画像をアノテーション → DB 保存し ``summary`` を更新する。
 
     Args:
+        records_chunk: チャンク全レコード (保存スコープ・JSON emit 用)。
+        loaded_records: ロード成功レコード。images[i] と 1:1 対応 (phash_list 構築用)。
         images: ロード済み PIL 画像 (非空)。
         annotator: アノテータ。
         save_service: 保存サービス。
@@ -512,9 +520,10 @@ def _annotate_and_save_chunk(
     """
     try:
         # Issue #245: AnnotatorLibraryAdapter.annotate は kwarg `litellm_model_ids` を受け取る。
-        # Issue #706: --resolution 時は処理済み画像を読むが pHash は元画像の値を使う必要がある。
-        # records には DB 上の phash が入っているため、常に phash_list を渡して再計算を抑制する。
-        phash_list = [str(r["phash"]) for r in records_chunk if r.get("phash") is not None]
+        # Issue #706: --resolution 時は処理済み画像から pHash を再計算すると元画像の pHash と
+        # 不一致になり DB 保存が 0 件になる。loaded_records は images と 1:1 対応しているため
+        # phash_list を渡して再計算を抑制し DB 上の元 pHash をキーとして使わせる。
+        phash_list = [str(r["phash"]) for r in loaded_records if r.get("phash") is not None]
         results = annotator.annotate(
             images,
             litellm_model_ids=resolved_litellm_ids,

--- a/src/lorairo/cli/commands/annotate.py
+++ b/src/lorairo/cli/commands/annotate.py
@@ -512,7 +512,14 @@ def _annotate_and_save_chunk(
     """
     try:
         # Issue #245: AnnotatorLibraryAdapter.annotate は kwarg `litellm_model_ids` を受け取る。
-        results = annotator.annotate(images, litellm_model_ids=resolved_litellm_ids)
+        # Issue #706: --resolution 時は処理済み画像を読むが pHash は元画像の値を使う必要がある。
+        # records には DB 上の phash が入っているため、常に phash_list を渡して再計算を抑制する。
+        phash_list = [str(r["phash"]) for r in records_chunk if r.get("phash") is not None]
+        results = annotator.annotate(
+            images,
+            litellm_model_ids=resolved_litellm_ids,
+            phash_list=phash_list if phash_list else None,
+        )
     except Exception as e:
         logger.error(f"Annotation error: {e}", exc_info=True)
         raise AnnotationFailedError(", ".join(resolved_litellm_ids), len(images), str(e)) from e

--- a/src/lorairo/database/db_core.py
+++ b/src/lorairo/database/db_core.py
@@ -216,7 +216,7 @@ def resolve_stored_path(stored_path: str) -> Path:
     except ValueError:
         pass
 
-    resolved = project_root / stored_path
+    resolved = project_root / path  # バックスラッシュ正規化済みの path を使う (Issue #707)
     logger.trace(f"パス解決: {stored_path} -> {resolved}")
     _resolve_cache[stored_path] = resolved
     return resolved

--- a/tests/unit/cli/test_annotate_load_failure.py
+++ b/tests/unit/cli/test_annotate_load_failure.py
@@ -85,7 +85,7 @@ def _build_container(image_files: list[Path]) -> MagicMock:
     mock_config = MagicMock()
     mock_config.get_setting.return_value = "test_key"
 
-    def _annotate(images, litellm_model_ids):
+    def _annotate(images, litellm_model_ids, **_kwargs):
         return {f"hash_{idx}": {"gpt-4o-mini": MagicMock(error=None)} for idx in range(len(images))}
 
     mock_annotator.annotate.side_effect = _annotate

--- a/tests/unit/cli/test_annotate_streaming.py
+++ b/tests/unit/cli/test_annotate_streaming.py
@@ -89,7 +89,7 @@ def _build_container(image_files: list[Path]) -> MagicMock:
     mock_config.get_setting.return_value = "test_key"
 
     # 成功結果 (error=None) を 1 モデル分返す。
-    def _annotate(images, litellm_model_ids):
+    def _annotate(images, litellm_model_ids, **_kwargs):
         return {f"hash_{idx}": {"gpt-4o-mini": MagicMock(error=None)} for idx in range(len(images))}
 
     mock_annotator.annotate.side_effect = _annotate


### PR DESCRIPTION
## Summary

- **Issue #707 再修正**: `resolve_stored_path()` の fallback パス結合でバックスラッシュ正規化済みの `path` を使うよう修正（旧コードは `stored_path`（バックスラッシュ含む）を使っていたため Linux で `exists=False` になっていた）
- **Issue #706 pHash 修正**: `_annotate_and_save_chunk` で DB レコードの `phash` を `phash_list` に渡して `annotate()` の pHash 再計算を抑制。`--resolution` 時に処理済み画像から pHash が再計算されると元画像の pHash と不一致になり保存が 0 件になっていた

## Root cause

### #707
`db_core.py:219` で `project_root / stored_path` としていたが、Linux では `\\` は Path セパレータとして扱われないため、`image_dataset\img.jpg` が単一ファイル名として結合されていた。

### #706
`--resolution` 適用後は `stored_image_path` が処理済み画像パスに差し替えられる。`annotate()` に `phash_list` を渡さないと lib が読んだ画像（512px 処理済み）から pHash を計算するが、DB には元画像の pHash しかないため `find_image_ids_by_phashes_multi` の lookup が失敗し保存 0 件になっていた。

## Test plan

- [ ] CI-equivalent filter 全 pass (`4042 passed`)
- [ ] mypy 全 pass (`no issues found in 186 source files`)
- [ ] `--resolution 512` + Windows backslash path で実測確認（ユーザー環境）

🤖 Generated with [Claude Code](https://claude.com/claude-code)