### PR TITLE
feat(prompt): WebAPI アノテーションプロンプトを設定可能に + BASE_PROMPT 改訂

### DIFF
--- a/src/lorairo/annotations/annotator_adapter.py
+++ b/src/lorairo/annotations/annotator_adapter.py
@@ -194,6 +194,9 @@ class AnnotatorLibraryAdapter:
             api_keys = self._prepare_api_keys()
             logger.debug(f"利用可能プロバイダー: {list(api_keys.keys()) if api_keys else '（なし）'}")
 
+            # additional_prompt: 空文字列は None に統一（追記しない）
+            additional_prompt = self.config_service.get_setting("prompts", "additional", "") or None
+
             # image-annotator-lib API呼び出し
             from image_annotator_lib import annotate
 
@@ -204,6 +207,7 @@ class AnnotatorLibraryAdapter:
                 model_name_list=litellm_model_ids,
                 phash_list=phash_list,
                 api_keys=api_keys,  # 明示的に引数として渡す
+                additional_prompt=additional_prompt,
             )
 
             logger.info(f"アノテーション実行完了: {len(results)}件の結果")

--- a/src/lorairo/gui/window/configuration_window.py
+++ b/src/lorairo/gui/window/configuration_window.py
@@ -12,6 +12,7 @@ from PySide6.QtWidgets import (
     QDialogButtonBox,
     QFormLayout,
     QGroupBox,
+    QLabel,
     QLineEdit,
     QMessageBox,
     QPlainTextEdit,
@@ -184,12 +185,23 @@ class ConfigurationWindow(QDialog):
         tab_layout.addWidget(model_group)
 
         # プロンプト設定
-        prompt_group = QGroupBox("プロンプト")
+        prompt_group = QGroupBox("WebAPI 追加プロンプト")
         prompt_layout = QVBoxLayout(prompt_group)
+
+        prompt_label = QLabel(
+            "WebAPI アノテーション時にベースプロンプトの末尾に追記するテキスト。\n"
+            "ポーズ・照明・構図・スタイル以外に注目させたい指示を入力してください。\n"
+            "空欄の場合はデフォルトのベースプロンプトのみ使用されます。"
+        )
+        prompt_label.setWordWrap(True)
+        prompt_layout.addWidget(prompt_label)
 
         self._text_edit_prompt = QPlainTextEdit()
         self._text_edit_prompt.setObjectName("textEditPrompt")
         self._text_edit_prompt.setMaximumHeight(120)
+        self._text_edit_prompt.setPlaceholderText(
+            "例: Focus on any text or logos visible in the image. Note the language and font style."
+        )
         prompt_layout.addWidget(self._text_edit_prompt)
 
         tab_layout.addWidget(prompt_group)

--- a/tests/unit/annotations/test_annotator_adapter_prompt.py
+++ b/tests/unit/annotations/test_annotator_adapter_prompt.py
@@ -1,0 +1,67 @@
+"""AnnotatorLibraryAdapter.annotate() の additional_prompt 引数渡しテスト。"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from PIL import Image
+
+from lorairo.annotations.annotator_adapter import AnnotatorLibraryAdapter
+
+
+@pytest.fixture
+def dummy_image() -> Image.Image:
+    return Image.new("RGB", (64, 64))
+
+
+@pytest.fixture
+def adapter_with_prompt() -> AnnotatorLibraryAdapter:
+    config_service = MagicMock()
+
+    def get_setting(section: str, key: str, default: str = "") -> str:
+        if section == "prompts" and key == "additional":
+            return "test instruction"
+        return default
+
+    config_service.get_setting.side_effect = get_setting
+    return AnnotatorLibraryAdapter(config_service)
+
+
+@pytest.fixture
+def adapter_without_prompt() -> AnnotatorLibraryAdapter:
+    config_service = MagicMock()
+
+    def get_setting(section: str, key: str, default: str = "") -> str:
+        if section == "prompts" and key == "additional":
+            return ""
+        return default
+
+    config_service.get_setting.side_effect = get_setting
+    return AnnotatorLibraryAdapter(config_service)
+
+
+@pytest.mark.unit
+def test_annotate_passes_additional_prompt_to_lib(
+    adapter_with_prompt: AnnotatorLibraryAdapter,
+    dummy_image: Image.Image,
+) -> None:
+    """config に additional が設定されている場合、annotate() に渡されることを確認。"""
+    with patch("image_annotator_lib.annotate") as mock_annotate:
+        mock_annotate.return_value = {}
+        adapter_with_prompt.annotate([dummy_image], ["openai/gpt-4o"])
+
+    call_kwargs = mock_annotate.call_args.kwargs
+    assert call_kwargs["additional_prompt"] == "test instruction"
+
+
+@pytest.mark.unit
+def test_annotate_passes_none_when_prompt_empty(
+    adapter_without_prompt: AnnotatorLibraryAdapter,
+    dummy_image: Image.Image,
+) -> None:
+    """config の additional が空文字列の場合、additional_prompt=None が渡されることを確認。"""
+    with patch("image_annotator_lib.annotate") as mock_annotate:
+        mock_annotate.return_value = {}
+        adapter_without_prompt.annotate([dummy_image], ["openai/gpt-4o"])
+
+    call_kwargs = mock_annotate.call_args.kwargs
+    assert call_kwargs["additional_prompt"] is None

--- a/tests/unit/test_annotator_adapter_model_registry.py
+++ b/tests/unit/test_annotator_adapter_model_registry.py
@@ -390,6 +390,7 @@ def test_annotate_calls_library_annotate_with_correct_args() -> None:
         model_name_list=["openai/gpt-4o", "google/gemini-1.5-flash"],
         phash_list=["hash001"],
         api_keys={},
+        additional_prompt=None,
     )
 
 


### PR DESCRIPTION
<!-- CI-EQUIV-TESTED: iam-lib (webapi/annotation_runner 86 tests pass) + LoRAIro CI-equivalent filter 実行済み。残る失敗は本変更と無関係の libcudnn.so.9 環境制約 (origin/main baseline でも同一再現) -->

## 概要

LoRAIro の `prompts.additional` 設定値を WebAPI アノテーションのシステムプロンプトに反映できるようにする。`additional_prompt` 引数を iam-lib のコールチェーン全体に通し、ベースプロンプト末尾へ追記する。あわせて BASE_PROMPT をポーズ・光源・構図・スタイル重視（tagger モデルの弱点補完）の内容に全面改訂した。

## 変更内容

### image-annotator-lib (submodule pin `d9227d3`、既に upstream main へ merge 済み)
- `webapi_shared.py`: BASE_PROMPT をポーズ・ライティング・構図・スタイル重視に全面改訂（出力フォーマットの `captions` 整合も修正）
- `webapi/provider_manager.py`: `_build_system_prompt()` / `run_inference_with_model_async()` / `run_inference_with_model()` に `additional_prompt: str | None = None` を追加。空文字列・空白のみは追記しない
- `webapi/annotator.py`: `WebApiAnnotator.__init__()` に `additional_prompt` 属性を追加し `_run_inference()` で受け渡し
- `core/annotation_runner.py`: `run_annotation()` → `_execute_model_annotation()` → `get_annotator_instance()` → `_create_annotator_instance()` のチェーンに `additional_prompt` を貫通
- `api.py`: 公開 API `annotate()` に `additional_prompt` 引数を追加
- 新規テスト `tests/unit/webapi/test_build_system_prompt.py`（追記/空文字/空白/RATINGS 併用 7 ケース）

### LoRAIro
- `annotations/annotator_adapter.py`: `annotate()` で `config_service.get_setting("prompts", "additional", "")` を読み、空文字列は `None` に正規化して iam-lib `annotate()` へ渡す
- `gui/window/configuration_window.py`: 設定ウィンドウの追加プロンプト入力欄にラベル・説明・プレースホルダを追加
- 新規テスト `tests/unit/annotations/test_annotator_adapter_prompt.py`（設定あり→渡る / 空→None の 2 ケース）

## 後方互換性

全新引数に `additional_prompt: str | None = None` のデフォルトを設定済み。既存の呼び出し元（Batch API・既存テスト）は引数なしでそのまま動作する。

## テスト

- iam-lib: `additional_prompt` コールチェーン関連 86 tests PASS（webapi / annotation_runner / build_system_prompt）
- LoRAIro: CI-equivalent filter で 3966 passed
- 補足: この devcontainer は CUDA/cuDNN 非搭載のため torch import 依存テスト（`lorairo.editor` 経由）が `libcudnn.so.9` で collection/実行失敗するが、これは本変更と無関係の環境制約であり origin/main baseline でも同一に再現する。実行環境を持つ CI で検証される。

## 手動確認 (推奨)

- [ ] 設定ウィンドウで `prompts.additional` を入力 → WebAPI アノテーション実行 → ログで additional_prompt がシステムプロンプトに反映されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)