### PR TITLE
feat(annotate): Wireframes v11 Phase 6a — ステージ中心パイプライン構成ビュー

### DIFF
--- a/src/lorairo/gui/widgets/inference_ledger_widget.py
+++ b/src/lorairo/gui/widgets/inference_ledger_widget.py
@@ -1,0 +1,116 @@
+"""Wireframes v11 Frame 2A の INFERENCE LEDGER (推論台帳) widget (Phase 6a: 表示専用)。
+
+推論回数 = ユニークモデル × ステージング枚数 の式と、ユニークモデルごとの
+エントリチップ (multimodal は「N枠 → 1推論」バッジ併記) を描画する。
+"""
+
+from __future__ import annotations
+
+from PySide6.QtWidgets import QHBoxLayout, QLabel, QVBoxLayout, QWidget
+
+from lorairo.services.pipeline_composition import InferenceLedger, LedgerEntry
+
+_TITLE_TEXT = "INFERENCE LEDGER — 推論回数 = ユニークモデル × ステージング枚数"
+_PLACEHOLDER_TEXT = "モデル未選択"
+
+_ENTRY_CHIP_STYLE = (
+    "QLabel { border: 1px solid #5b8def; border-radius: 8px;"
+    " padding: 2px 8px; background-color: #eef4ff; color: #1a3b6e; }"
+)
+_MULTI_BADGE_STYLE = (
+    "QLabel { border: 1px solid #7b4fd8; border-radius: 8px;"
+    " padding: 2px 6px; background-color: #f3edff; color: #3d2376; }"
+)
+
+
+class InferenceLedgerWidget(QWidget):
+    """Wireframes v11 Frame 2A の INFERENCE LEDGER (推論台帳)。"""
+
+    def __init__(self, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+
+        title = QLabel(_TITLE_TEXT, self)
+        title.setObjectName("ledgerTitleLabel")
+        title_font = title.font()
+        title_font.setBold(True)
+        title.setFont(title_font)
+        layout.addWidget(title)
+
+        self._entries_layout = QHBoxLayout()
+        self._entries_layout.setContentsMargins(0, 2, 0, 2)
+        layout.addLayout(self._entries_layout)
+
+        self._formula_label = QLabel("", self)
+        self._formula_label.setObjectName("ledgerFormulaLabel")
+        layout.addWidget(self._formula_label)
+
+        self._placeholder_label = QLabel(_PLACEHOLDER_TEXT, self)
+        self._placeholder_label.setObjectName("ledgerPlaceholderLabel")
+        layout.addWidget(self._placeholder_label)
+
+        layout.addStretch(1)
+
+        self.clear()
+
+    def display(self, ledger: InferenceLedger) -> None:
+        """台帳を再描画する。"""
+        self._clear_entries()
+        if not ledger.entries or ledger.staged_count == 0:
+            self._show_placeholder()
+            return
+
+        self._placeholder_label.setText("")
+        self._placeholder_label.setVisible(False)
+
+        for entry in ledger.entries:
+            self._add_entry_chip(entry, ledger.staged_count)
+        self._entries_layout.addStretch(1)
+
+        formula = (
+            f"{ledger.unique_model_count} ユニークモデル × {ledger.staged_count} 枚"
+            f" = {ledger.total_jobs} 推論ジョブ"
+            f" （local {ledger.local_count} · API {ledger.api_count}）"
+        )
+        self._formula_label.setText(formula)
+        self._formula_label.setVisible(True)
+
+    def clear(self) -> None:
+        """空表示にする。"""
+        self._clear_entries()
+        self._show_placeholder()
+
+    def _show_placeholder(self) -> None:
+        """「モデル未選択」プレースホルダ状態に切り替える。"""
+        self._formula_label.setText("")
+        self._formula_label.setVisible(False)
+        self._placeholder_label.setText(_PLACEHOLDER_TEXT)
+        self._placeholder_label.setVisible(True)
+
+    def _clear_entries(self) -> None:
+        """既存のエントリチップを layout から外して破棄する。"""
+        while self._entries_layout.count():
+            item = self._entries_layout.takeAt(0)
+            if item is None:
+                continue
+            widget = item.widget()
+            if widget is not None:
+                # findChildren で前回チップが見えないよう、即時に親子関係を切る
+                widget.setParent(None)
+                widget.deleteLater()
+
+    def _add_entry_chip(self, entry: LedgerEntry, staged_count: int) -> None:
+        """エントリチップ (+ multimodal バッジ) を 1 つ追加する。"""
+        chip = QLabel(f"{entry.model.display_name} ×{staged_count}枚", self)
+        chip.setObjectName("ledgerChip")
+        chip.setStyleSheet(_ENTRY_CHIP_STYLE)
+        self._entries_layout.addWidget(chip)
+
+        if entry.model.is_multimodal:
+            badge = QLabel(f"{entry.stage_count}枠 → 1推論", self)
+            badge.setObjectName("ledgerMultiBadge")
+            badge.setStyleSheet(_MULTI_BADGE_STYLE)
+            badge.setToolTip("multimodal モデルは複数ステージに出力しても 1 推論として課金されます")
+            self._entries_layout.addWidget(badge)

--- a/src/lorairo/gui/widgets/pipeline_stage_table_widget.py
+++ b/src/lorairo/gui/widgets/pipeline_stage_table_widget.py
@@ -1,0 +1,162 @@
+"""Wireframes v11 Frame 2A のステージ中心パイプラインテーブル (Phase 6a: 表示専用)。
+
+TAGS/CAPTION/SCORE/RATING の 4 ステージ行に、明示割当 (primary) チップと
+multimodal 派生 (derived) チップを描画する。Phase 6a では remove 等の操作は
+提供しない (Phase 6b で追加)。
+"""
+
+from __future__ import annotations
+
+from PySide6.QtWidgets import QHBoxLayout, QLabel, QVBoxLayout, QWidget
+
+from lorairo.services.pipeline_composition import DerivedChip, PipelineStage, StageModelInfo, StageRow
+
+# 表示順 (Wireframes v11 Frame 2A の行順)
+_STAGE_ORDER: tuple[PipelineStage, ...] = (
+    PipelineStage.TAGS,
+    PipelineStage.CAPTION,
+    PipelineStage.SCORE,
+    PipelineStage.RATING,
+)
+
+_LEGEND_TEXT = (
+    "MULTI model-name = 主割当 / ↝ model-name = 派生 = 同推論の副産物 · 操作不可（Results で却下）"
+)
+
+_DERIVED_TOOLTIP = (
+    "派生 = 同一推論の副産物。構成時には外せません（外しても課金は同じ 1 推論）。"
+    "不要なら Results で却下してください"
+)
+
+_RATING_NOTE_TEXT = "multimodal 派生なし †"
+_RATING_NOTE_TOOLTIP = (
+    "multimodal の 1 推論は tags+captions+score を返し rating には届きません。"
+    "rating は rating 対応モデルか送信前プリフライト (OpenAI Moderations) 由来です"
+)
+
+_PRIMARY_CHIP_STYLE = (
+    "QLabel { border: 1px solid #5b8def; border-radius: 8px;"
+    " padding: 2px 8px; background-color: #eef4ff; color: #1a3b6e; }"
+)
+_MULTI_CHIP_STYLE = (
+    "QLabel { border: 2px solid #7b4fd8; border-radius: 8px;"
+    " padding: 2px 8px; background-color: #f3edff; color: #3d2376; }"
+)
+_DERIVED_CHIP_STYLE = (
+    "QLabel { border: 1px dashed #9aa0a6; border-radius: 8px;"
+    " padding: 2px 8px; color: #6b7075; font-style: italic; }"
+)
+
+
+class PipelineStageTableWidget(QWidget):
+    """Wireframes v11 Frame 2A のステージテーブル (Phase 6a: 表示専用)。"""
+
+    def __init__(self, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+
+        legend = QLabel(_LEGEND_TEXT, self)
+        legend.setObjectName("pipelineLegendLabel")
+        legend_font = legend.font()
+        legend_font.setPointSize(max(6, legend_font.pointSize() - 2))
+        legend.setFont(legend_font)
+        layout.addWidget(legend)
+
+        self._rows_layout = QVBoxLayout()
+        self._rows_layout.setContentsMargins(0, 0, 0, 0)
+        layout.addLayout(self._rows_layout)
+        layout.addStretch(1)
+
+        self.clear()
+
+    def display(self, rows: list[StageRow]) -> None:
+        """4 ステージ行を再描画する。"""
+        rows_by_stage = {row.stage: row for row in rows}
+        self._clear_rows()
+        for stage in _STAGE_ORDER:
+            self._rows_layout.addWidget(self._build_stage_row(stage, rows_by_stage.get(stage)))
+
+    def clear(self) -> None:
+        """全行を空表示にする。"""
+        self.display([])
+
+    def _clear_rows(self) -> None:
+        """既存のステージ行 widget を layout から外して破棄する。"""
+        while self._rows_layout.count():
+            item = self._rows_layout.takeAt(0)
+            if item is None:
+                continue
+            widget = item.widget()
+            if widget is not None:
+                # findChildren で前回チップが見えないよう、即時に親子関係を切る
+                widget.setParent(None)
+                widget.deleteLater()
+
+    def _build_stage_row(self, stage: PipelineStage, row: StageRow | None) -> QWidget:
+        """ステージ 1 行分の container widget を構築する。"""
+        container = QWidget(self)
+        container.setObjectName(f"stageRow_{stage.name}")
+        row_layout = QHBoxLayout(container)
+        row_layout.setContentsMargins(0, 2, 0, 2)
+
+        name_label = QLabel(stage.name, container)
+        name_label.setObjectName(f"stageName_{stage.name}")
+        name_font = name_label.font()
+        name_font.setBold(True)
+        name_label.setFont(name_font)
+        name_label.setFixedWidth(72)
+        row_layout.addWidget(name_label)
+
+        primary_models = row.primary_models if row is not None else ()
+        derived_chips = row.derived_chips if row is not None else ()
+
+        count_text = str(len(primary_models))
+        if derived_chips:
+            count_text += f" + ↝{len(derived_chips)}"
+        count_label = QLabel(count_text, container)
+        count_label.setObjectName(f"stageCount_{stage.name}")
+        row_layout.addWidget(count_label)
+
+        for model in primary_models:
+            row_layout.addWidget(self._build_primary_chip(model, stage, container))
+        for derived in derived_chips:
+            row_layout.addWidget(self._build_derived_chip(derived, container))
+
+        if stage is PipelineStage.RATING:
+            note = QLabel(_RATING_NOTE_TEXT, container)
+            note.setObjectName("ratingNoDerivedNote")
+            note.setToolTip(_RATING_NOTE_TOOLTIP)
+            row_layout.addWidget(note)
+
+        row_layout.addStretch(1)
+        return container
+
+    def _build_primary_chip(self, model: StageModelInfo, stage: PipelineStage, parent: QWidget) -> QLabel:
+        """明示割当チップ (multimodal は MULTI バッジ + 派生ファンアウト注記付き)。"""
+        if model.is_multimodal:
+            fanout_stages = [s for s in _STAGE_ORDER if s in model.fill_stages() and s is not stage]
+            text = f"MULTI {model.display_name}"
+            if fanout_stages:
+                letters = " ".join(s.name[0] for s in fanout_stages)
+                text += f" +派生 {letters}"
+            chip = QLabel(text, parent)
+            chip.setStyleSheet(_MULTI_CHIP_STYLE)
+            chip.setToolTip("multimodal: 1 推論で tags / caption / score を同時に出力します")
+        else:
+            chip = QLabel(model.display_name, parent)
+            chip.setStyleSheet(_PRIMARY_CHIP_STYLE)
+        chip.setObjectName("primaryChip")
+        return chip
+
+    def _build_derived_chip(self, derived: DerivedChip, parent: QWidget) -> QLabel:
+        """派生チップ (↝、斜体グレー、操作不可)。"""
+        chip = QLabel(
+            f"↝ {derived.model.display_name} from {derived.origin_stage.name}",
+            parent,
+        )
+        chip.setObjectName("derivedChip")
+        chip.setStyleSheet(_DERIVED_CHIP_STYLE)
+        chip.setToolTip(_DERIVED_TOOLTIP)
+        return chip

--- a/src/lorairo/gui/window/main_window.py
+++ b/src/lorairo/gui/window/main_window.py
@@ -25,6 +25,7 @@ from ...services.configuration_service import ConfigurationService
 from ...services.model_selection_service import ModelSelectionService
 from ...services.error_triage_service import ErrorFilter, ErrorRow, ErrorTriageService
 from ...services.quality_issue_detection_service import QualityIssueDetectionService
+from ...services.pipeline_composition import PipelineCompositionService, StageModelInfo
 from ...services.selection_state_service import SelectionStateService
 from ...services.service_container import ServiceContainer
 from ...storage.file_system import FileSystemManager
@@ -46,6 +47,8 @@ from ..widgets.errors_triage_widget import ErrorsTriageWidget
 from ..widgets.error_notification_widget import ErrorNotificationWidget
 from ..widgets.filter_search_panel import FilterSearchPanel
 from ..widgets.image_preview import ImagePreviewWidget
+from ..widgets.inference_ledger_widget import InferenceLedgerWidget
+from ..widgets.pipeline_stage_table_widget import PipelineStageTableWidget
 from ..widgets.provider_batch_job_widget import ProviderBatchJobWidget
 from ..widgets.quick_tag_dialog import QuickTagDialog
 from ..widgets.results_widget import ResultsWidget
@@ -82,6 +85,8 @@ class MainWindow(QMainWindow, Ui_MainWindow):
     annotation_workflow_controller: AnnotationWorkflowController | None
     settings_controller: SettingsController | None
     export_widget: DatasetExportWidget | None
+    pipeline_stage_table: PipelineStageTableWidget | None
+    inference_ledger_widget: InferenceLedgerWidget | None
     result_handler_service: ResultHandlerService | None
     pipeline_control_service: PipelineControlService | None
     progress_state_service: ProgressStateService | None
@@ -379,6 +384,9 @@ class MainWindow(QMainWindow, Ui_MainWindow):
         # BatchTagAddWidget再配置（Phase 2.5統合、Day 2）
         WidgetSetupService.setup_batch_tag_tab_widgets(self)
 
+        # パイプライン構成ビュー（Phase 6a、batchModelSelection 構築後に配置）
+        self._setup_pipeline_composition_panel()
+
         # QTabWidget初期化（タブ切り替え用）
         self._setup_tab_widget()
         self._setup_provider_batch_tab()
@@ -618,6 +626,96 @@ class MainWindow(QMainWindow, Ui_MainWindow):
         container.layout().addWidget(widget)
         self.export_widget = widget
         logger.info("✅ エクスポートタブ (DatasetExportWidget) initialized")
+
+    def _setup_pipeline_composition_panel(self) -> None:
+        """アノテーショングループにパイプライン構成ビューを常設する。
+
+        Wireframes v11 Frame 2A · Phase 6a (表示専用)。ModelSelectionWidget の選択を
+        購読して TAGS/CAPTION/SCORE/RATING への自動仕分け・multimodal 派生チップ・
+        推論台帳 (INFERENCE LEDGER) をリアルタイム表示する。per-stage 明示割当は
+        Phase 6b で追加する。
+        """
+        self.pipeline_composition_service = PipelineCompositionService()
+        self._pipeline_staged_count = 0
+
+        annotation_group = getattr(self, "groupBoxAnnotation", None)
+        model_widget = getattr(self, "batchModelSelection", None)
+        if annotation_group is None or model_widget is None:
+            logger.warning("groupBoxAnnotation/batchModelSelection 未構築 - パイプライン構成ビュー skipped")
+            self.pipeline_stage_table = None
+            self.inference_ledger_widget = None
+            return
+
+        self.pipeline_stage_table = PipelineStageTableWidget(parent=annotation_group)
+        self.inference_ledger_widget = InferenceLedgerWidget(parent=annotation_group)
+        layout = annotation_group.layout()
+        layout.addWidget(self.pipeline_stage_table)
+        layout.addWidget(self.inference_ledger_widget)
+
+        model_widget.model_selection_changed.connect(self._on_pipeline_models_changed)
+        self._refresh_pipeline_panel([])
+        logger.info("✅ パイプライン構成ビュー (Frame 2A) initialized")
+
+    def _on_pipeline_models_changed(self, selected_litellm_model_ids: list[str]) -> None:
+        """モデル選択変化でパイプライン構成ビューを再計算する (Phase 6a)。"""
+        self._refresh_pipeline_panel(list(selected_litellm_model_ids))
+
+    def _refresh_pipeline_panel(self, selected_ids: list[str] | None = None) -> None:
+        """ステージテーブルと推論台帳を現在の選択・ステージング件数で再描画する。
+
+        Args:
+            selected_ids: 選択中の litellm_model_id。None なら ModelSelectionWidget
+                から現在値を取得する（ステージング件数変化時の再計算用）。
+        """
+        stage_table = getattr(self, "pipeline_stage_table", None)
+        ledger_widget = getattr(self, "inference_ledger_widget", None)
+        if stage_table is None or ledger_widget is None:
+            return
+
+        if selected_ids is None:
+            model_widget = getattr(self, "batchModelSelection", None)
+            selected_ids = model_widget.get_selected_models() if model_widget is not None else []
+
+        infos = self._build_stage_model_infos(selected_ids)
+        self.pipeline_composition_service.compose_from_models(infos)
+        stage_table.display(self.pipeline_composition_service.stage_rows())
+        ledger_widget.display(self.pipeline_composition_service.ledger(self._pipeline_staged_count))
+
+    def _build_stage_model_infos(self, selected_ids: list[str]) -> list[StageModelInfo]:
+        """選択 litellm_model_id を StageModelInfo へ変換する。
+
+        capabilities は DB Model の model_types 由来。provider が空または "local" の
+        モデルはローカル ML として扱う（ModelSelectionService._provider_key と同じ規約）。
+
+        Args:
+            selected_ids: ModelSelectionWidget で選択中の litellm_model_id リスト。
+
+        Returns:
+            変換済み StageModelInfo リスト。DB に見つからない ID はスキップする。
+        """
+        model_widget = getattr(self, "batchModelSelection", None)
+        service = getattr(model_widget, "model_selection_service", None)
+        all_models = service.load_models() if service is not None else []
+        models_by_id = {m.litellm_model_id: m for m in all_models}
+
+        infos: list[StageModelInfo] = []
+        for litellm_id in selected_ids:
+            model = models_by_id.get(litellm_id)
+            if model is None:
+                logger.debug(f"選択モデルが DB モデル一覧に見つかりません: {litellm_id}")
+                continue
+            provider = model.provider
+            is_api = bool(provider) and provider.lower() != "local"
+            infos.append(
+                StageModelInfo(
+                    litellm_model_id=litellm_id,
+                    display_name=model.name,
+                    provider=provider,
+                    is_api=is_api,
+                    capabilities=frozenset(str(c) for c in model.capabilities),
+                )
+            )
+        return infos
 
     def _refresh_errors_tab(self) -> None:
         """エラータブ表示時 / フィルタ変更時にトリアージを再計算して描画する。"""
@@ -1441,6 +1539,9 @@ class MainWindow(QMainWindow, Ui_MainWindow):
         export_widget = getattr(self, "export_widget", None)
         if export_widget is not None:
             export_widget.set_image_ids(list(image_ids) if image_ids else [])
+        # Phase 6a: 推論台帳の枚数もステージング件数と同期する
+        self._pipeline_staged_count = count
+        self._refresh_pipeline_panel()
 
     def _update_annotation_target_ui(self, staging_count: int) -> None:
         """アノテーション対象UIを更新

--- a/src/lorairo/services/pipeline_composition.py
+++ b/src/lorairo/services/pipeline_composition.py
@@ -1,0 +1,159 @@
+# src/lorairo/services/pipeline_composition.py
+"""アノテーションパイプライン構成の Qt-free ドメインモデル (Wireframes v11 Frame 2A / Phase 6a)。
+
+ステージ中心パイプライン (TAGS/CAPTION/SCORE/RATING) のモデル割当状態と、
+multimodal 派生出力・推論台帳 (INFERENCE LEDGER) の計算を担う。
+
+設計確定事項 (デザインセッション 2026-06-11 / docs/design/wireframes-v11):
+- multimodal の AnnotationSchema は {tags, captions, score} 固定 — 派生は
+  TAGS / CAPTION / SCORE のみで RATING には決して届かない (ADR 0023/0031)
+- 派生チップは read-only (opt-out なし)。不要な派生出力は Results の
+  soft-reject (#719) で事後却下する
+- 推論回数 = ユニークモデル数 × ステージング枚数。同一モデルを複数ステージに
+  明示割当しても dedupe され、コストは増えない
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import StrEnum
+
+
+class PipelineStage(StrEnum):
+    """パイプラインの出力ステージ (Wireframes v11 Frame 2A の 4 行)。"""
+
+    TAGS = "tags"
+    CAPTION = "caption"
+    SCORE = "score"
+    RATING = "rating"
+
+
+# capability 名 (model_types) → ステージの対応。
+# "multimodal" は capability ではなく派生挙動のマーカーなので含めない。
+CAPABILITY_TO_STAGE: dict[str, PipelineStage] = {
+    "tags": PipelineStage.TAGS,
+    "caption": PipelineStage.CAPTION,
+    "scores": PipelineStage.SCORE,
+    "ratings": PipelineStage.RATING,
+}
+
+# multimodal モデルの 1 推論が埋めるステージ集合 (AnnotationSchema 固定)。
+MULTIMODAL_FILL_STAGES: frozenset[PipelineStage] = frozenset(
+    {PipelineStage.TAGS, PipelineStage.CAPTION, PipelineStage.SCORE}
+)
+
+
+@dataclass(frozen=True)
+class StageModelInfo:
+    """ステージに割り当てるモデルの表示・計算用スナップショット。
+
+    Attributes:
+        litellm_model_id: モデルの一意キー (Model.litellm_model_id)。
+        display_name: チップに表示する名前 (Model.name)。
+        provider: プロバイダ名。ローカル ML は None。
+        is_api: WebAPI モデルなら True、ローカル ML なら False。
+        capabilities: model_types 由来の capability 名集合
+            ({"tags", "caption", "scores", "ratings", "multimodal"} の部分集合)。
+    """
+
+    litellm_model_id: str
+    display_name: str
+    provider: str | None
+    is_api: bool
+    capabilities: frozenset[str]
+
+    @property
+    def is_multimodal(self) -> bool:
+        """1 推論で複数出力を返す WebAPI multimodal モデルか。"""
+        return self.is_api and "multimodal" in self.capabilities
+
+    def fill_stages(self) -> frozenset[PipelineStage]:
+        """このモデルの 1 推論が出力を届けるステージ集合を返す。"""
+        if self.is_multimodal:
+            return MULTIMODAL_FILL_STAGES
+        stages = {CAPABILITY_TO_STAGE[name] for name in self.capabilities if name in CAPABILITY_TO_STAGE}
+        return frozenset(stages)
+
+
+@dataclass(frozen=True)
+class DerivedChip:
+    """派生チップ (↝): 同一推論の副産物としてステージに届く出力。read-only。"""
+
+    model: StageModelInfo
+    origin_stage: PipelineStage
+
+
+@dataclass(frozen=True)
+class StageRow:
+    """ステージテーブルの 1 行分の表示データ。"""
+
+    stage: PipelineStage
+    primary_models: tuple[StageModelInfo, ...]
+    derived_chips: tuple[DerivedChip, ...]
+
+
+@dataclass(frozen=True)
+class LedgerEntry:
+    """推論台帳の 1 エントリ (ユニークモデル単位)。"""
+
+    model: StageModelInfo
+    stage_count: int  # このモデルが出力を届けるステージ数 (明示+派生)
+
+
+@dataclass(frozen=True)
+class InferenceLedger:
+    """INFERENCE LEDGER: 推論回数 = ユニークモデル × ステージング枚数。"""
+
+    entries: tuple[LedgerEntry, ...]
+    staged_count: int
+    unique_model_count: int = field(init=False)
+    total_jobs: int = field(init=False)
+    local_count: int = field(init=False)
+    api_count: int = field(init=False)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "unique_model_count", len(self.entries))
+        object.__setattr__(self, "total_jobs", len(self.entries) * self.staged_count)
+        object.__setattr__(self, "local_count", sum(1 for e in self.entries if not e.model.is_api))
+        object.__setattr__(self, "api_count", sum(1 for e in self.entries if e.model.is_api))
+
+
+class PipelineCompositionService:
+    """ステージ割当状態を保持し、派生表示と推論台帳を計算する (Qt-free)。
+
+    Phase 6a では選択モデル集合からの自動仕分け (`compose_from_models`) を
+    入力経路とし、Phase 6b で per-stage 明示割当 (`assign`/`remove`) に拡張する。
+    """
+
+    def __init__(self) -> None:
+        self._assignments: dict[PipelineStage, list[StageModelInfo]] = {
+            stage: [] for stage in PipelineStage
+        }
+
+    # --- 入力 (Track A 実装) -------------------------------------------------
+
+    def compose_from_models(self, models: list[StageModelInfo]) -> None:
+        """選択モデル集合をステージへ自動仕分けする (Phase 6a の入力経路)。"""
+        raise NotImplementedError
+
+    def assign(self, stage: PipelineStage, model: StageModelInfo) -> None:
+        """モデルをステージに明示割当する (Phase 6b)。"""
+        raise NotImplementedError
+
+    def remove(self, stage: PipelineStage, litellm_model_id: str) -> None:
+        """ステージから明示割当を外す (Phase 6b)。派生チップは外せない。"""
+        raise NotImplementedError
+
+    # --- 出力 (Track A 実装) -------------------------------------------------
+
+    def stage_rows(self) -> list[StageRow]:
+        """4 ステージ分の表示行 (明示チップ + 派生チップ) を返す。"""
+        raise NotImplementedError
+
+    def ledger(self, staged_count: int) -> InferenceLedger:
+        """推論台帳を返す。multimodal の多段出現は dedupe する。"""
+        raise NotImplementedError
+
+    def unique_model_ids(self) -> list[str]:
+        """実行に渡すユニーク litellm_model_id リストを返す (割当順)。"""
+        raise NotImplementedError

--- a/src/lorairo/services/pipeline_composition.py
+++ b/src/lorairo/services/pipeline_composition.py
@@ -133,27 +133,98 @@ class PipelineCompositionService:
     # --- 入力 (Track A 実装) -------------------------------------------------
 
     def compose_from_models(self, models: list[StageModelInfo]) -> None:
-        """選択モデル集合をステージへ自動仕分けする (Phase 6a の入力経路)。"""
-        raise NotImplementedError
+        """選択モデル集合をステージへ自動仕分けする (Phase 6a の入力経路)。
+
+        - multimodal モデルは CAPTION に明示割当 (v11: 1 推論の主目的を caption とみなす)
+        - 非 multimodal は capability が対応する各ステージに明示割当
+        - 同一 litellm_model_id の重複入力は 1 つに dedupe
+        - 呼ぶたびに既存の割当をクリアして作り直す
+        """
+        self._assignments = {stage: [] for stage in PipelineStage}
+        seen_ids: set[str] = set()
+        for model in models:
+            if model.litellm_model_id in seen_ids:
+                continue
+            seen_ids.add(model.litellm_model_id)
+            if model.is_multimodal:
+                self.assign(PipelineStage.CAPTION, model)
+                continue
+            target_stages = model.fill_stages()
+            for stage in PipelineStage:
+                if stage in target_stages:
+                    self.assign(stage, model)
 
     def assign(self, stage: PipelineStage, model: StageModelInfo) -> None:
-        """モデルをステージに明示割当する (Phase 6b)。"""
-        raise NotImplementedError
+        """モデルをステージに明示割当する (Phase 6b)。同一モデルの重複割当は無視。"""
+        assigned = self._assignments[stage]
+        if any(m.litellm_model_id == model.litellm_model_id for m in assigned):
+            return
+        assigned.append(model)
 
     def remove(self, stage: PipelineStage, litellm_model_id: str) -> None:
-        """ステージから明示割当を外す (Phase 6b)。派生チップは外せない。"""
-        raise NotImplementedError
+        """ステージから明示割当を外す (Phase 6b)。派生チップは外せない。該当なしは no-op。"""
+        self._assignments[stage] = [
+            m for m in self._assignments[stage] if m.litellm_model_id != litellm_model_id
+        ]
 
     # --- 出力 (Track A 実装) -------------------------------------------------
 
     def stage_rows(self) -> list[StageRow]:
-        """4 ステージ分の表示行 (明示チップ + 派生チップ) を返す。"""
-        raise NotImplementedError
+        """4 ステージ分の表示行 (明示チップ + 派生チップ) を返す。
+
+        派生チップは明示割当済み multimodal モデルの fill_stages のうち、
+        そのモデルが明示割当されていないステージに出す。RATING は
+        MULTIMODAL_FILL_STAGES に含まれないため派生が届くことはない。
+        """
+        origins = self._multimodal_origins()
+        rows: list[StageRow] = []
+        for stage in PipelineStage:
+            primary = tuple(self._assignments[stage])
+            primary_ids = {m.litellm_model_id for m in primary}
+            chips: list[DerivedChip] = []
+            for model_id, (model, origin_stage) in origins.items():
+                if stage not in model.fill_stages() or model_id in primary_ids:
+                    continue
+                chips.append(DerivedChip(model=model, origin_stage=origin_stage))
+            rows.append(StageRow(stage=stage, primary_models=primary, derived_chips=tuple(chips)))
+        return rows
 
     def ledger(self, staged_count: int) -> InferenceLedger:
         """推論台帳を返す。multimodal の多段出現は dedupe する。"""
-        raise NotImplementedError
+        unique_models: dict[str, StageModelInfo] = {}
+        explicit_stages: dict[str, set[PipelineStage]] = {}
+        for stage in PipelineStage:
+            for model in self._assignments[stage]:
+                unique_models.setdefault(model.litellm_model_id, model)
+                explicit_stages.setdefault(model.litellm_model_id, set()).add(stage)
+        entries: list[LedgerEntry] = []
+        for model_id, model in unique_models.items():
+            delivered = set(explicit_stages[model_id])
+            if model.is_multimodal:
+                delivered |= model.fill_stages()
+            entries.append(LedgerEntry(model=model, stage_count=len(delivered)))
+        return InferenceLedger(entries=tuple(entries), staged_count=staged_count)
 
     def unique_model_ids(self) -> list[str]:
         """実行に渡すユニーク litellm_model_id リストを返す (割当順)。"""
-        raise NotImplementedError
+        ordered_ids: list[str] = []
+        for stage in PipelineStage:
+            for model in self._assignments[stage]:
+                if model.litellm_model_id not in ordered_ids:
+                    ordered_ids.append(model.litellm_model_id)
+        return ordered_ids
+
+    # --- private -------------------------------------------------------------
+
+    def _multimodal_origins(self) -> dict[str, tuple[StageModelInfo, PipelineStage]]:
+        """明示割当済み multimodal モデル → (モデル, 最初の明示割当ステージ)。
+
+        ステージは PipelineStage 定義順に走査し、同一モデルが複数ステージに
+        明示割当されている場合は最初に見つかったステージを origin とする。
+        """
+        origins: dict[str, tuple[StageModelInfo, PipelineStage]] = {}
+        for stage in PipelineStage:
+            for model in self._assignments[stage]:
+                if model.is_multimodal and model.litellm_model_id not in origins:
+                    origins[model.litellm_model_id] = (model, stage)
+        return origins

--- a/tests/integration/test_main_window_tab_integration.py
+++ b/tests/integration/test_main_window_tab_integration.py
@@ -82,6 +82,14 @@ class TestMainWindowTabInitialization:
         assert widget is not None
         assert main_window_with_tabs.export_widget is widget
 
+    def test_pipeline_panel_embedded_in_annotation_group(self, main_window_with_tabs):
+        """アノテーショングループにパイプライン構成ビューが常設される (Phase 6a)"""
+        window = main_window_with_tabs
+        assert window.pipeline_stage_table is not None
+        assert window.inference_ledger_widget is not None
+        assert window.pipeline_stage_table.parent() is window.groupBoxAnnotation
+        assert window.inference_ledger_widget.parent() is window.groupBoxAnnotation
+
     def test_errors_resolve_marks_resolved(self, main_window_with_tabs):
         """resolve_requested シグナルで mark_errors_resolved_batch が呼ばれる"""
         from unittest.mock import Mock

--- a/tests/unit/gui/widgets/test_inference_ledger_widget.py
+++ b/tests/unit/gui/widgets/test_inference_ledger_widget.py
@@ -1,0 +1,112 @@
+"""InferenceLedgerWidget 単体テスト"""
+
+from __future__ import annotations
+
+import pytest
+from PySide6.QtWidgets import QLabel
+
+from lorairo.gui.widgets.inference_ledger_widget import InferenceLedgerWidget
+from lorairo.services.pipeline_composition import (
+    InferenceLedger,
+    LedgerEntry,
+    StageModelInfo,
+)
+
+pytestmark = [pytest.mark.unit, pytest.mark.gui]
+
+GPT4O = StageModelInfo(
+    litellm_model_id="openai/gpt-4o",
+    display_name="gpt-4o",
+    provider="openai",
+    is_api=True,
+    capabilities=frozenset({"multimodal", "caption", "tags", "scores"}),
+)
+
+
+def _local_model(name: str, capability: str) -> StageModelInfo:
+    return StageModelInfo(
+        litellm_model_id=name,
+        display_name=name,
+        provider=None,
+        is_api=False,
+        capabilities=frozenset({capability}),
+    )
+
+
+def _sample_ledger() -> InferenceLedger:
+    """local 5 + API 1 (multimodal 3 枠) × 9 枚 = 54 推論ジョブ。"""
+    entries = (
+        LedgerEntry(model=GPT4O, stage_count=3),
+        LedgerEntry(model=_local_model("wd-v1-4-tagger", "tags"), stage_count=1),
+        LedgerEntry(model=_local_model("blip2-caption", "caption"), stage_count=1),
+        LedgerEntry(model=_local_model("aesthetic-scorer", "scores"), stage_count=1),
+        LedgerEntry(model=_local_model("cafe-aesthetic", "scores"), stage_count=1),
+        LedgerEntry(model=_local_model("nsfw-rater", "ratings"), stage_count=1),
+    )
+    return InferenceLedger(entries=entries, staged_count=9)
+
+
+@pytest.fixture
+def widget(qtbot):
+    w = InferenceLedgerWidget()
+    qtbot.addWidget(w)
+    return w
+
+
+class TestInferenceLedgerWidgetFormula:
+    def test_formula_shows_unique_staged_and_total(self, widget):
+        widget.display(_sample_ledger())
+        formula = widget._formula_label.text()
+        assert "6 ユニークモデル" in formula
+        assert "9 枚" in formula
+        assert "54 推論ジョブ" in formula
+
+    def test_formula_shows_local_api_breakdown(self, widget):
+        widget.display(_sample_ledger())
+        formula = widget._formula_label.text()
+        assert "local 5" in formula
+        assert "API 1" in formula
+
+
+class TestInferenceLedgerWidgetChips:
+    def test_one_chip_per_unique_model_with_staged_count(self, widget):
+        widget.display(_sample_ledger())
+        chips = widget.findChildren(QLabel, "ledgerChip")
+        assert len(chips) == 6
+        chip_texts = [chip.text() for chip in chips]
+        assert any("gpt-4o" in text and "×9枚" in text for text in chip_texts)
+        assert any("wd-v1-4-tagger" in text and "×9枚" in text for text in chip_texts)
+
+    def test_multimodal_entry_has_frame_to_inference_badge(self, widget):
+        widget.display(_sample_ledger())
+        badges = widget.findChildren(QLabel, "ledgerMultiBadge")
+        assert len(badges) == 1
+        assert badges[0].text() == "3枠 → 1推論"
+
+    def test_display_twice_does_not_duplicate_chips(self, widget):
+        widget.display(_sample_ledger())
+        widget.display(_sample_ledger())
+        assert len(widget.findChildren(QLabel, "ledgerChip")) == 6
+        assert len(widget.findChildren(QLabel, "ledgerMultiBadge")) == 1
+
+
+class TestInferenceLedgerWidgetPlaceholder:
+    def test_empty_entries_shows_placeholder(self, widget):
+        widget.display(InferenceLedger(entries=(), staged_count=9))
+        assert widget._placeholder_label.text() == "モデル未選択"
+        assert widget._formula_label.text() == ""
+        assert widget.findChildren(QLabel, "ledgerChip") == []
+
+    def test_zero_staged_count_shows_placeholder(self, widget):
+        ledger = InferenceLedger(entries=_sample_ledger().entries, staged_count=0)
+        widget.display(ledger)
+        assert widget._placeholder_label.text() == "モデル未選択"
+        assert widget.findChildren(QLabel, "ledgerChip") == []
+
+    def test_clear_resets_to_placeholder(self, widget):
+        widget.display(_sample_ledger())
+        widget.clear()
+        assert widget._placeholder_label.text() == "モデル未選択"
+        assert widget._formula_label.text() == ""
+        assert widget.findChildren(QLabel, "ledgerChip") == []
+        assert widget.findChildren(QLabel, "ledgerMultiBadge") == []

--- a/tests/unit/gui/widgets/test_pipeline_stage_table_widget.py
+++ b/tests/unit/gui/widgets/test_pipeline_stage_table_widget.py
@@ -1,0 +1,142 @@
+"""PipelineStageTableWidget 単体テスト"""
+
+from __future__ import annotations
+
+import pytest
+from PySide6.QtWidgets import QLabel, QWidget
+
+from lorairo.gui.widgets.pipeline_stage_table_widget import PipelineStageTableWidget
+from lorairo.services.pipeline_composition import (
+    DerivedChip,
+    PipelineStage,
+    StageModelInfo,
+    StageRow,
+)
+
+pytestmark = [pytest.mark.unit, pytest.mark.gui]
+
+GPT4O = StageModelInfo(
+    litellm_model_id="openai/gpt-4o",
+    display_name="gpt-4o",
+    provider="openai",
+    is_api=True,
+    capabilities=frozenset({"multimodal", "caption", "tags", "scores"}),
+)
+WD_TAGGER = StageModelInfo(
+    litellm_model_id="wd-v1-4-tagger",
+    display_name="wd-v1-4-tagger",
+    provider=None,
+    is_api=False,
+    capabilities=frozenset({"tags"}),
+)
+
+
+@pytest.fixture
+def widget(qtbot):
+    w = PipelineStageTableWidget()
+    qtbot.addWidget(w)
+    return w
+
+
+def _sample_rows() -> list[StageRow]:
+    """CAPTION に multimodal 明示割当、TAGS に local 明示 + 派生、の典型構成。"""
+    return [
+        StageRow(
+            stage=PipelineStage.TAGS,
+            primary_models=(WD_TAGGER,),
+            derived_chips=(DerivedChip(model=GPT4O, origin_stage=PipelineStage.CAPTION),),
+        ),
+        StageRow(
+            stage=PipelineStage.CAPTION,
+            primary_models=(GPT4O,),
+            derived_chips=(),
+        ),
+        StageRow(
+            stage=PipelineStage.SCORE,
+            primary_models=(),
+            derived_chips=(DerivedChip(model=GPT4O, origin_stage=PipelineStage.CAPTION),),
+        ),
+        StageRow(stage=PipelineStage.RATING, primary_models=(), derived_chips=()),
+    ]
+
+
+def _label_texts(widget: QWidget, object_name: str) -> list[str]:
+    return [label.text() for label in widget.findChildren(QLabel, object_name)]
+
+
+class TestPipelineStageTableWidgetStructure:
+    def test_empty_display_renders_four_stage_rows_and_legend(self, widget):
+        widget.display([])
+        for stage in ("TAGS", "CAPTION", "SCORE", "RATING"):
+            assert len(widget.findChildren(QWidget, f"stageRow_{stage}")) == 1
+        legends = widget.findChildren(QLabel, "pipelineLegendLabel")
+        assert len(legends) == 1
+        assert "↝" in legends[0].text()
+        assert "MULTI" in legends[0].text()
+
+    def test_clear_renders_four_empty_rows(self, widget):
+        widget.display(_sample_rows())
+        widget.clear()
+        for stage in ("TAGS", "CAPTION", "SCORE", "RATING"):
+            assert len(widget.findChildren(QWidget, f"stageRow_{stage}")) == 1
+        assert widget.findChildren(QLabel, "primaryChip") == []
+        assert widget.findChildren(QLabel, "derivedChip") == []
+
+
+class TestPipelineStageTableWidgetChips:
+    def test_primary_chip_shows_display_name(self, widget):
+        widget.display(_sample_rows())
+        primary_texts = _label_texts(widget, "primaryChip")
+        assert any("wd-v1-4-tagger" in text for text in primary_texts)
+
+    def test_derived_chip_shows_arrow_and_origin_stage(self, widget):
+        widget.display(_sample_rows())
+        derived_texts = _label_texts(widget, "derivedChip")
+        assert len(derived_texts) == 2
+        assert all(text.startswith("↝") for text in derived_texts)
+        assert all("from CAPTION" in text for text in derived_texts)
+        assert all("gpt-4o" in text for text in derived_texts)
+
+    def test_multimodal_primary_chip_has_multi_badge(self, widget):
+        widget.display(_sample_rows())
+        primary_texts = _label_texts(widget, "primaryChip")
+        multi_texts = [text for text in primary_texts if "MULTI" in text]
+        assert len(multi_texts) == 1
+        assert "gpt-4o" in multi_texts[0]
+        # CAPTION 割当の multimodal は TAGS / SCORE へファンアウトする注記を持つ
+        assert "派生" in multi_texts[0]
+        assert "T" in multi_texts[0]
+        assert "S" in multi_texts[0]
+
+    def test_count_label_shows_primary_and_derived_counts(self, widget):
+        widget.display(_sample_rows())
+        assert _label_texts(widget, "stageCount_TAGS") == ["1 + ↝1"]
+        assert _label_texts(widget, "stageCount_CAPTION") == ["1"]
+        assert _label_texts(widget, "stageCount_SCORE") == ["0 + ↝1"]
+        assert _label_texts(widget, "stageCount_RATING") == ["0"]
+
+
+class TestPipelineStageTableWidgetRatingNote:
+    def test_rating_row_has_no_derived_note(self, widget):
+        widget.display(_sample_rows())
+        notes = widget.findChildren(QLabel, "ratingNoDerivedNote")
+        assert len(notes) == 1
+        assert "multimodal 派生なし" in notes[0].text()
+        assert notes[0].toolTip() != ""
+
+    def test_derived_chip_has_readonly_tooltip(self, widget):
+        widget.display(_sample_rows())
+        derived = widget.findChildren(QLabel, "derivedChip")
+        assert all("Results" in chip.toolTip() for chip in derived)
+
+
+class TestPipelineStageTableWidgetRedisplay:
+    def test_display_twice_does_not_duplicate_chips(self, widget):
+        widget.display(_sample_rows())
+        first_primary = len(widget.findChildren(QLabel, "primaryChip"))
+        first_derived = len(widget.findChildren(QLabel, "derivedChip"))
+        widget.display(_sample_rows())
+        assert len(widget.findChildren(QLabel, "primaryChip")) == first_primary
+        assert len(widget.findChildren(QLabel, "derivedChip")) == first_derived
+        for stage in ("TAGS", "CAPTION", "SCORE", "RATING"):
+            assert len(widget.findChildren(QWidget, f"stageRow_{stage}")) == 1

--- a/tests/unit/gui/window/test_main_window_export_entry.py
+++ b/tests/unit/gui/window/test_main_window_export_entry.py
@@ -48,6 +48,11 @@ class _BareMainWindow(QMainWindow, Ui_MainWindow):
     def send_selected_to_batch_tag(self) -> None:
         pass
 
+    # Phase 6a: _on_staged_images_changed がパイプライン構成ビューを再描画するため、
+    # サービス未初期化の素ウィンドウでは no-op スタブで受ける
+    def _refresh_pipeline_panel(self, selected_ids: list[str] | None = None) -> None:
+        pass
+
 
 @pytest.fixture
 def bare_window(qtbot):

--- a/tests/unit/gui/window/test_main_window_pipeline_panel.py
+++ b/tests/unit/gui/window/test_main_window_pipeline_panel.py
@@ -1,0 +1,145 @@
+"""MainWindow × パイプライン構成ビュー (Phase 6a) の配線テスト。
+
+Wireframes v11 Frame 2A: ModelSelectionWidget の選択購読 → ステージ自動仕分け →
+派生チップ・推論台帳のリアルタイム表示の配線を Mock ベースで検証する。
+"""
+
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+
+from lorairo.services.pipeline_composition import (
+    PipelineCompositionService,
+    PipelineStage,
+    StageModelInfo,
+)
+
+GPT4O_INFO = StageModelInfo(
+    litellm_model_id="openai/gpt-4o",
+    display_name="gpt-4o",
+    provider="openai",
+    is_api=True,
+    capabilities=frozenset({"multimodal", "caption", "tags", "scores"}),
+)
+
+
+@pytest.mark.unit
+class TestBuildStageModelInfos:
+    """litellm_model_id → StageModelInfo 変換の検証。"""
+
+    def _make_window(self, models: list[SimpleNamespace]) -> Mock:
+        mock_window = Mock()
+        mock_window.batchModelSelection.model_selection_service.load_models.return_value = models
+        return mock_window
+
+    def test_converts_api_model_with_capabilities(self):
+        from lorairo.gui.window.main_window import MainWindow
+
+        model = SimpleNamespace(
+            litellm_model_id="openai/gpt-4o",
+            name="gpt-4o",
+            provider="openai",
+            capabilities=["multimodal", "caption", "tags", "scores"],
+        )
+        mock_window = self._make_window([model])
+        infos = MainWindow._build_stage_model_infos(mock_window, ["openai/gpt-4o"])
+
+        assert len(infos) == 1
+        assert infos[0].is_api is True
+        assert infos[0].is_multimodal is True
+        assert infos[0].capabilities == frozenset({"multimodal", "caption", "tags", "scores"})
+
+    def test_local_provider_none_is_not_api(self):
+        from lorairo.gui.window.main_window import MainWindow
+
+        model = SimpleNamespace(
+            litellm_model_id="wd-v1-4-tagger",
+            name="wd-v1-4-tagger",
+            provider=None,
+            capabilities=["tags"],
+        )
+        mock_window = self._make_window([model])
+        infos = MainWindow._build_stage_model_infos(mock_window, ["wd-v1-4-tagger"])
+
+        assert infos[0].is_api is False
+        assert infos[0].is_multimodal is False
+
+    def test_provider_local_string_is_not_api(self):
+        from lorairo.gui.window.main_window import MainWindow
+
+        model = SimpleNamespace(
+            litellm_model_id="aesthetic-v2",
+            name="aesthetic-v2",
+            provider="local",
+            capabilities=["scores"],
+        )
+        mock_window = self._make_window([model])
+        infos = MainWindow._build_stage_model_infos(mock_window, ["aesthetic-v2"])
+
+        assert infos[0].is_api is False
+
+    def test_unknown_id_is_skipped(self):
+        from lorairo.gui.window.main_window import MainWindow
+
+        mock_window = self._make_window([])
+        infos = MainWindow._build_stage_model_infos(mock_window, ["missing/model"])
+
+        assert infos == []
+
+
+@pytest.mark.unit
+class TestPipelinePanelRefresh:
+    """選択変化・ステージング変化での再描画配線の検証。"""
+
+    def test_models_changed_triggers_refresh_with_ids(self):
+        from lorairo.gui.window.main_window import MainWindow
+
+        mock_window = Mock()
+        MainWindow._on_pipeline_models_changed(mock_window, ["openai/gpt-4o"])
+        mock_window._refresh_pipeline_panel.assert_called_once_with(["openai/gpt-4o"])
+
+    def test_refresh_skips_when_widgets_missing(self):
+        from lorairo.gui.window.main_window import MainWindow
+
+        mock_window = Mock()
+        mock_window.pipeline_stage_table = None
+        mock_window.inference_ledger_widget = None
+        # widget 未構築でも例外なく早期 return する
+        MainWindow._refresh_pipeline_panel(mock_window, ["openai/gpt-4o"])
+        mock_window.pipeline_composition_service.compose_from_models.assert_not_called()
+
+    def test_refresh_composes_and_displays(self):
+        """実 PipelineCompositionService で multimodal 構成が表示に渡ることを検証。"""
+        from lorairo.gui.window.main_window import MainWindow
+
+        mock_window = Mock()
+        mock_window.pipeline_composition_service = PipelineCompositionService()
+        mock_window._pipeline_staged_count = 9
+        mock_window._build_stage_model_infos = lambda ids: [GPT4O_INFO]
+
+        MainWindow._refresh_pipeline_panel(mock_window, ["openai/gpt-4o"])
+
+        rows = mock_window.pipeline_stage_table.display.call_args[0][0]
+        rows_by_stage = {row.stage: row for row in rows}
+        # multimodal は CAPTION に明示割当、TAGS/SCORE に派生、RATING には届かない
+        assert [m.litellm_model_id for m in rows_by_stage[PipelineStage.CAPTION].primary_models] == [
+            "openai/gpt-4o"
+        ]
+        assert [c.model.litellm_model_id for c in rows_by_stage[PipelineStage.TAGS].derived_chips] == [
+            "openai/gpt-4o"
+        ]
+        assert rows_by_stage[PipelineStage.RATING].derived_chips == ()
+
+        ledger = mock_window.inference_ledger_widget.display.call_args[0][0]
+        assert ledger.unique_model_count == 1
+        assert ledger.total_jobs == 9
+
+    def test_staged_images_changed_syncs_ledger_count(self):
+        from lorairo.gui.window.main_window import MainWindow
+
+        mock_window = Mock()
+        MainWindow._on_staged_images_changed(mock_window, [1, 2, 3])
+
+        assert mock_window._pipeline_staged_count == 3
+        mock_window._refresh_pipeline_panel.assert_called_once_with()

--- a/tests/unit/services/test_pipeline_composition.py
+++ b/tests/unit/services/test_pipeline_composition.py
@@ -1,0 +1,262 @@
+# tests/unit/services/test_pipeline_composition.py
+"""PipelineCompositionService の計算ロジックのユニットテスト (Phase 6a Track A)。
+
+Wireframes v11 Frame 2A のリファレンス構成 (タガー2 + multimodal1 +
+スコアラー2 + レーター1) を中心に、自動仕分け・派生チップ・推論台帳を検証する。
+"""
+
+import pytest
+
+from lorairo.services.pipeline_composition import (
+    MULTIMODAL_FILL_STAGES,
+    DerivedChip,
+    PipelineCompositionService,
+    PipelineStage,
+    StageModelInfo,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _model(
+    model_id: str,
+    capabilities: set[str],
+    *,
+    is_api: bool = False,
+    provider: str | None = None,
+) -> StageModelInfo:
+    """テスト用 StageModelInfo を生成するヘルパー。"""
+    return StageModelInfo(
+        litellm_model_id=model_id,
+        display_name=model_id,
+        provider=provider,
+        is_api=is_api,
+        capabilities=frozenset(capabilities),
+    )
+
+
+@pytest.fixture
+def v11_reference_models() -> list[StageModelInfo]:
+    """v11 リファレンス構成: タガー2 + multimodal1 + スコアラー2 + レーター1。"""
+    return [
+        _model("wd-v1-4", {"tags"}),
+        _model("wd-eva02", {"tags"}),
+        _model("openai/gpt-4o", {"multimodal"}, is_api=True, provider="openai"),
+        _model("aesthetic-shadow", {"scores"}),
+        _model("cafe-aesthetic", {"scores"}),
+        _model("classification-rater", {"ratings"}),
+    ]
+
+
+@pytest.fixture
+def service() -> PipelineCompositionService:
+    return PipelineCompositionService()
+
+
+class TestStageModelInfo:
+    def test_fill_stages_multimodal_returns_fill_stages_without_rating(self) -> None:
+        model = _model("openai/gpt-4o", {"multimodal"}, is_api=True)
+        assert model.fill_stages() == MULTIMODAL_FILL_STAGES
+        assert model.fill_stages() == frozenset(
+            {PipelineStage.TAGS, PipelineStage.CAPTION, PipelineStage.SCORE}
+        )
+        assert PipelineStage.RATING not in model.fill_stages()
+
+    def test_fill_stages_tags_only_returns_tags(self) -> None:
+        model = _model("wd-v1-4", {"tags"})
+        assert model.fill_stages() == frozenset({PipelineStage.TAGS})
+
+    def test_fill_stages_ratings_returns_rating(self) -> None:
+        model = _model("classification-rater", {"ratings"})
+        assert model.fill_stages() == frozenset({PipelineStage.RATING})
+
+    def test_fill_stages_multi_capability_local_returns_each_stage(self) -> None:
+        model = _model("local-tagger-captioner", {"tags", "caption"})
+        assert model.fill_stages() == frozenset({PipelineStage.TAGS, PipelineStage.CAPTION})
+
+    def test_is_multimodal_local_model_is_false(self) -> None:
+        # ローカルモデルは "multimodal" capability があっても multimodal 扱いしない
+        model = _model("local-multi", {"multimodal"}, is_api=False)
+        assert model.is_multimodal is False
+
+    def test_is_multimodal_api_model_is_true(self) -> None:
+        model = _model("openai/gpt-4o", {"multimodal"}, is_api=True)
+        assert model.is_multimodal is True
+
+
+class TestComposeFromModels:
+    def test_v11_reference_stage_rows(
+        self, service: PipelineCompositionService, v11_reference_models: list[StageModelInfo]
+    ) -> None:
+        service.compose_from_models(v11_reference_models)
+        rows = service.stage_rows()
+
+        assert [row.stage for row in rows] == list(PipelineStage)
+        rows_by_stage = {row.stage: row for row in rows}
+
+        # TAGS: primary 2 + derived 1 (gpt-4o from CAPTION)
+        tags_row = rows_by_stage[PipelineStage.TAGS]
+        assert [m.litellm_model_id for m in tags_row.primary_models] == ["wd-v1-4", "wd-eva02"]
+        assert [c.model.litellm_model_id for c in tags_row.derived_chips] == ["openai/gpt-4o"]
+        assert tags_row.derived_chips[0].origin_stage == PipelineStage.CAPTION
+
+        # CAPTION: primary 1 (gpt-4o)、derived 0
+        caption_row = rows_by_stage[PipelineStage.CAPTION]
+        assert [m.litellm_model_id for m in caption_row.primary_models] == ["openai/gpt-4o"]
+        assert caption_row.derived_chips == ()
+
+        # SCORE: primary 2 + derived 1 (gpt-4o from CAPTION)
+        score_row = rows_by_stage[PipelineStage.SCORE]
+        assert [m.litellm_model_id for m in score_row.primary_models] == [
+            "aesthetic-shadow",
+            "cafe-aesthetic",
+        ]
+        assert score_row.derived_chips == (
+            DerivedChip(model=v11_reference_models[2], origin_stage=PipelineStage.CAPTION),
+        )
+
+        # RATING: primary 1、derived は決して出ない
+        rating_row = rows_by_stage[PipelineStage.RATING]
+        assert [m.litellm_model_id for m in rating_row.primary_models] == ["classification-rater"]
+        assert rating_row.derived_chips == ()
+
+    def test_duplicate_model_ids_are_deduped(self, service: PipelineCompositionService) -> None:
+        tagger = _model("wd-v1-4", {"tags"})
+        service.compose_from_models([tagger, tagger, _model("wd-v1-4", {"tags"})])
+        rows_by_stage = {row.stage: row for row in service.stage_rows()}
+        assert len(rows_by_stage[PipelineStage.TAGS].primary_models) == 1
+
+    def test_multi_capability_local_model_assigned_to_each_stage(
+        self, service: PipelineCompositionService
+    ) -> None:
+        # 非 multimodal の複数 capability は対応する複数ステージそれぞれに明示割当
+        model = _model("local-tagger-captioner", {"tags", "caption"})
+        service.compose_from_models([model])
+        rows_by_stage = {row.stage: row for row in service.stage_rows()}
+        assert rows_by_stage[PipelineStage.TAGS].primary_models == (model,)
+        assert rows_by_stage[PipelineStage.CAPTION].primary_models == (model,)
+        # 非 multimodal は派生を出さない
+        assert all(row.derived_chips == () for row in service.stage_rows())
+
+    def test_recompose_clears_previous_assignments(
+        self, service: PipelineCompositionService, v11_reference_models: list[StageModelInfo]
+    ) -> None:
+        service.compose_from_models(v11_reference_models)
+        rater_only = [_model("classification-rater", {"ratings"})]
+        service.compose_from_models(rater_only)
+
+        rows_by_stage = {row.stage: row for row in service.stage_rows()}
+        assert rows_by_stage[PipelineStage.TAGS].primary_models == ()
+        assert rows_by_stage[PipelineStage.TAGS].derived_chips == ()
+        assert rows_by_stage[PipelineStage.CAPTION].primary_models == ()
+        assert rows_by_stage[PipelineStage.SCORE].primary_models == ()
+        assert [m.litellm_model_id for m in rows_by_stage[PipelineStage.RATING].primary_models] == [
+            "classification-rater"
+        ]
+        assert service.unique_model_ids() == ["classification-rater"]
+
+    def test_empty_input_yields_empty_rows_and_zero_ledger(
+        self, service: PipelineCompositionService
+    ) -> None:
+        service.compose_from_models([])
+        rows = service.stage_rows()
+        assert len(rows) == 4
+        assert all(row.primary_models == () and row.derived_chips == () for row in rows)
+
+        ledger = service.ledger(staged_count=9)
+        assert ledger.entries == ()
+        assert ledger.unique_model_count == 0
+        assert ledger.total_jobs == 0
+        assert ledger.local_count == 0
+        assert ledger.api_count == 0
+        assert service.unique_model_ids() == []
+
+
+class TestAssignRemove:
+    def test_assign_is_idempotent_per_stage(self, service: PipelineCompositionService) -> None:
+        model = _model("wd-v1-4", {"tags"})
+        service.assign(PipelineStage.TAGS, model)
+        service.assign(PipelineStage.TAGS, model)
+        rows_by_stage = {row.stage: row for row in service.stage_rows()}
+        assert rows_by_stage[PipelineStage.TAGS].primary_models == (model,)
+
+    def test_remove_missing_model_is_noop(self, service: PipelineCompositionService) -> None:
+        model = _model("wd-v1-4", {"tags"})
+        service.assign(PipelineStage.TAGS, model)
+        service.remove(PipelineStage.TAGS, "unknown-model")
+        rows_by_stage = {row.stage: row for row in service.stage_rows()}
+        assert rows_by_stage[PipelineStage.TAGS].primary_models == (model,)
+
+    def test_same_multimodal_assigned_to_two_stages_dedupes(
+        self, service: PipelineCompositionService
+    ) -> None:
+        gpt4o = _model("openai/gpt-4o", {"multimodal"}, is_api=True, provider="openai")
+        service.assign(PipelineStage.TAGS, gpt4o)
+        service.assign(PipelineStage.CAPTION, gpt4o)
+
+        rows_by_stage = {row.stage: row for row in service.stage_rows()}
+        # 明示割当されたステージには derived を出さない
+        assert rows_by_stage[PipelineStage.TAGS].primary_models == (gpt4o,)
+        assert rows_by_stage[PipelineStage.TAGS].derived_chips == ()
+        assert rows_by_stage[PipelineStage.CAPTION].primary_models == (gpt4o,)
+        assert rows_by_stage[PipelineStage.CAPTION].derived_chips == ()
+        # SCORE のみ derived。origin は最初の割当ステージ (TAGS)
+        assert rows_by_stage[PipelineStage.SCORE].derived_chips == (
+            DerivedChip(model=gpt4o, origin_stage=PipelineStage.TAGS),
+        )
+        assert rows_by_stage[PipelineStage.RATING].derived_chips == ()
+
+        # 台帳は 1 エントリのまま (dedupe)、届くステージは 3 つ
+        ledger = service.ledger(staged_count=10)
+        assert ledger.unique_model_count == 1
+        assert ledger.entries[0].stage_count == 3
+        assert ledger.total_jobs == 10
+
+    def test_remove_multimodal_from_caption_clears_all_derived(
+        self, service: PipelineCompositionService, v11_reference_models: list[StageModelInfo]
+    ) -> None:
+        service.compose_from_models(v11_reference_models)
+        service.remove(PipelineStage.CAPTION, "openai/gpt-4o")
+
+        rows = service.stage_rows()
+        assert all(row.derived_chips == () for row in rows)
+        rows_by_stage = {row.stage: row for row in rows}
+        assert rows_by_stage[PipelineStage.CAPTION].primary_models == ()
+
+        ledger = service.ledger(staged_count=9)
+        assert ledger.unique_model_count == 5
+        assert ledger.api_count == 0
+        assert "openai/gpt-4o" not in service.unique_model_ids()
+
+
+class TestLedger:
+    def test_v11_reference_ledger(
+        self, service: PipelineCompositionService, v11_reference_models: list[StageModelInfo]
+    ) -> None:
+        service.compose_from_models(v11_reference_models)
+        ledger = service.ledger(staged_count=9)
+
+        assert ledger.unique_model_count == 6
+        assert ledger.staged_count == 9
+        assert ledger.total_jobs == 54
+        assert ledger.local_count == 5
+        assert ledger.api_count == 1
+
+        entries_by_id = {entry.model.litellm_model_id: entry for entry in ledger.entries}
+        assert entries_by_id["openai/gpt-4o"].stage_count == 3
+        assert entries_by_id["wd-v1-4"].stage_count == 1
+        assert entries_by_id["aesthetic-shadow"].stage_count == 1
+        assert entries_by_id["classification-rater"].stage_count == 1
+
+    def test_unique_model_ids_in_assignment_order(
+        self, service: PipelineCompositionService, v11_reference_models: list[StageModelInfo]
+    ) -> None:
+        service.compose_from_models(v11_reference_models)
+        assert service.unique_model_ids() == [
+            "wd-v1-4",
+            "wd-eva02",
+            "openai/gpt-4o",
+            "aesthetic-shadow",
+            "cafe-aesthetic",
+            "classification-rater",
+        ]


### PR DESCRIPTION
## 概要

Wireframes v11 Frame 2A · Annotate の Phase 6a 実装。アノテーショングループに「ステージ中心パイプライン構成ビュー」を常設し、選択モデルの TAGS/CAPTION/SCORE/RATING 自動仕分け・multimodal 派生チップ・推論台帳 (INFERENCE LEDGER) をリアルタイム表示する。

Refs #722 / Epic #731

## デザイン確定事項の反映 (handoff 0d_Bf0ZM3o51dfKlaybtmA, 2026-06-11)

- **multimodal の派生先は TAGS + CAPTION + SCORE のみ** — AnnotationSchema = {tags, captions, score}。**RATING には決して届かない**（rating は rating 対応モデルか Moderations preflight 由来）。RATING 行に「multimodal 派生なし †」注記 + tooltip
- **チップ語彙**: Primary（MULTI バッジ + ＋派生 T S ファンアウト）/ Derived（↝ · 斜体 · from CAPTION · 操作不可、soft-reject #719 誘導 tooltip）+ 凡例行
- **INFERENCE LEDGER**: 推論回数 = ユニークモデル × ステージング枚数。multimodal の多段出現は dedupe（`3枠 → 1推論` バッジ）、式表示 `6 ユニークモデル × 9 枚 = 54 推論ジョブ（local 5 · API 1）`

## 構成 (骨格 → Track A/B 並列 → Lead)

| Track | 内容 |
|---|---|
| 骨格 | `pipeline_composition.py` — PipelineStage / StageModelInfo / DerivedChip / StageRow / InferenceLedger のドメイン契約 |
| A (Qt-free) | `PipelineCompositionService` — 自動仕分け / 派生計算（都度導出・状態なし）/ 台帳 dedupe。17 tests |
| B (Qt) | `PipelineStageTableWidget` + `InferenceLedgerWidget`。17 tests |
| Lead | `groupBoxAnnotation` へ常設、`model_selection_changed` 購読、litellm_id → StageModelInfo 変換、ステージング件数同期。9 tests + 統合 1 |

## スコープ (Phase 6 分割)

- **6a (本 PR)**: 表示専用の構成ビュー。実行経路 (AnnotationWorkflowController) は無傷
- **6b (後続)**: ステージ click → per-stage モデルピッカー (Frame 2B)、明示 assign/remove
- **除外**: コスト表示 ($/img) — litellm pricing 未配線のため Issue 分離予定

## テスト

- 新規 44 tests 全 pass、対象範囲 207 tests pass
- CI-equivalent filter: 4100+ passed。local 失敗は libcudnn 欠如 (CUDA 非搭載 devcontainer の既知制約) + baseline でも再現する環境起因のみ（stash A/B で本変更起因ゼロを確認）

🤖 Generated with [Claude Code](https://claude.com/claude-code)