### PR TITLE
feat(gui): Wireframes v11 Phase 2b — Results accept 永続化

### DIFF
--- a/src/lorairo/database/db_manager.py
+++ b/src/lorairo/database/db_manager.py
@@ -1006,6 +1006,27 @@ class ImageDatabaseManager:
             logger.error(f"画像メタデータ取得中にエラーが発生しました: {e}", exc_info=True)
             raise  # Repositoryでエラーが発生したら上に伝える
 
+    def mark_image_reviewed(self, image_id: int, *, reviewed: bool = True) -> bool:
+        """画像のレビュー完了状態 (reviewed_at) を設定/解除する。
+
+        Wireframes v11 Frame 5 · Results の accept 永続化。
+
+        Args:
+            image_id: 対象画像 ID。
+            reviewed: True なら accept (reviewed_at=now)、False なら undo (NULL)。
+
+        Returns:
+            更新できた場合 True、対象が未登録なら False。
+
+        Raises:
+            SQLAlchemyError: DB 操作に失敗した場合は呼び出し元に伝播させる。
+        """
+        try:
+            return self.image_repo.set_image_reviewed(image_id, reviewed=reviewed)
+        except SQLAlchemyError as e:
+            logger.error(f"画像レビュー状態の更新中にエラー (ID: {image_id}): {e}", exc_info=True)
+            raise
+
     def get_processed_metadata(self, image_id: int) -> list[dict[str, Any]] | None:
         """指定された元画像IDに関連する全ての処理済み画像のメタデータを取得します。
 

--- a/src/lorairo/database/migrations/versions/d2e3f4a5b6c7_add_image_reviewed_at.py
+++ b/src/lorairo/database/migrations/versions/d2e3f4a5b6c7_add_image_reviewed_at.py
@@ -1,0 +1,46 @@
+"""Add review-completed timestamp for image-level annotation triage.
+
+Wireframes v11 Frame 5 · Results の accept (採用) 永続化。
+``images.reviewed_at`` は NULL=未レビュー / 値あり=accept 済み。
+タグ単位の ``rejected_at`` (e2f3a4b5c6d7) と対称な画像単位のレビュー状態。
+
+Revision ID: d2e3f4a5b6c7
+Revises: e2f3a4b5c6d7
+Create Date: 2026-06-11
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "d2e3f4a5b6c7"
+down_revision: str | None = "e2f3a4b5c6d7"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    inspector = sa.inspect(op.get_bind())
+    table_names = set(inspector.get_table_names())
+
+    if "images" in table_names:
+        image_columns = {column["name"] for column in inspector.get_columns("images")}
+        image_indexes = {index["name"] for index in inspector.get_indexes("images")}
+        if "reviewed_at" not in image_columns:
+            op.add_column("images", sa.Column("reviewed_at", sa.TIMESTAMP(timezone=True), nullable=True))
+        if "ix_images_reviewed_at" not in image_indexes:
+            op.create_index("ix_images_reviewed_at", "images", ["reviewed_at"])
+
+
+def downgrade() -> None:
+    inspector = sa.inspect(op.get_bind())
+    table_names = set(inspector.get_table_names())
+
+    if "images" in table_names:
+        image_columns = {column["name"] for column in inspector.get_columns("images")}
+        image_indexes = {index["name"] for index in inspector.get_indexes("images")}
+        if "ix_images_reviewed_at" in image_indexes:
+            op.drop_index("ix_images_reviewed_at", table_name="images")
+        if "reviewed_at" in image_columns:
+            op.drop_column("images", "reviewed_at")

--- a/src/lorairo/database/repository/image.py
+++ b/src/lorairo/database/repository/image.py
@@ -763,6 +763,36 @@ class ImageRepository(BaseRepository):
                 )
                 raise
 
+    def set_image_reviewed(self, image_id: int, *, reviewed: bool) -> bool:
+        """画像のレビュー完了状態 (reviewed_at) を設定/解除する。
+
+        Wireframes v11 Frame 5 · Results の accept (採用) 永続化。
+        accept で ``reviewed_at`` に現在時刻を、undo で NULL を設定する。
+
+        Args:
+            image_id: 対象画像 ID。
+            reviewed: True なら accept (reviewed_at=now)、False なら undo (NULL)。
+
+        Returns:
+            対象画像が存在し更新できた場合 True、未登録なら False。
+
+        Raises:
+            SQLAlchemyError: DB 操作に失敗した場合は呼び出し元に伝播させる。
+        """
+        with self.session_factory() as session:
+            try:
+                image: Image | None = session.get(Image, image_id)
+                if image is None:
+                    logger.warning(f"レビュー状態設定対象が見つかりません: image_id={image_id}")
+                    return False
+                image.reviewed_at = datetime.datetime.now(datetime.UTC) if reviewed else None
+                session.commit()
+                return True
+            except SQLAlchemyError as e:
+                session.rollback()
+                logger.error(f"レビュー状態の設定に失敗しました (ID: {image_id}): {e}", exc_info=True)
+                raise
+
     def get_images_metadata_batch(self, image_ids: list[int]) -> list[dict[str, Any]]:
         """指定された複数IDのオリジナル画像メタデータを一括取得する。
 

--- a/src/lorairo/database/schema.py
+++ b/src/lorairo/database/schema.py
@@ -202,6 +202,11 @@ class Image(Base):
         nullable=True,
         index=True,
     )
+    # アノテーション品質レビュー完了タイムスタンプ (Wireframes v11 Frame 5 · Results)。
+    # NULL = 未レビュー、値あり = accept 済み (確認完了)。rejected_at (タグ単位) と対称。
+    reviewed_at: Mapped[datetime.datetime | None] = mapped_column(
+        TIMESTAMP(timezone=True), nullable=True, index=True
+    )
     created_at: Mapped[datetime.datetime] = mapped_column(
         TIMESTAMP(timezone=True), server_default=func.now()
     )

--- a/src/lorairo/gui/widgets/results_widget.py
+++ b/src/lorairo/gui/widgets/results_widget.py
@@ -41,7 +41,10 @@ _DIM_CONFIDENCE: float = 0.5
 class ResultsWidget(QWidget):
     """Frame 5 · Results 読み取り専用トリアージ表示。objectName = "resultsWidget"。"""
 
-    review_requested = Signal(int)  # image_id (Annotate へ遷移要求。Phase 2b で接続)
+    review_requested = Signal(int)  # image_id (Annotate へ遷移要求。Phase 6 で接続)
+    accept_requested = Signal(int)  # image_id (この画像を accept = reviewed_at 設定)
+    unaccept_requested = Signal(int)  # image_id (accept を取り消す = reviewed_at 解除)
+    accept_clean_requested = Signal(list)  # list[int] (問題なし画像を一括 accept)
 
     def __init__(self, parent: QWidget | None = None) -> None:
         super().__init__(parent)
@@ -88,6 +91,31 @@ class ResultsWidget(QWidget):
         scroll.setWidget(rows_container)
         self._root.addWidget(scroll, stretch=1)
 
+        footer = self._build_bulk_footer(ordered)
+        if footer is not None:
+            self._root.addWidget(footer)
+
+    def _build_bulk_footer(self, results: list[ImageTriageResult]) -> QWidget | None:
+        """「問題なしを一括 accept」フッタを構築する (対象が無ければ None)。"""
+        # 問題なし かつ 未 accept の画像を一括 accept 対象にする。
+        clean_unaccepted = [r.image_id for r in results if not r.issues and not r.reviewed]
+        if not clean_unaccepted:
+            return None
+
+        footer = QFrame()
+        footer.setObjectName("resultsBulkFooter")
+        layout = QHBoxLayout(footer)
+        layout.addWidget(QLabel(f"問題なし {len(clean_unaccepted)} 件"))
+        layout.addStretch(1)
+
+        button = QPushButton(f"✓ 問題なしを一括 accept ({len(clean_unaccepted)})")
+        button.setObjectName("resultsAcceptCleanButton")
+        button.clicked.connect(
+            lambda _checked=False, ids=clean_unaccepted: self.accept_clean_requested.emit(ids)
+        )
+        layout.addWidget(button)
+        return footer
+
     def clear(self) -> None:
         """空状態 (ステージング 0 件) を表示する。"""
         self._reset()
@@ -133,6 +161,7 @@ class ResultsWidget(QWidget):
             f"バッチ: {summary.batch_size} 件",
             f"要レビュー: {summary.needs_review_count}",
             f"clean: {summary.clean_count}",
+            f"accepted: {summary.accepted_count}/{summary.batch_size}",
             f"tier: {tier_text}",
             f"issue 総数: {issue_total}",
         ]
@@ -193,6 +222,8 @@ class ResultsWidget(QWidget):
         row.setFrameShape(QFrame.Shape.StyledPanel)
         if result.needs_review:
             row.setProperty("needsReview", True)
+        if result.reviewed:
+            row.setProperty("accepted", True)
         layout = QVBoxLayout(row)
 
         layout.addWidget(self._build_row_header(result))
@@ -224,6 +255,22 @@ class ResultsWidget(QWidget):
             lambda _checked=False, image_id=result.image_id: self.review_requested.emit(image_id)
         )
         layout.addWidget(button)
+
+        # accept 済みなら undo、未 accept なら accept ボタンを出す。
+        if result.reviewed:
+            undo = QPushButton("↩ 取消")
+            undo.setObjectName(f"resultsUnacceptButton_{result.image_id}")
+            undo.clicked.connect(
+                lambda _checked=False, image_id=result.image_id: self.unaccept_requested.emit(image_id)
+            )
+            layout.addWidget(undo)
+        else:
+            accept = QPushButton("✓ accept")
+            accept.setObjectName(f"resultsAcceptButton_{result.image_id}")
+            accept.clicked.connect(
+                lambda _checked=False, image_id=result.image_id: self.accept_requested.emit(image_id)
+            )
+            layout.addWidget(accept)
         return header
 
     def _format_dimensions(self, width: int | None, height: int | None) -> str:

--- a/src/lorairo/gui/window/main_window.py
+++ b/src/lorairo/gui/window/main_window.py
@@ -509,9 +509,32 @@ class MainWindow(QMainWindow, Ui_MainWindow):
             stub.deleteLater()
 
         widget = ResultsWidget(parent=container)
+        widget.accept_requested.connect(self._on_results_accept)
+        widget.unaccept_requested.connect(self._on_results_unaccept)
+        widget.accept_clean_requested.connect(self._on_results_accept_clean)
         container.layout().addWidget(widget)
         self.results_widget = widget
         logger.info("✅ 結果タブ (ResultsWidget) initialized")
+
+    def _on_results_accept(self, image_id: int) -> None:
+        """Results 行の accept: reviewed_at を設定して再描画する。"""
+        if self.db_manager:
+            self.db_manager.mark_image_reviewed(image_id, reviewed=True)
+        self._refresh_results_tab()
+
+    def _on_results_unaccept(self, image_id: int) -> None:
+        """Results 行の accept 取消: reviewed_at を解除して再描画する。"""
+        if self.db_manager:
+            self.db_manager.mark_image_reviewed(image_id, reviewed=False)
+        self._refresh_results_tab()
+
+    def _on_results_accept_clean(self, image_ids: list[int]) -> None:
+        """問題なし画像を一括 accept して再描画する。"""
+        if self.db_manager:
+            for image_id in image_ids:
+                self.db_manager.mark_image_reviewed(image_id, reviewed=True)
+            logger.info(f"一括 accept 完了: {len(image_ids)} 件")
+        self._refresh_results_tab()
 
     def _refresh_results_tab(self) -> None:
         """結果タブ表示時に、ステージング集合のトリアージを再計算して描画する。"""
@@ -541,6 +564,7 @@ class MainWindow(QMainWindow, Ui_MainWindow):
                 "uuid": metadata.get("uuid"),
                 "width": metadata.get("width"),
                 "height": metadata.get("height"),
+                "reviewed_at": metadata.get("reviewed_at"),
             }
             results.append(
                 self.quality_issue_detection_service.detect_image(image_id, image_meta, annotations)

--- a/src/lorairo/services/quality_issue_detection_service.py
+++ b/src/lorairo/services/quality_issue_detection_service.py
@@ -79,11 +79,12 @@ class ImageTriageResult:
     canonical_tier: QualityTier | None  # scorer tier の median 相当
     scorers: list[ScorerView]
     issues: list[IssueType]  # 検出された構造的問題 (空なら clean)
+    reviewed: bool = False  # accept 済み (Image.reviewed_at が値あり) なら True
 
     @property
     def needs_review(self) -> bool:
-        """構造的問題が 1 件以上あれば要レビュー。"""
-        return len(self.issues) > 0
+        """構造的問題が 1 件以上あり、まだ accept されていなければ要レビュー。"""
+        return len(self.issues) > 0 and not self.reviewed
 
 
 @dataclass(frozen=True)
@@ -96,6 +97,7 @@ class BatchTriageSummary:
     issue_counts: dict[IssueType, int]  # issue 種別ごとの件数
     tier_distribution: dict[QualityTier, int]
     no_tier_count: int  # tier 算出不能 (no-score / unknown) の件数
+    accepted_count: int = 0  # accept 済み (reviewed) 画像の件数
 
 
 class QualityIssueDetectionService:
@@ -108,7 +110,8 @@ class QualityIssueDetectionService:
 
         Args:
             image_id: 画像 ID。
-            image_meta: ``{"uuid": str|None, "width": int|None, "height": int|None}``。
+            image_meta: ``{"uuid", "width", "height", "reviewed_at"}`` を含む dict。
+                ``reviewed_at`` が非 None なら accept 済みと判定する。
             annotations: ``db_manager.get_image_annotations`` の戻り値
                 (tags / captions / scores / score_labels / ratings)。
 
@@ -158,6 +161,7 @@ class QualityIssueDetectionService:
             canonical_tier=canonical_tier,
             scorers=scorer_views,
             issues=issues,
+            reviewed=image_meta.get("reviewed_at") is not None,
         )
 
     def summarize(self, results: list[ImageTriageResult]) -> BatchTriageSummary:
@@ -169,8 +173,10 @@ class QualityIssueDetectionService:
         Returns:
             バッチ全体のサマリ。
         """
+        # needs_review = issue 有 かつ 未 accept。clean = issue 無し。accepted = reviewed。
         needs_review_count = sum(1 for r in results if r.needs_review)
-        clean_count = len(results) - needs_review_count
+        clean_count = sum(1 for r in results if not r.issues)
+        accepted_count = sum(1 for r in results if r.reviewed)
 
         issue_counts: dict[IssueType, int] = dict.fromkeys(IssueType, 0)
         tier_distribution: dict[QualityTier, int] = {}
@@ -192,6 +198,7 @@ class QualityIssueDetectionService:
             issue_counts=issue_counts,
             tier_distribution=tier_distribution,
             no_tier_count=no_tier_count,
+            accepted_count=accepted_count,
         )
 
     @staticmethod

--- a/tests/integration/test_main_window_tab_integration.py
+++ b/tests/integration/test_main_window_tab_integration.py
@@ -91,6 +91,26 @@ class TestMainWindowTabInitialization:
         stub = main_window_with_tabs.tabResults.findChild(QLabel, "labelResultsStub")
         assert stub is None
 
+    def test_results_accept_marks_image_reviewed(self, main_window_with_tabs):
+        """ResultsWidget の accept シグナルで db_manager.mark_image_reviewed が呼ばれる"""
+        from unittest.mock import Mock
+
+        window = main_window_with_tabs
+        mark = Mock(return_value=True)
+        window.db_manager.mark_image_reviewed = mark
+        window.results_widget.accept_requested.emit(42)
+        mark.assert_called_once_with(42, reviewed=True)
+
+    def test_results_accept_clean_marks_all(self, main_window_with_tabs):
+        """accept_clean シグナルで複数画像が reviewed=True にマークされる"""
+        from unittest.mock import Mock
+
+        window = main_window_with_tabs
+        mark = Mock(return_value=True)
+        window.db_manager.mark_image_reviewed = mark
+        window.results_widget.accept_clean_requested.emit([1, 2, 3])
+        assert mark.call_count == 3
+
     def test_workspace_tab_contains_splitter(self, main_window_with_tabs):
         """ワークスペースタブにsplitterMainWorkAreaが含まれる"""
         workspace_tab = main_window_with_tabs.tabWidgetMainMode.widget(0)

--- a/tests/unit/database/repository/test_image_repository.py
+++ b/tests/unit/database/repository/test_image_repository.py
@@ -982,3 +982,29 @@ class TestGetImagesByIdsChunking:
         monkeypatch.setattr(image_repository, "BATCH_CHUNK_SIZE", 2)
         rows = image_repository.get_images_by_ids(ids)
         assert {m["id"] for m in rows} == set(ids)
+
+
+@pytest.mark.unit
+class TestSetImageReviewed:
+    """set_image_reviewed (Wireframes v11 Frame 5 accept 永続化) のテスト。"""
+
+    def test_accept_sets_reviewed_at(self, image_repository: ImageRepository) -> None:
+        """accept で reviewed_at に値が入り、metadata に反映される。"""
+        image_id = _insert_image(image_repository, uuid="rev-1", phash="rev-ph-1")
+        assert image_repository.set_image_reviewed(image_id, reviewed=True) is True
+        metadata = image_repository.get_image_metadata(image_id)
+        assert metadata is not None
+        assert metadata["reviewed_at"] is not None
+
+    def test_undo_clears_reviewed_at(self, image_repository: ImageRepository) -> None:
+        """undo で reviewed_at が NULL に戻る。"""
+        image_id = _insert_image(image_repository, uuid="rev-2", phash="rev-ph-2")
+        image_repository.set_image_reviewed(image_id, reviewed=True)
+        assert image_repository.set_image_reviewed(image_id, reviewed=False) is True
+        metadata = image_repository.get_image_metadata(image_id)
+        assert metadata is not None
+        assert metadata["reviewed_at"] is None
+
+    def test_missing_image_returns_false(self, image_repository: ImageRepository) -> None:
+        """未登録 image_id では False を返す。"""
+        assert image_repository.set_image_reviewed(99999, reviewed=True) is False

--- a/tests/unit/database/test_migration_d2e3f4a5b6c7_image_reviewed.py
+++ b/tests/unit/database/test_migration_d2e3f4a5b6c7_image_reviewed.py
@@ -1,0 +1,81 @@
+"""Alembic migration `d2e3f4a5b6c7` image reviewed_at column checks."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from alembic import command
+from alembic.config import Config
+from sqlalchemy import create_engine, inspect, text
+
+
+def _make_alembic_config(db_path: Path) -> Config:
+    project_root = Path(__file__).resolve().parents[3]
+    cfg = Config(str(project_root / "alembic.ini"))
+    cfg.set_main_option("script_location", str(project_root / "src/lorairo/database/migrations"))
+    cfg.set_main_option("sqlalchemy.url", f"sqlite:///{db_path}")
+    return cfg
+
+
+@pytest.mark.unit
+def test_image_reviewed_migration_adds_reviewed_at(tmp_path: Path) -> None:
+    db_path = tmp_path / "image_reviewed.db"
+    cfg = _make_alembic_config(db_path)
+    engine = create_engine(f"sqlite:///{db_path}")
+    with engine.begin() as conn:
+        conn.execute(
+            text(
+                """
+                CREATE TABLE images (
+                    id INTEGER NOT NULL PRIMARY KEY,
+                    uuid VARCHAR NOT NULL
+                )
+                """
+            )
+        )
+        conn.execute(text("CREATE TABLE alembic_version (version_num VARCHAR(32) PRIMARY KEY)"))
+        conn.execute(text("INSERT INTO alembic_version (version_num) VALUES ('e2f3a4b5c6d7')"))
+    engine.dispose()
+
+    command.upgrade(cfg, "head")
+
+    engine = create_engine(f"sqlite:///{db_path}")
+    inspector = inspect(engine)
+    image_columns = {column["name"] for column in inspector.get_columns("images")}
+    image_indexes = {index["name"] for index in inspector.get_indexes("images")}
+    engine.dispose()
+
+    assert "reviewed_at" in image_columns
+    assert "ix_images_reviewed_at" in image_indexes
+
+
+@pytest.mark.unit
+def test_image_reviewed_migration_downgrade_removes_column(tmp_path: Path) -> None:
+    db_path = tmp_path / "image_reviewed_down.db"
+    cfg = _make_alembic_config(db_path)
+    engine = create_engine(f"sqlite:///{db_path}")
+    with engine.begin() as conn:
+        conn.execute(
+            text(
+                """
+                CREATE TABLE images (
+                    id INTEGER NOT NULL PRIMARY KEY,
+                    uuid VARCHAR NOT NULL
+                )
+                """
+            )
+        )
+        conn.execute(text("CREATE TABLE alembic_version (version_num VARCHAR(32) PRIMARY KEY)"))
+        conn.execute(text("INSERT INTO alembic_version (version_num) VALUES ('e2f3a4b5c6d7')"))
+    engine.dispose()
+
+    command.upgrade(cfg, "d2e3f4a5b6c7")
+    command.downgrade(cfg, "e2f3a4b5c6d7")
+
+    engine = create_engine(f"sqlite:///{db_path}")
+    inspector = inspect(engine)
+    image_columns = {column["name"] for column in inspector.get_columns("images")}
+    engine.dispose()
+
+    assert "reviewed_at" not in image_columns

--- a/tests/unit/gui/widgets/test_results_widget.py
+++ b/tests/unit/gui/widgets/test_results_widget.py
@@ -91,3 +91,69 @@ def test_display_after_display_clears_previous_rows(qapp):
     assert widget.findChild(object, "resultsRow_10") is None
     assert widget.findChild(object, "resultsRow_11") is None
     assert widget.findChild(object, "resultsRow_20") is not None
+
+
+def _reviewed_result(image_id: int, issues: list[IssueType], reviewed: bool) -> ImageTriageResult:
+    return ImageTriageResult(
+        image_id=image_id,
+        uuid="abcd1234",
+        width=1024,
+        height=1024,
+        tags=[TagView(tag="dog", confidence_score=0.9, model_id=1)],
+        caption="a dog on grass",
+        caption_word_count=4,
+        canonical_rating="PG",
+        ratings=[RatingView(model="wd-rater", normalized_rating="PG", confidence_score=0.9)],
+        canonical_tier=QualityTier.GOOD_QUALITY,
+        scorers=[ScorerView(model="aesthetic_shadow_v2", label="aesthetic", tier=QualityTier.BEST_QUALITY)],
+        issues=issues,
+        reviewed=reviewed,
+    )
+
+
+def test_accept_button_emitted_for_unreviewed(qapp, qtbot):
+    widget = ResultsWidget()
+    widget.display(_summary(), [_reviewed_result(10, [IssueType.EMPTY_TAGS], reviewed=False)])
+    button = widget.findChild(object, "resultsAcceptButton_10")
+    assert button is not None
+    with qtbot.waitSignal(widget.accept_requested, timeout=1000) as blocker:
+        button.click()
+    assert blocker.args == [10]
+
+
+def test_reviewed_row_shows_undo_not_accept(qapp):
+    widget = ResultsWidget()
+    widget.display(_summary(), [_reviewed_result(10, [IssueType.EMPTY_TAGS], reviewed=True)])
+    assert widget.findChild(object, "resultsUnacceptButton_10") is not None
+    assert widget.findChild(object, "resultsAcceptButton_10") is None
+
+
+def test_unaccept_button_emits_signal(qapp, qtbot):
+    widget = ResultsWidget()
+    widget.display(_summary(), [_reviewed_result(10, [IssueType.EMPTY_TAGS], reviewed=True)])
+    button = widget.findChild(object, "resultsUnacceptButton_10")
+    with qtbot.waitSignal(widget.unaccept_requested, timeout=1000) as blocker:
+        button.click()
+    assert blocker.args == [10]
+
+
+def test_bulk_accept_clean_emits_clean_ids(qapp, qtbot):
+    widget = ResultsWidget()
+    # clean かつ未 reviewed の #11 のみ一括対象、#10 は issue 有で対象外。
+    results = [
+        _reviewed_result(10, [IssueType.EMPTY_TAGS], reviewed=False),
+        _reviewed_result(11, [], reviewed=False),
+    ]
+    widget.display(_summary(), results)
+    button = widget.findChild(object, "resultsAcceptCleanButton")
+    assert button is not None
+    with qtbot.waitSignal(widget.accept_clean_requested, timeout=1000) as blocker:
+        button.click()
+    assert blocker.args == [[11]]
+
+
+def test_no_bulk_footer_when_no_clean_unreviewed(qapp):
+    widget = ResultsWidget()
+    # 全て issue 有 → 一括対象なし → フッタ無し。
+    widget.display(_summary(), [_reviewed_result(10, [IssueType.EMPTY_TAGS], reviewed=False)])
+    assert widget.findChild(object, "resultsAcceptCleanButton") is None

--- a/tests/unit/services/test_quality_issue_detection_service.py
+++ b/tests/unit/services/test_quality_issue_detection_service.py
@@ -208,3 +208,36 @@ def test_canonical_rating_orders_xxx_strictest(service):
     )
     assert result.canonical_rating == "XXX"
     assert IssueType.RATING_DISAGREEMENT in result.issues
+
+
+def test_reviewed_image_is_not_needs_review(service):
+    """reviewed_at が値ありなら issue があっても needs_review にならない。"""
+    meta = {**META, "reviewed_at": "2026-06-11T00:00:00Z"}
+    result = service.detect_image(1, meta, _ann())  # 空 = EMPTY_TAGS + NO_SCORE
+    assert result.reviewed is True
+    assert result.issues  # issue 自体は検出される
+    assert result.needs_review is False
+
+
+def test_unreviewed_image_with_issue_needs_review(service):
+    """reviewed_at が None なら issue 有で needs_review。"""
+    meta = {**META, "reviewed_at": None}
+    result = service.detect_image(1, meta, _ann())
+    assert result.reviewed is False
+    assert result.needs_review is True
+
+
+def test_summarize_counts_accepted(service):
+    """summarize が accepted_count を集計する。"""
+    accepted = service.detect_image(
+        1,
+        {**META, "reviewed_at": "2026-06-11T00:00:00Z"},
+        _ann(
+            tags=[{"tag": "a", "confidence_score": 0.9, "model_id": 1, "rejected_at": None}],
+            score_labels=[{"model": "aesthetic_shadow_v2", "label": "aesthetic"}],
+            ratings=[{"model": "wd-rater", "normalized_rating": "PG", "confidence_score": 0.9}],
+        ),
+    )
+    unreviewed = service.detect_image(2, {**META, "reviewed_at": None}, _ann())
+    summary = service.summarize([accepted, unreviewed])
+    assert summary.accepted_count == 1


### PR DESCRIPTION
## Summary

Wireframes v11 Frame 5 · Results に **accept（採用）アクションと永続化**を実装。Phase 2（読み取り専用トリアージ）の MVC 基盤に書き込み層を追加する。

epic: #731 / 子: #726 (Phase 2 系)

### スコープ判断
- **accept のみ実装**: `Image.reviewed_at`（画像単位レビュー状態）。AskUserQuestion で確定済みの機構
- **reject は Phase 6 Annotate に委譲**: Results 画像行の reject は意味が曖昧（全タグ却下 / バッチ除外 / per-tag）。既存 `rejected_at` は**タグ単位**の細粒度判断で、これは Annotate 右パネルの領分。Results では image 単位 accept が主、というワイヤー設計に沿う

### 変更内容
- **migration** `d2e3f4a5b6c7`: `images.reviewed_at`（nullable, indexed）。`rejected_at` と対称
- **data**: `ImageRepository.set_image_reviewed` / `db_manager.mark_image_reviewed`
- **contract 拡張**: `ImageTriageResult.reviewed` + `BatchTriageSummary.accepted_count`。`needs_review = issue 有 かつ 未 accept`
- **widget**: per-row accept/undo + 「問題なしを一括 accept」フッタ + accepted サマリ + 視覚状態
- **wiring**: accept/unaccept/accept_clean シグナル → `reviewed_at` 更新 → 再描画

## マージ先
**epic 統合ブランチ `epic/gui-wireframes-v11`**（#731）。

## Test plan
- [x] migration upgrade/downgrade 2 tests
- [x] `set_image_reviewed` repository 3 tests
- [x] service reviewed contract 3 tests
- [x] widget accept/undo/bulk 5 tests
- [x] integration accept wiring 2 tests
- [x] GUI+DB スコープ 2087 passed（torch 環境依存の thumbnail 3 失敗は CI が SSoT）
- [x] mypy clean / 単一 migration head

🤖 Generated with [Claude Code](https://claude.com/claude-code)