### PR TITLE
feat(search): Phase 4 Search サイドバー強化 — facet フィルタ 5 種 + DATE ヒストグラム

### DIFF
--- a/src/lorairo/database/db_manager.py
+++ b/src/lorairo/database/db_manager.py
@@ -1821,6 +1821,28 @@ class ImageDatabaseManager:
             logger.error(f"ファイルパスからの画像ID取得エラー: {e}", exc_info=True)
             raise
 
+    def get_created_at_histogram(self, bins: int = 20) -> list[tuple[datetime, datetime, int]]:
+        """Image.created_at 分布ヒストグラムを取得する。
+
+        Args:
+            bins: ビン数（デフォルト 20）。
+
+        Returns:
+            list of (bin_start, bin_end, count)。空データの場合は空リスト。
+        """
+        return self.image_repo.get_created_at_histogram(bins=bins)
+
+    def get_recently_used_model_ids(self, limit: int = 10) -> list[str]:
+        """アノテーション実績があるモデルの litellm_model_id を返す。
+
+        Args:
+            limit: 最大件数（デフォルト 10）。
+
+        Returns:
+            litellm_model_id のリスト。
+        """
+        return self.image_repo.get_recently_used_model_ids(limit=limit)
+
 
 # --- 初期化チェック ---
 # try:

--- a/src/lorairo/database/filter_criteria.py
+++ b/src/lorairo/database/filter_criteria.py
@@ -66,6 +66,10 @@ class ImageFilterCriteria:
     manual_edit_filter: bool | None = None
     score_min: float | None = None
     score_max: float | None = None
+    # Phase 4: Search サイドバー強化 facets
+    reviewed_at_filter: str | None = None  # "unreviewed" | "reviewed" | None=全て
+    error_state_filter: str | None = None  # "has_error" | "no_error" | None=全て
+    model_filter: list[str] | None = None  # litellm_id リスト。None=全モデル
     # Phase C (projects テーブル追加) 完了後に DB フィルタを有効化
     project_name: str | None = None
     project_id: int | None = None
@@ -129,6 +133,9 @@ class ImageFilterCriteria:
             "manual_edit_filter": self.manual_edit_filter,
             "score_min": self.score_min,
             "score_max": self.score_max,
+            "reviewed_at_filter": self.reviewed_at_filter,
+            "error_state_filter": self.error_state_filter,
+            "model_filter": self.model_filter,
             "project_name": self.project_name,
             "project_id": self.project_id,
             "limit": self.limit,

--- a/src/lorairo/database/repository/image.py
+++ b/src/lorairo/database/repository/image.py
@@ -51,6 +51,7 @@ from ..schema import (
     MANUAL_EDIT_LITELLM_ID,
     MANUAL_EDIT_NAME,
     Caption,
+    ErrorRecord,
     Image,
     ImageFilenameAlias,
     Model,
@@ -1752,6 +1753,65 @@ class ImageRepository(BaseRepository):
 
         return query
 
+    def _apply_reviewed_at_filter(self, query: Select[Any], reviewed_at_filter: str | None) -> Select[Any]:
+        """クエリにレビュー状態フィルタを適用する。
+
+        Args:
+            query: 元のSelectクエリ。
+            reviewed_at_filter: フィルタ値。"unreviewed" | "reviewed" | None=全て。
+
+        Returns:
+            フィルタ適用後のクエリ。
+        """
+        if reviewed_at_filter == "unreviewed":
+            query = query.where(Image.reviewed_at.is_(None))
+        elif reviewed_at_filter == "reviewed":
+            query = query.where(Image.reviewed_at.is_not(None))
+        return query
+
+    def _apply_error_state_filter(self, query: Select[Any], error_state_filter: str | None) -> Select[Any]:
+        """クエリにエラー状態フィルタを適用する。未解決エラー（resolved_at IS NULL）を基準にする。
+
+        Args:
+            query: 元のSelectクエリ。
+            error_state_filter: フィルタ値。"has_error" | "no_error" | None=全て。
+
+        Returns:
+            フィルタ適用後のクエリ。
+        """
+        if error_state_filter not in ("has_error", "no_error"):
+            return query
+        has_unresolved = (
+            exists()
+            .where(ErrorRecord.image_id == Image.id, ErrorRecord.resolved_at.is_(None))
+            .correlate(Image)
+        )
+        if error_state_filter == "has_error":
+            return query.where(has_unresolved)
+        return query.where(~has_unresolved)
+
+    def _apply_model_filter(self, query: Select[Any], model_filter: list[str] | None) -> Select[Any]:
+        """クエリにモデルフィルタを適用する。指定 litellm_model_id のアノテーションを持つ画像のみ。
+
+        Args:
+            query: 元のSelectクエリ。
+            model_filter: litellm_model_id のリスト。None または空リストの場合はフィルタなし。
+
+        Returns:
+            フィルタ適用後のクエリ。
+        """
+        if not model_filter:
+            return query
+        model_id_subq = select(Model.id).where(Model.litellm_model_id.in_(model_filter)).scalar_subquery()
+        has_annotation = or_(
+            exists().where(Tag.image_id == Image.id, Tag.model_id.in_(model_id_subq)).correlate(Image),
+            exists()
+            .where(Caption.image_id == Image.id, Caption.model_id.in_(model_id_subq))
+            .correlate(Image),
+            exists().where(Score.image_id == Image.id, Score.model_id.in_(model_id_subq)).correlate(Image),
+        )
+        return query.where(has_annotation)
+
     # --- Annotation Format for Metadata (batch read helpers) ---
 
     @staticmethod
@@ -2169,6 +2229,9 @@ class ImageRepository(BaseRepository):
         score_max: float | None = None,
         project_name: str | None = None,
         project_id: int | None = None,
+        reviewed_at_filter: str | None = None,
+        error_state_filter: str | None = None,
+        model_filter: list[str] | None = None,
     ) -> Select[Any]:
         """画像フィルタ条件を適用したクエリを構築する。
 
@@ -2192,6 +2255,9 @@ class ImageRepository(BaseRepository):
             score_max: 最大スコア値（0.0-10.0）。
             project_name: プロジェクト名フィルタ（Phase C完了後に有効化）。
             project_id: プロジェクトIDフィルタ（Phase C完了後に有効化）。
+            reviewed_at_filter: レビュー状態フィルタ。"unreviewed" | "reviewed" | None=全て。
+            error_state_filter: エラー状態フィルタ。"has_error" | "no_error" | None=全て。
+            model_filter: モデルフィルタ。litellm_model_id のリスト。None=全モデル。
 
         Returns:
             フィルタ適用済みのSelectクエリ。
@@ -2240,6 +2306,11 @@ class ImageRepository(BaseRepository):
 
         # Project Filter (Phase C完了後に有効化)
         query = self._apply_project_filter(query, project_name, project_id)
+
+        # Phase 4: Search サイドバー強化 facets
+        query = self._apply_reviewed_at_filter(query, reviewed_at_filter)
+        query = self._apply_error_state_filter(query, error_state_filter)
+        query = self._apply_model_filter(query, model_filter)
 
         return query.distinct()
 
@@ -2367,6 +2438,9 @@ class ImageRepository(BaseRepository):
                     score_max=filter_criteria.score_max,
                     project_name=filter_criteria.project_name,
                     project_id=filter_criteria.project_id,
+                    reviewed_at_filter=filter_criteria.reviewed_at_filter,
+                    error_state_filter=filter_criteria.error_state_filter,
+                    model_filter=filter_criteria.model_filter,
                 )
                 query = self._apply_processed_resolution_filter(query, filter_criteria.resolution)
 
@@ -2453,6 +2527,9 @@ class ImageRepository(BaseRepository):
                     score_max=filter_criteria.score_max,
                     project_name=filter_criteria.project_name,
                     project_id=filter_criteria.project_id,
+                    reviewed_at_filter=filter_criteria.reviewed_at_filter,
+                    error_state_filter=filter_criteria.error_state_filter,
+                    model_filter=filter_criteria.model_filter,
                 )
                 filtered_query = self._apply_processed_resolution_filter(
                     filtered_query, filter_criteria.resolution
@@ -2509,6 +2586,9 @@ class ImageRepository(BaseRepository):
                     score_max=filter_criteria.score_max,
                     project_name=filter_criteria.project_name,
                     project_id=filter_criteria.project_id,
+                    reviewed_at_filter=filter_criteria.reviewed_at_filter,
+                    error_state_filter=filter_criteria.error_state_filter,
+                    model_filter=filter_criteria.model_filter,
                 )
                 filtered_query = self._apply_processed_resolution_filter(
                     filtered_query, filter_criteria.resolution
@@ -2903,3 +2983,72 @@ class ImageRepository(BaseRepository):
             except Exception as e:
                 logger.error(f"バッチ pHash 解決エラー: {e}", exc_info=True)
                 return result
+
+    def get_created_at_histogram(
+        self, bins: int = 20
+    ) -> list[tuple[datetime.datetime, datetime.datetime, int]]:
+        """Image.created_at の分布ヒストグラムを返す。
+
+        Args:
+            bins: ビン数（デフォルト 20）。
+
+        Returns:
+            list of (bin_start, bin_end, count)。空データの場合は空リスト。
+        """
+        with self.session_factory() as session:
+            result = session.execute(select(func.min(Image.created_at), func.max(Image.created_at))).one()
+            min_dt, max_dt = result[0], result[1]
+            if min_dt is None or max_dt is None:
+                return []
+            if min_dt == max_dt:
+                count = session.execute(select(func.count(Image.id))).scalar_one()
+                return [(min_dt, max_dt, count)]
+
+            all_dates: list[datetime.datetime] = list(
+                session.execute(select(Image.created_at).where(Image.created_at.is_not(None)))
+                .scalars()
+                .all()
+            )
+
+            total_seconds = (max_dt - min_dt).total_seconds()
+            bin_width_sec = total_seconds / bins
+            counts = [0] * bins
+            for dt in all_dates:
+                idx = min(int((dt - min_dt).total_seconds() / bin_width_sec), bins - 1)
+                counts[idx] += 1
+
+            return [
+                (
+                    min_dt + datetime.timedelta(seconds=i * bin_width_sec),
+                    min_dt + datetime.timedelta(seconds=(i + 1) * bin_width_sec),
+                    counts[i],
+                )
+                for i in range(bins)
+            ]
+
+    def get_recently_used_model_ids(self, limit: int = 10) -> list[str]:
+        """アノテーション実績があるモデルの litellm_model_id を返す。
+
+        Tag / Caption / Score のいずれかにアノテーション実績があるモデルを
+        model.id 降順（最近登録順）で返す。
+
+        Args:
+            limit: 最大件数（デフォルト 10）。
+
+        Returns:
+            litellm_model_id のリスト。
+        """
+        with self.session_factory() as session:
+            annotated_model_ids = (
+                select(Model.litellm_model_id)
+                .where(
+                    or_(
+                        Model.id.in_(select(Tag.model_id).distinct()),
+                        Model.id.in_(select(Caption.model_id).distinct()),
+                        Model.id.in_(select(Score.model_id).distinct()),
+                    )
+                )
+                .order_by(Model.id.desc())
+                .limit(limit)
+            )
+            return list(session.execute(annotated_model_ids).scalars().all())

--- a/src/lorairo/gui/services/search_filter_service.py
+++ b/src/lorairo/gui/services/search_filter_service.py
@@ -434,3 +434,18 @@ class SearchFilterService:
         except SQLAlchemyError as e:
             logger.error(f"最近使用モデル取得エラー: {e}", exc_info=True)
             return []
+
+    def get_created_at_histogram(self, bins: int = 20) -> list[tuple[datetime, datetime, int]]:
+        """Image.created_at 分布ヒストグラムを取得する。
+
+        Args:
+            bins: ヒストグラムのビン数（デフォルト 20）。
+
+        Returns:
+            (bin_start, bin_end, count) のリスト。エラー時は空リスト。
+        """
+        try:
+            return self.db_manager.get_created_at_histogram(bins=bins)
+        except SQLAlchemyError as e:
+            logger.error(f"ヒストグラム取得エラー: {e}", exc_info=True)
+            return []

--- a/src/lorairo/gui/services/search_filter_service.py
+++ b/src/lorairo/gui/services/search_filter_service.py
@@ -4,6 +4,8 @@ from dataclasses import dataclass
 from datetime import datetime
 from typing import Any
 
+from sqlalchemy.exc import SQLAlchemyError
+
 from ...database.db_manager import ImageDatabaseManager
 from ...services.model_registry_protocol import (
     ModelRegistryServiceProtocol,
@@ -119,6 +121,10 @@ class SearchFilterService:
         include_unrated: bool = True,
         score_min: float | None = None,
         score_max: float | None = None,
+        manual_edit_filter: bool | None = None,
+        reviewed_at_filter: str | None = None,
+        error_state_filter: str | None = None,
+        model_filter: list[str] | None = None,
     ) -> SearchConditions:
         """UIフォームデータからSearchConditionsオブジェクトを作成
 
@@ -151,6 +157,10 @@ class SearchFilterService:
             include_unrated=include_unrated,
             score_min=score_min,
             score_max=score_max,
+            manual_edit_filter=manual_edit_filter,
+            reviewed_at_filter=reviewed_at_filter,
+            error_state_filter=error_state_filter,
+            model_filter=model_filter,
         )
 
         self.current_conditions = conditions
@@ -231,6 +241,24 @@ class SearchFilterService:
             return ["高度なモデルフィルター有効"]
         return []
 
+    def _format_phase4_parts(self, conditions: SearchConditions) -> list[str]:
+        """Phase 4 facet の検索プレビューパーツを返す。"""
+        parts: list[str] = []
+        if conditions.manual_edit_filter is not None:
+            label = "手動編集あり" if conditions.manual_edit_filter else "手動編集なし"
+            parts.append(label)
+        if conditions.reviewed_at_filter == "unreviewed":
+            parts.append("未レビュー")
+        elif conditions.reviewed_at_filter == "reviewed":
+            parts.append("レビュー済み")
+        if conditions.error_state_filter == "has_error":
+            parts.append("エラーあり")
+        elif conditions.error_state_filter == "no_error":
+            parts.append("エラーなし")
+        if conditions.model_filter:
+            parts.append(f"モデル: {', '.join(conditions.model_filter)}")
+        return parts
+
     def create_search_preview(self, conditions: SearchConditions) -> str:
         """人間が読みやすい検索条件プレビューの生成
 
@@ -247,6 +275,7 @@ class SearchFilterService:
         preview_parts.extend(self._format_flag_parts(conditions))
         preview_parts.extend(self._format_rating_parts(conditions))
         preview_parts.extend(self._format_model_parts(conditions))
+        preview_parts.extend(self._format_phase4_parts(conditions))
 
         if not preview_parts:
             return "すべての画像"
@@ -390,3 +419,18 @@ class SearchFilterService:
         except Exception as e:
             logger.error(f"状態カウント取得エラー: {e}", exc_info=True)
             return AnnotationStatusCounts()  # デフォルト値（全て0）
+
+    def get_recently_used_model_ids(self, limit: int = 10) -> list[str]:
+        """アノテーション実績があるモデルの litellm_model_id を返す。
+
+        Args:
+            limit: 最大件数（デフォルト 10）。
+
+        Returns:
+            litellm_model_id のリスト。エラー時は空リスト。
+        """
+        try:
+            return self.db_manager.get_recently_used_model_ids(limit=limit)
+        except SQLAlchemyError as e:
+            logger.error(f"最近使用モデル取得エラー: {e}", exc_info=True)
+            return []

--- a/src/lorairo/gui/widgets/date_histogram_widget.py
+++ b/src/lorairo/gui/widgets/date_histogram_widget.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import datetime
+
+from PySide6.QtCore import QSize, Signal
+from PySide6.QtGui import QColor, QMouseEvent, QPaintEvent, QPainter
+from PySide6.QtWidgets import QWidget
+
+
+class DateHistogramWidget(QWidget):
+    """Image.created_at 分布ヒストグラム表示ウィジェット。
+
+    バーをクリックすることで日付範囲フィルタを適用できる。
+    """
+
+    range_selected = Signal(datetime.datetime, datetime.datetime)
+
+    def __init__(self, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        self._bins: list[tuple[datetime.datetime, datetime.datetime, int]] = []
+        self._selected_idx: int | None = None
+        self.setMinimumHeight(50)
+        self.setToolTip("クリックして日付範囲でフィルタ")
+
+    def update_histogram(self, bins: list[tuple[datetime.datetime, datetime.datetime, int]]) -> None:
+        """ヒストグラムデータを更新して再描画する。
+
+        Args:
+            bins: (bin_start, bin_end, count) のリスト。空リストでクリア。
+        """
+        self._bins = bins
+        self._selected_idx = None
+        self.update()
+
+    def clear(self) -> None:
+        """ヒストグラムをクリアして空状態にする。"""
+        self._bins = []
+        self._selected_idx = None
+        self.update()
+
+    def sizeHint(self) -> QSize:
+        """推奨サイズを返す。"""
+        return QSize(300, 80)
+
+    def paintEvent(self, event: QPaintEvent) -> None:
+        """バーを描画する。"""
+        if not self._bins:
+            return
+        painter = QPainter(self)
+        painter.setRenderHint(QPainter.RenderHint.Antialiasing)
+        w = self.width()
+        h = self.height()
+        max_count = max(c for _, _, c in self._bins) or 1
+        bar_w = w / len(self._bins)
+        for i, (_, _, count) in enumerate(self._bins):
+            bar_h = max(2, int(count / max_count * h * 0.85))
+            x = int(i * bar_w)
+            color = QColor("#cc5555") if i == self._selected_idx else QColor("#5588cc")
+            painter.fillRect(x + 1, h - bar_h, int(bar_w) - 2, bar_h, color)
+        painter.end()
+
+    def mousePressEvent(self, event: QMouseEvent) -> None:
+        """クリックされたバーに対応する range_selected シグナルを発火する。"""
+        if not self._bins:
+            return
+        bar_w = self.width() / len(self._bins)
+        idx = int(event.position().x() / bar_w)
+        idx = max(0, min(idx, len(self._bins) - 1))
+        self._selected_idx = idx
+        self.update()
+        start, end, _ = self._bins[idx]
+        self.range_selected.emit(start, end)

--- a/src/lorairo/gui/widgets/filter_search_panel.py
+++ b/src/lorairo/gui/widgets/filter_search_panel.py
@@ -22,7 +22,7 @@ import 互換性: `PipelineState` Enum は本モジュールから引き続き e
 """
 
 from datetime import datetime
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 from PySide6.QtCore import Signal
 from PySide6.QtGui import QCloseEvent
@@ -39,6 +39,7 @@ from .filter_search import (
     PipelineStateMachine,
     TagSuggestionWidget,
 )
+from .search_facets_sidebar import SearchFacetsSidebar
 
 # 後方互換性: 旧 import path から PipelineState を export する
 __all__ = ["FilterSearchPanel", "PipelineState"]
@@ -82,6 +83,8 @@ class FilterSearchPanel(QScrollArea):
         self._tag_suggestion = TagSuggestionWidget(self)
         self._count_estimate = CountEstimateWidget(self)
         self._favorite_filter = FavoriteFilterPanel(self)
+        self._search_facets_sidebar = SearchFacetsSidebar(self)
+        self._facet_values: dict[str, object] = {}
 
         # 現在の SearchWorker の ID
         self._current_search_worker_id: str | None = None
@@ -235,10 +238,12 @@ class FilterSearchPanel(QScrollArea):
         self.ui.checkboxIncludeNSFW.setVisible(False)
 
         # お気に入りフィルター UI をメインレイアウトに追加
+        # Phase 4: Search サイドバー（フィルター UI の最後に追加）
         contents_layout = self.ui.scrollAreaWidgetContents.layout()
         if isinstance(contents_layout, QBoxLayout):
             insert_index = contents_layout.count() - 1
             contents_layout.insertWidget(insert_index, self._favorite_filter)
+            contents_layout.addWidget(self._search_facets_sidebar)
 
     def _setup_sub_components(self) -> None:
         """Sub-component の依存と連携を設定する。"""
@@ -294,6 +299,9 @@ class FilterSearchPanel(QScrollArea):
         self.date_range_slider.valueChanged.connect(self._on_filter_value_changed)
         self.score_range_slider.valueChanged.connect(self._on_filter_value_changed)
 
+        # Phase 4: facets サイドバー
+        self._search_facets_sidebar.facets_changed.connect(self._on_facets_changed)
+
     # ============================================================
     # ===  依存注入 setter (外部 API)
     # ============================================================
@@ -337,6 +345,14 @@ class FilterSearchPanel(QScrollArea):
             logger.warning(f"SearchFilterService missing methods: {missing}")
         else:
             logger.debug("SearchFilterService method validation: OK")
+
+        # Phase 4: 初期化時にモデルリストとヒストグラムを更新
+        if hasattr(service, "get_recently_used_model_ids"):
+            model_ids = service.get_recently_used_model_ids()
+            self._search_facets_sidebar.update_models(model_ids)
+        if hasattr(service, "get_created_at_histogram"):
+            histogram_bins = service.get_created_at_histogram()
+            self._search_facets_sidebar.update_histogram(histogram_bins)
 
     def set_tag_suggestion_service(self, service: "TagSuggestionService | None") -> None:
         """TagSuggestionService を設定する (旧 API 互換)。"""
@@ -721,6 +737,7 @@ class FilterSearchPanel(QScrollArea):
 
         score_min_internal, score_max_internal = self.score_range_slider.get_range()
         has_score_filter = score_min_internal != 0 or score_max_internal != 1000
+        has_facet_filter = any(v is not None for v in self._facet_values.values())
 
         if not keywords and not any(
             [
@@ -732,6 +749,7 @@ class FilterSearchPanel(QScrollArea):
                 self.ui.comboRating.currentText() != "----",
                 self.ui.comboAIRating.currentText() != "----",
                 has_score_filter,
+                has_facet_filter,
             ],
         ):
             logger.debug("検索条件が未指定のため検索をスキップ")
@@ -770,7 +788,16 @@ class FilterSearchPanel(QScrollArea):
             include_unrated=self.ui.checkboxIncludeUnrated.isChecked(),
             score_min=score_min,
             score_max=score_max,
+            manual_edit_filter=cast(bool | None, self._facet_values.get("manual_edit_filter")),
+            reviewed_at_filter=cast(str | None, self._facet_values.get("reviewed_at_filter")),
+            error_state_filter=cast(str | None, self._facet_values.get("error_state_filter")),
+            model_filter=cast(list[str] | None, self._facet_values.get("model_filter")),
         )
+
+    def _on_facets_changed(self, facets: dict[str, object]) -> None:
+        """Phase 4 facet 変化ハンドラ: facet 値を保存して検索を再実行する。"""
+        self._facet_values = facets
+        self._on_search_requested()
 
     def _on_search_requested(self) -> None:
         """検索要求処理: WorkerService 経由で非同期実行 (フォールバック: 同期)。"""

--- a/src/lorairo/gui/widgets/search_facets_sidebar.py
+++ b/src/lorairo/gui/widgets/search_facets_sidebar.py
@@ -1,0 +1,196 @@
+from __future__ import annotations
+
+import datetime
+
+from PySide6.QtWidgets import (
+    QButtonGroup,
+    QGroupBox,
+    QHBoxLayout,
+    QLabel,
+    QListWidget,
+    QRadioButton,
+    QScrollArea,
+    QVBoxLayout,
+    QWidget,
+)
+
+from lorairo.gui.widgets.date_histogram_widget import DateHistogramWidget
+
+
+class SearchFacetsSidebar(QWidget):
+    """検索ファセットサイドバーウィジェット。
+
+    手動編集・レビュー状態・エラー状態・モデル・登録日のファセットフィルタを提供する。
+    ファセット値が変化したとき facets_changed シグナルを発火する。
+    """
+
+    from PySide6.QtCore import Signal
+
+    facets_changed = Signal(dict)
+
+    def __init__(self, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        self._created_at_range: tuple[datetime.datetime, datetime.datetime] | None = None
+        self._setup_ui()
+
+    def _setup_ui(self) -> None:
+        """UIコンポーネントを初期化・配置する。"""
+        scroll_area = QScrollArea(self)
+        scroll_area.setWidgetResizable(True)
+
+        container = QWidget()
+        layout = QVBoxLayout(container)
+        layout.setContentsMargins(4, 4, 4, 4)
+        layout.setSpacing(6)
+
+        # 手動編集セクション
+        manual_box, self._manual_edit_group, self._manual_edit_buttons = self._make_radio_section(
+            "手動編集", ["全て", "あり", "なし"]
+        )
+        layout.addWidget(manual_box)
+
+        # レビュー状態セクション
+        reviewed_box, self._reviewed_group, self._reviewed_buttons = self._make_radio_section(
+            "レビュー", ["全て", "未レビュー", "済み"]
+        )
+        layout.addWidget(reviewed_box)
+
+        # エラー状態セクション
+        error_box, self._error_group, self._error_buttons = self._make_radio_section(
+            "エラー", ["全て", "あり", "なし"]
+        )
+        layout.addWidget(error_box)
+
+        # モデルセクション
+        model_box = QGroupBox("モデル")
+        model_layout = QVBoxLayout(model_box)
+        self._model_list = QListWidget()
+        self._model_list.setSelectionMode(QListWidget.SelectionMode.MultiSelection)
+        self._model_list.setMaximumHeight(120)
+        model_layout.addWidget(self._model_list)
+        layout.addWidget(model_box)
+
+        # 登録日セクション
+        date_box = QGroupBox("登録日")
+        date_layout = QVBoxLayout(date_box)
+        self._histogram = DateHistogramWidget()
+        date_layout.addWidget(self._histogram)
+        layout.addWidget(date_box)
+
+        layout.addStretch()
+        scroll_area.setWidget(container)
+
+        outer = QVBoxLayout(self)
+        outer.setContentsMargins(0, 0, 0, 0)
+        outer.addWidget(scroll_area)
+
+        # シグナル接続
+        self._manual_edit_group.buttonClicked.connect(lambda _: self._emit_facets_changed())
+        self._reviewed_group.buttonClicked.connect(lambda _: self._emit_facets_changed())
+        self._error_group.buttonClicked.connect(lambda _: self._emit_facets_changed())
+        self._model_list.itemSelectionChanged.connect(self._emit_facets_changed)
+        self._histogram.range_selected.connect(self._on_range_selected)
+
+    def _make_radio_section(
+        self, title: str, labels: list[str]
+    ) -> tuple[QGroupBox, QButtonGroup, list[QRadioButton]]:
+        """ラジオボタングループを含む QGroupBox を生成する。
+
+        Args:
+            title: グループボックスのタイトル。
+            labels: ラジオボタンのラベルリスト。先頭ボタンがデフォルト選択。
+
+        Returns:
+            (QGroupBox, QButtonGroup, ラジオボタンリスト) のタプル。
+        """
+        group_box = QGroupBox(title)
+        layout = QHBoxLayout(group_box)
+        btn_group = QButtonGroup(self)
+        btn_group.setExclusive(True)
+        buttons: list[QRadioButton] = []
+        for i, label in enumerate(labels):
+            rb = QRadioButton(label)
+            if i == 0:
+                rb.setChecked(True)
+            layout.addWidget(rb)
+            btn_group.addButton(rb, i)
+            buttons.append(rb)
+        return group_box, btn_group, buttons
+
+    def _get_radio_value(self, btn_group: QButtonGroup, values: list[object]) -> object:
+        """選択中ラジオボタンに対応する値を返す。
+
+        Args:
+            btn_group: 対象の QButtonGroup。
+            values: ボタンインデックスに対応する値リスト。
+
+        Returns:
+            選択中インデックスに対応する値。インデックス範囲外なら values[0]。
+        """
+        idx = btn_group.checkedId()
+        if idx < 0 or idx >= len(values):
+            return values[0]
+        return values[idx]
+
+    def _on_range_selected(self, start: datetime.datetime, end: datetime.datetime) -> None:
+        """ヒストグラムの range_selected シグナルを受け取って facets_changed を発火する。"""
+        self._created_at_range = (start, end)
+        self._emit_facets_changed()
+
+    def _emit_facets_changed(self) -> None:
+        """現在のファセット値を facets_changed シグナルで emit する。"""
+        self.facets_changed.emit(self.get_facet_values())
+
+    def get_facet_values(self) -> dict[str, object]:
+        """現在のすべての facet 値を返す。
+
+        Returns:
+            以下のキーを持つ辞書:
+                manual_edit_filter: True/False/None
+                reviewed_at_filter: "unreviewed"/"reviewed"/None
+                error_state_filter: "has_error"/"no_error"/None
+                model_filter: litellm_model_id のリスト / None
+                created_at_range: (start, end) タプル / None
+        """
+        manual_edit_filter = self._get_radio_value(self._manual_edit_group, [None, True, False])
+        reviewed_at_filter = self._get_radio_value(self._reviewed_group, [None, "unreviewed", "reviewed"])
+        error_state_filter = self._get_radio_value(self._error_group, [None, "has_error", "no_error"])
+
+        selected_items = self._model_list.selectedItems()
+        model_filter: list[str] | None = (
+            [item.text() for item in selected_items] if selected_items else None
+        )
+
+        return {
+            "manual_edit_filter": manual_edit_filter,
+            "reviewed_at_filter": reviewed_at_filter,
+            "error_state_filter": error_state_filter,
+            "model_filter": model_filter,
+            "created_at_range": self._created_at_range,
+        }
+
+    def update_models(self, model_ids: list[str]) -> None:
+        """モデルフィルタ用リストに model_ids を設定する。
+
+        Args:
+            model_ids: litellm_model_id のリスト。
+        """
+        self._model_list.clear()
+        self._model_list.addItems(model_ids)
+
+    def update_histogram(self, bins: list[tuple[datetime.datetime, datetime.datetime, int]]) -> None:
+        """DATE ヒストグラムにデータを渡す。
+
+        Args:
+            bins: (bin_start, bin_end, count) のリスト。
+        """
+        self._histogram.update_histogram(bins)
+
+    def clear_all(self) -> None:
+        """すべての facet を初期値（全て）にリセットする。"""
+        # ラジオボタンを先頭（全て）に戻す
+        for buttons in (self._manual_edit_buttons, self._reviewed_buttons, self._error_buttons):
+            buttons[0].setChecked(True)
+        self._model_list.clearSelection()
+        self._created_at_range = None
+        self._histogram.clear()

--- a/src/lorairo/services/search_models.py
+++ b/src/lorairo/services/search_models.py
@@ -48,6 +48,12 @@ class SearchConditions:
     score_min: float | None = None  # 最小スコア値（0.0-10.0）
     score_max: float | None = None  # 最大スコア値（0.0-10.0）
 
+    # Phase 4: Search サイドバー強化 facet fields
+    manual_edit_filter: bool | None = None  # 手動編集あり/なし/全て
+    reviewed_at_filter: str | None = None  # "unreviewed" | "reviewed" | None=全て
+    error_state_filter: str | None = None  # "has_error" | "no_error" | None=全て
+    model_filter: list[str] | None = None  # litellm_id リスト。None=全モデル
+
     def to_filter_criteria(self) -> ImageFilterCriteria:
         """DB層のImageFilterCriteriaオブジェクトに変換
 
@@ -71,6 +77,10 @@ class SearchConditions:
             ai_rating_filter=self.ai_rating_filter,
             score_min=self.score_min,
             score_max=self.score_max,
+            manual_edit_filter=self.manual_edit_filter,
+            reviewed_at_filter=self.reviewed_at_filter,
+            error_state_filter=self.error_state_filter,
+            model_filter=self.model_filter,
         )
 
     def to_db_filter_args(self) -> dict[str, Any]:

--- a/tests/integration/gui/test_filter_search_integration.py
+++ b/tests/integration/gui/test_filter_search_integration.py
@@ -60,6 +60,8 @@ class TestFilterSearchIntegration:
 
         mock_db_manager.get_images_by_filter.return_value = (mock_images, 2)
         mock_db_manager.check_image_has_annotation.return_value = True
+        mock_db_manager.get_recently_used_model_ids.return_value = []
+        mock_db_manager.get_created_at_histogram.return_value = []
 
         return {
             "db_manager": mock_db_manager,
@@ -485,6 +487,8 @@ class TestEndToEndIntegration:
         ]
         mock_db_manager.get_images_by_filter.return_value = (sample_images, 1)
         mock_db_manager.check_image_has_annotation.return_value = True
+        mock_db_manager.get_recently_used_model_ids.return_value = []
+        mock_db_manager.get_created_at_histogram.return_value = []
 
         # サービス層構築
         criteria_processor = SearchCriteriaProcessor(mock_db_manager)
@@ -613,8 +617,11 @@ class TestScoreFilterValues:
     @pytest.fixture
     def mock_dependencies(self):
         """統合テスト用モック"""
+        db_manager = Mock()
+        db_manager.get_recently_used_model_ids.return_value = []
+        db_manager.get_created_at_histogram.return_value = []
         return {
-            "db_manager": Mock(),
+            "db_manager": db_manager,
             "model_selection_service": Mock(),
         }
 

--- a/tests/unit/database/test_image_repo_phase4.py
+++ b/tests/unit/database/test_image_repo_phase4.py
@@ -1,0 +1,468 @@
+"""Phase 4 Search facets の ImageRepository フィルタテスト。
+
+_apply_reviewed_at_filter / _apply_error_state_filter / _apply_model_filter の
+クエリビルダー単体テストおよび get_recently_used_model_ids のテスト。
+"""
+
+import uuid
+
+import pytest
+from sqlalchemy import create_engine, select
+from sqlalchemy.orm import sessionmaker
+
+from lorairo.database.repository.image import ImageRepository
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_session_factory():
+    """in-memory SQLite セッションファクトリ（schema 全テーブル）。"""
+    from lorairo.database.schema import Base
+
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    return sessionmaker(engine)
+
+
+def _create_image(session_factory, reviewed_at=None):
+    """テスト用 Image を1件作成して id を返す。"""
+    from lorairo.database.schema import Image
+
+    with session_factory() as session:
+        img = Image(
+            uuid=str(uuid.uuid4()),
+            phash=f"aa{uuid.uuid4().hex[:10]}",
+            original_image_path=f"/tmp/{uuid.uuid4().hex}.png",
+            stored_image_path=f"/tmp/{uuid.uuid4().hex}.png",
+            width=100,
+            height=100,
+            format="PNG",
+            extension="png",
+            reviewed_at=reviewed_at,
+        )
+        session.add(img)
+        session.commit()
+        return img.id
+
+
+def _create_error_record(session_factory, image_id: int, resolved_at=None):
+    """テスト用 ErrorRecord を1件作成する。"""
+    from lorairo.database.schema import ErrorRecord
+
+    with session_factory() as session:
+        record = ErrorRecord(
+            image_id=image_id,
+            operation_type="annotation",
+            error_type="APIError",
+            error_message="test error",
+            resolved_at=resolved_at,
+        )
+        session.add(record)
+        session.commit()
+        return record.id
+
+
+def _create_model_with_tag(session_factory, litellm_model_id: str, image_id: int):
+    """テスト用 Model と Tag を作成して model.id を返す。"""
+    from lorairo.database.schema import Model, Tag
+
+    with session_factory() as session:
+        model = Model(
+            name=f"model_{uuid.uuid4().hex[:6]}",
+            litellm_model_id=litellm_model_id,
+        )
+        session.add(model)
+        session.flush()
+        tag = Tag(
+            image_id=image_id,
+            model_id=model.id,
+            tag="test_tag",
+        )
+        session.add(tag)
+        session.commit()
+        return model.id
+
+
+# ---------------------------------------------------------------------------
+# _apply_reviewed_at_filter
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestApplyReviewedAtFilter:
+    """_apply_reviewed_at_filter() メソッドのクエリビルダーテスト。"""
+
+    @pytest.fixture
+    def repository(self):
+        from unittest.mock import Mock
+
+        return ImageRepository(session_factory=Mock())
+
+    def test_unreviewed_filter_modifies_query(self, repository):
+        """ "unreviewed" 指定でクエリが変更される。"""
+        from lorairo.database.schema import Image
+
+        base_query = select(Image.id)
+        result = repository._apply_reviewed_at_filter(base_query, "unreviewed")
+        assert result is not None
+        assert result != base_query
+
+    def test_reviewed_filter_modifies_query(self, repository):
+        """ "reviewed" 指定でクエリが変更される。"""
+        from lorairo.database.schema import Image
+
+        base_query = select(Image.id)
+        result = repository._apply_reviewed_at_filter(base_query, "reviewed")
+        assert result is not None
+        assert result != base_query
+
+    def test_none_filter_does_not_modify_query(self, repository):
+        """None 指定でクエリが変更されない。"""
+        from lorairo.database.schema import Image
+
+        base_query = select(Image.id)
+        result = repository._apply_reviewed_at_filter(base_query, None)
+        assert result == base_query
+
+    def test_unknown_value_does_not_modify_query(self, repository):
+        """未知の値でクエリが変更されない。"""
+        from lorairo.database.schema import Image
+
+        base_query = select(Image.id)
+        result = repository._apply_reviewed_at_filter(base_query, "invalid_value")
+        assert result == base_query
+
+
+@pytest.mark.unit
+class TestApplyReviewedAtFilterIntegration:
+    """_apply_reviewed_at_filter() の DB 実行テスト。"""
+
+    @pytest.fixture
+    def session_factory(self):
+        return _make_session_factory()
+
+    @pytest.fixture
+    def repository(self, session_factory):
+        return ImageRepository(session_factory=session_factory)
+
+    def test_unreviewed_filter_excludes_reviewed_images(self, repository, session_factory):
+        """ "unreviewed" で reviewed_at IS NULL の画像のみ返る。"""
+        import datetime
+
+        from lorairo.database.schema import Image
+
+        id_unreviewed = _create_image(session_factory, reviewed_at=None)
+        id_reviewed = _create_image(
+            session_factory,
+            reviewed_at=datetime.datetime(2025, 1, 1, tzinfo=datetime.timezone.utc),
+        )
+
+        base_query = select(Image.id)
+        with session_factory() as session:
+            filtered = repository._apply_reviewed_at_filter(base_query, "unreviewed")
+            result_ids = list(session.execute(filtered).scalars().all())
+
+        assert id_unreviewed in result_ids
+        assert id_reviewed not in result_ids
+
+    def test_reviewed_filter_excludes_unreviewed_images(self, repository, session_factory):
+        """ "reviewed" で reviewed_at IS NOT NULL の画像のみ返る。"""
+        import datetime
+
+        from lorairo.database.schema import Image
+
+        id_unreviewed = _create_image(session_factory, reviewed_at=None)
+        id_reviewed = _create_image(
+            session_factory,
+            reviewed_at=datetime.datetime(2025, 1, 1, tzinfo=datetime.timezone.utc),
+        )
+
+        base_query = select(Image.id)
+        with session_factory() as session:
+            filtered = repository._apply_reviewed_at_filter(base_query, "reviewed")
+            result_ids = list(session.execute(filtered).scalars().all())
+
+        assert id_reviewed in result_ids
+        assert id_unreviewed not in result_ids
+
+    def test_none_filter_returns_all(self, repository, session_factory):
+        """None 指定で全件返る。"""
+        import datetime
+
+        from lorairo.database.schema import Image
+
+        id_unreviewed = _create_image(session_factory, reviewed_at=None)
+        id_reviewed = _create_image(
+            session_factory,
+            reviewed_at=datetime.datetime(2025, 1, 1, tzinfo=datetime.timezone.utc),
+        )
+
+        base_query = select(Image.id)
+        with session_factory() as session:
+            filtered = repository._apply_reviewed_at_filter(base_query, None)
+            result_ids = list(session.execute(filtered).scalars().all())
+
+        assert id_unreviewed in result_ids
+        assert id_reviewed in result_ids
+
+
+# ---------------------------------------------------------------------------
+# _apply_error_state_filter
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestApplyErrorStateFilter:
+    """_apply_error_state_filter() メソッドのクエリビルダーテスト。"""
+
+    @pytest.fixture
+    def repository(self):
+        from unittest.mock import Mock
+
+        return ImageRepository(session_factory=Mock())
+
+    def test_has_error_filter_modifies_query(self, repository):
+        """ "has_error" 指定でクエリが変更される。"""
+        from lorairo.database.schema import Image
+
+        base_query = select(Image.id)
+        result = repository._apply_error_state_filter(base_query, "has_error")
+        assert result is not None
+        assert result != base_query
+
+    def test_no_error_filter_modifies_query(self, repository):
+        """ "no_error" 指定でクエリが変更される。"""
+        from lorairo.database.schema import Image
+
+        base_query = select(Image.id)
+        result = repository._apply_error_state_filter(base_query, "no_error")
+        assert result is not None
+        assert result != base_query
+
+    def test_none_filter_does_not_modify_query(self, repository):
+        """None 指定でクエリが変更されない。"""
+        from lorairo.database.schema import Image
+
+        base_query = select(Image.id)
+        result = repository._apply_error_state_filter(base_query, None)
+        assert result == base_query
+
+    def test_unknown_value_does_not_modify_query(self, repository):
+        """未知の値でクエリが変更されない。"""
+        from lorairo.database.schema import Image
+
+        base_query = select(Image.id)
+        result = repository._apply_error_state_filter(base_query, "unknown_state")
+        assert result == base_query
+
+
+@pytest.mark.unit
+class TestApplyErrorStateFilterIntegration:
+    """_apply_error_state_filter() の DB 実行テスト。"""
+
+    @pytest.fixture
+    def session_factory(self):
+        return _make_session_factory()
+
+    @pytest.fixture
+    def repository(self, session_factory):
+        return ImageRepository(session_factory=session_factory)
+
+    def test_has_error_returns_only_images_with_unresolved_errors(self, repository, session_factory):
+        """ "has_error" で未解決エラーを持つ画像のみ返る。"""
+        from lorairo.database.schema import Image
+
+        id_with_error = _create_image(session_factory)
+        id_no_error = _create_image(session_factory)
+        _create_error_record(session_factory, id_with_error, resolved_at=None)
+
+        base_query = select(Image.id)
+        with session_factory() as session:
+            filtered = repository._apply_error_state_filter(base_query, "has_error")
+            result_ids = list(session.execute(filtered).scalars().all())
+
+        assert id_with_error in result_ids
+        assert id_no_error not in result_ids
+
+    def test_no_error_excludes_images_with_unresolved_errors(self, repository, session_factory):
+        """ "no_error" で未解決エラーを持つ画像が除外される。"""
+        from lorairo.database.schema import Image
+
+        id_with_error = _create_image(session_factory)
+        id_no_error = _create_image(session_factory)
+        _create_error_record(session_factory, id_with_error, resolved_at=None)
+
+        base_query = select(Image.id)
+        with session_factory() as session:
+            filtered = repository._apply_error_state_filter(base_query, "no_error")
+            result_ids = list(session.execute(filtered).scalars().all())
+
+        assert id_no_error in result_ids
+        assert id_with_error not in result_ids
+
+    def test_resolved_error_counted_as_no_error(self, repository, session_factory):
+        """解決済み（resolved_at IS NOT NULL）のエラーは "has_error" に数えない。"""
+        import datetime
+
+        from lorairo.database.schema import Image
+
+        id_with_resolved_error = _create_image(session_factory)
+        _create_error_record(
+            session_factory,
+            id_with_resolved_error,
+            resolved_at=datetime.datetime(2025, 1, 1, tzinfo=datetime.timezone.utc),
+        )
+
+        base_query = select(Image.id)
+        with session_factory() as session:
+            # 解決済みエラーのみの画像は "has_error" に該当しない
+            filtered = repository._apply_error_state_filter(base_query, "has_error")
+            result_ids = list(session.execute(filtered).scalars().all())
+        assert id_with_resolved_error not in result_ids
+
+        with session_factory() as session:
+            # "no_error" には該当する
+            filtered = repository._apply_error_state_filter(base_query, "no_error")
+            result_ids = list(session.execute(filtered).scalars().all())
+        assert id_with_resolved_error in result_ids
+
+
+# ---------------------------------------------------------------------------
+# _apply_model_filter
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestApplyModelFilter:
+    """_apply_model_filter() メソッドのクエリビルダーテスト。"""
+
+    @pytest.fixture
+    def repository(self):
+        from unittest.mock import Mock
+
+        return ImageRepository(session_factory=Mock())
+
+    def test_model_filter_with_ids_modifies_query(self, repository):
+        """model_filter 指定でクエリが変更される。"""
+        from lorairo.database.schema import Image
+
+        base_query = select(Image.id)
+        result = repository._apply_model_filter(base_query, ["gpt-4o"])
+        assert result is not None
+        assert result != base_query
+
+    def test_none_model_filter_does_not_modify_query(self, repository):
+        """None 指定でクエリが変更されない。"""
+        from lorairo.database.schema import Image
+
+        base_query = select(Image.id)
+        result = repository._apply_model_filter(base_query, None)
+        assert result == base_query
+
+    def test_empty_list_does_not_modify_query(self, repository):
+        """空リスト指定でクエリが変更されない。"""
+        from lorairo.database.schema import Image
+
+        base_query = select(Image.id)
+        result = repository._apply_model_filter(base_query, [])
+        assert result == base_query
+
+
+@pytest.mark.unit
+class TestApplyModelFilterIntegration:
+    """_apply_model_filter() の DB 実行テスト。"""
+
+    @pytest.fixture
+    def session_factory(self):
+        return _make_session_factory()
+
+    @pytest.fixture
+    def repository(self, session_factory):
+        return ImageRepository(session_factory=session_factory)
+
+    def test_model_filter_returns_only_images_with_annotation_from_model(self, repository, session_factory):
+        """指定モデルのアノテーションを持つ画像のみ返る。"""
+        from lorairo.database.schema import Image
+
+        id_with_model = _create_image(session_factory)
+        id_without_model = _create_image(session_factory)
+        _create_model_with_tag(session_factory, "gpt-4o", id_with_model)
+
+        base_query = select(Image.id)
+        with session_factory() as session:
+            filtered = repository._apply_model_filter(base_query, ["gpt-4o"])
+            result_ids = list(session.execute(filtered).scalars().all())
+
+        assert id_with_model in result_ids
+        assert id_without_model not in result_ids
+
+    def test_model_filter_unknown_model_returns_empty(self, repository, session_factory):
+        """存在しないモデルを指定した場合、結果は空になる。"""
+        from lorairo.database.schema import Image
+
+        _create_image(session_factory)
+
+        base_query = select(Image.id)
+        with session_factory() as session:
+            filtered = repository._apply_model_filter(base_query, ["nonexistent-model"])
+            result_ids = list(session.execute(filtered).scalars().all())
+
+        assert result_ids == []
+
+
+# ---------------------------------------------------------------------------
+# get_recently_used_model_ids
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestGetRecentlyUsedModelIds:
+    """get_recently_used_model_ids() メソッドのテスト。"""
+
+    @pytest.fixture
+    def session_factory(self):
+        return _make_session_factory()
+
+    @pytest.fixture
+    def repository(self, session_factory):
+        return ImageRepository(session_factory=session_factory)
+
+    def test_returns_empty_when_no_annotations(self, repository):
+        """アノテーションが1件もない場合、空リストを返す。"""
+        result = repository.get_recently_used_model_ids()
+        assert result == []
+
+    def test_returns_model_ids_with_annotations(self, repository, session_factory):
+        """アノテーション実績があるモデルの litellm_model_id を返す。"""
+        image_id = _create_image(session_factory)
+        _create_model_with_tag(session_factory, "gpt-4o", image_id)
+
+        result = repository.get_recently_used_model_ids()
+        assert "gpt-4o" in result
+
+    def test_does_not_return_models_without_annotations(self, repository, session_factory):
+        """アノテーションなしのモデルは返さない。"""
+        from lorairo.database.schema import Model
+
+        with session_factory() as session:
+            model = Model(
+                name="unused_model",
+                litellm_model_id="unused-model/v1",
+            )
+            session.add(model)
+            session.commit()
+
+        result = repository.get_recently_used_model_ids()
+        assert "unused-model/v1" not in result
+
+    def test_limit_parameter_is_respected(self, repository, session_factory):
+        """limit パラメータで件数が制限される。"""
+        image_id = _create_image(session_factory)
+        for i in range(5):
+            _create_model_with_tag(session_factory, f"model-{i}", image_id)
+
+        result = repository.get_recently_used_model_ids(limit=3)
+        assert len(result) <= 3

--- a/tests/unit/database/test_image_repository_histogram.py
+++ b/tests/unit/database/test_image_repository_histogram.py
@@ -1,0 +1,137 @@
+"""Phase 4: get_created_at_histogram() メソッドのテスト。"""
+
+import datetime
+import uuid
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from lorairo.database.repository.image import ImageRepository
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_session_factory():
+    """in-memory SQLite セッションファクトリ（schema 全テーブル）。"""
+    from lorairo.database.schema import Base
+
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    return sessionmaker(engine)
+
+
+def _create_image(session_factory, created_at: datetime.datetime | None = None):
+    """テスト用 Image を1件作成して id を返す。"""
+    from lorairo.database.schema import Image
+
+    with session_factory() as session:
+        img = Image(
+            uuid=str(uuid.uuid4()),
+            phash=f"aa{uuid.uuid4().hex[:10]}",
+            original_image_path=f"/tmp/{uuid.uuid4().hex}.png",
+            stored_image_path=f"/tmp/{uuid.uuid4().hex}.png",
+            width=100,
+            height=100,
+            format="PNG",
+            extension="png",
+            created_at=created_at,
+        )
+        session.add(img)
+        session.commit()
+        return img.id
+
+
+# ---------------------------------------------------------------------------
+# get_created_at_histogram
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestGetCreatedAtHistogram:
+    """get_created_at_histogram() メソッドのテスト。"""
+
+    @pytest.fixture
+    def session_factory(self):
+        return _make_session_factory()
+
+    @pytest.fixture
+    def repository(self, session_factory):
+        return ImageRepository(session_factory=session_factory)
+
+    def test_empty_db_returns_empty_list(self, repository):
+        """画像が存在しない場合は空リストを返す。"""
+        result = repository.get_created_at_histogram(bins=10)
+        assert result == []
+
+    def test_single_date_returns_single_bin(self, repository, session_factory):
+        """全画像が同一 created_at の場合、1 ビンのみ返す。"""
+        ts = datetime.datetime(2025, 6, 1, 12, 0, 0, tzinfo=datetime.timezone.utc)
+        _create_image(session_factory, created_at=ts)
+        _create_image(session_factory, created_at=ts)
+
+        result = repository.get_created_at_histogram(bins=5)
+        assert len(result) == 1
+        # count は画像数と一致
+        assert result[0][2] == 2
+
+    def test_returns_bins_count_tuples(self, repository, session_factory):
+        """bins 数と一致するタプルリストを返す。"""
+        base = datetime.datetime(2025, 1, 1, tzinfo=datetime.timezone.utc)
+        for i in range(20):
+            _create_image(
+                session_factory,
+                created_at=base + datetime.timedelta(days=i),
+            )
+
+        bins = 5
+        result = repository.get_created_at_histogram(bins=bins)
+        assert len(result) == bins
+
+    def test_total_count_equals_image_count(self, repository, session_factory):
+        """全ビンのカウント合計が総画像数と一致する。"""
+        base = datetime.datetime(2025, 1, 1, tzinfo=datetime.timezone.utc)
+        image_count = 15
+        for i in range(image_count):
+            _create_image(
+                session_factory,
+                created_at=base + datetime.timedelta(hours=i),
+            )
+
+        result = repository.get_created_at_histogram(bins=10)
+        total = sum(entry[2] for entry in result)
+        assert total == image_count
+
+    def test_bins_are_chronologically_ordered(self, repository, session_factory):
+        """ビンの開始時刻が昇順に並んでいる。"""
+        base = datetime.datetime(2025, 1, 1, tzinfo=datetime.timezone.utc)
+        for i in range(10):
+            _create_image(
+                session_factory,
+                created_at=base + datetime.timedelta(days=i),
+            )
+
+        result = repository.get_created_at_histogram(bins=5)
+        starts = [entry[0] for entry in result]
+        assert starts == sorted(starts)
+
+    def test_each_entry_is_tuple_of_datetime_datetime_int(self, repository, session_factory):
+        """各エントリが (datetime, datetime, int) の形式である。"""
+        base = datetime.datetime(2025, 3, 1, tzinfo=datetime.timezone.utc)
+        for i in range(6):
+            _create_image(
+                session_factory,
+                created_at=base + datetime.timedelta(days=i),
+            )
+
+        result = repository.get_created_at_histogram(bins=3)
+        for entry in result:
+            assert len(entry) == 3
+            bin_start, bin_end, count = entry
+            assert isinstance(bin_start, datetime.datetime)
+            assert isinstance(bin_end, datetime.datetime)
+            assert isinstance(count, int)
+            assert bin_start <= bin_end

--- a/tests/unit/gui/widgets/test_date_histogram_widget.py
+++ b/tests/unit/gui/widgets/test_date_histogram_widget.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+import datetime
+
+import pytest
+from PySide6.QtCore import QPoint, Qt
+
+from lorairo.gui.widgets.date_histogram_widget import DateHistogramWidget
+
+
+@pytest.mark.unit
+@pytest.mark.gui
+class TestDateHistogramWidget:
+    def test_initial_state_is_empty(self, qtbot: pytest.FixtureRequest) -> None:
+        """初期状態でビンが空であることを確認する。"""
+        widget = DateHistogramWidget()
+        qtbot.addWidget(widget)
+        assert widget._bins == []
+
+    def test_update_histogram_sets_bins(self, qtbot: pytest.FixtureRequest) -> None:
+        """update_histogram がビンデータを正しく設定することを確認する。"""
+        widget = DateHistogramWidget()
+        qtbot.addWidget(widget)
+        now = datetime.datetime.now(datetime.UTC)
+        bins = [(now, now + datetime.timedelta(days=1), 5)]
+        widget.update_histogram(bins)
+        assert widget._bins == bins
+
+    def test_update_histogram_clears_selected_idx(self, qtbot: pytest.FixtureRequest) -> None:
+        """update_histogram が選択インデックスをリセットすることを確認する。"""
+        widget = DateHistogramWidget()
+        qtbot.addWidget(widget)
+        now = datetime.datetime.now(datetime.UTC)
+        widget.update_histogram([(now, now, 1)])
+        widget._selected_idx = 0
+        widget.update_histogram([(now, now, 2)])
+        assert widget._selected_idx is None
+
+    def test_clear_resets_bins(self, qtbot: pytest.FixtureRequest) -> None:
+        """clear() がビンをクリアすることを確認する。"""
+        widget = DateHistogramWidget()
+        qtbot.addWidget(widget)
+        now = datetime.datetime.now(datetime.UTC)
+        widget.update_histogram([(now, now, 1)])
+        widget.clear()
+        assert widget._bins == []
+
+    def test_clear_resets_selected_idx(self, qtbot: pytest.FixtureRequest) -> None:
+        """clear() が選択インデックスをリセットすることを確認する。"""
+        widget = DateHistogramWidget()
+        qtbot.addWidget(widget)
+        now = datetime.datetime.now(datetime.UTC)
+        widget.update_histogram([(now, now, 1)])
+        widget._selected_idx = 0
+        widget.clear()
+        assert widget._selected_idx is None
+
+    def test_range_selected_signal_emitted_on_click(self, qtbot: pytest.FixtureRequest) -> None:
+        """クリック時に range_selected シグナルが発火することを確認する。"""
+        widget = DateHistogramWidget()
+        qtbot.addWidget(widget)
+        widget.resize(300, 80)
+        now = datetime.datetime.now(datetime.UTC)
+        end = now + datetime.timedelta(days=1)
+        widget.update_histogram([(now, end, 10)])
+
+        with qtbot.waitSignal(widget.range_selected, timeout=3000) as blocker:
+            qtbot.mouseClick(widget, Qt.MouseButton.LeftButton, pos=QPoint(10, 40))
+
+        assert blocker.signal_triggered
+        assert blocker.args[0] == now
+        assert blocker.args[1] == end
+
+    def test_click_sets_selected_idx(self, qtbot: pytest.FixtureRequest) -> None:
+        """クリック後に選択インデックスが設定されることを確認する。"""
+        widget = DateHistogramWidget()
+        qtbot.addWidget(widget)
+        widget.resize(300, 80)
+        now = datetime.datetime.now(datetime.UTC)
+        widget.update_histogram([(now, now, 3), (now, now, 5)])
+
+        qtbot.mouseClick(widget, Qt.MouseButton.LeftButton, pos=QPoint(10, 40))
+        assert widget._selected_idx == 0
+
+    def test_no_signal_when_bins_empty_on_click(self, qtbot: pytest.FixtureRequest) -> None:
+        """ビンが空のときにクリックしてもシグナルが発火しないことを確認する。"""
+        widget = DateHistogramWidget()
+        qtbot.addWidget(widget)
+        widget.resize(300, 80)
+
+        signal_fired = []
+        widget.range_selected.connect(lambda s, e: signal_fired.append((s, e)))
+        qtbot.mouseClick(widget, Qt.MouseButton.LeftButton, pos=QPoint(10, 40))
+
+        assert signal_fired == []
+
+    def test_size_hint(self, qtbot: pytest.FixtureRequest) -> None:
+        """sizeHint が (300, 80) を返すことを確認する。"""
+        widget = DateHistogramWidget()
+        qtbot.addWidget(widget)
+        hint = widget.sizeHint()
+        assert hint.width() == 300
+        assert hint.height() == 80

--- a/tests/unit/gui/widgets/test_filter_search_panel_phase4.py
+++ b/tests/unit/gui/widgets/test_filter_search_panel_phase4.py
@@ -1,0 +1,140 @@
+# tests/unit/gui/widgets/test_filter_search_panel_phase4.py
+"""FilterSearchPanel x SearchFacetsSidebar の統合テスト (Phase 4)。
+
+FilterSearchPanel が SearchFacetsSidebar を組み込み、
+facets_changed シグナルを受け取って検索条件に反映することを検証する。
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from lorairo.gui.widgets.filter_search_panel import FilterSearchPanel
+from lorairo.gui.widgets.search_facets_sidebar import SearchFacetsSidebar
+
+
+@pytest.fixture()
+def panel(qtbot):
+    """FilterSearchPanel インスタンスを作成して qtbot に登録する。"""
+    widget = FilterSearchPanel()
+    qtbot.addWidget(widget)
+    return widget
+
+
+@pytest.fixture()
+def panel_with_service(qtbot):
+    """SearchFilterService が設定された FilterSearchPanel を返す。"""
+    service = MagicMock()
+    service.create_search_conditions = MagicMock(return_value=MagicMock())
+    service.parse_search_input = MagicMock(return_value=([], []))
+    service.get_current_conditions = MagicMock(return_value=None)
+    service.get_recently_used_model_ids = MagicMock(return_value=["openai/gpt-4o", "anthropic/claude-3-5"])
+    service.get_created_at_histogram = MagicMock(return_value=[])
+    service.db_manager = MagicMock()
+    service.db_manager.repository = MagicMock()
+    service.db_manager.repository.merged_reader = None
+
+    widget = FilterSearchPanel()
+    qtbot.addWidget(widget)
+    widget.set_search_filter_service(service)
+    return widget, service
+
+
+@pytest.mark.unit
+@pytest.mark.gui
+class TestSearchFacetsSidebarComposition:
+    """SearchFacetsSidebar が FilterSearchPanel に正しく組み込まれることを検証する。"""
+
+    def test_search_facets_sidebar_is_created(self, panel):
+        """_search_facets_sidebar が SearchFacetsSidebar インスタンスである。"""
+        assert isinstance(panel._search_facets_sidebar, SearchFacetsSidebar)
+
+    def test_facet_values_initialized_empty(self, panel):
+        """_facet_values が空辞書で初期化されている。"""
+        assert panel._facet_values == {}
+
+    def test_search_facets_sidebar_has_parent(self, panel):
+        """_search_facets_sidebar が panel の子孫に含まれる。"""
+        # Qt は addWidget 後に親を layout の所有者に変更するため ancestor チェーンを確認する
+        widget = panel._search_facets_sidebar
+        current = widget
+        found = False
+        for _ in range(10):
+            parent = current.parent()
+            if parent is None:
+                break
+            if parent is panel:
+                found = True
+                break
+            current = parent
+        assert found, "_search_facets_sidebar の ancestor に FilterSearchPanel が含まれない"
+
+
+@pytest.mark.unit
+@pytest.mark.gui
+class TestFacetsChangedSignal:
+    """facets_changed シグナルのハンドリングを検証する。"""
+
+    def test_facets_changed_stores_values(self, panel):
+        """facets_changed シグナルで _facet_values が更新される。"""
+        test_facets: dict[str, object] = {
+            "manual_edit_filter": None,
+            "reviewed_at_filter": "unreviewed",
+            "error_state_filter": None,
+            "model_filter": None,
+            "created_at_range": None,
+        }
+        panel._search_facets_sidebar.facets_changed.emit(test_facets)
+        assert panel._facet_values == test_facets
+
+    def test_facets_changed_triggers_search(self, panel, monkeypatch):
+        """facets_changed シグナルで _on_search_requested が呼ばれる。"""
+        called: list[int] = []
+        monkeypatch.setattr(panel, "_on_search_requested", lambda: called.append(1))
+
+        test_facets: dict[str, object] = {"error_state_filter": "has_error"}
+        panel._search_facets_sidebar.facets_changed.emit(test_facets)
+        assert len(called) == 1
+
+    def test_facet_error_filter_stored(self, panel):
+        """error_state_filter='has_error' が _facet_values に正しく保存される。"""
+        panel._search_facets_sidebar.facets_changed.emit({"error_state_filter": "has_error"})
+        assert panel._facet_values.get("error_state_filter") == "has_error"
+
+    def test_facet_model_filter_stored(self, panel):
+        """model_filter がリストとして _facet_values に保存される。"""
+        model_ids = ["openai/gpt-4o", "anthropic/claude-3-5"]
+        panel._search_facets_sidebar.facets_changed.emit({"model_filter": model_ids})
+        assert panel._facet_values.get("model_filter") == model_ids
+
+
+@pytest.mark.unit
+@pytest.mark.gui
+class TestSetSearchFilterServicePhase4:
+    """set_search_filter_service での Phase 4 初期化を検証する。"""
+
+    def test_update_models_called_on_service_set(self, qtbot):
+        """set_search_filter_service 後に update_models が呼ばれる。"""
+        service = MagicMock()
+        service.create_search_conditions = MagicMock(return_value=MagicMock())
+        service.parse_search_input = MagicMock(return_value=([], []))
+        service.get_current_conditions = MagicMock(return_value=None)
+        service.get_recently_used_model_ids = MagicMock(return_value=["model-a", "model-b"])
+        service.get_created_at_histogram = MagicMock(return_value=[])
+        service.db_manager = MagicMock()
+        service.db_manager.repository = MagicMock()
+        service.db_manager.repository.merged_reader = None
+
+        panel = FilterSearchPanel()
+        qtbot.addWidget(panel)
+        panel.set_search_filter_service(service)
+
+        service.get_recently_used_model_ids.assert_called_once()
+        service.get_created_at_histogram.assert_called_once()
+
+    def test_models_populated_in_sidebar(self, panel_with_service):
+        """サービス設定後にサイドバーのモデルリストが更新される。"""
+        panel, service = panel_with_service
+        # get_recently_used_model_ids で返した 2 件がサイドバーに反映される
+        model_list = panel._search_facets_sidebar._model_list
+        assert model_list.count() == 2

--- a/tests/unit/gui/widgets/test_filter_search_panel_phase4.py
+++ b/tests/unit/gui/widgets/test_filter_search_panel_phase4.py
@@ -134,7 +134,7 @@ class TestSetSearchFilterServicePhase4:
 
     def test_models_populated_in_sidebar(self, panel_with_service):
         """サービス設定後にサイドバーのモデルリストが更新される。"""
-        panel, service = panel_with_service
+        panel, _service = panel_with_service
         # get_recently_used_model_ids で返した 2 件がサイドバーに反映される
         model_list = panel._search_facets_sidebar._model_list
         assert model_list.count() == 2

--- a/tests/unit/gui/widgets/test_search_facets_sidebar.py
+++ b/tests/unit/gui/widgets/test_search_facets_sidebar.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+
+import datetime
+
+import pytest
+
+from lorairo.gui.widgets.search_facets_sidebar import SearchFacetsSidebar
+
+
+@pytest.mark.unit
+@pytest.mark.gui
+class TestSearchFacetsSidebar:
+    def test_initial_facet_values_all_none(self, qtbot: pytest.FixtureRequest) -> None:
+        """初期状態で全ファセット値が None であることを確認する。"""
+        sidebar = SearchFacetsSidebar()
+        qtbot.addWidget(sidebar)
+        vals = sidebar.get_facet_values()
+        assert vals["manual_edit_filter"] is None
+        assert vals["reviewed_at_filter"] is None
+        assert vals["error_state_filter"] is None
+        assert vals["model_filter"] is None
+        assert vals["created_at_range"] is None
+
+    def test_facets_changed_signal_emitted_on_radio_change(self, qtbot: pytest.FixtureRequest) -> None:
+        """ラジオボタン変更時に facets_changed シグナルが発火することを確認する。"""
+        sidebar = SearchFacetsSidebar()
+        qtbot.addWidget(sidebar)
+        with qtbot.waitSignal(sidebar.facets_changed, timeout=3000):
+            sidebar._manual_edit_buttons[1].click()
+
+    def test_get_facet_values_manual_edit_true(self, qtbot: pytest.FixtureRequest) -> None:
+        """「あり」選択時に manual_edit_filter が True になることを確認する。"""
+        sidebar = SearchFacetsSidebar()
+        qtbot.addWidget(sidebar)
+        sidebar._manual_edit_buttons[1].click()
+        vals = sidebar.get_facet_values()
+        assert vals["manual_edit_filter"] is True
+
+    def test_get_facet_values_manual_edit_false(self, qtbot: pytest.FixtureRequest) -> None:
+        """「なし」選択時に manual_edit_filter が False になることを確認する。"""
+        sidebar = SearchFacetsSidebar()
+        qtbot.addWidget(sidebar)
+        sidebar._manual_edit_buttons[2].click()
+        vals = sidebar.get_facet_values()
+        assert vals["manual_edit_filter"] is False
+
+    def test_get_facet_values_reviewed_unreviewed(self, qtbot: pytest.FixtureRequest) -> None:
+        """「未レビュー」選択時に reviewed_at_filter が "unreviewed" になることを確認する。"""
+        sidebar = SearchFacetsSidebar()
+        qtbot.addWidget(sidebar)
+        sidebar._reviewed_buttons[1].click()
+        vals = sidebar.get_facet_values()
+        assert vals["reviewed_at_filter"] == "unreviewed"
+
+    def test_get_facet_values_reviewed_reviewed(self, qtbot: pytest.FixtureRequest) -> None:
+        """「済み」選択時に reviewed_at_filter が "reviewed" になることを確認する。"""
+        sidebar = SearchFacetsSidebar()
+        qtbot.addWidget(sidebar)
+        sidebar._reviewed_buttons[2].click()
+        vals = sidebar.get_facet_values()
+        assert vals["reviewed_at_filter"] == "reviewed"
+
+    def test_get_facet_values_error_has_error(self, qtbot: pytest.FixtureRequest) -> None:
+        """「あり」選択時に error_state_filter が "has_error" になることを確認する。"""
+        sidebar = SearchFacetsSidebar()
+        qtbot.addWidget(sidebar)
+        sidebar._error_buttons[1].click()
+        vals = sidebar.get_facet_values()
+        assert vals["error_state_filter"] == "has_error"
+
+    def test_get_facet_values_error_no_error(self, qtbot: pytest.FixtureRequest) -> None:
+        """「なし」選択時に error_state_filter が "no_error" になることを確認する。"""
+        sidebar = SearchFacetsSidebar()
+        qtbot.addWidget(sidebar)
+        sidebar._error_buttons[2].click()
+        vals = sidebar.get_facet_values()
+        assert vals["error_state_filter"] == "no_error"
+
+    def test_update_models_populates_list(self, qtbot: pytest.FixtureRequest) -> None:
+        """update_models がモデルリストに items を設定することを確認する。"""
+        sidebar = SearchFacetsSidebar()
+        qtbot.addWidget(sidebar)
+        sidebar.update_models(["openai/gpt-4o", "anthropic/claude-3-5-haiku"])
+        assert sidebar._model_list.count() == 2
+
+    def test_model_filter_none_when_no_selection(self, qtbot: pytest.FixtureRequest) -> None:
+        """モデル未選択時に model_filter が None になることを確認する。"""
+        sidebar = SearchFacetsSidebar()
+        qtbot.addWidget(sidebar)
+        sidebar.update_models(["openai/gpt-4o", "anthropic/claude-3-5-haiku"])
+        vals = sidebar.get_facet_values()
+        assert vals["model_filter"] is None
+
+    def test_model_filter_returns_selected_models(self, qtbot: pytest.FixtureRequest) -> None:
+        """モデル選択時に model_filter が選択済みモデルのリストを返すことを確認する。"""
+        sidebar = SearchFacetsSidebar()
+        qtbot.addWidget(sidebar)
+        sidebar.update_models(["openai/gpt-4o", "anthropic/claude-3-5-haiku"])
+        sidebar._model_list.item(0).setSelected(True)
+        vals = sidebar.get_facet_values()
+        assert vals["model_filter"] == ["openai/gpt-4o"]
+
+    def test_facets_changed_emitted_on_model_selection(self, qtbot: pytest.FixtureRequest) -> None:
+        """モデル選択変更時に facets_changed シグナルが発火することを確認する。"""
+        sidebar = SearchFacetsSidebar()
+        qtbot.addWidget(sidebar)
+        sidebar.update_models(["openai/gpt-4o"])
+        with qtbot.waitSignal(sidebar.facets_changed, timeout=3000):
+            sidebar._model_list.item(0).setSelected(True)
+
+    def test_clear_all_resets_to_initial(self, qtbot: pytest.FixtureRequest) -> None:
+        """clear_all() が全ファセットを初期値にリセットすることを確認する。"""
+        sidebar = SearchFacetsSidebar()
+        qtbot.addWidget(sidebar)
+        sidebar._manual_edit_buttons[1].click()
+        sidebar._reviewed_buttons[2].click()
+        sidebar._error_buttons[1].click()
+        sidebar.clear_all()
+        vals = sidebar.get_facet_values()
+        assert vals["manual_edit_filter"] is None
+        assert vals["reviewed_at_filter"] is None
+        assert vals["error_state_filter"] is None
+        assert vals["created_at_range"] is None
+
+    def test_histogram_range_updates_created_at_range(self, qtbot: pytest.FixtureRequest) -> None:
+        """ヒストグラムのクリックで created_at_range が更新されることを確認する。"""
+        sidebar = SearchFacetsSidebar()
+        qtbot.addWidget(sidebar)
+        now = datetime.datetime.now(datetime.UTC)
+        end = now + datetime.timedelta(days=1)
+
+        with qtbot.waitSignal(sidebar.facets_changed, timeout=3000) as blocker:
+            sidebar._histogram.range_selected.emit(now, end)
+
+        vals = blocker.args[0]
+        assert vals["created_at_range"] == (now, end)
+
+    def test_update_histogram_delegates_to_histogram_widget(self, qtbot: pytest.FixtureRequest) -> None:
+        """update_histogram が内部の DateHistogramWidget に委譲されることを確認する。"""
+        sidebar = SearchFacetsSidebar()
+        qtbot.addWidget(sidebar)
+        now = datetime.datetime.now(datetime.UTC)
+        bins = [(now, now + datetime.timedelta(days=1), 3)]
+        sidebar.update_histogram(bins)
+        assert sidebar._histogram._bins == bins


### PR DESCRIPTION
## 概要

Search サイドバーに 5 種の facet フィルタを追加する Phase 4 実装。

## 変更内容

### Qt-free Service/DB 層（Track A）
- `ImageRepository`: `_apply_reviewed_at_filter`, `_apply_error_state_filter`, `_apply_model_filter` を追加
- `ImageRepository`: `get_created_at_histogram(bins=20)`, `get_recently_used_model_ids(limit=10)` を追加
- `ImageDatabaseManager`: 上記 2 メソッドのプロキシを追加
- `SearchFilterService`: `create_search_conditions` に 4 パラメータ追加、`get_recently_used_model_ids`, `get_created_at_histogram` を追加

### Qt ウィジェット層（Track B）
- `DateHistogramWidget`: `paintEvent` 手書きバー、`range_selected` シグナル
- `SearchFacetsSidebar`: 手動編集/レビュー/エラー/モデル/DATE の 5 facet、`facets_changed` シグナル

### 統合（Lead）
- `FilterSearchPanel`: `SearchFacetsSidebar` をスクロールエリア末尾に追加、`facets_changed` → 検索再実行
- `SearchFilterService`: `get_created_at_histogram` を追加
- 統合テスト `test_filter_search_panel_phase4.py` (9 tests) を追加

## 設計メモ
- Error chip "あり" = `resolved_at IS NULL`（未解決エラーのみ）
- DATE ヒストグラム: 20 bins 固定、独立クエリ（他フィルタに依存しない）
- モデルフィルタ: Tag/Caption/Score の EXISTS サブクエリ

## テスト
- Unit: 新規 100+ テスト（DB フィルタ、ヒストグラム、ウィジェット、統合）
- Phase 4 関連テスト 94 件すべて pass 確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)