### PR TITLE
feat(cli): errors list / resolve コマンド追加 & キャンセル修正 (Issue #714 #715)

### DIFF
--- a/src/lorairo/cli/commands/errors.py
+++ b/src/lorairo/cli/commands/errors.py
@@ -1,0 +1,205 @@
+"""Error record management commands.
+
+DB の error_records テーブルを閲覧・解決マークするコマンド群。
+
+出力は ADR 0057/0058 に従う: ``--json`` 時は stdout に JSONL (item/result)、
+それ以外は rich 人間向け。
+"""
+
+from __future__ import annotations
+
+import click
+import typer
+from rich.table import Table
+
+from lorairo.api.project import get_project as api_get_project
+from lorairo.cli._boundary import command_boundary
+from lorairo.cli._console import make_console
+from lorairo.cli._emit import emit_item, emit_result
+from lorairo.cli._output_mode import is_json_mode
+from lorairo.services.service_container import get_service_container
+
+app = typer.Typer(help="Error record management commands")
+console = make_console()
+
+MAX_LIST_LIMIT = 500
+
+
+def _parse_ids(ids_csv: str) -> list[int]:
+    """カンマ区切り文字列を int リストに変換する。
+
+    Args:
+        ids_csv: カンマ区切りの ID 文字列。
+
+    Returns:
+        ID の整数リスト。
+
+    Raises:
+        click.UsageError: 整数に変換できない値が含まれていた場合。
+    """
+    try:
+        return [int(x.strip()) for x in ids_csv.split(",") if x.strip()]
+    except ValueError as e:
+        raise click.UsageError(f"--ids には整数のみ指定可: {e}") from e
+
+
+@app.command("list")
+def list_errors(
+    project: str = typer.Option(..., "--project", "-p", help="Project name"),
+    operation: str | None = typer.Option(
+        None, "--operation", help="Filter by operation_type (search/registration/annotation)"
+    ),
+    error_type: str | None = typer.Option(None, "--error-type", help="Filter by error_type"),
+    message_contains: str | None = typer.Option(
+        None, "--message-contains", help="Filter by partial error_message match"
+    ),
+    all_records: bool = typer.Option(
+        False, "--all", help="Include resolved records (default: unresolved only)"
+    ),
+    limit: int = typer.Option(50, "--limit", help="Max records to return (max 500)"),
+    offset: int = typer.Option(0, "--offset", help="Offset for pagination"),
+) -> None:
+    """List error records.
+
+    デフォルトは未解決のみ。--all で解決済みを含む全レコードを返す。
+
+    Example:
+        lorairo-cli errors list --project proj --operation search --error-type RuntimeError
+    """
+    with command_boundary():
+        api_get_project(project)
+        if limit > MAX_LIST_LIMIT:
+            raise click.UsageError(f"--limit は最大 {MAX_LIST_LIMIT}。")
+
+        container = get_service_container()
+        container.set_active_project(project)
+        repo = container.db_manager.error_record_repo
+
+        resolved_filter: bool | None = None if all_records else False
+
+        records = repo.get_error_records(
+            operation_type=operation,
+            error_type=error_type,
+            message_contains=message_contains,
+            resolved=resolved_filter,
+            limit=limit,
+            offset=offset,
+        )
+
+        if is_json_mode():
+            for r in records:
+                emit_item(
+                    {
+                        "id": r.id,
+                        "operation_type": r.operation_type,
+                        "error_type": r.error_type,
+                        "error_message": r.error_message,
+                        "model_name": r.model_name,
+                        "retry_count": r.retry_count,
+                        "resolved_at": r.resolved_at.isoformat() if r.resolved_at else None,
+                        "created_at": r.created_at.isoformat() if r.created_at else None,
+                    }
+                )
+            emit_result(f"{len(records)} error record(s)", count=len(records))
+            return
+
+        if not records:
+            console.print("[dim]No error records found.[/dim]")
+            return
+
+        table = Table(title=f"Error Records ({project})")
+        table.add_column("ID", style="cyan", width=6)
+        table.add_column("Op", style="blue", width=12)
+        table.add_column("Type", style="red", width=18)
+        table.add_column("Message", style="white")
+        table.add_column("Created", style="dim", width=20)
+
+        for r in records:
+            table.add_row(
+                str(r.id),
+                r.operation_type,
+                r.error_type,
+                (r.error_message or "")[:80],
+                r.created_at.isoformat()[:19] if r.created_at else "",
+            )
+        console.print(table)
+        console.print(f"[dim]{len(records)} record(s) shown[/dim]")
+
+
+@app.command("resolve")
+def resolve_errors(
+    project: str = typer.Option(..., "--project", "-p", help="Project name"),
+    ids: str | None = typer.Option(None, "--ids", help="Comma-separated error record IDs"),
+    operation: str | None = typer.Option(None, "--operation", help="Bulk-resolve by operation_type"),
+    error_type: str | None = typer.Option(None, "--error-type", help="Bulk-resolve by error_type"),
+    message_contains: str | None = typer.Option(
+        None, "--message-contains", help="Bulk-resolve by partial error_message match"
+    ),
+    dry_run: bool = typer.Option(False, "--dry-run", help="Show target count without writing"),
+) -> None:
+    """Mark error records as resolved.
+
+    --ids でレコード ID を指定するか、--operation / --error-type / --message-contains
+    でフィルターして一括解決する。
+
+    Example:
+        lorairo-cli errors resolve --project proj \\
+          --operation search --error-type RuntimeError \\
+          --message-contains "キャンセル"
+    """
+    with command_boundary():
+        if ids is None and operation is None and error_type is None and message_contains is None:
+            raise click.UsageError(
+                "--ids / --operation / --error-type / --message-contains のいずれかを指定してください。"
+            )
+
+        api_get_project(project)
+        container = get_service_container()
+        container.set_active_project(project)
+        repo = container.db_manager.error_record_repo
+
+        if ids is not None:
+            target_ids = _parse_ids(ids)
+            if not target_ids:
+                raise click.UsageError("--ids に有効な値がありません。")
+        else:
+            target_ids = repo.get_error_ids_by_filter(
+                operation_type=operation,
+                error_type=error_type,
+                message_contains=message_contains,
+            )
+
+        target_count = len(target_ids)
+
+        if dry_run:
+            if is_json_mode():
+                emit_result(
+                    f"Dry-run: {target_count} record(s) would be resolved",
+                    resolved=target_count,
+                    dry_run=True,
+                )
+            else:
+                console.print(f"[dim]Dry-run: {target_count} record(s) would be resolved[/dim]")
+            return
+
+        if not target_ids:
+            if is_json_mode():
+                emit_result("No matching error records found", resolved=0, dry_run=False)
+            else:
+                console.print("[dim]No matching error records found.[/dim]")
+            return
+
+        success, updated = repo.mark_errors_resolved_batch(target_ids)
+
+        if is_json_mode():
+            emit_result(
+                f"Resolved {updated} error record(s)",
+                ok=success,
+                resolved=updated,
+                dry_run=False,
+            )
+        else:
+            if success:
+                console.print(f"[green]Resolved {updated} error record(s)[/green]")
+            else:
+                console.print(f"[yellow]Partial resolve: {updated}/{target_count}[/yellow]")

--- a/src/lorairo/cli/commands/errors.py
+++ b/src/lorairo/cli/commands/errors.py
@@ -95,7 +95,6 @@ def list_errors(
                         "error_type": r.error_type,
                         "error_message": r.error_message,
                         "model_name": r.model_name,
-                        "retry_count": r.retry_count,
                         "resolved_at": r.resolved_at.isoformat() if r.resolved_at else None,
                         "created_at": r.created_at.isoformat() if r.created_at else None,
                     }

--- a/src/lorairo/cli/introspection.py
+++ b/src/lorairo/cli/introspection.py
@@ -547,6 +547,45 @@ class AnnotateImportBatchResult(BaseModel):
     model_config = ConfigDict(title="AnnotateImportBatchResult")
 
 
+class ErrorRecordItem(BaseModel):
+    """JSONL item payload emitted by ``errors list --json``."""
+
+    kind: Literal["item"] = "item"
+    id: int
+    operation_type: str
+    error_type: str
+    error_message: str
+    model_name: str | None = None
+    retry_count: int
+    resolved_at: str | None = None
+    created_at: str | None = None
+
+    model_config = ConfigDict(title="ErrorRecordItem")
+
+
+class ErrorListResult(BaseModel):
+    """JSONL result payload emitted by ``errors list --json``."""
+
+    kind: Literal["result"] = "result"
+    ok: Literal[True] = True
+    message: str
+    count: int
+
+    model_config = ConfigDict(title="ErrorListResult")
+
+
+class ErrorsResolveResult(BaseModel):
+    """JSONL result payload emitted by ``errors resolve --json``."""
+
+    kind: Literal["result"] = "result"
+    ok: bool
+    message: str
+    resolved: int
+    dry_run: bool
+
+    model_config = ConfigDict(title="ErrorsResolveResult")
+
+
 @dataclass(frozen=True)
 class FieldSpec:
     name: str
@@ -1526,6 +1565,89 @@ TOOL_SPECS: dict[str, ToolSpec] = {
                     _f("job_imported", "bool"),
                 ),
                 schema=BatchImportResult,
+            ),
+        ),
+        errors=(ERROR_MODEL,),
+    ),
+    "errors list": ToolSpec(
+        name="errors list",
+        path="errors list",
+        summary="List error records. Default: unresolved only.",
+        read_only=True,
+        side_effects=("db_read",),
+        inputs=(
+            _input(
+                "ErrorsListInput",
+                (
+                    _f("project", "str", required=True),
+                    _f(
+                        "operation",
+                        "str?",
+                        description="Filter by operation_type (search/registration/annotation)",
+                    ),
+                    _f("error_type", "str?", description="Filter by error_type"),
+                    _f("message_contains", "str?", description="Partial match on error_message"),
+                    _f("all", "bool", default=False, description="Include resolved records"),
+                    _f("limit", "int", default=50, description="Max records (max 500)"),
+                    _f("offset", "int", default=0),
+                ),
+            ),
+        ),
+        outputs=(
+            _output(
+                "ErrorRecordItem",
+                (
+                    _f("id", "int"),
+                    _f("operation_type", "str"),
+                    _f("error_type", "str"),
+                    _f("error_message", "str"),
+                    _f("model_name", "str?"),
+                    _f("retry_count", "int"),
+                    _f("resolved_at", "str?"),
+                    _f("created_at", "str?"),
+                ),
+                schema=ErrorRecordItem,
+            ),
+            _output(
+                "ErrorListResult",
+                (_f("count", "int"),),
+                schema=ErrorListResult,
+            ),
+        ),
+        errors=(ERROR_MODEL,),
+    ),
+    "errors resolve": ToolSpec(
+        name="errors resolve",
+        path="errors resolve",
+        summary="Mark error records as resolved. Use --dry-run to preview.",
+        read_only=False,
+        side_effects=("db_read", "db_write"),
+        inputs=(
+            _input(
+                "ErrorsResolveInput",
+                (
+                    _f("project", "str", required=True),
+                    _f("ids", "csv[int]?", description="Comma-separated error record IDs"),
+                    _f("operation", "str?", description="Bulk-resolve by operation_type"),
+                    _f("error_type", "str?", description="Bulk-resolve by error_type"),
+                    _f(
+                        "message_contains",
+                        "str?",
+                        description="Bulk-resolve by partial message match",
+                    ),
+                    _f("dry_run", "bool", default=False, description="Preview count without writing"),
+                ),
+            ),
+        ),
+        outputs=(
+            _output(
+                "ErrorsResolveResult",
+                (
+                    _f("ok", "bool"),
+                    _f("resolved", "int"),
+                    _f("dry_run", "bool"),
+                ),
+                schema=ErrorsResolveResult,
             ),
         ),
         errors=(ERROR_MODEL,),

--- a/src/lorairo/cli/introspection.py
+++ b/src/lorairo/cli/introspection.py
@@ -556,7 +556,6 @@ class ErrorRecordItem(BaseModel):
     error_type: str
     error_message: str
     model_name: str | None = None
-    retry_count: int
     resolved_at: str | None = None
     created_at: str | None = None
 
@@ -1602,7 +1601,6 @@ TOOL_SPECS: dict[str, ToolSpec] = {
                     _f("error_type", "str"),
                     _f("error_message", "str"),
                     _f("model_name", "str?"),
-                    _f("retry_count", "int"),
                     _f("resolved_at", "str?"),
                     _f("created_at", "str?"),
                 ),

--- a/src/lorairo/cli/main.py
+++ b/src/lorairo/cli/main.py
@@ -34,7 +34,7 @@ from lorairo.cli._output_mode import (
     set_json_mode,
     strip_mode_flags,
 )
-from lorairo.cli.commands import annotate, batch, export, images, models, project, tags
+from lorairo.cli.commands import annotate, batch, errors, export, images, models, project, tags
 from lorairo.cli.introspection import emit_describe, emit_list_commands
 from lorairo.services.service_container import get_service_container
 from lorairo.utils.config import DEFAULT_CLI_LOG_PATH, DEFAULT_CONFIG_PATH
@@ -90,6 +90,7 @@ app.add_typer(export.app, name="export", help="Dataset export commands")
 app.add_typer(models.app, name="models", help="Model registry commands")
 app.add_typer(batch.app, name="batch", help="Provider Batch API job commands")
 app.add_typer(tags.app, name="tags", help="Tag editing commands (agent-friendly)")
+app.add_typer(errors.app, name="errors", help="Error record management commands")
 
 
 @app.callback()

--- a/src/lorairo/database/repository/error_record.py
+++ b/src/lorairo/database/repository/error_record.py
@@ -163,6 +163,8 @@ class ErrorRecordRepository(BaseRepository):
     def get_error_records(
         self,
         operation_type: str | None = None,
+        error_type: str | None = None,
+        message_contains: str | None = None,
         resolved: bool | None = None,
         limit: int = 100,
         offset: int = 0,
@@ -171,6 +173,8 @@ class ErrorRecordRepository(BaseRepository):
 
         Args:
             operation_type: 操作種別フィルタ (None = 全操作)。
+            error_type: エラー種別フィルタ (None = 全種別)。
+            message_contains: error_message 部分一致フィルタ (None = 全メッセージ)。
             resolved: None = 全て、True = 解決済み、False = 未解決。
             limit: 取得件数上限。
             offset: オフセット。
@@ -186,6 +190,10 @@ class ErrorRecordRepository(BaseRepository):
                 query = select(ErrorRecord).order_by(ErrorRecord.created_at.desc())
                 if operation_type:
                     query = query.where(ErrorRecord.operation_type == operation_type)
+                if error_type:
+                    query = query.where(ErrorRecord.error_type == error_type)
+                if message_contains:
+                    query = query.where(ErrorRecord.error_message.contains(message_contains))
                 if resolved is not None:
                     if resolved:
                         query = query.where(ErrorRecord.resolved_at.is_not(None))
@@ -196,6 +204,8 @@ class ErrorRecordRepository(BaseRepository):
                 logger.debug(
                     f"エラーレコードを取得: {len(records)}件 "
                     f"(operation_type={operation_type or 'all'}, "
+                    f"error_type={error_type or 'all'}, "
+                    f"message_contains={message_contains!r}, "
                     f"resolved={resolved}, limit={limit}, offset={offset})",
                 )
                 return records
@@ -266,4 +276,83 @@ class ErrorRecordRepository(BaseRepository):
             except SQLAlchemyError as e:
                 session.rollback()
                 logger.error(f"エラーレコード一括解決失敗: {e}", exc_info=True)
+                raise
+
+    def count_error_records(
+        self,
+        operation_type: str | None = None,
+        error_type: str | None = None,
+        message_contains: str | None = None,
+        resolved: bool | None = None,
+    ) -> int:
+        """条件に一致するエラーレコード件数を返す (dry-run 用)。
+
+        Args:
+            operation_type: 操作種別フィルタ。
+            error_type: エラー種別フィルタ。
+            message_contains: error_message 部分一致フィルタ。
+            resolved: None = 全て、True = 解決済み、False = 未解決。
+
+        Returns:
+            int: 一致件数。
+
+        Raises:
+            SQLAlchemyError: データベース操作でエラーが発生した場合。
+        """
+        with self.session_factory() as session:
+            try:
+                query = select(func.count(ErrorRecord.id))
+                if operation_type:
+                    query = query.where(ErrorRecord.operation_type == operation_type)
+                if error_type:
+                    query = query.where(ErrorRecord.error_type == error_type)
+                if message_contains:
+                    query = query.where(ErrorRecord.error_message.contains(message_contains))
+                if resolved is not None:
+                    if resolved:
+                        query = query.where(ErrorRecord.resolved_at.is_not(None))
+                    else:
+                        query = query.where(ErrorRecord.resolved_at.is_(None))
+                count = session.execute(query).scalar() or 0
+                logger.debug(f"エラーレコード件数を集計: {count}件")
+                return count
+            except SQLAlchemyError as e:
+                logger.error(f"エラーレコード件数集計中にエラーが発生しました: {e}", exc_info=True)
+                raise
+
+    def get_error_ids_by_filter(
+        self,
+        operation_type: str | None = None,
+        error_type: str | None = None,
+        message_contains: str | None = None,
+    ) -> list[int]:
+        """未解決エラーレコードの ID リストをフィルター条件で取得する (一括 resolve 用)。
+
+        Args:
+            operation_type: 操作種別フィルタ。
+            error_type: エラー種別フィルタ。
+            message_contains: error_message 部分一致フィルタ。
+
+        Returns:
+            list[int]: 未解決エラーレコード ID リスト。
+
+        Raises:
+            SQLAlchemyError: データベース操作でエラーが発生した場合。
+        """
+        with self.session_factory() as session:
+            try:
+                query = (
+                    select(ErrorRecord.id).where(ErrorRecord.resolved_at.is_(None)).order_by(ErrorRecord.id)
+                )
+                if operation_type:
+                    query = query.where(ErrorRecord.operation_type == operation_type)
+                if error_type:
+                    query = query.where(ErrorRecord.error_type == error_type)
+                if message_contains:
+                    query = query.where(ErrorRecord.error_message.contains(message_contains))
+                ids = list(session.execute(query).scalars().all())
+                logger.debug(f"一括 resolve 対象 ID: {len(ids)}件")
+                return ids
+            except SQLAlchemyError as e:
+                logger.error(f"エラーレコード ID 取得中にエラーが発生しました: {e}", exc_info=True)
                 raise

--- a/src/lorairo/gui/workers/registration_worker.py
+++ b/src/lorairo/gui/workers/registration_worker.py
@@ -64,7 +64,7 @@ class DatabaseRegistrationWorker(LoRAIroWorkerBase[DatabaseRegistrationResult]):
             DatabaseRegistrationResult: 登録結果（成功数、スキップ数、エラー数、処理時間）
 
         Raises:
-            RuntimeError: 処理がキャンセルされた場合
+            CancellationError: 処理がキャンセルされた場合
         """
         import time
 

--- a/tests/unit/cli/test_commands_errors.py
+++ b/tests/unit/cli/test_commands_errors.py
@@ -1,0 +1,196 @@
+"""errors コマンド群のユニットテスト。"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from unittest.mock import MagicMock
+
+import pytest
+from typer.testing import CliRunner
+
+from lorairo.cli.main import app
+
+runner = CliRunner()
+
+_NOW = datetime(2026, 6, 11, 0, 0, 0, tzinfo=timezone.utc)
+
+
+def _make_error_record(
+    id: int = 1,
+    op: str = "search",
+    et: str = "RuntimeError",
+    msg: str = "処理がキャンセルされました",
+    model_name: str | None = None,
+    retry_count: int = 0,
+    resolved_at: datetime | None = None,
+    created_at: datetime = _NOW,
+) -> MagicMock:
+    r = MagicMock()
+    r.id = id
+    r.operation_type = op
+    r.error_type = et
+    r.error_message = msg
+    r.model_name = model_name
+    r.retry_count = retry_count
+    r.resolved_at = resolved_at
+    r.created_at = created_at
+    return r
+
+
+def _make_container(
+    records: list,
+    count: int = 0,
+    resolve_result: tuple = (True, 0),
+    ids: list[int] | None = None,
+) -> MagicMock:
+    container = MagicMock()
+    container.db_manager.error_record_repo.get_error_records.return_value = records
+    container.db_manager.error_record_repo.count_error_records.return_value = count
+    container.db_manager.error_record_repo.get_error_ids_by_filter.return_value = (
+        ids if ids is not None else [r.id for r in records]
+    )
+    container.db_manager.error_record_repo.mark_errors_resolved_batch.return_value = resolve_result
+    return container
+
+
+@pytest.fixture
+def mock_project_and_container(monkeypatch):
+    records = [_make_error_record(id=1), _make_error_record(id=2)]
+    container = _make_container(records, count=len(records), resolve_result=(True, 2))
+    monkeypatch.setattr("lorairo.cli.commands.errors.api_get_project", MagicMock(return_value=MagicMock()))
+    monkeypatch.setattr(
+        "lorairo.cli.commands.errors.get_service_container", MagicMock(return_value=container)
+    )
+    return container
+
+
+@pytest.mark.unit
+class TestErrorsList:
+    def test_list_json_emits_items_and_result(self, mock_project_and_container):
+        result = runner.invoke(
+            app,
+            ["--json", "errors", "list", "--project", "proj"],
+        )
+        assert result.exit_code == 0, result.output
+        lines = [json.loads(line) for line in result.stdout.strip().splitlines() if line.strip()]
+        item_rows = [r for r in lines if r.get("kind") == "item"]
+        result_row = next(r for r in lines if r.get("kind") == "result")
+        assert len(item_rows) == 2
+        assert result_row["ok"] is True
+        assert result_row["count"] == 2
+
+    def test_list_item_fields(self, mock_project_and_container):
+        result = runner.invoke(
+            app,
+            ["--json", "errors", "list", "--project", "proj"],
+        )
+        assert result.exit_code == 0
+        lines = [json.loads(line) for line in result.stdout.strip().splitlines() if line.strip()]
+        item = next(r for r in lines if r.get("kind") == "item")
+        for field in ("id", "operation_type", "error_type", "error_message", "created_at"):
+            assert field in item, f"Missing field: {field}"
+
+    def test_list_passes_operation_filter(self, mock_project_and_container):
+        runner.invoke(
+            app,
+            ["--json", "errors", "list", "--project", "proj", "--operation", "search"],
+        )
+        mock_project_and_container.db_manager.error_record_repo.get_error_records.assert_called_once()
+        kwargs = mock_project_and_container.db_manager.error_record_repo.get_error_records.call_args.kwargs
+        assert kwargs.get("operation_type") == "search"
+
+    def test_list_passes_error_type_filter(self, mock_project_and_container):
+        runner.invoke(
+            app,
+            ["--json", "errors", "list", "--project", "proj", "--error-type", "RuntimeError"],
+        )
+        kwargs = mock_project_and_container.db_manager.error_record_repo.get_error_records.call_args.kwargs
+        assert kwargs.get("error_type") == "RuntimeError"
+
+    def test_list_unresolved_only_by_default(self, mock_project_and_container):
+        runner.invoke(app, ["--json", "errors", "list", "--project", "proj"])
+        kwargs = mock_project_and_container.db_manager.error_record_repo.get_error_records.call_args.kwargs
+        assert kwargs.get("resolved") is False
+
+    def test_list_all_flag_includes_resolved(self, mock_project_and_container):
+        runner.invoke(app, ["--json", "errors", "list", "--project", "proj", "--all"])
+        kwargs = mock_project_and_container.db_manager.error_record_repo.get_error_records.call_args.kwargs
+        assert kwargs.get("resolved") is None
+
+
+@pytest.mark.unit
+class TestErrorsResolve:
+    def test_resolve_by_ids_calls_batch_mark(self, mock_project_and_container):
+        result = runner.invoke(
+            app,
+            ["--json", "errors", "resolve", "--project", "proj", "--ids", "1,2"],
+        )
+        assert result.exit_code == 0, result.output
+        mock_project_and_container.db_manager.error_record_repo.mark_errors_resolved_batch.assert_called_once_with(
+            [1, 2]
+        )
+
+    def test_resolve_dry_run_does_not_write(self, mock_project_and_container):
+        result = runner.invoke(
+            app,
+            ["--json", "errors", "resolve", "--project", "proj", "--operation", "search", "--dry-run"],
+        )
+        assert result.exit_code == 0, result.output
+        mock_project_and_container.db_manager.error_record_repo.mark_errors_resolved_batch.assert_not_called()
+
+    def test_resolve_dry_run_result_has_dry_run_true(self, mock_project_and_container):
+        result = runner.invoke(
+            app,
+            ["--json", "errors", "resolve", "--project", "proj", "--operation", "search", "--dry-run"],
+        )
+        assert result.exit_code == 0
+        lines = [json.loads(line) for line in result.stdout.strip().splitlines() if line.strip()]
+        result_row = next(r for r in lines if r.get("kind") == "result")
+        assert result_row["dry_run"] is True
+
+    def test_resolve_bulk_filter_uses_get_ids(self, mock_project_and_container):
+        result = runner.invoke(
+            app,
+            [
+                "--json",
+                "errors",
+                "resolve",
+                "--project",
+                "proj",
+                "--operation",
+                "search",
+                "--error-type",
+                "RuntimeError",
+                "--message-contains",
+                "キャンセル",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        mock_project_and_container.db_manager.error_record_repo.get_error_ids_by_filter.assert_called_once()
+
+    def test_resolve_result_json_fields(self, mock_project_and_container):
+        result = runner.invoke(
+            app,
+            ["--json", "errors", "resolve", "--project", "proj", "--ids", "1,2"],
+        )
+        assert result.exit_code == 0
+        lines = [json.loads(line) for line in result.stdout.strip().splitlines() if line.strip()]
+        result_row = next(r for r in lines if r.get("kind") == "result")
+        assert result_row["ok"] is True
+        for field in ("resolved", "dry_run"):
+            assert field in result_row, f"Missing field: {field}"
+
+    def test_resolve_no_filter_raises_usage_error(self, mock_project_and_container):
+        result = runner.invoke(
+            app,
+            ["--json", "errors", "resolve", "--project", "proj"],
+        )
+        assert result.exit_code != 0
+
+    def test_resolve_empty_ids_raises_usage_error(self, mock_project_and_container):
+        result = runner.invoke(
+            app,
+            ["--json", "errors", "resolve", "--project", "proj", "--ids", ""],
+        )
+        assert result.exit_code != 0

--- a/tests/unit/cli/test_commands_errors.py
+++ b/tests/unit/cli/test_commands_errors.py
@@ -22,7 +22,6 @@ def _make_error_record(
     et: str = "RuntimeError",
     msg: str = "処理がキャンセルされました",
     model_name: str | None = None,
-    retry_count: int = 0,
     resolved_at: datetime | None = None,
     created_at: datetime = _NOW,
 ) -> MagicMock:
@@ -32,7 +31,6 @@ def _make_error_record(
     r.error_type = et
     r.error_message = msg
     r.model_name = model_name
-    r.retry_count = retry_count
     r.resolved_at = resolved_at
     r.created_at = created_at
     return r

--- a/tests/unit/cli/test_introspection.py
+++ b/tests/unit/cli/test_introspection.py
@@ -558,3 +558,29 @@ def test_describe_tags_replace_json_schema_includes_input_and_result() -> None:
     input_schema = next(row for row in rows if row.get("name") == "TagsReplaceInput")
     input_props = set(input_schema["schema"]["properties"])
     assert {"project", "image_ids", "from_tag", "to_tag", "apply"} <= input_props
+
+
+def test_errors_commands_in_list_commands() -> None:
+    """errors list / errors resolve が list-commands に現れる (Issue #714)。"""
+    result = runner.invoke(app, ["--json", "list-commands"])
+    assert result.exit_code == 0
+    rows = _jsonl(result.stdout)
+    paths = {r.get("path") for r in rows if r.get("kind") == "item"}
+    assert "errors list" in paths
+    assert "errors resolve" in paths
+
+
+def test_describe_errors_list_exposes_required_fields() -> None:
+    """describe errors list が project 必須フィールドを返す (Issue #714)。"""
+    result = runner.invoke(app, ["--json", "describe", "errors list"])
+    assert result.exit_code == 0
+    rows = _jsonl(result.stdout)
+    assert rows[0]["path"] == "errors list"
+
+
+def test_describe_errors_resolve_exposes_required_fields() -> None:
+    """describe errors resolve が project 必須フィールドを返す (Issue #714)。"""
+    result = runner.invoke(app, ["--json", "describe", "errors resolve"])
+    assert result.exit_code == 0
+    rows = _jsonl(result.stdout)
+    assert rows[0]["path"] == "errors resolve"

--- a/tests/unit/database/test_db_repository_error_records.py
+++ b/tests/unit/database/test_db_repository_error_records.py
@@ -408,3 +408,99 @@ class TestGetSession:
 
         assert session == mock_session
         assert repository.session_factory.called
+
+
+class TestGetErrorRecordsFilters:
+    """get_error_records の error_type / message_contains フィルターのテスト"""
+
+    @pytest.fixture
+    def repo(self):
+        return ErrorRecordRepository(session_factory=MagicMock())
+
+    def test_filter_by_error_type(self, repo):
+        mock_session = Mock()
+        repo.session_factory.return_value.__enter__.return_value = mock_session
+        mock_session.execute.return_value.scalars.return_value.all.return_value = []
+        repo.get_error_records(error_type="RuntimeError")
+        assert mock_session.execute.called
+
+    def test_filter_by_message_contains(self, repo):
+        mock_session = Mock()
+        repo.session_factory.return_value.__enter__.return_value = mock_session
+        mock_session.execute.return_value.scalars.return_value.all.return_value = []
+        repo.get_error_records(message_contains="キャンセル")
+        assert mock_session.execute.called
+
+    def test_filter_combined(self, repo):
+        mock_session = Mock()
+        repo.session_factory.return_value.__enter__.return_value = mock_session
+        mock_session.execute.return_value.scalars.return_value.all.return_value = []
+        repo.get_error_records(
+            operation_type="search",
+            error_type="RuntimeError",
+            message_contains="キャンセル",
+            resolved=False,
+        )
+        assert mock_session.execute.called
+
+
+class TestCountErrorRecords:
+    """count_error_records のテスト"""
+
+    @pytest.fixture
+    def repo(self):
+        return ErrorRecordRepository(session_factory=MagicMock())
+
+    def test_count_unresolved(self, repo):
+        mock_session = Mock()
+        repo.session_factory.return_value.__enter__.return_value = mock_session
+        mock_session.execute.return_value.scalar.return_value = 42
+        result = repo.count_error_records(resolved=False)
+        assert result == 42
+
+    def test_count_with_filters(self, repo):
+        mock_session = Mock()
+        repo.session_factory.return_value.__enter__.return_value = mock_session
+        mock_session.execute.return_value.scalar.return_value = 10
+        result = repo.count_error_records(
+            operation_type="search",
+            error_type="RuntimeError",
+            message_contains="キャンセル",
+        )
+        assert result == 10
+
+    def test_count_returns_zero_on_none(self, repo):
+        mock_session = Mock()
+        repo.session_factory.return_value.__enter__.return_value = mock_session
+        mock_session.execute.return_value.scalar.return_value = None
+        result = repo.count_error_records()
+        assert result == 0
+
+
+class TestGetErrorIdsByFilter:
+    """get_error_ids_by_filter のテスト"""
+
+    @pytest.fixture
+    def repo(self):
+        return ErrorRecordRepository(session_factory=MagicMock())
+
+    def test_returns_id_list(self, repo):
+        mock_session = Mock()
+        repo.session_factory.return_value.__enter__.return_value = mock_session
+        mock_session.execute.return_value.scalars.return_value.all.return_value = [1, 2, 3]
+        result = repo.get_error_ids_by_filter(operation_type="search", error_type="RuntimeError")
+        assert result == [1, 2, 3]
+
+    def test_returns_empty_list_when_no_match(self, repo):
+        mock_session = Mock()
+        repo.session_factory.return_value.__enter__.return_value = mock_session
+        mock_session.execute.return_value.scalars.return_value.all.return_value = []
+        result = repo.get_error_ids_by_filter()
+        assert result == []
+
+    def test_filter_with_message_contains(self, repo):
+        mock_session = Mock()
+        repo.session_factory.return_value.__enter__.return_value = mock_session
+        mock_session.execute.return_value.scalars.return_value.all.return_value = [5, 6]
+        result = repo.get_error_ids_by_filter(message_contains="キャンセル")
+        assert result == [5, 6]

--- a/tests/unit/gui/workers/test_base_worker.py
+++ b/tests/unit/gui/workers/test_base_worker.py
@@ -496,3 +496,31 @@ class TestLoRAIroWorkerBaseAlias:
         worker = ConcreteWorker()
         assert isinstance(worker, LoRAIroWorkerBase)
         assert isinstance(worker, LoRAIroWorkerBase)
+
+
+class TestSearchWorkerCancellation:
+    """SearchWorker のキャンセルが error_records に記録されないことを検証する (Issue #715)。"""
+
+    def test_search_worker_cancellation_not_recorded(self):
+        """SearchWorker キャンセルが save_error_record を呼ばない回帰テスト。"""
+        from unittest.mock import MagicMock, Mock
+
+        from lorairo.gui.workers.search_worker import SearchWorker
+
+        mock_db = Mock()
+        mock_conditions = MagicMock()
+
+        worker = SearchWorker(db_manager=mock_db, search_conditions=mock_conditions)
+        # execute() の _check_cancellation() で CancellationError が raise されるよう cancellation フラグをセット
+        worker.cancellation.cancel()
+
+        canceled_mock = Mock()
+        error_mock = Mock()
+        worker.canceled.connect(canceled_mock)
+        worker.error_occurred.connect(error_mock)
+
+        worker.run()
+
+        error_mock.assert_not_called()
+        canceled_mock.assert_called_once()
+        mock_db.save_error_record.assert_not_called()


### PR DESCRIPTION
## Summary

- `errors list` / `errors resolve` CLI コマンドを追加（Issue #714）
- `ErrorRecordRepository` に `error_type` / `message_contains` フィルター、`count_error_records()`、`get_error_ids_by_filter()` メソッドを追加
- `introspection.py` に `errors list` / `errors resolve` の ToolSpec を追加
- `RegistrationWorker` の stale docstring を `CancellationError` に修正（Issue #715）
- `SearchWorker` キャンセル非記録リグレッションテストを追加

## Changed Files

| ファイル | 種別 |
|---|---|
| `src/lorairo/database/repository/error_record.py` | 修正（フィルター・count・get_ids 追加） |
| `src/lorairo/cli/commands/errors.py` | 新規（errors list / resolve コマンド） |
| `src/lorairo/cli/main.py` | 修正（errors サブコマンド登録） |
| `src/lorairo/cli/introspection.py` | 修正（ToolSpec 追加） |
| `src/lorairo/gui/workers/registration_worker.py` | 修正（stale docstring 修正） |
| `tests/unit/database/test_db_repository_error_records.py` | 修正（3クラス・フィルターテスト追加） |
| `tests/unit/cli/test_commands_errors.py` | 新規（13テスト） |
| `tests/unit/cli/test_introspection.py` | 修正（3テスト追加） |
| `tests/unit/gui/workers/test_base_worker.py` | 修正（キャンセル非記録テスト追加） |

## Test plan

- [x] `uv run pytest tests/unit/cli/test_commands_errors.py tests/unit/cli/test_introspection.py tests/unit/database/test_db_repository_error_records.py tests/unit/gui/workers/test_base_worker.py` — 103 passed
- [x] CI-equivalent filter（`not gui_show and not calls_real_webapi and not downloads_and_runs_model and not slow`）— 3990 passed、20 failed（全て CUDA 環境依存または本 PR 起票前から存在するプリ既存失敗）

Closes #714
Closes #715

🤖 Generated with [Claude Code](https://claude.com/claude-code)