### PR TITLE
feat: add tag/caption soft-reject policy

### DIFF
--- a/docs/decisions/0065-tag-caption-soft-reject.md
+++ b/docs/decisions/0065-tag-caption-soft-reject.md
@@ -1,0 +1,35 @@
+# 0065. Tag/Caption Soft-Reject And Export Resolution
+
+## Context
+
+Tag and caption annotations can be produced by multiple models for the same image. Tags were exported by concatenating every row, so identical strings from different models appeared more than once. Captions were also concatenated into one `.caption` file, which creates invalid training text when several models remain.
+
+Physical deletion is not a durable reject operation. A rejected tag or caption can be inserted again by a later annotation run, and GUI triage cannot undo the decision.
+
+## Decision
+
+`tags` and `captions` have a nullable `rejected_at` timestamp.
+
+- `NULL` means the row is adopted.
+- Non-`NULL` means the row is soft-rejected and excluded from adopted reads and export.
+- `rejected_at` only means "this tag or caption is wrong for this image." It is target-independent.
+- Export-target vocabulary differences are not represented with `rejected_at`.
+- No per-row by export-target adoption matrix is introduced.
+- Annotation upsert does not revive a rejected row for the same image/model/content identity.
+- Existing tag removal operations mark rows rejected instead of deleting them.
+- Export resolves adopted tags by string union with duplicate removal. Manually edited tags win when the same string appears multiple times.
+- Export resolves adopted captions to one row. Manually edited captions win; otherwise the newest adopted row wins.
+
+## Rationale
+
+Soft-reject preserves user judgement across model reruns and keeps reject operations undoable for later GUI workflows. A nullable timestamp matches the existing `ErrorRecord.resolved_at` vocabulary while avoiding a second active state such as explicit accept.
+
+Target-specific Danbooru/Pony vocabulary and style choices should be derived from tag DB format/alias conversion and export rules. Encoding those choices into `rejected_at` would duplicate derivable information and create an N by M state matrix.
+
+Manual edits should be canonical when they collide with AI output because they represent direct user intent. Caption UI selection is still expected to grow in the results triage design, so the export fallback is deterministic without pretending to be the final UX policy.
+
+## Consequences
+
+Queries that present adopted tags or captions should filter `rejected_at IS NULL` by default. Code that needs audit/history rows must opt into rejected rows explicitly. Future caption selection UI should update `rejected_at` rather than physically deleting rows.
+
+Future export profiles may add target-specific format selection, category exclusion, or generated quality tags, but those profiles must not reinterpret `rejected_at` as a target-specific adoption state.

--- a/src/lorairo/database/db_manager.py
+++ b/src/lorairo/database/db_manager.py
@@ -1343,8 +1343,8 @@ class ImageDatabaseManager:
             with session:
                 completed_query = text("""
                     SELECT COUNT(DISTINCT i.id) FROM images i
-                    LEFT JOIN tags t ON i.id = t.image_id
-                    LEFT JOIN captions c ON i.id = c.image_id
+                    LEFT JOIN tags t ON i.id = t.image_id AND t.rejected_at IS NULL
+                    LEFT JOIN captions c ON i.id = c.image_id AND c.rejected_at IS NULL
                     WHERE t.id IS NOT NULL OR c.id IS NOT NULL
                 """)
                 result: Result[Any] = session.execute(completed_query)
@@ -1395,8 +1395,8 @@ class ImageDatabaseManager:
                     # 完了画像（タグまたはキャプション有り）
                     query = text("""
                         SELECT DISTINCT i.* FROM images i
-                        LEFT JOIN tags t ON i.id = t.image_id
-                        LEFT JOIN captions c ON i.id = c.image_id
+                        LEFT JOIN tags t ON i.id = t.image_id AND t.rejected_at IS NULL
+                        LEFT JOIN captions c ON i.id = c.image_id AND c.rejected_at IS NULL
                         WHERE t.id IS NOT NULL OR c.id IS NOT NULL
                     """)
                 elif error:

--- a/src/lorairo/database/db_manager.py
+++ b/src/lorairo/database/db_manager.py
@@ -1035,15 +1035,24 @@ class ImageDatabaseManager:
             logger.error(f"処理済み画像メタデータ取得中にエラーが発生しました: {e}", exc_info=True)
             raise
 
-    def get_image_annotations(self, image_id: int) -> dict[str, list[dict[str, Any]]]:
+    def get_image_annotations(
+        self,
+        image_id: int,
+        *,
+        include_rejected: bool = False,
+    ) -> dict[str, list[dict[str, Any]]]:
         """指定された画像のアノテーション(タグ、キャプション、スコア、レーティング)を取得します。
+
+        Args:
+            image_id: 対象画像 ID。
+            include_rejected: True の場合、soft-rejected Tag/Caption も返す。
 
         Raises:
             SQLAlchemyError: DB 操作に失敗した場合は呼び出し元 (Worker boundary) に伝播させる。
 
         """
         try:
-            return self.image_repo.get_image_annotations(image_id)
+            return self.image_repo.get_image_annotations(image_id, include_rejected=include_rejected)
         except SQLAlchemyError as e:
             logger.error(f"画像ID {image_id} のアノテーション取得中にエラー: {e}", exc_info=True)
             raise

--- a/src/lorairo/database/migrations/versions/e2f3a4b5c6d7_add_tag_caption_rejected_at.py
+++ b/src/lorairo/database/migrations/versions/e2f3a4b5c6d7_add_tag_caption_rejected_at.py
@@ -1,0 +1,30 @@
+"""Add soft-reject timestamps for tag and caption annotations.
+
+Revision ID: e2f3a4b5c6d7
+Revises: d1e2f3a4b5c6
+Create Date: 2026-06-11
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "e2f3a4b5c6d7"
+down_revision: str | None = "d1e2f3a4b5c6"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column("tags", sa.Column("rejected_at", sa.TIMESTAMP(timezone=True), nullable=True))
+    op.add_column("captions", sa.Column("rejected_at", sa.TIMESTAMP(timezone=True), nullable=True))
+    op.create_index("ix_tags_rejected_at", "tags", ["rejected_at"])
+    op.create_index("ix_captions_rejected_at", "captions", ["rejected_at"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_captions_rejected_at", table_name="captions")
+    op.drop_index("ix_tags_rejected_at", table_name="tags")
+    op.drop_column("captions", "rejected_at")
+    op.drop_column("tags", "rejected_at")

--- a/src/lorairo/database/migrations/versions/e2f3a4b5c6d7_add_tag_caption_rejected_at.py
+++ b/src/lorairo/database/migrations/versions/e2f3a4b5c6d7_add_tag_caption_rejected_at.py
@@ -17,14 +17,42 @@ depends_on: str | Sequence[str] | None = None
 
 
 def upgrade() -> None:
-    op.add_column("tags", sa.Column("rejected_at", sa.TIMESTAMP(timezone=True), nullable=True))
-    op.add_column("captions", sa.Column("rejected_at", sa.TIMESTAMP(timezone=True), nullable=True))
-    op.create_index("ix_tags_rejected_at", "tags", ["rejected_at"])
-    op.create_index("ix_captions_rejected_at", "captions", ["rejected_at"])
+    inspector = sa.inspect(op.get_bind())
+    table_names = set(inspector.get_table_names())
+
+    if "tags" in table_names:
+        tag_columns = {column["name"] for column in inspector.get_columns("tags")}
+        tag_indexes = {index["name"] for index in inspector.get_indexes("tags")}
+        if "rejected_at" not in tag_columns:
+            op.add_column("tags", sa.Column("rejected_at", sa.TIMESTAMP(timezone=True), nullable=True))
+        if "ix_tags_rejected_at" not in tag_indexes:
+            op.create_index("ix_tags_rejected_at", "tags", ["rejected_at"])
+
+    if "captions" in table_names:
+        caption_columns = {column["name"] for column in inspector.get_columns("captions")}
+        caption_indexes = {index["name"] for index in inspector.get_indexes("captions")}
+        if "rejected_at" not in caption_columns:
+            op.add_column("captions", sa.Column("rejected_at", sa.TIMESTAMP(timezone=True), nullable=True))
+        if "ix_captions_rejected_at" not in caption_indexes:
+            op.create_index("ix_captions_rejected_at", "captions", ["rejected_at"])
 
 
 def downgrade() -> None:
-    op.drop_index("ix_captions_rejected_at", table_name="captions")
-    op.drop_index("ix_tags_rejected_at", table_name="tags")
-    op.drop_column("captions", "rejected_at")
-    op.drop_column("tags", "rejected_at")
+    inspector = sa.inspect(op.get_bind())
+    table_names = set(inspector.get_table_names())
+
+    if "captions" in table_names:
+        caption_columns = {column["name"] for column in inspector.get_columns("captions")}
+        caption_indexes = {index["name"] for index in inspector.get_indexes("captions")}
+        if "ix_captions_rejected_at" in caption_indexes:
+            op.drop_index("ix_captions_rejected_at", table_name="captions")
+        if "rejected_at" in caption_columns:
+            op.drop_column("captions", "rejected_at")
+
+    if "tags" in table_names:
+        tag_columns = {column["name"] for column in inspector.get_columns("tags")}
+        tag_indexes = {index["name"] for index in inspector.get_indexes("tags")}
+        if "ix_tags_rejected_at" in tag_indexes:
+            op.drop_index("ix_tags_rejected_at", table_name="tags")
+        if "rejected_at" in tag_columns:
+            op.drop_column("tags", "rejected_at")

--- a/src/lorairo/database/repository/annotation_record.py
+++ b/src/lorairo/database/repository/annotation_record.py
@@ -39,6 +39,7 @@ genai-tag-db-tools (外部 tag_db) 統合を本 Repository に集約する。
 
 from __future__ import annotations
 
+import datetime
 from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import Any, cast
@@ -312,7 +313,10 @@ class AnnotationRepository(BaseRepository):
             image_id -> タグ名(小文字)のセットのマッピング。
 
         """
-        existing_tags_stmt = select(Tag).where(Tag.image_id.in_(image_ids))
+        existing_tags_stmt = select(Tag).where(
+            Tag.image_id.in_(image_ids),
+            Tag.rejected_at.is_(None),
+        )
         all_existing_tags = session.execute(existing_tags_stmt).scalars().all()
 
         existing_tags_by_image: dict[int, set[str]] = {}
@@ -448,13 +452,19 @@ class AnnotationRepository(BaseRepository):
                     else:
                         per_item.append((image_id, "changed"))
 
-                # bulk DELETE (1回のみ)
-                images_to_delete = [iid for iid, s in per_item if s == "changed"]
-                if images_to_delete:
+                # bulk soft-reject (1回のみ)
+                images_to_reject = [iid for iid, s in per_item if s == "changed"]
+                if images_to_reject:
                     session.execute(
-                        delete(Tag).where(
-                            Tag.image_id.in_(images_to_delete),
+                        update(Tag)
+                        .where(
+                            Tag.image_id.in_(images_to_reject),
                             Tag.tag == normalized_tag,
+                            Tag.rejected_at.is_(None),
+                        )
+                        .values(
+                            rejected_at=datetime.datetime.now(datetime.UTC),
+                            updated_at=datetime.datetime.now(datetime.UTC),
                         )
                     )
 
@@ -462,7 +472,7 @@ class AnnotationRepository(BaseRepository):
                 changed = sum(1 for _, s in per_item if s == "changed")
                 logger.info(
                     f"Atomic batch tag remove completed: tag='{normalized_tag}', "
-                    f"processed={len(image_ids)}, removed={changed}",
+                    f"processed={len(image_ids)}, rejected={changed}",
                 )
                 return (True, per_item)
 
@@ -519,13 +529,19 @@ class AnnotationRepository(BaseRepository):
                     else:
                         per_item.append((image_id, "changed"))
 
-                # bulk DELETE: 変換元タグを持つ画像から一括削除
+                # bulk soft-reject: 変換元タグを持つ画像から一括除外
                 images_to_change = [iid for iid, s in per_item if s == "changed"]
                 if images_to_change:
                     session.execute(
-                        delete(Tag).where(
+                        update(Tag)
+                        .where(
                             Tag.image_id.in_(images_to_change),
                             Tag.tag == normalized_from,
+                            Tag.rejected_at.is_(None),
+                        )
+                        .values(
+                            rejected_at=datetime.datetime.now(datetime.UTC),
+                            updated_at=datetime.datetime.now(datetime.UTC),
                         )
                     )
 

--- a/src/lorairo/database/repository/image.py
+++ b/src/lorairo/database/repository/image.py
@@ -1724,6 +1724,11 @@ class ImageRepository(BaseRepository):
 
     # --- Annotation Format for Metadata (batch read helpers) ---
 
+    @staticmethod
+    def _is_annotation_adopted(annotation: Any) -> bool:
+        """Return False only for concrete soft-rejected Tag/Caption rows."""
+        return not isinstance(getattr(annotation, "rejected_at", None), datetime.datetime)
+
     def _format_tags(self, image: Image, annotations: dict[str, Any]) -> None:
         """タグアノテーション情報をフォーマットする。
 
@@ -1732,7 +1737,7 @@ class ImageRepository(BaseRepository):
             annotations: フォーマット結果を格納する辞書（直接更新される）。
 
         """
-        adopted_tags = [tag for tag in image.tags if tag.rejected_at is None] if image.tags else []
+        adopted_tags = [tag for tag in image.tags if self._is_annotation_adopted(tag)] if image.tags else []
         if adopted_tags:
             annotations["tags"] = [
                 {
@@ -1764,7 +1769,9 @@ class ImageRepository(BaseRepository):
 
         """
         adopted_captions = (
-            [caption for caption in image.captions if caption.rejected_at is None] if image.captions else []
+            [caption for caption in image.captions if self._is_annotation_adopted(caption)]
+            if image.captions
+            else []
         )
         if adopted_captions:
             annotations["captions"] = [

--- a/src/lorairo/database/repository/image.py
+++ b/src/lorairo/database/repository/image.py
@@ -465,8 +465,14 @@ class ImageRepository(BaseRepository):
                         .where(Image.id.in_(chunk))
                         .where(
                             or_(
-                                exists().where(Tag.image_id == Image.id),
-                                exists().where(Caption.image_id == Image.id),
+                                exists().where(
+                                    Tag.image_id == Image.id,
+                                    Tag.rejected_at.is_(None),
+                                ),
+                                exists().where(
+                                    Caption.image_id == Image.id,
+                                    Caption.rejected_at.is_(None),
+                                ),
                             ),
                         )
                     )
@@ -1035,6 +1041,7 @@ class ImageRepository(BaseRepository):
             "existing": tag.existing,
             "is_edited_manually": tag.is_edited_manually,
             "confidence_score": tag.confidence_score,
+            "rejected_at": tag.rejected_at,
             "created_at": tag.created_at,
             "updated_at": tag.updated_at,
         }
@@ -1056,6 +1063,7 @@ class ImageRepository(BaseRepository):
             "model_id": caption.model_id,
             "existing": caption.existing,
             "is_edited_manually": caption.is_edited_manually,
+            "rejected_at": caption.rejected_at,
             "created_at": caption.created_at,
             "updated_at": caption.updated_at,
         }
@@ -1131,13 +1139,14 @@ class ImageRepository(BaseRepository):
             "updated_at": sl.updated_at,
         }
 
-    def get_image_annotations(self, image_id: int) -> dict[str, Any]:
+    def get_image_annotations(self, image_id: int, *, include_rejected: bool = False) -> dict[str, Any]:
         """指定された画像IDのアノテーション(タグ、キャプション、スコア、スコアラベル、レーティング)を取得する。
 
         Eager Loadingを使用して関連データを効率的に取得する。
 
         Args:
             image_id: アノテーションを取得する画像のID。
+            include_rejected: True の場合、soft-rejected Tag/Caption も返す。
 
         Returns:
             アノテーションデータを含む辞書。
@@ -1182,9 +1191,17 @@ class ImageRepository(BaseRepository):
                     return annotations
 
                 if image.tags:
-                    annotations["tags"] = [self._format_tag_annotation(t) for t in image.tags]
+                    tags = (
+                        image.tags if include_rejected else [t for t in image.tags if t.rejected_at is None]
+                    )
+                    annotations["tags"] = [self._format_tag_annotation(t) for t in tags]
                 if image.captions:
-                    annotations["captions"] = [self._format_caption_annotation(c) for c in image.captions]
+                    captions = (
+                        image.captions
+                        if include_rejected
+                        else [c for c in image.captions if c.rejected_at is None]
+                    )
+                    annotations["captions"] = [self._format_caption_annotation(c) for c in captions]
                 if image.scores:
                     annotations["scores"] = [self._format_score_annotation(s) for s in image.scores]
                 if image.score_labels:
@@ -1313,7 +1330,10 @@ class ImageRepository(BaseRepository):
         if include_untagged:
             # タグが存在しない画像 (outerjoinしてTag.idがNULL)
             # 注: この条件は他のタグ/キャプション条件と併用されない前提 (Manager側で制御想定)
-            query = query.outerjoin(Tag, Image.id == Tag.image_id).where(Tag.id.is_(None))
+            query = query.outerjoin(
+                Tag,
+                and_(Image.id == Tag.image_id, Tag.rejected_at.is_(None)),
+            ).where(Tag.id.is_(None))
         elif tags:
             # use_and (AND検索) の場合、タグごとにJOIN条件を追加する
             if use_and:
@@ -1327,6 +1347,7 @@ class ImageRepository(BaseRepository):
                         select(Tag.id)  # SELECT句は何でもよい (通常は 1 や PK)
                         .where(
                             Tag.image_id == Image.id,  # WHERE句に明示的な相関条件は残す
+                            Tag.rejected_at.is_(None),
                             subquery_condition,
                         )
                         .correlate(Image)  # 明示的に相関させる
@@ -1345,7 +1366,10 @@ class ImageRepository(BaseRepository):
                     else:
                         tag_criteria.append(Tag.tag.like(pattern))
                 if tag_criteria:
-                    query = query.join(Tag, Image.id == Tag.image_id).where(or_(*tag_criteria))
+                    query = query.join(Tag, Image.id == Tag.image_id).where(
+                        Tag.rejected_at.is_(None),
+                        or_(*tag_criteria),
+                    )
                     # logger.debug(f"Query after OR tag join: {query}") # クエリ確認用
 
         if excluded_tags and not include_untagged:
@@ -1357,6 +1381,7 @@ class ImageRepository(BaseRepository):
                     select(Tag.id)
                     .where(
                         Tag.image_id == Image.id,
+                        Tag.rejected_at.is_(None),
                         excluded_condition,
                     )
                     .correlate(Image)
@@ -1379,6 +1404,7 @@ class ImageRepository(BaseRepository):
                 select(Caption.id)
                 .where(
                     Caption.image_id == Image.id,  # メインクエリの Image と相関させる
+                    Caption.rejected_at.is_(None),
                     caption_filter,
                 )
                 .correlate(Image)  # 明示的に相関させる
@@ -1505,13 +1531,20 @@ class ImageRepository(BaseRepository):
 
         model_id_subquery = select(Model.id).where(Model.litellm_model_id == missing_model_litellm_id)
         has_tag = (
-            exists().where(Tag.image_id == Image.id, Tag.model_id.in_(model_id_subquery)).correlate(Image)
+            exists()
+            .where(
+                Tag.image_id == Image.id,
+                Tag.model_id.in_(model_id_subquery),
+                Tag.rejected_at.is_(None),
+            )
+            .correlate(Image)
         )
         has_caption = (
             exists()
             .where(
                 Caption.image_id == Image.id,
                 Caption.model_id.in_(model_id_subquery),
+                Caption.rejected_at.is_(None),
             )
             .correlate(Image)
         )
@@ -1576,7 +1609,11 @@ class ImageRepository(BaseRepository):
             # タグベースのNSFW判定（"nsfw" / "explicit" タグが付いている画像を除外）
             tag_nsfw_condition = (
                 exists()
-                .where(Tag.image_id == Image.id, func.lower(Tag.tag).in_(["nsfw", "explicit"]))
+                .where(
+                    Tag.image_id == Image.id,
+                    Tag.rejected_at.is_(None),
+                    func.lower(Tag.tag).in_(["nsfw", "explicit"]),
+                )
                 .correlate(Image)
             )
 
@@ -1661,9 +1698,19 @@ class ImageRepository(BaseRepository):
 
         if manual_edit_filter is not None:
             has_manual_edit = or_(
-                exists().where(Tag.image_id == Image.id, Tag.is_edited_manually.is_(True)).correlate(Image),
                 exists()
-                .where(Caption.image_id == Image.id, Caption.is_edited_manually.is_(True))
+                .where(
+                    Tag.image_id == Image.id,
+                    Tag.rejected_at.is_(None),
+                    Tag.is_edited_manually.is_(True),
+                )
+                .correlate(Image),
+                exists()
+                .where(
+                    Caption.image_id == Image.id,
+                    Caption.rejected_at.is_(None),
+                    Caption.is_edited_manually.is_(True),
+                )
                 .correlate(Image),
                 exists().where(Score.image_id == Image.id, Score.is_edited_manually).correlate(Image),
             )
@@ -1685,7 +1732,8 @@ class ImageRepository(BaseRepository):
             annotations: フォーマット結果を格納する辞書（直接更新される）。
 
         """
-        if image.tags:
+        adopted_tags = [tag for tag in image.tags if tag.rejected_at is None] if image.tags else []
+        if adopted_tags:
             annotations["tags"] = [
                 {
                     "id": tag.id,
@@ -1700,9 +1748,9 @@ class ImageRepository(BaseRepository):
                     "created_at": tag.created_at,
                     "updated_at": tag.updated_at,
                 }
-                for tag in image.tags
+                for tag in adopted_tags
             ]
-            annotations["tags_text"] = ", ".join([tag.tag for tag in image.tags])
+            annotations["tags_text"] = ", ".join([tag.tag for tag in adopted_tags])
         else:
             annotations["tags"] = []
             annotations["tags_text"] = ""
@@ -1715,7 +1763,10 @@ class ImageRepository(BaseRepository):
             annotations: フォーマット結果を格納する辞書（直接更新される）。
 
         """
-        if image.captions:
+        adopted_captions = (
+            [caption for caption in image.captions if caption.rejected_at is None] if image.captions else []
+        )
+        if adopted_captions:
             annotations["captions"] = [
                 {
                     "id": caption.id,
@@ -1727,12 +1778,12 @@ class ImageRepository(BaseRepository):
                     "created_at": caption.created_at,
                     "updated_at": caption.updated_at,
                 }
-                for caption in image.captions
+                for caption in adopted_captions
             ]
             from datetime import datetime
 
             latest_caption = max(
-                image.captions,
+                adopted_captions,
                 key=lambda c: c.created_at or datetime.min,
             )
             annotations["caption_text"] = latest_caption.caption

--- a/src/lorairo/database/schema.py
+++ b/src/lorairo/database/schema.py
@@ -294,6 +294,7 @@ class Tag(Base):
     existing: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
     is_edited_manually: Mapped[bool | None] = mapped_column(Boolean, nullable=True)
     confidence_score: Mapped[float | None] = mapped_column(Float)
+    rejected_at: Mapped[datetime.datetime | None] = mapped_column(TIMESTAMP(timezone=True))
     created_at: Mapped[datetime.datetime] = mapped_column(
         TIMESTAMP(timezone=True), server_default=func.now()
     )
@@ -308,6 +309,7 @@ class Tag(Base):
     __table_args__ = (
         Index("ix_tags_image_id", "image_id"),
         Index("ix_tags_tag", "tag"),
+        Index("ix_tags_rejected_at", "rejected_at"),
     )
 
     def __repr__(self) -> str:
@@ -326,6 +328,7 @@ class Caption(Base):
     # existing: 元ファイル由来のキャプションかどうかを示すフラグ
     existing: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
     is_edited_manually: Mapped[bool | None] = mapped_column(Boolean, nullable=True)
+    rejected_at: Mapped[datetime.datetime | None] = mapped_column(TIMESTAMP(timezone=True))
     created_at: Mapped[datetime.datetime] = mapped_column(
         TIMESTAMP(timezone=True), server_default=func.now()
     )
@@ -337,7 +340,10 @@ class Caption(Base):
     image: Mapped[Image] = relationship("Image", back_populates="captions")
     model: Mapped[Model] = relationship("Model", back_populates="captions")
 
-    __table_args__ = (Index("ix_captions_image_id", "image_id"),)
+    __table_args__ = (
+        Index("ix_captions_image_id", "image_id"),
+        Index("ix_captions_rejected_at", "rejected_at"),
+    )
 
     def __repr__(self) -> str:
         return f"<Caption(id={self.id}, image_id={self.image_id}, caption='{self.caption[:20]}...')>"

--- a/src/lorairo/services/dataset_export_service.py
+++ b/src/lorairo/services/dataset_export_service.py
@@ -111,21 +111,19 @@ class DatasetExportService:
                 self.file_system_manager.copy_file(processed_image_path, output_image_path)
 
                 # Write tag file
-                tags = ", ".join([tag_data["tag"] for tag_data in image_data["tags"]])
-                if merge_caption and image_data["captions"]:
-                    captions = ", ".join(
-                        [caption_data["caption"] for caption_data in image_data["captions"]]
-                    )
+                export_tags = self._resolve_export_tags(image_data["tags"])
+                export_caption = self._resolve_export_caption(image_data["captions"])
+                tags = ", ".join([tag_data["tag"] for tag_data in export_tags])
+                if merge_caption and export_caption:
+                    captions = export_caption["caption"]
                     tags = f"{tags}, {captions}" if tags else captions
 
                 with open(txt_file, "w", encoding="utf-8") as f:
                     f.write(tags)
 
                 # Write caption file
-                if image_data["captions"]:
-                    captions = ", ".join(
-                        [caption_data["caption"] for caption_data in image_data["captions"]]
-                    )
+                if export_caption:
+                    captions = export_caption["caption"]
                     with open(caption_file, "w", encoding="utf-8") as f:
                         f.write(captions)
 
@@ -198,12 +196,10 @@ class DatasetExportService:
                 self.file_system_manager.copy_file(processed_image_path, output_image_path)
 
                 # Build metadata entry
-                tags = ", ".join([tag_data["tag"] for tag_data in image_data["tags"]])
-                captions = (
-                    ", ".join([caption_data["caption"] for caption_data in image_data["captions"]])
-                    if image_data["captions"]
-                    else ""
-                )
+                export_tags = self._resolve_export_tags(image_data["tags"])
+                export_caption = self._resolve_export_caption(image_data["captions"])
+                tags = ", ".join([tag_data["tag"] for tag_data in export_tags])
+                captions = export_caption["caption"] if export_caption else ""
                 # ADR 0028: score_labels は {model, label} を主とする JSON-safe な形で埋め込む
                 score_labels = [
                     {
@@ -405,6 +401,46 @@ class DatasetExportService:
             Dictionary mapping image_id -> list of available resolutions
         """
         return self.db_manager.get_batch_available_resolutions(image_ids)
+
+    @staticmethod
+    def _resolve_export_tags(tags: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        """Resolve adopted tags to a stable string union for export.
+
+        `rejected_at` is target-independent correctness state. Export target
+        vocabulary conversion belongs to export profiles, not this resolver.
+        """
+        resolved_by_tag: dict[str, dict[str, Any]] = {}
+        for tag_data in tags:
+            if tag_data.get("rejected_at") is not None:
+                continue
+            tag = tag_data.get("tag")
+            if not isinstance(tag, str) or not tag:
+                continue
+            current = resolved_by_tag.get(tag)
+            if current is None or (
+                bool(tag_data.get("is_edited_manually")) and not bool(current.get("is_edited_manually"))
+            ):
+                resolved_by_tag[tag] = tag_data
+        return list(resolved_by_tag.values())
+
+    @staticmethod
+    def _resolve_export_caption(captions: list[dict[str, Any]]) -> dict[str, Any] | None:
+        """Resolve adopted captions to the single row used by training export."""
+        adopted = [
+            caption_data
+            for caption_data in captions
+            if caption_data.get("rejected_at") is None and caption_data.get("caption")
+        ]
+        if not adopted:
+            return None
+
+        def sort_key(indexed_caption: tuple[int, dict[str, Any]]) -> tuple[bool, float, int]:
+            index, caption_data = indexed_caption
+            timestamp = caption_data.get("updated_at") or caption_data.get("created_at")
+            timestamp_value = timestamp.timestamp() if isinstance(timestamp, datetime) else 0.0
+            return (bool(caption_data.get("is_edited_manually")), timestamp_value, -index)
+
+        return max(enumerate(adopted), key=sort_key)[1]
 
     def filter_changed_since(self, image_ids: list[int], since: datetime) -> list[int]:
         """指定日時以降にタグ変更があった image_id に絞り込む (#614)。

--- a/tests/unit/database/repository/test_annotation_record_repository.py
+++ b/tests/unit/database/repository/test_annotation_record_repository.py
@@ -22,6 +22,7 @@
 
 from __future__ import annotations
 
+import datetime
 from unittest.mock import MagicMock, Mock
 
 import pytest
@@ -353,6 +354,64 @@ class TestSaveTagsAndCaptions:
             assert len(rows) == 1
             assert "cat" in rows[0].caption
 
+    def test_save_tags_does_not_revive_rejected_row(
+        self,
+        annotation_repository: AnnotationRepository,
+        image_id: int,
+        memory_session_factory,
+    ) -> None:
+        rejected_at = datetime.datetime(2026, 6, 11, tzinfo=datetime.UTC)
+        with memory_session_factory() as session:
+            session.add(
+                Tag(
+                    image_id=image_id,
+                    model_id=None,
+                    tag="blue_hair",
+                    rejected_at=rejected_at,
+                    existing=False,
+                )
+            )
+            session.commit()
+
+        annotation_repository.save_annotations(
+            image_id=image_id,
+            annotations={"tags": [{"tag": "blue_hair", "model_id": None, "tag_id": None}]},
+        )
+
+        with memory_session_factory() as session:
+            rows = session.execute(select(Tag).where(Tag.image_id == image_id)).scalars().all()
+            assert len(rows) == 1
+            assert rows[0].rejected_at is not None
+
+    def test_save_captions_does_not_revive_rejected_row(
+        self,
+        annotation_repository: AnnotationRepository,
+        image_id: int,
+        memory_session_factory,
+    ) -> None:
+        rejected_at = datetime.datetime(2026, 6, 11, tzinfo=datetime.UTC)
+        with memory_session_factory() as session:
+            session.add(
+                Caption(
+                    image_id=image_id,
+                    model_id=None,
+                    caption="wrong caption",
+                    rejected_at=rejected_at,
+                    existing=False,
+                )
+            )
+            session.commit()
+
+        annotation_repository.save_annotations(
+            image_id=image_id,
+            annotations={"captions": [{"caption": "wrong caption", "model_id": None}]},
+        )
+
+        with memory_session_factory() as session:
+            rows = session.execute(select(Caption).where(Caption.image_id == image_id)).scalars().all()
+            assert len(rows) == 1
+            assert rows[0].rejected_at is not None
+
 
 @pytest.mark.unit
 class TestAddTagToImagesBatch:
@@ -382,6 +441,24 @@ class TestAddTagToImagesBatch:
         with memory_session_factory() as session:
             rows = session.execute(select(Tag).where(Tag.image_id == image_id)).scalars().all()
             assert any(t.tag == "blue_sky" for t in rows)
+
+    def test_remove_tag_soft_rejects_without_physical_delete(
+        self,
+        annotation_repository: AnnotationRepository,
+        image_id: int,
+        memory_session_factory,
+    ) -> None:
+        annotation_repository.add_tag_to_images_batch([image_id], "blue_sky", model_id=None)
+
+        ok, results = annotation_repository.remove_tag_from_images_batch([image_id], "blue_sky")
+
+        assert ok is True
+        assert results == [(image_id, "changed")]
+        with memory_session_factory() as session:
+            rows = session.execute(select(Tag).where(Tag.image_id == image_id)).scalars().all()
+            assert len(rows) == 1
+            assert rows[0].tag == "blue_sky"
+            assert rows[0].rejected_at is not None
 
 
 @pytest.mark.unit

--- a/tests/unit/database/repository/test_image_repository.py
+++ b/tests/unit/database/repository/test_image_repository.py
@@ -33,6 +33,7 @@ from lorairo.database.filter_criteria import ImageFilterCriteria
 from lorairo.database.repository.base import BaseRepository
 from lorairo.database.repository.image import ImageRepository
 from lorairo.database.schema import (
+    Caption,
     Image,
     ImageFilenameAlias,
     ProcessedImage,
@@ -532,6 +533,7 @@ class TestFormatAnnotationStatics:
             existing=False,
             is_edited_manually=False,
             confidence_score=0.9,
+            rejected_at=None,
             created_at=None,
             updated_at=None,
         )
@@ -606,6 +608,87 @@ class TestImageDatabaseManagerDIContract:
         assert manager.image_repo.session_factory is memory_session_factory
         # 他 Repo も同じ session_factory を共有していることを確認
         assert manager.annotation_repo.session_factory is memory_session_factory
+
+
+@pytest.mark.unit
+class TestGetImageAnnotationsSoftReject:
+    """Tag/Caption soft-reject の採用ビューを検証する。"""
+
+    def test_excludes_rejected_tags_and_captions_by_default(
+        self, image_repository: ImageRepository, memory_session_factory
+    ) -> None:
+        image_id = _insert_image(
+            image_repository,
+            uuid="soft-reject-default",
+            phash="soft-reject-default",
+            filename="soft-reject-default.png",
+        )
+        rejected_at = datetime.datetime(2026, 6, 11, tzinfo=datetime.UTC)
+        with memory_session_factory() as session:
+            session.add_all(
+                [
+                    Tag(image_id=image_id, tag="black_hair", rejected_at=None),
+                    Tag(image_id=image_id, tag="blue_hair", rejected_at=rejected_at),
+                    Caption(image_id=image_id, caption="adopted caption", rejected_at=None),
+                    Caption(image_id=image_id, caption="rejected caption", rejected_at=rejected_at),
+                ]
+            )
+            session.commit()
+
+        annotations = image_repository.get_image_annotations(image_id)
+
+        assert [tag["tag"] for tag in annotations["tags"]] == ["black_hair"]
+        assert [caption["caption"] for caption in annotations["captions"]] == ["adopted caption"]
+
+    def test_can_include_rejected_tags_and_captions_explicitly(
+        self, image_repository: ImageRepository, memory_session_factory
+    ) -> None:
+        image_id = _insert_image(
+            image_repository,
+            uuid="soft-reject-history",
+            phash="soft-reject-history",
+            filename="soft-reject-history.png",
+        )
+        rejected_at = datetime.datetime(2026, 6, 11, tzinfo=datetime.UTC)
+        with memory_session_factory() as session:
+            session.add_all(
+                [
+                    Tag(image_id=image_id, tag="black_hair", rejected_at=None),
+                    Tag(image_id=image_id, tag="blue_hair", rejected_at=rejected_at),
+                    Caption(image_id=image_id, caption="adopted caption", rejected_at=None),
+                    Caption(image_id=image_id, caption="rejected caption", rejected_at=rejected_at),
+                ]
+            )
+            session.commit()
+
+        annotations = image_repository.get_image_annotations(image_id, include_rejected=True)
+
+        assert {tag["tag"] for tag in annotations["tags"]} == {"black_hair", "blue_hair"}
+        assert {caption["caption"] for caption in annotations["captions"]} == {
+            "adopted caption",
+            "rejected caption",
+        }
+
+    def test_get_annotated_image_ids_ignores_rejected_only_annotations(
+        self, image_repository: ImageRepository, memory_session_factory
+    ) -> None:
+        image_id = _insert_image(
+            image_repository,
+            uuid="soft-reject-annotated",
+            phash="soft-reject-annotated",
+            filename="soft-reject-annotated.png",
+        )
+        with memory_session_factory() as session:
+            session.add(
+                Tag(
+                    image_id=image_id,
+                    tag="blue_hair",
+                    rejected_at=datetime.datetime(2026, 6, 11, tzinfo=datetime.UTC),
+                )
+            )
+            session.commit()
+
+        assert image_repository.get_annotated_image_ids([image_id]) == set()
 
 
 def _insert_tag(
@@ -740,6 +823,29 @@ class TestImageFilterCriteriaExactSet:
         ids = {m["id"] for m in exact}
         assert ids == {img_cat, img_plain}
         assert count == 2
+
+    def test_tag_filter_ignores_rejected_tags(
+        self, image_repository: ImageRepository, memory_session_factory
+    ) -> None:
+        img_adopted = _insert_image(image_repository, uuid="u-adopt", phash="p-adopt", filename="a.png")
+        img_rejected = _insert_image(image_repository, uuid="u-reject", phash="p-reject", filename="r.png")
+        with memory_session_factory() as session:
+            session.add_all(
+                [
+                    Tag(image_id=img_adopted, tag="cat", rejected_at=None),
+                    Tag(
+                        image_id=img_rejected,
+                        tag="cat",
+                        rejected_at=datetime.datetime(2026, 6, 11, tzinfo=datetime.UTC),
+                    ),
+                ]
+            )
+            session.commit()
+
+        rows, count = image_repository.get_images_by_filter(ImageFilterCriteria(tags=["cat"]))
+
+        assert {row["id"] for row in rows} == {img_adopted}
+        assert count == 1
 
     def test_image_ids_bypass_nsfw_exclusion(
         self, image_repository: ImageRepository, memory_session_factory

--- a/tests/unit/database/test_db_manager_extended.py
+++ b/tests/unit/database/test_db_manager_extended.py
@@ -871,11 +871,14 @@ class TestGetAnnotationStatusCounts:
         mock_image_repo.get_session.return_value = mock_session
 
         result = manager.get_annotation_status_counts()
+        executed_query = str(mock_session.execute.call_args.args[0])
 
         assert result["total"] == 10
         assert result["completed"] == 7
         assert result["error"] == 2
         assert result["completion_rate"] == 70.0
+        assert "t.rejected_at IS NULL" in executed_query
+        assert "c.rejected_at IS NULL" in executed_query
 
     def test_raises_on_sqlalchemy_error(self, manager: ImageDatabaseManager, mock_image_repo: Mock) -> None:
         """SQLAlchemyError は呼び出し元に伝播 (silent return しない)。"""
@@ -911,9 +914,12 @@ class TestFilterByAnnotationStatusExtended:
         mock_image_repo.get_session.return_value = mock_session
 
         result = manager.filter_by_annotation_status(completed=True)
+        executed_query = str(mock_session.execute.call_args.args[0])
 
         assert len(result) == 1
         assert result[0]["id"] == 1
+        assert "t.rejected_at IS NULL" in executed_query
+        assert "c.rejected_at IS NULL" in executed_query
 
     def test_returns_all_images_when_no_filter(
         self, manager: ImageDatabaseManager, mock_image_repo: Mock

--- a/tests/unit/database/test_migration_e2f3a4b5c6d7_soft_reject.py
+++ b/tests/unit/database/test_migration_e2f3a4b5c6d7_soft_reject.py
@@ -1,0 +1,64 @@
+"""Alembic migration `e2f3a4b5c6d7` soft-reject column checks."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from alembic import command
+from alembic.config import Config
+from sqlalchemy import create_engine, inspect, text
+
+
+def _make_alembic_config(db_path: Path) -> Config:
+    project_root = Path(__file__).resolve().parents[3]
+    cfg = Config(str(project_root / "alembic.ini"))
+    cfg.set_main_option("script_location", str(project_root / "src/lorairo/database/migrations"))
+    cfg.set_main_option("sqlalchemy.url", f"sqlite:///{db_path}")
+    return cfg
+
+
+@pytest.mark.unit
+def test_soft_reject_migration_adds_tag_and_caption_rejected_at(tmp_path: Path) -> None:
+    db_path = tmp_path / "soft_reject.db"
+    cfg = _make_alembic_config(db_path)
+    engine = create_engine(f"sqlite:///{db_path}")
+    with engine.begin() as conn:
+        conn.execute(
+            text(
+                """
+                CREATE TABLE tags (
+                    id INTEGER NOT NULL PRIMARY KEY,
+                    tag VARCHAR NOT NULL
+                )
+                """
+            )
+        )
+        conn.execute(
+            text(
+                """
+                CREATE TABLE captions (
+                    id INTEGER NOT NULL PRIMARY KEY,
+                    caption VARCHAR NOT NULL
+                )
+                """
+            )
+        )
+        conn.execute(text("CREATE TABLE alembic_version (version_num VARCHAR(32) PRIMARY KEY)"))
+        conn.execute(text("INSERT INTO alembic_version (version_num) VALUES ('d1e2f3a4b5c6')"))
+    engine.dispose()
+
+    command.upgrade(cfg, "head")
+
+    engine = create_engine(f"sqlite:///{db_path}")
+    inspector = inspect(engine)
+    tag_columns = {column["name"] for column in inspector.get_columns("tags")}
+    caption_columns = {column["name"] for column in inspector.get_columns("captions")}
+    tag_indexes = {index["name"] for index in inspector.get_indexes("tags")}
+    caption_indexes = {index["name"] for index in inspector.get_indexes("captions")}
+    engine.dispose()
+
+    assert "rejected_at" in tag_columns
+    assert "rejected_at" in caption_columns
+    assert "ix_tags_rejected_at" in tag_indexes
+    assert "ix_captions_rejected_at" in caption_indexes

--- a/tests/unit/test_dataset_export_service.py
+++ b/tests/unit/test_dataset_export_service.py
@@ -9,6 +9,7 @@
 
 import json
 import tempfile
+from datetime import UTC, datetime
 from pathlib import Path
 from unittest.mock import MagicMock, Mock, patch
 
@@ -134,10 +135,7 @@ class TestDatasetExportService:
                 # キャプションファイルの内容確認
                 with open(caption_file, encoding="utf-8") as f:
                     caption_content = f.read()
-                assert (
-                    "A young anime girl in school uniform, Beautiful anime character artwork"
-                    == caption_content
-                )
+                assert "A young anime girl in school uniform" == caption_content
 
                 # ファイルコピーが呼び出されたことを確認
                 mock_file_system_manager.copy_file.assert_called_once()
@@ -173,7 +171,7 @@ class TestDatasetExportService:
                 with open(txt_file, encoding="utf-8") as f:
                     content = f.read()
 
-                expected = "anime, girl, school_uniform, A young anime girl in school uniform, Beautiful anime character artwork"
+                expected = "anime, girl, school_uniform, A young anime girl in school uniform"
                 assert content == expected
 
     def test_export_dataset_json_format_success(
@@ -218,10 +216,85 @@ class TestDatasetExportService:
 
                 image_metadata = metadata[expected_image_path]
                 assert image_metadata["tags"] == "anime, girl, school_uniform"
-                assert (
-                    image_metadata["caption"]
-                    == "A young anime girl in school uniform, Beautiful anime character artwork"
-                )
+                assert image_metadata["caption"] == "A young anime girl in school uniform"
+
+    def test_export_dataset_txt_format_deduplicates_tags_and_excludes_rejected(
+        self, dataset_export_service, mock_file_system_manager
+    ):
+        """TXT export は rejected を除外し、同じタグ文字列を1回だけ出力する。"""
+        image_data = {
+            "metadata": {"id": 1},
+            "tags": [
+                {"tag": "1girl", "model_id": 1, "is_edited_manually": False, "rejected_at": None},
+                {"tag": "1girl", "model_id": 2, "is_edited_manually": True, "rejected_at": None},
+                {"tag": "blue_hair", "model_id": 1, "rejected_at": datetime(2026, 6, 11, tzinfo=UTC)},
+                {"tag": "black_hair", "model_id": 1, "rejected_at": None},
+            ],
+            "captions": [],
+        }
+        with tempfile.TemporaryDirectory() as temp_dir:
+            output_path = Path(temp_dir) / "export"
+            output_path.mkdir()
+            processed_image_path = Path("/mock/processed/test_project_00001.webp")
+
+            with (
+                patch.object(
+                    dataset_export_service,
+                    "_resolve_processed_image_path",
+                    return_value=processed_image_path,
+                ),
+                patch.object(dataset_export_service, "_get_image_export_data", return_value=image_data),
+            ):
+                dataset_export_service.export_dataset_txt_format([1], output_path)
+
+            with open(output_path / "test_project_00001.txt", encoding="utf-8") as f:
+                assert f.read() == "1girl, black_hair"
+
+    def test_export_dataset_txt_format_uses_single_manual_caption(
+        self, dataset_export_service, mock_file_system_manager
+    ):
+        """複数 caption は rejected 除外後、手動編集を優先して1本だけ出力する。"""
+        image_data = {
+            "metadata": {"id": 1},
+            "tags": [],
+            "captions": [
+                {
+                    "caption": "ai caption",
+                    "is_edited_manually": False,
+                    "updated_at": datetime(2026, 6, 10, tzinfo=UTC),
+                    "rejected_at": None,
+                },
+                {
+                    "caption": "manual caption",
+                    "is_edited_manually": True,
+                    "updated_at": datetime(2026, 6, 9, tzinfo=UTC),
+                    "rejected_at": None,
+                },
+                {
+                    "caption": "rejected caption",
+                    "is_edited_manually": True,
+                    "updated_at": datetime(2026, 6, 11, tzinfo=UTC),
+                    "rejected_at": datetime(2026, 6, 11, tzinfo=UTC),
+                },
+            ],
+        }
+        with tempfile.TemporaryDirectory() as temp_dir:
+            output_path = Path(temp_dir) / "export"
+            output_path.mkdir()
+            processed_image_path = Path("/mock/processed/test_project_00001.webp")
+
+            with (
+                patch.object(
+                    dataset_export_service,
+                    "_resolve_processed_image_path",
+                    return_value=processed_image_path,
+                ),
+                patch.object(dataset_export_service, "_get_image_export_data", return_value=image_data),
+            ):
+                dataset_export_service.export_dataset_txt_format([1], output_path)
+
+            with open(output_path / "test_project_00001.caption", encoding="utf-8") as f:
+                assert f.read() == "manual caption"
 
     def test_export_dataset_txt_format_empty_image_list(self, dataset_export_service):
         """空の画像リストでのエクスポートエラーテスト"""


### PR DESCRIPTION
## Summary
- Fixes #718.
- Branch: issue-718-soft-reject
- Worktree: /workspaces/LoRAIro/.agents/worktree/issue-718-soft-reject
- ADR: docs/decisions/0065-tag-caption-soft-reject.md

## Changes
- Add nullable tags.rejected_at and captions.rejected_at with Alembic migration e2f3a4b5c6d7.
- Treat rejected_at as target-independent correctness state only; no export-target adoption matrix is introduced.
- Change tag remove/replace flows to soft-reject adopted tag rows instead of physically deleting them.
- Exclude rejected Tag/Caption rows from adopted reads, search/filter surfaces, annotation presence checks, and dataset export.
- Resolve export tags by adopted string union with duplicate removal and manual-edit preference.
- Resolve export captions to one adopted caption, preferring manual edits and then newest rows.

## Verification
- uv run --no-sync ruff check src/lorairo/database/db_manager.py src/lorairo/database/repository/annotation_record.py src/lorairo/database/repository/image.py src/lorairo/database/schema.py src/lorairo/services/dataset_export_service.py tests/unit/test_dataset_export_service.py tests/unit/database/repository/test_annotation_record_repository.py tests/unit/database/repository/test_image_repository.py tests/unit/database/test_migration_e2f3a4b5c6d7_soft_reject.py
- uv run --no-sync ruff format --check src/lorairo/database/db_manager.py src/lorairo/database/repository/annotation_record.py src/lorairo/database/repository/image.py src/lorairo/database/schema.py src/lorairo/services/dataset_export_service.py tests/unit/test_dataset_export_service.py tests/unit/database/repository/test_annotation_record_repository.py tests/unit/database/repository/test_image_repository.py tests/unit/database/test_migration_e2f3a4b5c6d7_soft_reject.py
- uv run --no-sync pytest tests/unit/test_dataset_export_service.py tests/unit/database/repository/test_annotation_record_repository.py tests/unit/database/repository/test_image_repository.py tests/unit/database/test_migration_e2f3a4b5c6d7_soft_reject.py tests/unit/cli/test_commands_tags.py tests/unit/database/repository/test_tags_batch_ops.py -q