### PR TITLE
feat(gui): Wireframes v11 Phase 1 — メインナビ 6 タブ骨格

### DIFF
--- a/docs/design/wireframes-v11/HANDOFF.md
+++ b/docs/design/wireframes-v11/HANDOFF.md
@@ -1,0 +1,218 @@
+# LoRAIro Wireframes — 引き継ぎメモ
+
+最新ファイル: `Wireframes v11.html`
+v1〜v10 は履歴として残置（参照用）。次の作業は v11 を上書き更新でOK。
+
+> **v11 追記 (CLI 大改装 #634 対応)**: agent-friendly CLI 契約を図解する **Frame 8 · CLI** を追加。
+> 詳細は末尾「Frame 8 · CLI」節。ナビは `Search⌘1 / Map⌘2 / Annotate⌘3 / Jobs⌘4 / Results⌘5 / Errors⌘6 / Export⌘7 / CLI⌘8`。
+
+---
+
+## プロジェクト概要
+
+LoRA 学習用の画像素材データセット管理ツール `LoRAIro` の UI ワイヤーフレーム。
+schema.py のデータモデルに沿って画面を構成し、紙＋手書き調の low-fi スタイルで提案。
+
+### スタイル
+- フォント: `Kalam` (手書き) + `JetBrains Mono`
+- カラー: `--ink #1a1a1a` / `--paper #fbfaf6` / `--accent oklch(0.62 0.14 32)` 暖色アクセント
+- 影は `3px 3px 0 var(--rule)` の hard shadow。border は `2px solid` で枠を切る
+
+### スキーマ（schema.py 由来）の主要モデル
+- `Image` (width, height, format[webp固定], has_alpha, uuid, phash, created_at)
+- `ProcessedImage` (upscaler_used)
+- `Tag` (image_id, tag, model_id, confidence_score, existing, is_edited_manually)
+- `Caption` (image_id, model_id, text, existing, is_edited_manually)
+- `Score` (image_id, model_id, score, is_edited_manually)
+- `Rating` (image_id, normalized_rating ∈ PG/PG-13/R/X/XXX, confidence_score)
+- `Model` (name, type ∈ multimodal/tagger/scorer/rater/upscaler, requires_api_key, estimated_size_gb, discontinued_at)
+- `ErrorRecord` (operation_type, error_type, error_message, image_id, model, retry_count, resolved_at, stack_trace)
+- `Project` `ImageFilenameAlias` 等
+
+---
+
+## i18n 規約 (v10 で導入)
+
+- `<body data-lang="ja|en">` + CSS で排他表示
+- 3 語以上の英文 → `<span class="tx-ja">…</span><span class="tx-en">…</span>` のペアで両言語持つ
+- 2 語以下の識別子、schema 参照、コード、モデル名 → 英語のまま固定
+- Tweaks パネルの `Language` セグメントで切替（保存される）
+
+---
+
+## 確定済み設計判断
+
+### 実行UIの A/B — B（独立 Jobs タブ）で決着 (2026-06-11)
+- **決定**: 実行UIは **B: 独立 Jobs タブ**。現実装の進捗ポップアップ（A）は**廃止予定の暫定実装**として移行期のみ併存
+- **理由**: Provider Batch は実装でも既にタブ（`provider_batch_job_widget.py`）であり「同期だけポップアップ」の分断を解消するため。「Job 完了 ⇢ auto Results・issue は紅バッジ」の中核フローは常設タブがないと成立しない（履歴・並行ジョブ・完了後導線の置き場）
+- **反映済み (v11)**: FLOW 図と Annotate の実行ボタンに「Jobs タブへ自動スイッチ」を明記 / REJECTED に「実行ポップアップ維持（A案）」追加 / Frame 3 に DECIDED ノート / 履歴に CANCELED 行 + ADR 0034 terminal 語彙（FAILED / CANCELED / TERMINATED / UNRESPONSIVE）の凡例
+- **検証**: `Jobs Flow Prototype.html`（操作プロト、Tweaks で A / B / B' 切替）でユーザ確認済み「違和感なし」。未決の微調整: 完了時 auto-Results vs バッジのみ / Jobs の情報密度 standard vs focus はプロトの Tweaks で引き続き比較可
+- **規模前提**: 同期ジョブの母集団はステージング集合（上限 500）
+
+### Import / 重複検出フロー — 専用画面は不要として取り下げ (2026-06-11)
+- 登録ロジック側 (#633 / ADR 0061 §4 の統一登録エントリ・`registration_worker.py`) が pHash で **重複 (自動 skip + `ImageFilenameAlias` 自動記録) / 別版 (variant 登録) / 新規** を全自動分類。手動の重複解決 UI は不要
+- chat3 で Errors から重複エラー行を削除した判断と整合
+- 残っていた UX ギャップ（登録結果が statusBar に5秒出て消えるだけ）は **「登録完了サマリ」パネル**として v11 Frame 1 (Search・qbar の上) に描画済み: registered / variant / skipped / errors の件数 + skip/variant 行から「同一と判定された既存画像」へのリンク。独立 frame にはしない。✕ で閉じるまで残る
+
+### 規模対応と空状態 — FRAME 9 · STATES として描画 (2026-06-11)
+- 設計メモの「500で仮想スクロール、9kで per-row 非表示」を状態カタログフレーム（カード6枚）として実体化。数字キー 9 / data-screen-label="09 States"
+- カード: ① Search 0 hit（トークン別 hit 数で矛盾を診断・「どれを外せば何件」提示・NLQ タイムアウトも同所）② Results 未実行（次アクションへの案内板）③ Results 0 issues（clean を祝って Export へ素通り）④ Jobs 空（履歴は消さない）⑤ Results@500（仮想スクロール + 同種 issue を1カードに集約・ページングなし）⑥ Results@9k（per-row 非描画・patterns のみ・pattern → Search へ絞り込み受け渡し）
+- OPEN: issue → query 変換の文法
+
+### rejected_at はターゲット非依存の正誤判断のみ (2026-06-11)
+- `rejected_at` は「この画像にこのタグは誤り」という**正誤判断のみ**（ターゲット非依存）
+- Danbooru 系 / Pony 系などターゲットごとの語彙差は、右パネルの採用操作では扱わない。タグ DB (genai-tag-db-tools) の format/エイリアス変換と Export 側のターゲット別規則（Export frame の責務）で解決
+- → **Annotate 右パネルに「ターゲット別の採用切替」のような UI は描かないこと**
+- → Export frame の frame-notes に「出力 format (danbooru / e621 / pony 等) の選択と変換プレビューの余地」をメモ済み (FORMAT ノート)
+
+### 不要なフィルタ
+- **画像拡張子フィルタ** — DB 登録時に webp に統一済なので削除
+- **has_alpha フィルタ** — α 背景でも特別仕様なし、削除済
+- **format / has_alpha 系のメタ表示** — サムネメタからも撤去（width × height のみ）
+
+### モデル × ステージの設計（重要）
+v10 の核心。Frame 2 (Annotate) のモデル実行 UX を再設計した。
+
+- **ステージ中心**: `TAGS / CAPTION / SCORE / RATING / UPSCALE` の5ステージは schema の出力テーブル (Tag/Caption/Score/Rating/ProcessedImage) に対応
+- **マルチモーダルモデルの扱い**: 1推論で取れる出力をすべて自動保存
+  - 例: `gpt-4o-caption` を CAPTION ステージに置くと、副産物の tag + rating も同時取得して保存
+  - 副産物側ステージ (TAGS / RATING) には `↝ shadow chip`（破線+斜体）で「自動取得される」と視覚表示
+  - ピッカーの sub に `1推論で tags + caption + rating 取得` と明記
+  - `llava-next` `qwen-vl-chat` は rating 出力なし → `tags + caption` のみ
+- **ジョブ数表示**: 「N モデル × M枚」ではなく「N 推論 × M枚」。マルチモーダルは1推論扱い
+
+### モデルピッカー (Frame 2B)
+- 左レール: `Model.type` / Provider / Availability / Capabilities
+- メイン: 検索 + ソート、行ごとに `name · type · status · size/cost · 信頼度閾値スライダ`
+- ステータス: `● installed` / `● API ready` / `○ needs key` / `○ discontinued`
+- `discontinued_at` モデルは取り消し線 + disabled で残す（履歴目的で消さない）
+- プリセット: Default / Tags only / Full caption / Score · rate / Multimodal only など
+
+### Search サイドバー (Frame 1)
+- **DATE フィルタ**: chip → 20本ヒストグラム + 範囲スライダ + プリセット chip にアップグレード
+- **annotations state**: `is_edited_manually` を tag / caption / score 統合の「手動編集あり」フィルタに。下に内訳
+- **model filter**: 検索ボックス + 📌ピン留め + 「最近使用」 + 「他N個を表示」展開。0使用モデルは折りたたみ
+- **error state**: chip 3択 (all / エラーありのみ / エラーを除外)
+
+### Jobs と Errors は分離 (v10 後半)
+- ~~旧 Frame 3 (JOBS / ERRORS 合体)~~ → **Frame 3 · JOBS** と **Frame 4 · ERRORS** に分離
+- ナビ: `Search⌘1 / Map⌘2 / Annotate⌘3 / Jobs⌘4 / Errors⌘5 / Export⌘6`
+
+#### Frame 3 · JOBS
+- 性質: lifecycle (実行中 / キュー / 履歴)
+- サマリ: 実行中 / キュー / 過去7日完了 / API使用状況 (rate)
+- Running カード: ステージ × モデルの進捗バー、rate待機は縞模様、Pause/Cancel
+- Queue: 並び替え、推定時間
+- History: テーブル、失敗行から `→ Errors` で triage
+
+#### Frame 4 · ERRORS
+- 性質: 失敗の triage
+- サマリ: 未解決 / 24h / 解決済 / error_type 別
+- クロスフィルタ: status × operation × model × time
+- **デフォルトはグルーピング表示** (同一原因を集約) — 個別行モードも切替可
+- 各グループ: 件数、エラーメッセージ + バッジ、影響画像リンク、retry可/上限到達、過去7日スパークライン、状況別アクション (retry / resolve / ignore / 再インポート)
+- bottom bulk: 「retry可をすべて再実行」「選択を無視」
+
+---
+
+## 未着手 / 検討中
+
+### 次の優先課題（ユーザ承認済）
+**1. Frame 5 · RESULTS（アノテーション品質トリアージ）**
+- 目的: 画像素材ではなく **アノテーションの品質チェック**（明確化済）
+- バッチは少数（〜10枚程度）想定
+- 構成方針:
+  1. **品質問題を最上段に集約** — 低信頼度・短すぎる caption・モデル間 rating コンフリクト・空タグなどを自動検出して issue カードとして掲示
+  2. **画像単位の要約リスト** — サムネ + アノテーション一式の要約。`▸ レビュー` で Annotate に直行
+  3. **アクション** — 1件ずつ accept/edit/reject + bulk 「問題なければ承認」
+- CSS は既に追加済（`.res-summary` `.issues-band` `.issue-card` `.res-row` `.res-foot`）→ あとは HTML 本体を Frame 4 の後ろに追加するだけ
+
+### 残作業（優先順）
+1. **Frame 5 · RESULTS の HTML 実装**（CSS 準備済）
+2. **Frame 2 右側パネル（Tag/Caption/Score/Rating 詳細）** の整理
+   - マルチモーダル対応した今、モデル別グルーピング・採用ワークフローが弱い
+   - 「このモデルの tag を全採用」「競合解決」UI
+   - **制約**: 採用操作はターゲット非依存（`rejected_at` = 正誤判断のみ）。ターゲット別の採用切替 UI は描かない（↑確定済み設計判断参照）
+3. **Settings / API key 設定 / Model installer** — ✅ v11 で **Frame 2C · SETTINGS（独立ウィンドウ）** として実装 (2026-06-11)
+   - needs key は「可視 + その場で解消」に統一: Frame 2B の needs key chip クリック → Settings の該当プロバイダ欄（ハイライト）→ 保存 → ● API ready。実装の「キー未設定モデルを非表示」仕様はこのワイヤーを正に改める予定
+   - 9個目のタブにはしない（現実装どおり ConfigurationWindow 独立ウィンドウ、タイトルバー ⚙ から）。中身は API keys（マスク・表示切替なし・保存済かだけ分かる・config/lorairo.toml [api]）/ モデル経路 (auto/direct/openrouter · "all" は CLI 専用) / installer の最小構成
+   - **Model installer（新設）**: 初回推論時の暗黙 HuggingFace DL を明示的な **install ジョブ**に。estimated_size_gb 表示・進捗は Jobs lifecycle に同居（中止 = CANCELED · ADR 0034）・uninstall / 容量合計あり。未 install モデルをパイプラインに置くと install ジョブが自動先行
+   - discontinued は現状維持（取り消し線 + disabled）
+4. **Map / Export タブ** — 中身未設計、優先度低
+
+~~Import / 重複検出フロー~~ — 実装済み（pHash 全自動分類）のため取り下げ。代替の「登録完了サマリ」は Frame 1 に描画済み（↑確定済み設計判断参照）
+
+---
+
+## ファイル構成
+
+```
+Wireframes.html         初版
+Wireframes v2〜 v10.html  履歴
+Wireframes v11.html     ← 最新作業対象 (CLI frame 追加・Jobs A/B 決着反映済)
+Jobs Flow Prototype.html  操作プロト (A/B/B' 切替・proto/ 以下に JSX)
+HANDOFF.md              ← 本ファイル
+```
+
+---
+
+## Frame 8 · CLI（agent-friendly CLI 契約 / issue #634）
+
+GUI とは別の **第二の操作面**として CLI 契約を図解する frame を追加。リポジトリの
+実装 (`src/lorairo/cli/`) と `docs/cli.md` を読み、実際の出力形式に合わせている。
+
+### 出典（GitHub `NEXTAltair/LoRAIro` から取得して反映）
+- ADR 0057 (`_emit.py` / `_errors.py` / `_boundary.py`) — JSONL & 構造化エラー契約
+- ADR 0058 (`_output_mode.py`) — `--json`/`--no-json` > env `LORAIRO_CLI_JSON` > 既定 rich
+- ADR 0059 (`introspection.py`) — `list-commands` / `describe` / `--schema json_schema`
+- ADR 0060 — bounded pagination (`limit ≤ 500` / `RESULT_SET_TOO_LARGE`)
+
+### frame の構成（7 バンド）
+1. **契約 + 出力モード解決** — 「既存 CLI に被せた機械可読契約レイヤー」+ ADR チップ
+2. **stdout=JSONL / stderr=ログ** — 同一コマンドの 2 ペイン端末（中心ビジュアル）
+3. **3 つの kind** — `item` / `result` / `error`
+4. **構造化エラー契約** — error JSONL 例 + 15 codes（共有11/AI3/pagination1）+ exit 0/2/1 + flags
+5. **introspection** — `list-commands`(type:tool) / `describe`(type:model/schema)
+6. **bounded pagination** — `count`/`total`/`has_more` + `RESULT_SET_TOO_LARGE`
+7. **agent driving flow** — project create → images register → annotate run → export create、`code`/`has_more` 分岐
+
+### コマンド総覧（reference バンド）
+`annotate`(2) `batch`(6) `export`(1) `images`(3) `models`(2) `project`(3) + top-level `version/status/list-commands/describe` = 17 サブコマンド。各コマンドに read-only / side_effect バッジ。
+
+### スタイル / 実装メモ
+- 端末ペインは `#23211d` ダーク + JSONL シンタックス色分け（`.j-k/.j-s/.j-n/.j-b`）。kind バッジ `.kb.item/.result/.error`。
+- CSS は全て `#frame-cli` プレフィックスでスコープ（既存トークン衝突回避）。
+- ナビ: proto controller が **全 `.topnav` に CLI タブを JS で注入**（8 nav 手編集を回避）。`SCREENS.cli` / `NUM2KEY['8']` / `TAB2KEY.CLI` を追加。
+- frame は `.app` 内に配置（他 frame と左 32px 揃え）。proto-bar ヒントは `1–8` に更新。
+
+---
+
+## Tweaks
+- `lang: ja | en` — i18n 切替
+- `sidebar_collapsed`
+- `show_map` — Schema mapping パネル表示
+- `show_schema_tags` — `.schema-tag` / `.src` バッジ表示
+
+`/*EDITMODE-BEGIN*/ … /*EDITMODE-END*/` で囲まれた JSON が永続化対象。
+
+---
+
+## ファイル構成（旧記述・上の最新版を参照）
+
+```
+Wireframes.html         初版
+Wireframes v2〜v9.html   履歴
+Wireframes v10.html     ← 最新作業対象
+HANDOFF.md              ← 本ファイル
+```
+
+v11 を切るのか v10 を継続編集するかは次セッションで判断。
+小修正は v10 で続行、大規模再構成なら v11 にコピーする方針。
+
+---
+
+## 直近のユーザ要望
+
+- アノテーション品質のトリアージ画面が欲しい（画像チェックではない）
+- 一度に実行する枚数は多くない（少数バッチ前提）
+- → **Frame 5 · RESULTS** として上記方針で実装するのが次の作業

--- a/docs/superpowers/plans/2026-06-11-gui-wireframes-v11-phase1-nav-skeleton.md
+++ b/docs/superpowers/plans/2026-06-11-gui-wireframes-v11-phase1-nav-skeleton.md
@@ -1,0 +1,731 @@
+# GUI Wireframes v11 — Phase 1 ナビ骨格 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Claude Design ハンドオフバンドル「Wireframes v11」のナビゲーション構造への第一歩として、MainWindow を 6 タブ構成（検索 / マップ / アノテーション / ジョブ / 結果 / エラー）に再構築する。
+
+**Architecture:** 既存の `tabWidgetMainMode`（ワークスペース / バッチタグ / バッチAPI の 3 タブ）を Wireframes v11 のナビ語彙に揃え、Map / Results のスタブページと Errors タブ（既存 `ErrorLogViewerWidget` の埋め込み）を追加する。タブ index のマジックナンバーを widget 同一性ベースに置換し、後続フェーズでのタブ増減に耐える構造にする。既存 widget の中身（FilterSearchPanel / BatchTagAddWidget / ProviderBatchJobWidget）は一切変更しない。
+
+**Tech Stack:** PySide6 / Qt Designer (.ui + `scripts/generate_ui.py`) / pytest-qt
+
+---
+
+## 背景: デザインバンドルとロードマップ
+
+### 出典
+
+- Claude Design ハンドオフ: `https://api.anthropic.com/v1/design/h/lLO11YeFNJwtj0F1a0msIA`
+- リポジトリ内コピー（本計画と同時に取り込み済み）:
+  - `docs/design/wireframes-v11/wireframes-v11.html` — ワイヤーフレーム本体（8 フレーム）
+  - `docs/design/wireframes-v11/HANDOFF.md` — デザインセッションの引き継ぎメモ
+  - `docs/design/wireframes-v11/decisions-impact-on-wireframe.md` — ADR 0019–0055 の影響分析
+
+### 設計の中心仮説（v11 設計メモより）
+
+「アノテーション結果は人間が 1 枚ずつレビューするのではなく、**機械にトリアージさせて要レビューだけ人が触る**」。各画面は「次にとる 1 アクション」を 1 つに絞る。フロー: Search → stage → Annotate → (preflight) → Jobs → ✓done ⇢auto Results → Export。
+
+### v11 フレーム ↔ 現行実装の対応とフェーズ分割
+
+| Phase | v11 フレーム | 現状 | 内容 | 依存 / 未決事項 |
+|---|---|---|---|---|
+| **1 (本計画)** | ナビ全体 | 3 タブ | 6 タブ化 + スタブ + index マジックナンバー排除 | なし |
+| 2 | Frame 5 Results | **未実装** | 品質トリアージ画面（品質ティア分布サマリ・issue カード集約・per-image 行 + accept/edit/reject・bulk 承認）。500 枚で仮想スクロール、9k 枚で per-row 非表示 | ADR 0029/0027/0028/0031。OPEN: 閾値スコープ (batch/project/global)、auto-accept 可否 |
+| 3 | Frame 4 Errors | フラットなログビューア | トリアージ UI 化（同一原因グルーピング・status×operation×model クロスフィルタ・日本語タイトル + mono 技術詳細の 2 段組・retry/resolve/ignore + bulk・ADR 0034 worker lifecycle 語彙）。`ErrorLogViewerDialog` の廃止クリーンアップもここで | errors CLI 作業 (`2026-06-11-errors-cli-and-cancellation-fix.md`) と整合させる |
+| 4 | Frame 1 Search | FilterSearchPanel あり | 品質ティア facet / AI・手動 2 軸 rating filter + 不一致クイック / scorer 合意状態・ペア比較 facet / DATE ヒストグラム。**画像サイズ・拡張子・has_alpha filter は追加しない**（設計で削除済み） | ADR 0029/0031/0015。OPEN: save query = live view / snapshot |
+| 5 | Frame 7 Export | `DatasetExportWidget` (QDialog) | QWidget 化してエクスポートタブ常設。対象 = ステージング集合（ADR 0055/0019）、exact-set bypass の可視化 | OPEN: discontinued モデルの過去結果の扱い |
+| 6 | Frame 2/2B Annotate | tabBatchTag あり | ステージ中心パイプライン（TAGS/CAPTION/SCORE/RATING、UPSCALE は別ジョブで含めない）、multimodal の ↝ shadow chip と「N 推論 × M 枚」表示、rating preflight ゲート表示（ADR 0031/0042）、環境ファースト二段モデルピッカー（ADR 0030） | OPEN: multimodal 派生出力の表示方法 |
+| 7 | Frame 3 Jobs | 実行 = ポップアップ、Provider Batch = タブ | 同期実行と Provider Batch の統合 Jobs ビュー | **未決: ポップアップ維持 (実装追従 A) vs 独立タブ化 (提案 B)** — デザインセッションでも未回答。着手前にユーザー決定 + ADR 必須 |
+| 8 | Frame Map | **未実装** | embedding 散布図 + クラスタ俯瞰（HDBSCAN 等）。バックエンド新規 | 要 ADR（embedding 計算・キャッシュ戦略）。HANDOFF でも優先度最低 |
+| — | Frame 8 CLI | **実装済み** | ワイヤーが実装 (ADR 0057–0060) から逆起こししたもの。GUI 作業なし | — |
+
+各フェーズは着手時に個別の実装計画を作成する（本ドキュメントは Phase 1 のみ詳細化）。
+
+### Phase 1 のスコープ判断
+
+- v11 ナビは 8 画面（⌘1–⌘8）だが、Phase 1 のタブは **6 枚**:
+  - **CLI タブは作らない** — CLI は GUI とは別の操作面であり、ワイヤーの Frame 8 は契約の図解。Qt タブにする意味がない。
+  - **エクスポートタブは Phase 5 に先送り** — `DatasetExportWidget` が QDialog 実装のため、タブ埋め込みは QWidget 化リファクタリングが必要。骨格フェーズでは既存のダイアログ起動（`btnExportData` / `actionExport`）を維持する。
+- タブ名は v11 ナビの日本語語彙（検索 / マップ / アノテーション / ジョブ / 結果 / エラー）に揃える。objectName（`tabWorkspace` / `tabBatchTag`）は参照箇所が多いため**変更しない**（タイトル文字列のみ変更）。
+- 過去の教訓（lessons-learned「UIファイル生成を忘れると連鎖エラー」）: `.ui` 変更後は必ず `uv run python scripts/generate_ui.py` を実行する。
+
+---
+
+## File Structure
+
+| ファイル | 変更内容 |
+|---|---|
+| `src/lorairo/gui/designer/MainWindow.ui` | Modify: タブタイトル変更（検索 / アノテーション）、windowTitle 変更、`tabMap` / `tabResults` / `tabErrors` ページ追加 |
+| `src/lorairo/gui/designer/MainWindow_ui.py` | Regenerate: `scripts/generate_ui.py` で再生成（手編集禁止） |
+| `src/lorairo/gui/window/main_window.py` | Modify: ジョブタブ挿入位置 / index マジックナンバー排除 / Errors タブ埋め込み / 通知導線 / Ctrl+1–6 ショートカット / `SETTINGS_VERSION` bump |
+| `src/lorairo/gui/services/tab_reorganization_service.py` | Modify: `REQUIRED_WIDGETS` に新タブ 3 件追加 |
+| `tests/integration/test_main_window_tab_integration.py` | Modify: 6 タブ構成への期待値更新 + 新規テスト |
+| `tests/unit/gui/services/test_tab_reorganization_service.py` | Modify: 定数テスト更新 |
+| `docs/design/wireframes-v11/*` | Add: デザイン資産 3 ファイル（取り込み済み・要 git add） |
+
+---
+
+### Task 1: Worktree 準備
+
+実装作業は共有 checkout でなく専用 worktree で行う（`rules/git-workflow.md`）。共有 checkout には errors CLI の未コミット作業が進行中のため、触らないこと。
+
+- [ ] **Step 1: worktree 作成**
+
+```bash
+cd /workspaces/LoRAIro
+git fetch origin
+git worktree add .agents/worktree/gui-v11-phase1 -b feat/gui-v11-phase1-nav-skeleton origin/main
+cd /workspaces/LoRAIro/.agents/worktree/gui-v11-phase1
+```
+
+- [ ] **Step 2: 共有 venv で動作確認**
+
+worktree 内の `uv run` は `.claude/settings.json` の `UV_PROJECT_ENVIRONMENT=/workspaces/LoRAIro/.venv` 常設で共有 venv を使う。worktree 内に `.venv` を作らない。
+
+```bash
+uv run --no-sync python -c "import lorairo; print('ok')"
+```
+
+Expected: `ok`
+
+> **注意（lessons-learned: worktree 検証は main checkout を見る）**: editable install のため worktree からの pytest/mypy は main checkout 側のコードを解決することがある。本計画のタスクごとの pytest はテストファイル自体を worktree パスで指定し、最終検証は push 後の CI を SSoT とする。確実にしたい場合は `PYTHONPATH=$(pwd)/src uv run --no-sync pytest ...` を使う。
+
+### Task 2: デザイン資産の取り込みコミット
+
+資産は共有 checkout の `docs/design/wireframes-v11/` に展開済み（本計画作成時にバンドルからコピー）。worktree へコピーしてコミットする。
+
+- [ ] **Step 1: 資産を worktree へコピー**
+
+```bash
+mkdir -p docs/design/wireframes-v11
+cp /workspaces/LoRAIro/docs/design/wireframes-v11/wireframes-v11.html docs/design/wireframes-v11/
+cp /workspaces/LoRAIro/docs/design/wireframes-v11/HANDOFF.md docs/design/wireframes-v11/
+cp /workspaces/LoRAIro/docs/design/wireframes-v11/decisions-impact-on-wireframe.md docs/design/wireframes-v11/
+```
+
+（共有 checkout 側に無い場合のフォールバック: ハンドオフ URL `https://api.anthropic.com/v1/design/h/lLO11YeFNJwtj0F1a0msIA` は gzip tar バンドル。`lorairo-01/project/Wireframes v11.html` 等を展開して取得する）
+
+- [ ] **Step 2: 計画ドキュメントもコピーしてコミット**
+
+```bash
+cp /workspaces/LoRAIro/docs/superpowers/plans/2026-06-11-gui-wireframes-v11-phase1-nav-skeleton.md docs/superpowers/plans/
+git add docs/design/wireframes-v11/ docs/superpowers/plans/2026-06-11-gui-wireframes-v11-phase1-nav-skeleton.md
+git commit -m "docs: Wireframes v11 デザイン資産と Phase 1 実装計画を追加"
+```
+
+### Task 3: メインタブ 6 枚構成への再編
+
+**Files:**
+- Modify: `tests/integration/test_main_window_tab_integration.py`
+- Modify: `src/lorairo/gui/designer/MainWindow.ui`
+- Regenerate: `src/lorairo/gui/designer/MainWindow_ui.py`
+- Modify: `src/lorairo/gui/window/main_window.py`
+
+- [ ] **Step 1: 統合テストを 6 タブ期待値に更新（red）**
+
+`tests/integration/test_main_window_tab_integration.py` を以下のように変更する。
+
+`test_three_tabs_created` を置換:
+
+```python
+    def test_six_tabs_created(self, main_window_with_tabs):
+        """6つのタブ（検索/マップ/アノテーション/ジョブ/結果/エラー）が作成される"""
+        tab_widget = main_window_with_tabs.tabWidgetMainMode
+        assert tab_widget.count() == 6
+        assert [tab_widget.tabText(i) for i in range(tab_widget.count())] == [
+            "検索",
+            "マップ",
+            "アノテーション",
+            "ジョブ",
+            "結果",
+            "エラー",
+        ]
+```
+
+新規テストを `TestMainWindowTabInitialization` に追加:
+
+```python
+    def test_stub_pages_exist(self, main_window_with_tabs):
+        """マップ/結果タブはスタブページとして存在する"""
+        tab_widget = main_window_with_tabs.tabWidgetMainMode
+        assert tab_widget.widget(1).objectName() == "tabMap"
+        assert tab_widget.widget(4).objectName() == "tabResults"
+
+    def test_tab_order_matches_wireframe_nav(self, main_window_with_tabs):
+        """タブ順序が Wireframes v11 のナビ順 (Search/Map/Annotate/Jobs/Results/Errors) に一致する"""
+        window = main_window_with_tabs
+        tab_widget = window.tabWidgetMainMode
+        assert tab_widget.widget(0) is window.tabWorkspace
+        assert tab_widget.widget(2) is window.tabBatchTag
+        assert tab_widget.widget(3) is window.provider_batch_job_widget
+        assert tab_widget.widget(5).objectName() == "tabErrors"
+```
+
+index 直書き箇所を widget 同一性ベースに更新:
+
+- `test_batch_tag_tab_structure` / `test_batchtagaddwidget_in_batch_tag_tab` / `test_batchtagaddwidget_placeholder_replaced` / `test_annotation_display_in_batch_tag_tab` の `tab_widget.widget(1)` →
+  `main_window_with_tabs.tabBatchTag`（`tabWidgetMainMode.widget(...)` 経由をやめ、直接属性を使う）
+- `test_provider_batch_tab_structure` の `widget(2)` → `widget(3)`
+- `test_can_switch_to_batch_tag_tab` / `test_can_switch_back_to_workspace` / `test_dataset_state_manager_preserved_across_tabs` の `setCurrentIndex(1)` →
+
+```python
+        tab_widget.setCurrentIndex(tab_widget.indexOf(main_window_with_tabs.tabBatchTag))
+```
+
+  （`assert tab_widget.currentIndex() == 1` も `assert tab_widget.currentWidget() is main_window_with_tabs.tabBatchTag` に変更）
+- `test_can_switch_to_provider_batch_tab` の `setCurrentIndex(2)` / `== 2` →
+
+```python
+        tab_widget.setCurrentIndex(tab_widget.indexOf(main_window_with_tabs.provider_batch_job_widget))
+        qtbot.wait(10)
+        assert tab_widget.currentWidget() is main_window_with_tabs.provider_batch_job_widget
+```
+
+- `test_stage_toolbar_button_treats_clicked_bool_as_selection_request` の
+  `assert main_window_with_tabs.tabWidgetMainMode.currentIndex() == 1` →
+
+```python
+        assert (
+            main_window_with_tabs.tabWidgetMainMode.currentWidget()
+            is main_window_with_tabs.tabBatchTag
+        )
+```
+
+- [ ] **Step 2: テスト実行で失敗を確認**
+
+```bash
+uv run pytest tests/integration/test_main_window_tab_integration.py -v
+```
+
+Expected: FAIL（`tab_widget.count() == 6` が 3 で失敗、ほか）
+
+- [ ] **Step 3: MainWindow.ui を編集**
+
+`src/lorairo/gui/designer/MainWindow.ui`:
+
+1. windowTitle 変更:
+
+```xml
+  <property name="windowTitle">
+   <string>LoRAIro</string>
+  </property>
+```
+
+2. `tabWorkspace` の title `ワークスペース` → `検索`:
+
+```xml
+      <widget class="QWidget" name="tabWorkspace">
+       <attribute name="title">
+        <string>検索</string>
+       </attribute>
+```
+
+3. `tabWorkspace` の閉じタグ（`</widget>` — `tabBatchTag` 定義の直前）の直後に `tabMap` ページを挿入:
+
+```xml
+      <widget class="QWidget" name="tabMap">
+       <attribute name="title">
+        <string>マップ</string>
+       </attribute>
+       <layout class="QVBoxLayout" name="verticalLayout_map">
+        <item>
+         <widget class="QLabel" name="labelMapStub">
+          <property name="text">
+           <string>マップビューは未実装です。
+embedding 散布図によるデータセット俯瞰を予定（Wireframes v11 · Map / 実装ロードマップ Phase 8）。</string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignmentFlag::AlignCenter</set>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </widget>
+```
+
+4. `tabBatchTag` の title `バッチタグ` → `アノテーション`:
+
+```xml
+      <widget class="QWidget" name="tabBatchTag">
+       <attribute name="title">
+        <string>アノテーション</string>
+       </attribute>
+```
+
+5. `tabBatchTag` の閉じタグの直後（`tabWidgetMainMode` の閉じタグの前）に `tabResults` と `tabErrors` を挿入:
+
+```xml
+      <widget class="QWidget" name="tabResults">
+       <attribute name="title">
+        <string>結果</string>
+       </attribute>
+       <layout class="QVBoxLayout" name="verticalLayout_results">
+        <item>
+         <widget class="QLabel" name="labelResultsStub">
+          <property name="text">
+           <string>結果ビューは未実装です。
+アノテーション品質トリアージ（issue 集約 + accept/edit/reject）を予定（Wireframes v11 · Frame 5 / 実装ロードマップ Phase 2）。</string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignmentFlag::AlignCenter</set>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </widget>
+      <widget class="QWidget" name="tabErrors">
+       <attribute name="title">
+        <string>エラー</string>
+       </attribute>
+       <layout class="QVBoxLayout" name="verticalLayout_errors"/>
+      </widget>
+```
+
+- [ ] **Step 4: UI コード再生成**
+
+```bash
+uv run python scripts/generate_ui.py
+```
+
+Expected: `MainWindow_ui.py` が再生成され、`tabMap` / `tabResults` / `tabErrors` / `labelMapStub` / `labelResultsStub` が含まれる
+
+```bash
+grep -c "tabMap\|tabResults\|tabErrors" src/lorairo/gui/designer/MainWindow_ui.py
+```
+
+Expected: 1 以上の数値
+
+- [ ] **Step 5: main_window.py — ジョブタブ挿入位置と index マジックナンバー排除**
+
+`src/lorairo/gui/window/main_window.py` を変更:
+
+(a) `_setup_provider_batch_tab` の `addTab` を `insertTab` に変更（結果タブの直前 = ジョブの位置に挿入）:
+
+```python
+            self.provider_batch_job_widget = widget
+            insert_index = self.tabWidgetMainMode.indexOf(self.tabResults)
+            self.tabWidgetMainMode.insertTab(insert_index, widget, "ジョブ")
+            logger.info("✅ ジョブタブ (Provider Batch) initialized")
+```
+
+(b) `_on_main_tab_changed` を index 比較から widget 同一性比較に書き換え:
+
+```python
+    def _on_main_tab_changed(self, index: int) -> None:
+        """メインタブ切り替えハンドラ
+
+        Args:
+            index: 切り替え先のタブインデックス
+        """
+        current = self.tabWidgetMainMode.widget(index)
+        if current is getattr(self, "tabBatchTag", None):
+            logger.info("Switched to Annotate tab")
+            self._refresh_batch_tag_staging()
+        elif self.provider_batch_job_widget is not None and current is self.provider_batch_job_widget:
+            logger.info("Switched to Jobs tab")
+            self.provider_batch_job_widget.refresh_jobs()
+```
+
+（`else: logger.warning(f"Unknown tab index: {index}")` は削除する — スタブタブ切替が警告になるため）
+
+(c) アノテーション実行時のタブ判定（旧 line 1513 付近）:
+
+```python
+        # アノテーションタブの場合はステージング画像を使用
+        override_image_paths: list[str] | None = None
+        if self.tabWidgetMainMode.currentWidget() is self.tabBatchTag:
+```
+
+(d) ステージ遷移（旧 line 1689 付近）:
+
+```python
+        # アノテーションタブへ移動してステージングタブを表示
+        if hasattr(self, "tabWidgetMainMode") and self.tabWidgetMainMode:
+            self.tabWidgetMainMode.setCurrentIndex(self.tabWidgetMainMode.indexOf(self.tabBatchTag))
+```
+
+(e) UI 構造変更のため `SETTINGS_VERSION` を bump:
+
+```python
+    SETTINGS_VERSION = 2
+```
+
+- [ ] **Step 6: テスト実行（green）**
+
+```bash
+uv run pytest tests/integration/test_main_window_tab_integration.py -v
+```
+
+Expected: PASS（Errors 埋め込みテストは Task 4 で追加するためまだ無い）
+
+- [ ] **Step 7: コミット**
+
+```bash
+git add src/lorairo/gui/designer/MainWindow.ui src/lorairo/gui/designer/MainWindow_ui.py \
+        src/lorairo/gui/window/main_window.py tests/integration/test_main_window_tab_integration.py
+git commit -m "feat(gui): メインタブを Wireframes v11 ナビ構成 (6タブ) に再編"
+```
+
+### Task 4: エラータブ — ErrorLogViewerWidget 埋め込みと通知導線
+
+現状エラーログは StatusBar 通知クリック → `ErrorLogViewerDialog`（ポップアップ）。これをエラータブ常設に変え、通知クリックはタブ遷移にする。`ErrorLogViewerDialog` クラス自体は削除しない（Phase 3 Errors トリアージで widget ごと刷新する際にクリーンアップ）。MainWindow からの参照のみ除去する。
+
+**Files:**
+- Modify: `src/lorairo/gui/window/main_window.py`
+- Modify: `tests/integration/test_main_window_tab_integration.py`
+
+- [ ] **Step 1: テスト追加（red）**
+
+`tests/integration/test_main_window_tab_integration.py` の import に追加:
+
+```python
+from lorairo.gui.widgets.error_log_viewer_widget import ErrorLogViewerWidget
+```
+
+`TestMainWindowTabInitialization` にテスト追加:
+
+```python
+    def test_errors_tab_embeds_error_log_viewer(self, main_window_with_tabs):
+        """エラータブに ErrorLogViewerWidget が常設される"""
+        errors_tab = main_window_with_tabs.tabWidgetMainMode.widget(5)
+        assert errors_tab.objectName() == "tabErrors"
+        viewer = errors_tab.findChild(ErrorLogViewerWidget)
+        assert viewer is not None
+        assert main_window_with_tabs.error_log_viewer_widget is viewer
+
+    def test_error_notification_click_navigates_to_errors_tab(self, main_window_with_tabs):
+        """エラー通知クリックでエラータブへ遷移する"""
+        window = main_window_with_tabs
+        window._on_error_notification_clicked()
+        assert window.tabWidgetMainMode.currentWidget() is window.tabErrors
+```
+
+- [ ] **Step 2: テスト実行で失敗を確認**
+
+```bash
+uv run pytest tests/integration/test_main_window_tab_integration.py -v -k "errors_tab or error_notification"
+```
+
+Expected: FAIL（`error_log_viewer_widget` 属性なし / `_on_error_notification_clicked` なし）
+
+- [ ] **Step 3: 実装**
+
+`src/lorairo/gui/window/main_window.py`:
+
+(a) import 変更 — `ErrorLogViewerDialog` を外し `ErrorLogViewerWidget` を入れる:
+
+```python
+from ..widgets.error_log_viewer_widget import ErrorLogViewerWidget
+```
+
+(b) クラス属性アノテーション変更 — `error_log_dialog: ErrorLogViewerDialog | None` を削除し:
+
+```python
+    error_log_viewer_widget: ErrorLogViewerWidget | None
+```
+
+(c) `_setup_error_notification` 内の変更:
+
+```python
+            # クリックでエラータブへ遷移
+            self.error_notification_widget.clicked.connect(self._on_error_notification_clicked)
+
+            # Dialog初期化（遅延生成）
+            self.tag_management_dialog = None
+```
+
+（`self.error_log_dialog = None` の行は削除）
+
+(d) `_show_error_log_dialog` メソッドを丸ごと削除し、代わりに以下を追加:
+
+```python
+    def _on_error_notification_clicked(self) -> None:
+        """エラー通知クリックでエラータブへ遷移する。"""
+        self.tabWidgetMainMode.setCurrentIndex(self.tabWidgetMainMode.indexOf(self.tabErrors))
+```
+
+(e) エラータブ埋め込みメソッドを追加し、`_setup_provider_batch_tab()` 呼び出しの直後で呼ぶ:
+
+```python
+        self._setup_tab_widget()
+        self._setup_provider_batch_tab()
+        self._setup_errors_tab()
+```
+
+```python
+    def _setup_errors_tab(self) -> None:
+        """エラータブに ErrorLogViewerWidget を埋め込む。"""
+        container = getattr(self, "tabErrors", None)
+        if container is None:
+            logger.warning("tabErrors not found - errors tab skipped")
+            self.error_log_viewer_widget = None
+            return
+
+        widget = ErrorLogViewerWidget(parent=container)
+        if self.db_manager:
+            widget.set_db_manager(self.db_manager)
+        widget.error_resolved.connect(self._on_error_resolved)
+        container.layout().addWidget(widget)
+        self.error_log_viewer_widget = widget
+        logger.info("✅ エラータブ (ErrorLogViewerWidget) initialized")
+```
+
+(f) `_on_main_tab_changed` にエラータブ分岐を追加（タブ表示のたびに最新化）:
+
+```python
+        elif current is getattr(self, "tabErrors", None):
+            logger.info("Switched to Errors tab")
+            if self.error_log_viewer_widget is not None and self.db_manager:
+                self.error_log_viewer_widget.load_error_records()
+```
+
+- [ ] **Step 4: テスト実行（green）**
+
+```bash
+uv run pytest tests/integration/test_main_window_tab_integration.py -v
+```
+
+Expected: 全 PASS
+
+- [ ] **Step 5: ErrorLogViewerDialog の残参照がないことを確認**
+
+```bash
+grep -rn "ErrorLogViewerDialog\|error_log_dialog" src/lorairo/gui/window/main_window.py
+```
+
+Expected: ヒットなし。`grep -rn "error_log_dialog" tests/` でヒットした既存テスト（あれば）は `error_log_viewer_widget` ベースの検証に書き換えるか、ダイアログ単体テスト（`ErrorLogViewerDialog` を直接 import するもの）なら据え置く。
+
+- [ ] **Step 6: コミット**
+
+```bash
+git add src/lorairo/gui/window/main_window.py tests/integration/test_main_window_tab_integration.py
+git commit -m "feat(gui): エラータブに ErrorLogViewerWidget を常設し通知クリックをタブ遷移化"
+```
+
+### Task 5: Ctrl+1〜6 タブ切替ショートカット
+
+v11 ナビの ⌘1–⌘8 に対応する Qt 実装。
+
+**Files:**
+- Modify: `src/lorairo/gui/window/main_window.py`
+- Modify: `tests/integration/test_main_window_tab_integration.py`
+
+- [ ] **Step 1: テスト追加（red）**
+
+`TestTabSwitching` に追加:
+
+```python
+    def test_ctrl_number_shortcut_switches_tab(self, main_window_with_tabs, qtbot):
+        """Ctrl+数字キーでメインタブが切り替わる"""
+        window = main_window_with_tabs
+        window.show()
+        qtbot.waitExposed(window)
+
+        qtbot.keyClick(window, Qt.Key.Key_4, Qt.KeyboardModifier.ControlModifier)
+        assert window.tabWidgetMainMode.currentIndex() == 3
+
+        qtbot.keyClick(window, Qt.Key.Key_1, Qt.KeyboardModifier.ControlModifier)
+        assert window.tabWidgetMainMode.currentIndex() == 0
+```
+
+- [ ] **Step 2: テスト実行で失敗を確認**
+
+```bash
+uv run pytest tests/integration/test_main_window_tab_integration.py -v -k shortcut
+```
+
+Expected: FAIL（currentIndex が変化しない）
+
+- [ ] **Step 3: 実装**
+
+`src/lorairo/gui/window/main_window.py`:
+
+(a) import 追加（既存の `PySide6.QtGui` import 行に統合、`functools.partial` は標準ライブラリブロックへ）:
+
+```python
+from functools import partial
+from PySide6.QtGui import QCloseEvent, QKeySequence, QShortcut
+```
+
+（既存の QtGui import 内容は維持して追記する）
+
+(b) メソッド追加。`_setup_errors_tab()` 呼び出しの直後に `self._setup_tab_shortcuts()` を追加:
+
+```python
+    def _setup_tab_shortcuts(self) -> None:
+        """Ctrl+1〜N でメインタブを切り替えるショートカットを登録する。
+
+        Wireframes v11 のナビショートカット (⌘1–⌘8) に対応する。
+        """
+        for i in range(self.tabWidgetMainMode.count()):
+            shortcut = QShortcut(QKeySequence(f"Ctrl+{i + 1}"), self)
+            shortcut.setContext(Qt.ShortcutContext.ApplicationShortcut)
+            shortcut.activated.connect(partial(self.tabWidgetMainMode.setCurrentIndex, i))
+        logger.debug(f"Tab shortcuts registered: Ctrl+1..Ctrl+{self.tabWidgetMainMode.count()}")
+```
+
+（`Qt` は `PySide6.QtCore` から import 済みであることを確認、なければ追加）
+
+- [ ] **Step 4: テスト実行（green）**
+
+```bash
+uv run pytest tests/integration/test_main_window_tab_integration.py -v
+```
+
+Expected: 全 PASS
+
+- [ ] **Step 5: コミット**
+
+```bash
+git add src/lorairo/gui/window/main_window.py tests/integration/test_main_window_tab_integration.py
+git commit -m "feat(gui): Ctrl+1-6 のメインタブ切替ショートカットを追加"
+```
+
+### Task 6: TabReorganizationService の必須ウィジェット更新
+
+**Files:**
+- Modify: `src/lorairo/gui/services/tab_reorganization_service.py`
+- Modify: `tests/unit/gui/services/test_tab_reorganization_service.py`
+
+- [ ] **Step 1: テスト更新（red）**
+
+`tests/unit/gui/services/test_tab_reorganization_service.py` の `test_required_widgets_contains_tab_structure` に追記:
+
+```python
+        assert "tabMap" in required
+        assert "tabResults" in required
+        assert "tabErrors" in required
+```
+
+- [ ] **Step 2: テスト実行で失敗を確認**
+
+```bash
+uv run pytest tests/unit/gui/services/test_tab_reorganization_service.py -v
+```
+
+Expected: FAIL（`tabMap` が `REQUIRED_WIDGETS` にない）
+
+- [ ] **Step 3: 実装**
+
+`src/lorairo/gui/services/tab_reorganization_service.py` の `REQUIRED_WIDGETS` を更新:
+
+```python
+    REQUIRED_WIDGETS: ClassVar[list[str]] = [
+        "tabWidgetMainMode",
+        "tabWorkspace",
+        "tabMap",
+        "tabBatchTag",
+        "tabResults",
+        "tabErrors",
+        "splitterBatchTagMain",
+        "groupBoxBatchOperations",
+        "groupBoxAnnotation",
+    ]
+```
+
+- [ ] **Step 4: テスト実行（green）**
+
+```bash
+uv run pytest tests/unit/gui/services/test_tab_reorganization_service.py -v
+```
+
+Expected: 全 PASS（`test_validate_with_complete_widget_hierarchy` が新必須 widget の不足で落ちる場合は、そのテストの階層構築部に以下を追加する）
+
+```python
+        map_tab = QWidget()
+        map_tab.setObjectName("tabMap")
+        tab_widget.addTab(map_tab, "マップ")
+
+        results_tab = QWidget()
+        results_tab.setObjectName("tabResults")
+        tab_widget.addTab(results_tab, "結果")
+
+        errors_tab = QWidget()
+        errors_tab.setObjectName("tabErrors")
+        tab_widget.addTab(errors_tab, "エラー")
+```
+
+- [ ] **Step 5: コミット**
+
+```bash
+git add src/lorairo/gui/services/tab_reorganization_service.py tests/unit/gui/services/test_tab_reorganization_service.py
+git commit -m "test(gui): TabReorganizationService の必須ウィジェットに新タブを追加"
+```
+
+### Task 7: 全体検証（CI-equivalent filter）
+
+- [ ] **Step 1: フォーマット + 型チェック**
+
+```bash
+uv run ruff format src/ tests/
+uv run ruff check src/ tests/ --fix
+uv run mypy -p lorairo
+```
+
+Expected: ruff エラーなし、mypy 既存エラー以外の新規エラーなし
+
+- [ ] **Step 2: CI-equivalent filter で全テスト**
+
+```bash
+uv run pytest -m "not gui_show and not calls_real_webapi and not downloads_and_runs_model and not slow" --timeout=60
+```
+
+Expected: 全 PASS。タブ index に依存していた他テストが落ちた場合は、widget 同一性ベース（`currentWidget() is window.tabBatchTag` 等）に修正して再実行する。
+
+- [ ] **Step 3: 修正があればコミット**
+
+```bash
+git add -A
+git commit -m "test: タブ index 依存箇所を widget 同一性ベースに修正"
+```
+
+（修正がなければスキップ）
+
+### Task 8: PR 起票と保守
+
+- [ ] **Step 1: push + PR 作成**
+
+```bash
+git push -u origin feat/gui-v11-phase1-nav-skeleton
+gh pr create --title "feat(gui): Wireframes v11 Phase 1 — メインナビ 6 タブ骨格" --body "$(cat <<'EOF'
+## Summary
+- Claude Design「Wireframes v11」ハンドオフのナビ構造への第一歩として、メインタブを 6 枚構成（検索 / マップ / アノテーション / ジョブ / 結果 / エラー）に再編
+- マップ / 結果タブはスタブ（それぞれ Phase 8 / Phase 2 で実装予定）
+- エラータブに ErrorLogViewerWidget を常設し、StatusBar 通知クリックをダイアログ表示からタブ遷移に変更
+- Ctrl+1–6 タブ切替ショートカット追加
+- タブ index のマジックナンバーを widget 同一性ベースに置換、SETTINGS_VERSION を 2 に bump
+- デザイン資産 (`docs/design/wireframes-v11/`) とロードマップ付き実装計画を同梱
+
+## Test plan
+- [ ] `tests/integration/test_main_window_tab_integration.py` 全 PASS
+- [ ] CI-equivalent filter 全 PASS
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 2: PR 保守自走**
+
+`agent-pr-autoloop` skill で CI / bot レビューを監視し、safe なら squash merge。merge 後:
+
+```bash
+cd /workspaces/LoRAIro
+git worktree remove .agents/worktree/gui-v11-phase1
+```
+
+---
+
+## リスクと注意事項
+
+- **QSettings 互換**: `restoreState` はタブ構成変更の影響を受けないが、保存済みタブ index の意味が変わるため `SETTINGS_VERSION` を 2 に bump する（Task 3 Step 5e）。
+- **タブ index 依存の他テスト**: Task 7 Step 2 で網羅的に検出する。`tabWidgetMainMode` への index 直書きは本計画ですべて widget 同一性参照に置換するのが原則。
+- **submodule 変更なし**: 本 PR は `local_packages/*` に触れないため、pre-PR submodule hook の対象外。
+- **ErrorLogViewerDialog**: クラスは残存（未使用）。Phase 3（Errors トリアージ）で widget 刷新時に削除する。
+- **Export タブなし**: v11 ナビとの差分として PR 説明に明記済み。Phase 5 で対応。
+
+## 後続フェーズ着手時のチェックリスト
+
+1. `docs/design/wireframes-v11/wireframes-v11.html` の該当フレーム（`data-screen-label` で検索）を精読する
+2. `docs/design/wireframes-v11/decisions-impact-on-wireframe.md` と関連 ADR を確認する
+3. 表「v11 フレーム ↔ 現行実装の対応」の未決事項（Phase 7 の A/B、Phase 8 の ADR）はユーザー決定を取ってから着手する
+4. フェーズごとに `docs/superpowers/plans/` に個別計画を作成する

--- a/src/lorairo/gui/designer/MainWindow.ui
+++ b/src/lorairo/gui/designer/MainWindow.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>LoRAIro - ワークスペース</string>
+   <string>LoRAIro</string>
   </property>
   <property name="windowIcon">
    <iconset>
@@ -41,7 +41,7 @@
       </property>
       <widget class="QWidget" name="tabWorkspace">
        <attribute name="title">
-        <string>ワークスペース</string>
+        <string>検索</string>
        </attribute>
        <layout class="QVBoxLayout" name="verticalLayout_workspace">
         <property name="spacing">
@@ -545,9 +545,30 @@
         </item>
        </layout>
       </widget>
+      <widget class="QWidget" name="tabMap">
+       <attribute name="title">
+        <string>マップ</string>
+       </attribute>
+       <layout class="QVBoxLayout" name="verticalLayout_map">
+        <item>
+         <widget class="QLabel" name="labelMapStub">
+          <property name="text">
+           <string>マップビューは未実装です。
+embedding 散布図によるデータセット俯瞰を予定（Wireframes v11 · Map / 実装ロードマップ Phase 8）。</string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignmentFlag::AlignCenter</set>
+          </property>
+          <property name="wordWrap">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </widget>
       <widget class="QWidget" name="tabBatchTag">
        <attribute name="title">
-        <string>バッチタグ</string>
+        <string>アノテーション</string>
        </attribute>
        <layout class="QVBoxLayout" name="verticalLayout_batchTag">
         <property name="spacing">
@@ -670,6 +691,33 @@
          </widget>
         </item>
        </layout>
+      </widget>
+      <widget class="QWidget" name="tabResults">
+       <attribute name="title">
+        <string>結果</string>
+       </attribute>
+       <layout class="QVBoxLayout" name="verticalLayout_results">
+        <item>
+         <widget class="QLabel" name="labelResultsStub">
+          <property name="text">
+           <string>結果ビューは未実装です。
+アノテーション品質トリアージ（issue 集約 + accept/edit/reject）を予定（Wireframes v11 · Frame 5 / 実装ロードマップ Phase 2）。</string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignmentFlag::AlignCenter</set>
+          </property>
+          <property name="wordWrap">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </widget>
+      <widget class="QWidget" name="tabErrors">
+       <attribute name="title">
+        <string>エラー</string>
+       </attribute>
+       <layout class="QVBoxLayout" name="verticalLayout_errors"/>
       </widget>
      </widget>
     </item>

--- a/src/lorairo/gui/designer/MainWindow_ui.py
+++ b/src/lorairo/gui/designer/MainWindow_ui.py
@@ -325,6 +325,18 @@ class Ui_MainWindow(object):
         self.verticalLayout_workspace.addWidget(self.frameActionToolbar)
 
         self.tabWidgetMainMode.addTab(self.tabWorkspace, "")
+        self.tabMap = QWidget()
+        self.tabMap.setObjectName(u"tabMap")
+        self.verticalLayout_map = QVBoxLayout(self.tabMap)
+        self.verticalLayout_map.setObjectName(u"verticalLayout_map")
+        self.labelMapStub = QLabel(self.tabMap)
+        self.labelMapStub.setObjectName(u"labelMapStub")
+        self.labelMapStub.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        self.labelMapStub.setWordWrap(True)
+
+        self.verticalLayout_map.addWidget(self.labelMapStub)
+
+        self.tabWidgetMainMode.addTab(self.tabMap, "")
         self.tabBatchTag = QWidget()
         self.tabBatchTag.setObjectName(u"tabBatchTag")
         self.verticalLayout_batchTag = QVBoxLayout(self.tabBatchTag)
@@ -404,6 +416,23 @@ class Ui_MainWindow(object):
         self.verticalLayout_batchTag.addWidget(self.splitterBatchTagMain)
 
         self.tabWidgetMainMode.addTab(self.tabBatchTag, "")
+        self.tabResults = QWidget()
+        self.tabResults.setObjectName(u"tabResults")
+        self.verticalLayout_results = QVBoxLayout(self.tabResults)
+        self.verticalLayout_results.setObjectName(u"verticalLayout_results")
+        self.labelResultsStub = QLabel(self.tabResults)
+        self.labelResultsStub.setObjectName(u"labelResultsStub")
+        self.labelResultsStub.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        self.labelResultsStub.setWordWrap(True)
+
+        self.verticalLayout_results.addWidget(self.labelResultsStub)
+
+        self.tabWidgetMainMode.addTab(self.tabResults, "")
+        self.tabErrors = QWidget()
+        self.tabErrors.setObjectName(u"tabErrors")
+        self.verticalLayout_errors = QVBoxLayout(self.tabErrors)
+        self.verticalLayout_errors.setObjectName(u"verticalLayout_errors")
+        self.tabWidgetMainMode.addTab(self.tabErrors, "")
 
         self.verticalLayout_main.addWidget(self.tabWidgetMainMode)
 
@@ -469,7 +498,7 @@ class Ui_MainWindow(object):
     # setupUi
 
     def retranslateUi(self, MainWindow: QWidget) -> None:
-        MainWindow.setWindowTitle(QCoreApplication.translate("MainWindow", u"LoRAIro - \u30ef\u30fc\u30af\u30b9\u30da\u30fc\u30b9", None))
+        MainWindow.setWindowTitle(QCoreApplication.translate("MainWindow", u"LoRAIro", None))
         self.actionOpenDataset.setText(QCoreApplication.translate("MainWindow", u"\u30c7\u30fc\u30bf\u30bb\u30c3\u30c8\u3092\u958b\u304f", None))
 #if QT_CONFIG(shortcut)
         self.actionOpenDataset.setShortcut(QCoreApplication.translate("MainWindow", u"Ctrl+O", None))
@@ -539,14 +568,21 @@ class Ui_MainWindow(object):
 #endif // QT_CONFIG(tooltip)
         self.pushButtonStageToBatchTag.setText(QCoreApplication.translate("MainWindow", u"\u9078\u629e\u3092\u30b9\u30c6\u30fc\u30b8\u30f3\u30b0\u3078", None))
         self.labelStatus.setText(QCoreApplication.translate("MainWindow", u"\u6e96\u5099\u5b8c\u4e86", None))
-        self.tabWidgetMainMode.setTabText(self.tabWidgetMainMode.indexOf(self.tabWorkspace), QCoreApplication.translate("MainWindow", u"\u30ef\u30fc\u30af\u30b9\u30da\u30fc\u30b9", None))
+        self.tabWidgetMainMode.setTabText(self.tabWidgetMainMode.indexOf(self.tabWorkspace), QCoreApplication.translate("MainWindow", u"\u691c\u7d22", None))
+        self.labelMapStub.setText(QCoreApplication.translate("MainWindow", u"\u30de\u30c3\u30d7\u30d3\u30e5\u30fc\u306f\u672a\u5b9f\u88c5\u3067\u3059\u3002\n"
+"embedding \u6563\u5e03\u56f3\u306b\u3088\u308b\u30c7\u30fc\u30bf\u30bb\u30c3\u30c8\u4fef\u77b0\u3092\u4e88\u5b9a\uff08Wireframes v11 \u00b7 Map / \u5b9f\u88c5\u30ed\u30fc\u30c9\u30de\u30c3\u30d7 Phase 8\uff09\u3002", None))
+        self.tabWidgetMainMode.setTabText(self.tabWidgetMainMode.indexOf(self.tabMap), QCoreApplication.translate("MainWindow", u"\u30de\u30c3\u30d7", None))
         self.groupBoxBatchOperations.setTitle(QCoreApplication.translate("MainWindow", u"\u64cd\u4f5c", None))
         self.tabWidgetBatchTagWorkflow.setTabText(self.tabWidgetBatchTagWorkflow.indexOf(self.tabBatchTagTagAdd), QCoreApplication.translate("MainWindow", u"\u30bf\u30b0\u8ffd\u52a0", None))
         self.groupBoxAnnotation.setTitle(QCoreApplication.translate("MainWindow", u"\u30a2\u30ce\u30c6\u30fc\u30b7\u30e7\u30f3", None))
         self.labelAnnotationTarget.setText(QCoreApplication.translate("MainWindow", u"\u5bfe\u8c61: \u30b9\u30c6\u30fc\u30b8\u30f3\u30b0\u6e08\u307f\u753b\u50cf", None))
         self.btnAnnotationExecute.setText(QCoreApplication.translate("MainWindow", u"\u30a2\u30ce\u30c6\u30fc\u30b7\u30e7\u30f3\u5b9f\u884c", None))
         self.tabWidgetBatchTagWorkflow.setTabText(self.tabWidgetBatchTagWorkflow.indexOf(self.tabBatchTagAnnotation), QCoreApplication.translate("MainWindow", u"\u30a2\u30ce\u30c6\u30fc\u30b7\u30e7\u30f3\u8a2d\u5b9a", None))
-        self.tabWidgetMainMode.setTabText(self.tabWidgetMainMode.indexOf(self.tabBatchTag), QCoreApplication.translate("MainWindow", u"\u30d0\u30c3\u30c1\u30bf\u30b0", None))
+        self.tabWidgetMainMode.setTabText(self.tabWidgetMainMode.indexOf(self.tabBatchTag), QCoreApplication.translate("MainWindow", u"\u30a2\u30ce\u30c6\u30fc\u30b7\u30e7\u30f3", None))
+        self.labelResultsStub.setText(QCoreApplication.translate("MainWindow", u"\u7d50\u679c\u30d3\u30e5\u30fc\u306f\u672a\u5b9f\u88c5\u3067\u3059\u3002\n"
+"\u30a2\u30ce\u30c6\u30fc\u30b7\u30e7\u30f3\u54c1\u8cea\u30c8\u30ea\u30a2\u30fc\u30b8\uff08issue \u96c6\u7d04 + accept/edit/reject\uff09\u3092\u4e88\u5b9a\uff08Wireframes v11 \u00b7 Frame 5 / \u5b9f\u88c5\u30ed\u30fc\u30c9\u30de\u30c3\u30d7 Phase 2\uff09\u3002", None))
+        self.tabWidgetMainMode.setTabText(self.tabWidgetMainMode.indexOf(self.tabResults), QCoreApplication.translate("MainWindow", u"\u7d50\u679c", None))
+        self.tabWidgetMainMode.setTabText(self.tabWidgetMainMode.indexOf(self.tabErrors), QCoreApplication.translate("MainWindow", u"\u30a8\u30e9\u30fc", None))
         self.menuFile.setTitle(QCoreApplication.translate("MainWindow", u"\u30d5\u30a1\u30a4\u30eb", None))
         self.menuEdit.setTitle(QCoreApplication.translate("MainWindow", u"\u7de8\u96c6", None))
         self.menuView.setTitle(QCoreApplication.translate("MainWindow", u"\u8868\u793a", None))

--- a/src/lorairo/gui/services/tab_reorganization_service.py
+++ b/src/lorairo/gui/services/tab_reorganization_service.py
@@ -54,7 +54,10 @@ class TabReorganizationService:
     REQUIRED_WIDGETS: ClassVar[list[str]] = [
         "tabWidgetMainMode",
         "tabWorkspace",
+        "tabMap",
         "tabBatchTag",
+        "tabResults",
+        "tabErrors",
         "splitterBatchTagMain",
         "groupBoxBatchOperations",
         "groupBoxAnnotation",

--- a/src/lorairo/gui/services/widget_setup_service.py
+++ b/src/lorairo/gui/services/widget_setup_service.py
@@ -220,10 +220,10 @@ class WidgetSetupService:
             logger.error("❌ tabWidgetMainMode が存在しません")
             return
 
-        # バッチタグタブ取得（タブインデックス1）
-        batch_tag_tab = main_window.tabWidgetMainMode.widget(1)
+        # アノテーションタブ取得（tabBatchTag、index 非依存）
+        batch_tag_tab = getattr(main_window, "tabBatchTag", None)
         if not batch_tag_tab:
-            logger.error("❌ バッチタグタブ（インデックス1）が存在しません")
+            logger.error("❌ アノテーションタブ（tabBatchTag）が存在しません")
             return
 
         # バッチタグタブのメインスプリッター取得（左右2カラム）

--- a/src/lorairo/gui/window/main_window.py
+++ b/src/lorairo/gui/window/main_window.py
@@ -56,7 +56,8 @@ class MainWindow(QMainWindow, Ui_MainWindow):
     """
 
     # QSettings バージョン（UI構造変更時にインクリメント）
-    SETTINGS_VERSION = 1
+    # 2: Wireframes v11 · 6 タブ化（検索/マップ/アノテーション/ジョブ/結果/エラー）
+    SETTINGS_VERSION = 2
 
     # シグナル
     dataset_loaded = Signal(str)  # dataset_path
@@ -381,9 +382,13 @@ class MainWindow(QMainWindow, Ui_MainWindow):
         self._setup_provider_batch_tab()
 
     def _setup_provider_batch_tab(self) -> None:
-        """バッチAPI job management tab を追加する。"""
+        """ジョブタブ (Provider Batch job management) を追加する。
+
+        Wireframes v11 ナビ順（検索 / マップ / アノテーション / ジョブ / 結果 / エラー）
+        に従い、結果タブ (tabResults) の直前へ挿入する。
+        """
         if not hasattr(self, "tabWidgetMainMode") or not self.tabWidgetMainMode:
-            logger.warning("tabWidgetMainMode not found - バッチAPI tab skipped")
+            logger.warning("tabWidgetMainMode not found - ジョブタブ skipped")
             self.provider_batch_job_widget = None
             return
 
@@ -403,11 +408,12 @@ class MainWindow(QMainWindow, Ui_MainWindow):
                 widget.staging_cleared.connect(self._handle_staging_cleared)
                 widget.staged_images_changed.connect(self._on_staged_images_changed)
             self.provider_batch_job_widget = widget
-            self.tabWidgetMainMode.addTab(widget, "バッチAPI")
-            logger.info("✅ バッチAPI tab initialized")
+            insert_index = self.tabWidgetMainMode.indexOf(self.tabResults)
+            self.tabWidgetMainMode.insertTab(insert_index, widget, "ジョブ")
+            logger.info("✅ ジョブタブ (Provider Batch) initialized")
         except Exception as e:
             self.provider_batch_job_widget = None
-            logger.error(f"❌ バッチAPI tab initialization failed: {e}", exc_info=True)
+            logger.error(f"❌ ジョブタブ initialization failed: {e}", exc_info=True)
 
     def _verify_state_management_connections(self) -> None:
         """状態管理接続の検証（SelectionStateServiceに委譲）"""
@@ -1508,9 +1514,9 @@ class MainWindow(QMainWindow, Ui_MainWindow):
                 f"batchModelSelectionから選択されたモデル (litellm_model_ids): {selected_litellm_model_ids}"
             )
 
-        # バッチタグタブの場合はステージング画像を使用
+        # アノテーションタブの場合はステージング画像を使用
         override_image_paths: list[str] | None = None
-        if self.tabWidgetMainMode.currentIndex() == 1:  # tabBatchTag
+        if self.tabWidgetMainMode.currentWidget() is self.tabBatchTag:
             override_image_paths = self._get_staged_image_paths_for_annotation()
             if not override_image_paths:
                 QMessageBox.information(
@@ -1684,9 +1690,9 @@ class MainWindow(QMainWindow, Ui_MainWindow):
             QMessageBox.information(self, "選択なし", "バッチタグに追加する画像が選択されていません。")
             return
 
-        # バッチタグタブへ移動してステージングタブを表示
+        # アノテーションタブへ移動してステージングタブを表示
         if hasattr(self, "tabWidgetMainMode") and self.tabWidgetMainMode:
-            self.tabWidgetMainMode.setCurrentIndex(1)
+            self.tabWidgetMainMode.setCurrentWidget(self.tabBatchTag)
         if hasattr(self, "tabWidgetBatchTagWorkflow") and self.tabWidgetBatchTagWorkflow:
             self.tabWidgetBatchTagWorkflow.setCurrentIndex(0)
 
@@ -1725,25 +1731,24 @@ class MainWindow(QMainWindow, Ui_MainWindow):
         logger.info("Main tab connections setup completed")
 
     def _on_main_tab_changed(self, index: int) -> None:
-        """
-        メインタブ切り替えハンドラ
+        """メインタブ切り替えハンドラ。
+
+        タブ構成変更（Wireframes v11 · 6 タブ化）に耐えるよう、index の
+        マジックナンバーではなく widget 同一性で分岐する。
 
         Args:
-            index: 切り替え先のタブインデックス（0=ワークスペース、1=バッチタグ）
+            index: 切り替え先のタブインデックス。
         """
-        if index == 0:  # ワークスペース
-            logger.info("Switched to Workspace tab")
-            # ワークスペースタブに切り替え時の処理（必要に応じて実装）
-        elif index == 1:  # バッチタグ
-            logger.info("Switched to Batch Tag tab")
+        current = self.tabWidgetMainMode.widget(index)
+        if current is getattr(self, "tabBatchTag", None):
+            logger.info("Switched to Annotate tab")
             self._refresh_batch_tag_staging()
-        elif index == 2:  # バッチAPI
-            logger.info("Switched to バッチAPI tab")
-            widget = getattr(self, "provider_batch_job_widget", None)
-            if widget is not None:
-                widget.refresh_jobs()
-        else:
-            logger.warning(f"Unknown tab index: {index}")
+        elif (
+            getattr(self, "provider_batch_job_widget", None) is not None
+            and current is self.provider_batch_job_widget
+        ):
+            logger.info("Switched to Jobs tab")
+            self.provider_batch_job_widget.refresh_jobs()
 
     def _refresh_batch_tag_staging(self) -> None:
         """

--- a/src/lorairo/gui/window/main_window.py
+++ b/src/lorairo/gui/window/main_window.py
@@ -1,11 +1,12 @@
 # src/lorairo/gui/window/main_window.py
 
 from collections.abc import Callable
+from functools import partial
 from pathlib import Path
 from typing import Any, cast
 
-from PySide6.QtCore import QEasingCurve, QPropertyAnimation, QSettings, QTimer, Signal
-from PySide6.QtGui import QCloseEvent, QResizeEvent
+from PySide6.QtCore import QEasingCurve, QPropertyAnimation, QSettings, Qt, QTimer, Signal
+from PySide6.QtGui import QCloseEvent, QKeySequence, QResizeEvent, QShortcut
 from PySide6.QtWidgets import (
     QFileDialog,
     QGraphicsOpacityEffect,
@@ -381,6 +382,7 @@ class MainWindow(QMainWindow, Ui_MainWindow):
         self._setup_tab_widget()
         self._setup_provider_batch_tab()
         self._setup_errors_tab()
+        self._setup_tab_shortcuts()
 
     def _setup_provider_batch_tab(self) -> None:
         """ジョブタブ (Provider Batch job management) を追加する。
@@ -465,6 +467,17 @@ class MainWindow(QMainWindow, Ui_MainWindow):
         # 初期表示は画像詳細タブ（インデックス0）
         self.tab_widget_right_panel.setCurrentIndex(0)
         logger.info("tabWidgetRightPanel initialized with 1 tab: 画像詳細")
+
+    def _setup_tab_shortcuts(self) -> None:
+        """Ctrl+1〜N でメインタブを切り替えるショートカットを登録する。
+
+        Wireframes v11 のナビショートカット (⌘1–⌘8) に対応する。
+        """
+        for i in range(self.tabWidgetMainMode.count()):
+            shortcut = QShortcut(QKeySequence(f"Ctrl+{i + 1}"), self)
+            shortcut.setContext(Qt.ShortcutContext.ApplicationShortcut)
+            shortcut.activated.connect(partial(self.tabWidgetMainMode.setCurrentIndex, i))
+        logger.debug(f"Tab shortcuts registered: Ctrl+1..Ctrl+{self.tabWidgetMainMode.count()}")
 
     def _setup_errors_tab(self) -> None:
         """エラータブに ErrorLogViewerWidget を埋め込む。

--- a/src/lorairo/gui/window/main_window.py
+++ b/src/lorairo/gui/window/main_window.py
@@ -1753,10 +1753,7 @@ class MainWindow(QMainWindow, Ui_MainWindow):
         if current is getattr(self, "tabBatchTag", None):
             logger.info("Switched to Annotate tab")
             self._refresh_batch_tag_staging()
-        elif (
-            getattr(self, "provider_batch_job_widget", None) is not None
-            and current is self.provider_batch_job_widget
-        ):
+        elif self.provider_batch_job_widget is not None and current is self.provider_batch_job_widget:
             logger.info("Switched to Jobs tab")
             self.provider_batch_job_widget.refresh_jobs()
         elif current is getattr(self, "tabErrors", None):

--- a/src/lorairo/gui/window/main_window.py
+++ b/src/lorairo/gui/window/main_window.py
@@ -38,7 +38,7 @@ from ..services.tab_reorganization_service import TabReorganizationService
 from ..services.widget_setup_service import WidgetSetupService
 from ..services.worker_service import WorkerService
 from ..state.dataset_state import DatasetStateManager
-from ..widgets.error_log_viewer_dialog import ErrorLogViewerDialog
+from ..widgets.error_log_viewer_widget import ErrorLogViewerWidget
 from ..widgets.error_notification_widget import ErrorNotificationWidget
 from ..widgets.filter_search_panel import FilterSearchPanel
 from ..widgets.image_preview import ImagePreviewWidget
@@ -97,7 +97,7 @@ class MainWindow(QMainWindow, Ui_MainWindow):
 
     # Error handling UI components
     error_notification_widget: ErrorNotificationWidget | None
-    error_log_dialog: ErrorLogViewerDialog | None
+    error_log_viewer_widget: ErrorLogViewerWidget | None
 
     # Tag management UI components
     tag_management_dialog: TagManagementDialog | None
@@ -118,7 +118,7 @@ class MainWindow(QMainWindow, Ui_MainWindow):
 
             # エラーログメニューアクション接続（UI生成後に接続）
             if hasattr(self, "actionErrorLog"):
-                self.actionErrorLog.triggered.connect(self._show_error_log_dialog)
+                self.actionErrorLog.triggered.connect(self._on_error_notification_clicked)
                 logger.debug("Error log menu action connected")
 
             # タグ管理メニューアクション追加（プログラム的に追加）
@@ -380,6 +380,7 @@ class MainWindow(QMainWindow, Ui_MainWindow):
         # QTabWidget初期化（タブ切り替え用）
         self._setup_tab_widget()
         self._setup_provider_batch_tab()
+        self._setup_errors_tab()
 
     def _setup_provider_batch_tab(self) -> None:
         """ジョブタブ (Provider Batch job management) を追加する。
@@ -442,11 +443,10 @@ class MainWindow(QMainWindow, Ui_MainWindow):
             # StatusBarに追加（permanent widget = 右端固定）
             self.statusBar().addPermanentWidget(self.error_notification_widget)
 
-            # クリックでダイアログ表示
-            self.error_notification_widget.clicked.connect(self._show_error_log_dialog)
+            # クリックでエラータブへ遷移
+            self.error_notification_widget.clicked.connect(self._on_error_notification_clicked)
 
             # Dialog初期化（遅延生成）
-            self.error_log_dialog = None
             self.tag_management_dialog = None
 
         except Exception as e:
@@ -466,35 +466,29 @@ class MainWindow(QMainWindow, Ui_MainWindow):
         self.tab_widget_right_panel.setCurrentIndex(0)
         logger.info("tabWidgetRightPanel initialized with 1 tab: 画像詳細")
 
-    def _show_error_log_dialog(self) -> None:
-        """エラーログダイアログを表示（オンデマンド）"""
-        try:
-            # Lazy initialization (singleton pattern)
-            if self.error_log_dialog is None:
-                if not self.db_manager:
-                    logger.error("ImageDatabaseManager not available")
-                    QMessageBox.warning(self, "エラー", "データベース接続が確立されていません")
-                    return
+    def _setup_errors_tab(self) -> None:
+        """エラータブに ErrorLogViewerWidget を埋め込む。
 
-                self.error_log_dialog = ErrorLogViewerDialog(
-                    db_manager=self.db_manager,
-                    parent=self,
-                    auto_load=True,
-                )
+        Wireframes v11 · エラータブ常設化。従来の ErrorLogViewerDialog
+        （ポップアップ）を廃し、常設 widget としてタブに配置する。
+        """
+        container = getattr(self, "tabErrors", None)
+        if container is None:
+            logger.warning("tabErrors not found - errors tab skipped")
+            self.error_log_viewer_widget = None
+            return
 
-                # Signal接続（error_resolvedで通知Widget更新）
-                self.error_log_dialog.error_resolved.connect(self._on_error_resolved)
+        widget = ErrorLogViewerWidget(parent=container)
+        if self.db_manager:
+            widget.set_db_manager(self.db_manager)
+        widget.error_resolved.connect(self._on_error_resolved)
+        container.layout().addWidget(widget)
+        self.error_log_viewer_widget = widget
+        logger.info("✅ エラータブ (ErrorLogViewerWidget) initialized")
 
-                logger.info("ErrorLogViewerDialog created (lazy initialization)")
-
-            # Dialog表示
-            self.error_log_dialog.show()
-            self.error_log_dialog.raise_()  # 前面表示
-            self.error_log_dialog.activateWindow()  # アクティブ化
-
-        except Exception as e:
-            logger.error(f"Failed to show error log dialog: {e}", exc_info=True)
-            QMessageBox.critical(self, "エラー", f"エラーログの表示に失敗しました:\n{e}")
+    def _on_error_notification_clicked(self) -> None:
+        """エラー通知 / メニュー操作でエラータブへ遷移する。"""
+        self.tabWidgetMainMode.setCurrentWidget(self.tabErrors)
 
     def _on_error_resolved(self, error_id: int) -> None:
         """エラー解決時の処理（通知Widget更新）"""
@@ -1749,6 +1743,10 @@ class MainWindow(QMainWindow, Ui_MainWindow):
         ):
             logger.info("Switched to Jobs tab")
             self.provider_batch_job_widget.refresh_jobs()
+        elif current is getattr(self, "tabErrors", None):
+            logger.info("Switched to Errors tab")
+            if self.error_log_viewer_widget is not None and self.db_manager:
+                self.error_log_viewer_widget.load_error_records()
 
     def _refresh_batch_tag_staging(self) -> None:
         """

--- a/src/lorairo/gui/window/main_window.py
+++ b/src/lorairo/gui/window/main_window.py
@@ -473,6 +473,9 @@ class MainWindow(QMainWindow, Ui_MainWindow):
 
         Wireframes v11 のナビショートカット (⌘1–⌘8) に対応する。
         """
+        if not hasattr(self, "tabWidgetMainMode") or not self.tabWidgetMainMode:
+            logger.warning("tabWidgetMainMode not found - tab shortcuts skipped")
+            return
         for i in range(self.tabWidgetMainMode.count()):
             shortcut = QShortcut(QKeySequence(f"Ctrl+{i + 1}"), self)
             shortcut.setContext(Qt.ShortcutContext.ApplicationShortcut)

--- a/tests/integration/test_main_window_tab_integration.py
+++ b/tests/integration/test_main_window_tab_integration.py
@@ -33,13 +33,33 @@ class TestMainWindowTabInitialization:
         assert main_window_with_tabs.tabWidgetMainMode is not None
         assert isinstance(main_window_with_tabs.tabWidgetMainMode, QTabWidget)
 
-    def test_three_tabs_created(self, main_window_with_tabs):
-        """3つのタブ（ワークスペース、バッチタグ、バッチAPI）が作成される"""
+    def test_six_tabs_created(self, main_window_with_tabs):
+        """6つのタブ（検索/マップ/アノテーション/ジョブ/結果/エラー）が作成される"""
         tab_widget = main_window_with_tabs.tabWidgetMainMode
-        assert tab_widget.count() == 3
-        assert tab_widget.tabText(0) == "ワークスペース"
-        assert tab_widget.tabText(1) == "バッチタグ"
-        assert tab_widget.tabText(2) == "バッチAPI"
+        assert tab_widget.count() == 6
+        assert [tab_widget.tabText(i) for i in range(tab_widget.count())] == [
+            "検索",
+            "マップ",
+            "アノテーション",
+            "ジョブ",
+            "結果",
+            "エラー",
+        ]
+
+    def test_stub_pages_exist(self, main_window_with_tabs):
+        """マップ/結果タブはスタブページとして存在する"""
+        tab_widget = main_window_with_tabs.tabWidgetMainMode
+        assert tab_widget.widget(1).objectName() == "tabMap"
+        assert tab_widget.widget(4).objectName() == "tabResults"
+
+    def test_tab_order_matches_wireframe_nav(self, main_window_with_tabs):
+        """タブ順序が Wireframes v11 のナビ順に一致する"""
+        window = main_window_with_tabs
+        tab_widget = window.tabWidgetMainMode
+        assert tab_widget.widget(0) is window.tabWorkspace
+        assert tab_widget.widget(2) is window.tabBatchTag
+        assert tab_widget.widget(3) is window.provider_batch_job_widget
+        assert tab_widget.widget(5).objectName() == "tabErrors"
 
     def test_workspace_tab_contains_splitter(self, main_window_with_tabs):
         """ワークスペースタブにsplitterMainWorkAreaが含まれる"""
@@ -61,8 +81,8 @@ class TestMainWindowTabInitialization:
         assert found, "splitterMainWorkArea should be a descendant of workspace tab"
 
     def test_batch_tag_tab_structure(self, main_window_with_tabs):
-        """バッチタグタブが適切な構造を持つ"""
-        batch_tag_tab = main_window_with_tabs.tabWidgetMainMode.widget(1)
+        """アノテーションタブが適切な構造を持つ"""
+        batch_tag_tab = main_window_with_tabs.tabBatchTag
         assert batch_tag_tab is not None
         assert batch_tag_tab.objectName() == "tabBatchTag"
 
@@ -71,11 +91,12 @@ class TestMainWindowTabInitialization:
         assert operations_group is not None
 
     def test_provider_batch_tab_structure(self, main_window_with_tabs):
-        """バッチAPIタブが適切な構造を持つ"""
-        provider_batch_tab = main_window_with_tabs.tabWidgetMainMode.widget(2)
+        """ジョブタブ（Provider Batch）が適切な構造を持つ"""
+        provider_batch_tab = main_window_with_tabs.provider_batch_job_widget
         assert provider_batch_tab is not None
         assert provider_batch_tab.objectName() == "providerBatchJobWidget"
-        assert main_window_with_tabs.provider_batch_job_widget is provider_batch_tab
+        tab_widget = main_window_with_tabs.tabWidgetMainMode
+        assert tab_widget.widget(tab_widget.indexOf(provider_batch_tab)) is provider_batch_tab
 
 
 class TestTabSwitching:
@@ -87,39 +108,42 @@ class TestTabSwitching:
         assert tab_widget.currentIndex() == 0
 
     def test_can_switch_to_batch_tag_tab(self, main_window_with_tabs, qtbot):
-        """バッチタグタブに切り替えられる"""
-        tab_widget = main_window_with_tabs.tabWidgetMainMode
+        """アノテーションタブに切り替えられる"""
+        window = main_window_with_tabs
+        tab_widget = window.tabWidgetMainMode
 
-        # バッチタグタブに切り替え
-        tab_widget.setCurrentIndex(1)
+        # アノテーションタブに切り替え
+        tab_widget.setCurrentWidget(window.tabBatchTag)
 
         # イベント処理を待つ
         qtbot.wait(10)
 
-        assert tab_widget.currentIndex() == 1
+        assert tab_widget.currentWidget() is window.tabBatchTag
 
     def test_can_switch_back_to_workspace(self, main_window_with_tabs, qtbot):
-        """ワークスペースタブに戻せる"""
-        tab_widget = main_window_with_tabs.tabWidgetMainMode
+        """検索（ワークスペース）タブに戻せる"""
+        window = main_window_with_tabs
+        tab_widget = window.tabWidgetMainMode
 
-        # バッチタグタブに切り替え
-        tab_widget.setCurrentIndex(1)
+        # アノテーションタブに切り替え
+        tab_widget.setCurrentWidget(window.tabBatchTag)
         qtbot.wait(10)
 
-        # ワークスペースタブに戻す
-        tab_widget.setCurrentIndex(0)
+        # 検索タブに戻す
+        tab_widget.setCurrentWidget(window.tabWorkspace)
         qtbot.wait(10)
 
-        assert tab_widget.currentIndex() == 0
+        assert tab_widget.currentWidget() is window.tabWorkspace
 
     def test_can_switch_to_provider_batch_tab(self, main_window_with_tabs, qtbot):
-        """バッチAPIタブに切り替えられる"""
-        tab_widget = main_window_with_tabs.tabWidgetMainMode
+        """ジョブタブ（Provider Batch）に切り替えられる"""
+        window = main_window_with_tabs
+        tab_widget = window.tabWidgetMainMode
 
-        tab_widget.setCurrentIndex(2)
+        tab_widget.setCurrentWidget(window.provider_batch_job_widget)
         qtbot.wait(10)
 
-        assert tab_widget.currentIndex() == 2
+        assert tab_widget.currentWidget() is window.provider_batch_job_widget
 
     def test_provider_batch_shares_batch_tag_staging(self, main_window_with_tabs):
         """通常アノテーションとバッチAPIは同じステージング状態を共有する。"""
@@ -163,11 +187,11 @@ class TestBatchTagWidgetIntegration:
 
         add_to_staging.assert_called_once_with([101, 102])
         information.assert_not_called()
-        assert main_window_with_tabs.tabWidgetMainMode.currentIndex() == 1
+        assert main_window_with_tabs.tabWidgetMainMode.currentWidget() is main_window_with_tabs.tabBatchTag
 
     def test_batchtagaddwidget_in_batch_tag_tab(self, main_window_with_tabs):
-        """BatchTagAddWidgetがバッチタグタブ内に配置されている"""
-        batch_tag_tab = main_window_with_tabs.tabWidgetMainMode.widget(1)
+        """BatchTagAddWidgetがアノテーションタブ内に配置されている"""
+        batch_tag_tab = main_window_with_tabs.tabBatchTag
         batch_tag_widget = main_window_with_tabs.batchTagAddWidget
 
         # BatchTagAddWidgetの親を辿ってbatch_tag_tabに到達できる
@@ -189,7 +213,7 @@ class TestBatchTagWidgetIntegration:
         assert batch_tag_widget.objectName() == "batchTagAddWidget"
 
         # BatchTagAddWidgetがスプリッター内に正しく配置されている
-        batch_tag_tab = main_window_with_tabs.tabWidgetMainMode.widget(1)
+        batch_tag_tab = main_window_with_tabs.tabBatchTag
         splitter = batch_tag_tab.findChild(object, "splitterBatchTagMain")
         if splitter:
             # スプリッター内にBatchTagAddWidgetが含まれている
@@ -225,10 +249,10 @@ class TestStatePreservation:
         # ワークスペースタブのDatasetStateManager
         workspace_state = main_window_with_tabs.dataset_state_manager
 
-        # バッチタグタブに切り替え
-        tab_widget.setCurrentIndex(1)
+        # アノテーションタブに切り替え
+        tab_widget.setCurrentWidget(main_window_with_tabs.tabBatchTag)
 
-        # バッチタグタブでもDatasetStateManagerが同じインスタンス
+        # アノテーションタブでもDatasetStateManagerが同じインスタンス
         batch_tag_state = main_window_with_tabs.dataset_state_manager
 
         assert workspace_state is dataset_state
@@ -253,8 +277,8 @@ class TestAnnotationDataDisplayWidget:
         assert main_window_with_tabs.batchTagAnnotationDisplay is not None
 
     def test_annotation_display_in_batch_tag_tab(self, main_window_with_tabs):
-        """AnnotationDataDisplayWidgetがバッチタグタブ内に配置されている"""
-        batch_tag_tab = main_window_with_tabs.tabWidgetMainMode.widget(1)
+        """AnnotationDataDisplayWidgetがアノテーションタブ内に配置されている"""
+        batch_tag_tab = main_window_with_tabs.tabBatchTag
         annotation_display = main_window_with_tabs.batchTagAnnotationDisplay
 
         # AnnotationDataDisplayWidgetの親を辿ってbatch_tag_tabに到達できる

--- a/tests/integration/test_main_window_tab_integration.py
+++ b/tests/integration/test_main_window_tab_integration.py
@@ -7,7 +7,7 @@ MainWindow初期化、タブ切り替え、ウィジェット統合を検証。
 from unittest.mock import Mock
 
 import pytest
-from PySide6.QtCore import Qt
+from PySide6.QtGui import QShortcut
 from PySide6.QtWidgets import QTabWidget
 
 from lorairo.gui.widgets.error_log_viewer_widget import ErrorLogViewerWidget
@@ -175,6 +175,24 @@ class TestTabSwitching:
         assert model_selection.objectName() == "providerBatchModelSelection"
         assert provider_widget.modelSelectionPlaceholder.parent() is None
         assert provider_widget.executionLayout.indexOf(model_selection) != -1
+
+    def test_tab_shortcuts_registered_for_all_tabs(self, main_window_with_tabs):
+        """Ctrl+1〜N のショートカットがタブ数分登録される"""
+        window = main_window_with_tabs
+        sequences = {sc.key().toString() for sc in window.findChildren(QShortcut)}
+        expected = {f"Ctrl+{i + 1}" for i in range(window.tabWidgetMainMode.count())}
+        assert expected.issubset(sequences)
+
+    def test_tab_shortcut_activation_switches_tab(self, main_window_with_tabs):
+        """ショートカット発火でメインタブが切り替わる"""
+        window = main_window_with_tabs
+        shortcut_by_seq = {sc.key().toString(): sc for sc in window.findChildren(QShortcut)}
+
+        shortcut_by_seq["Ctrl+4"].activated.emit()
+        assert window.tabWidgetMainMode.currentIndex() == 3
+
+        shortcut_by_seq["Ctrl+1"].activated.emit()
+        assert window.tabWidgetMainMode.currentIndex() == 0
 
 
 class TestBatchTagWidgetIntegration:

--- a/tests/integration/test_main_window_tab_integration.py
+++ b/tests/integration/test_main_window_tab_integration.py
@@ -10,6 +10,7 @@ import pytest
 from PySide6.QtCore import Qt
 from PySide6.QtWidgets import QTabWidget
 
+from lorairo.gui.widgets.error_log_viewer_widget import ErrorLogViewerWidget
 from lorairo.gui.window.main_window import MainWindow
 
 
@@ -60,6 +61,20 @@ class TestMainWindowTabInitialization:
         assert tab_widget.widget(2) is window.tabBatchTag
         assert tab_widget.widget(3) is window.provider_batch_job_widget
         assert tab_widget.widget(5).objectName() == "tabErrors"
+
+    def test_errors_tab_embeds_error_log_viewer(self, main_window_with_tabs):
+        """エラータブに ErrorLogViewerWidget が常設される"""
+        errors_tab = main_window_with_tabs.tabWidgetMainMode.widget(5)
+        assert errors_tab.objectName() == "tabErrors"
+        viewer = errors_tab.findChild(ErrorLogViewerWidget)
+        assert viewer is not None
+        assert main_window_with_tabs.error_log_viewer_widget is viewer
+
+    def test_error_notification_click_navigates_to_errors_tab(self, main_window_with_tabs):
+        """エラー通知クリックでエラータブへ遷移する"""
+        window = main_window_with_tabs
+        window._on_error_notification_clicked()
+        assert window.tabWidgetMainMode.currentWidget() is window.tabErrors
 
     def test_workspace_tab_contains_splitter(self, main_window_with_tabs):
         """ワークスペースタブにsplitterMainWorkAreaが含まれる"""

--- a/tests/unit/gui/services/test_tab_reorganization_service.py
+++ b/tests/unit/gui/services/test_tab_reorganization_service.py
@@ -20,7 +20,10 @@ class TestRequiredConstants:
 
         assert "tabWidgetMainMode" in required
         assert "tabWorkspace" in required
+        assert "tabMap" in required
         assert "tabBatchTag" in required
+        assert "tabResults" in required
+        assert "tabErrors" in required
         assert "splitterBatchTagMain" in required
         assert "groupBoxBatchOperations" in required
         assert "groupBoxAnnotation" in required
@@ -138,15 +141,30 @@ class TestIntegrationWithRealWidgets:
         tab_widget = QTabWidget(parent)
         tab_widget.setObjectName("tabWidgetMainMode")
 
-        # ワークスペースタブ
+        # 検索タブ
         workspace_tab = QWidget()
         workspace_tab.setObjectName("tabWorkspace")
-        tab_widget.addTab(workspace_tab, "ワークスペース")
+        tab_widget.addTab(workspace_tab, "検索")
 
-        # バッチタグタブ
+        # マップタブ（スタブ）
+        map_tab = QWidget()
+        map_tab.setObjectName("tabMap")
+        tab_widget.addTab(map_tab, "マップ")
+
+        # アノテーションタブ
         batch_tag_tab = QWidget()
         batch_tag_tab.setObjectName("tabBatchTag")
-        tab_widget.addTab(batch_tag_tab, "バッチタグ")
+        tab_widget.addTab(batch_tag_tab, "アノテーション")
+
+        # 結果タブ（スタブ）
+        results_tab = QWidget()
+        results_tab.setObjectName("tabResults")
+        tab_widget.addTab(results_tab, "結果")
+
+        # エラータブ
+        errors_tab = QWidget()
+        errors_tab.setObjectName("tabErrors")
+        tab_widget.addTab(errors_tab, "エラー")
 
         # UIファイルのタブ構造に合わせて splitterBatchTagMain を追加
         splitter = QSplitter(batch_tag_tab)

--- a/tests/unit/gui/window/test_main_window_coverage.py
+++ b/tests/unit/gui/window/test_main_window_coverage.py
@@ -786,31 +786,48 @@ class TestOpenDialogs:
 
 
 class TestTabChangedHandler:
-    """メインタブ切り替えハンドラのテスト"""
+    """メインタブ切り替えハンドラのテスト（widget 同一性ベース）"""
 
-    def test_on_main_tab_changed_workspace_tab_logs_info(self):
+    def test_on_main_tab_changed_annotate_tab_refreshes(self):
         from lorairo.gui.window.main_window import MainWindow
 
         mock_window = Mock()
-        with patch("lorairo.gui.window.main_window.logger") as mock_logger:
-            MainWindow._on_main_tab_changed(mock_window, 0)
-            mock_logger.info.assert_called_once_with("Switched to Workspace tab")
-
-    def test_on_main_tab_changed_batch_tag_tab_refreshes(self):
-        from lorairo.gui.window.main_window import MainWindow
-
-        mock_window = Mock()
-        MainWindow._on_main_tab_changed(mock_window, 1)
+        annotate_tab = Mock()
+        mock_window.tabBatchTag = annotate_tab
+        mock_window.tabWidgetMainMode.widget.return_value = annotate_tab
+        MainWindow._on_main_tab_changed(mock_window, 2)
         mock_window._refresh_batch_tag_staging.assert_called_once()
 
-    def test_on_main_tab_changed_unknown_tab_logs_warning(self):
+    def test_on_main_tab_changed_jobs_tab_refreshes_jobs(self):
         from lorairo.gui.window.main_window import MainWindow
 
         mock_window = Mock()
-        with patch("lorairo.gui.window.main_window.logger") as mock_logger:
-            MainWindow._on_main_tab_changed(mock_window, 99)
-            mock_logger.warning.assert_called_once()
-            assert "99" in mock_logger.warning.call_args[0][0]
+        jobs_widget = Mock()
+        mock_window.provider_batch_job_widget = jobs_widget
+        mock_window.tabWidgetMainMode.widget.return_value = jobs_widget
+        MainWindow._on_main_tab_changed(mock_window, 3)
+        jobs_widget.refresh_jobs.assert_called_once()
+
+    def test_on_main_tab_changed_errors_tab_loads_records(self):
+        from lorairo.gui.window.main_window import MainWindow
+
+        mock_window = Mock()
+        errors_tab = Mock()
+        viewer = Mock()
+        mock_window.tabErrors = errors_tab
+        mock_window.error_log_viewer_widget = viewer
+        mock_window.tabWidgetMainMode.widget.return_value = errors_tab
+        MainWindow._on_main_tab_changed(mock_window, 5)
+        viewer.load_error_records.assert_called_once()
+
+    def test_on_main_tab_changed_search_tab_is_silent(self):
+        from lorairo.gui.window.main_window import MainWindow
+
+        mock_window = Mock()
+        # どの既知 widget にも一致しないタブ（検索 / マップ / 結果）は無処理
+        mock_window.tabWidgetMainMode.widget.return_value = Mock()
+        MainWindow._on_main_tab_changed(mock_window, 0)
+        mock_window._refresh_batch_tag_staging.assert_not_called()
 
 
 class TestRefreshBatchTagStaging:


### PR DESCRIPTION
## Summary

Claude Design「Wireframes v11」ハンドオフのナビ構造への第一歩。メインタブを 6 枚構成（検索 / マップ / アノテーション / ジョブ / 結果 / エラー）に再編する。

epic: #731 / 子: #730 (Phase 1)

- メインタブを 6 枚化（検索 / マップ / アノテーション / ジョブ / 結果 / エラー）— #727
- マップ / 結果タブはスタブ（それぞれ Phase 8 / Phase 2 で実装予定）
- エラータブに `ErrorLogViewerWidget` を常設し、StatusBar 通知 / メニュー操作をダイアログ表示からタブ遷移に変更 — #728
- Ctrl+1–N タブ切替ショートカット追加 + `TabReorganizationService.REQUIRED_WIDGETS` 更新 — #729
- タブ index のマジックナンバーを widget 同一性参照に置換、`SETTINGS_VERSION` を 2 に bump
- デザイン資産 (`docs/design/wireframes-v11/`) と Phase 1 実装計画を同梱

CLI タブはナビに追加せず（GUI とは別の操作面）、Export タブは Phase 5 に先送り。

## マージ先

通常の main ではなく **epic 統合ブランチ `epic/gui-wireframes-v11`**（#731）へマージ。

## Test plan

- [x] `tests/integration/test_main_window_tab_integration.py` 全 PASS（6 タブ / スタブ / エラー常設 / ショートカット）
- [x] `tests/unit/gui/services/test_tab_reorganization_service.py` 全 PASS
- [x] GUI unit + integration スコープ green（worktree の torch/libcudnn 環境失敗・main checkout submodule 由来の既存失敗を除く。真偽は CI が SSoT）

## Closes

Closes #727, #728, #729

🤖 Generated with [Claude Code](https://claude.com/claude-code)