### PR TITLE
feat(annotate): Wireframes v11 Phase 6b — per-stage モデルピッカー

### DIFF
--- a/src/lorairo/gui/widgets/pipeline_stage_table_widget.py
+++ b/src/lorairo/gui/widgets/pipeline_stage_table_widget.py
@@ -1,13 +1,16 @@
-"""Wireframes v11 Frame 2A のステージ中心パイプラインテーブル (Phase 6a: 表示専用)。
+"""Wireframes v11 Frame 2A/2B のステージ中心パイプラインテーブル。
 
 TAGS/CAPTION/SCORE/RATING の 4 ステージ行に、明示割当 (primary) チップと
-multimodal 派生 (derived) チップを描画する。Phase 6a では remove 等の操作は
-提供しない (Phase 6b で追加)。
+multimodal 派生 (derived) チップを描画する (Phase 6a)。Phase 6b で各行の
+「+ 追加」ボタンと primary チップの × ボタンを追加し、操作要求を Signal で
+通知する (SSoT は ModelSelectionWidget のチェック状態のため、本 widget は
+要求を emit するだけで状態を持たない)。
 """
 
 from __future__ import annotations
 
-from PySide6.QtWidgets import QHBoxLayout, QLabel, QVBoxLayout, QWidget
+from PySide6.QtCore import Signal
+from PySide6.QtWidgets import QHBoxLayout, QLabel, QToolButton, QVBoxLayout, QWidget
 
 from lorairo.services.pipeline_composition import DerivedChip, PipelineStage, StageModelInfo, StageRow
 
@@ -34,6 +37,9 @@ _RATING_NOTE_TOOLTIP = (
     "rating は rating 対応モデルか送信前プリフライト (OpenAI Moderations) 由来です"
 )
 
+_REMOVE_BUTTON_TOOLTIP = "選択から外す（このモデルは全ステージから外れます）"
+_ADD_BUTTON_TEXT = "+ 追加"
+
 _PRIMARY_CHIP_STYLE = (
     "QLabel { border: 1px solid #5b8def; border-radius: 8px;"
     " padding: 2px 8px; background-color: #eef4ff; color: #1a3b6e; }"
@@ -49,7 +55,12 @@ _DERIVED_CHIP_STYLE = (
 
 
 class PipelineStageTableWidget(QWidget):
-    """Wireframes v11 Frame 2A のステージテーブル (Phase 6a: 表示専用)。"""
+    """Wireframes v11 Frame 2A/2B のステージテーブル (表示 + ステージ単位の操作要求)。"""
+
+    # ステージ行の「+ 追加」が押された (引数: PipelineStage の value)
+    add_model_requested = Signal(str)
+    # primary チップの × が押された (引数: stage value, litellm_model_id)
+    remove_model_requested = Signal(str, str)
 
     def __init__(self, parent: QWidget | None = None) -> None:
         super().__init__(parent)
@@ -130,11 +141,24 @@ class PipelineStageTableWidget(QWidget):
             note.setToolTip(_RATING_NOTE_TOOLTIP)
             row_layout.addWidget(note)
 
+        add_button = QToolButton(container)
+        add_button.setObjectName("stageAddModelButton")
+        add_button.setText(_ADD_BUTTON_TEXT)
+        add_button.setToolTip(f"{stage.name} に出力を届けられるモデルを選択して追加します")
+        add_button.clicked.connect(
+            lambda _checked=False, value=stage.value: self.add_model_requested.emit(value)
+        )
+        row_layout.addWidget(add_button)
+
         row_layout.addStretch(1)
         return container
 
-    def _build_primary_chip(self, model: StageModelInfo, stage: PipelineStage, parent: QWidget) -> QLabel:
-        """明示割当チップ (multimodal は MULTI バッジ + 派生ファンアウト注記付き)。"""
+    def _build_primary_chip(self, model: StageModelInfo, stage: PipelineStage, parent: QWidget) -> QWidget:
+        """明示割当チップ (multimodal は MULTI バッジ + 派生ファンアウト注記付き)。
+
+        Phase 6b: チップ label と × ボタンを HBox で一体化した container を返す。
+        × は「選択集合から外す」操作で、押すと全ステージから消える (モデル単位実行)。
+        """
         if model.is_multimodal:
             fanout_stages = [s for s in _STAGE_ORDER if s in model.fill_stages() and s is not stage]
             text = f"MULTI {model.display_name}"
@@ -148,7 +172,26 @@ class PipelineStageTableWidget(QWidget):
             chip = QLabel(model.display_name, parent)
             chip.setStyleSheet(_PRIMARY_CHIP_STYLE)
         chip.setObjectName("primaryChip")
-        return chip
+
+        container = QWidget(parent)
+        container.setObjectName("primaryChipContainer")
+        chip_layout = QHBoxLayout(container)
+        chip_layout.setContentsMargins(0, 0, 0, 0)
+        chip_layout.setSpacing(2)
+        chip_layout.addWidget(chip)
+
+        remove_button = QToolButton(container)
+        remove_button.setObjectName("primaryChipRemoveButton")
+        remove_button.setText("×")
+        remove_button.setAutoRaise(True)
+        remove_button.setToolTip(_REMOVE_BUTTON_TOOLTIP)
+        remove_button.clicked.connect(
+            lambda _checked=False, value=stage.value, model_id=model.litellm_model_id: (
+                self.remove_model_requested.emit(value, model_id)
+            )
+        )
+        chip_layout.addWidget(remove_button)
+        return container
 
     def _build_derived_chip(self, derived: DerivedChip, parent: QWidget) -> QLabel:
         """派生チップ (↝、斜体グレー、操作不可)。"""

--- a/src/lorairo/gui/widgets/stage_model_picker_dialog.py
+++ b/src/lorairo/gui/widgets/stage_model_picker_dialog.py
@@ -1,0 +1,93 @@
+"""Wireframes v11 Frame 2B のステージ別モデルピッカー (Phase 6b)。
+
+ステージ行の「+ 追加」から開き、そのステージに出力を届けられる未選択モデルを
+チェック可能リストで提示する。OK 後の `selected_model_ids()` を呼び出し元
+(MainWindow) が ModelSelectionWidget のチェック ON に変換する — SSoT は
+あくまで「選択モデル集合」であり、本ダイアログは候補提示と選択結果の返却のみ。
+"""
+
+from __future__ import annotations
+
+from PySide6.QtCore import Qt
+from PySide6.QtWidgets import (
+    QDialog,
+    QDialogButtonBox,
+    QLabel,
+    QListWidget,
+    QListWidgetItem,
+    QVBoxLayout,
+    QWidget,
+)
+
+from lorairo.services.pipeline_composition import PipelineStage, StageModelInfo
+
+_EMPTY_CANDIDATES_TEXT = "このステージに追加できる未選択モデルがありません"
+_MULTIMODAL_NOTE = "· 1推論で T C S（R は preflight 由来）"
+
+
+class StageModelPickerDialog(QDialog):
+    """ステージに追加可能なモデル候補を列挙するチェックリストダイアログ。"""
+
+    def __init__(
+        self,
+        stage: PipelineStage,
+        candidates: list[StageModelInfo],
+        parent: QWidget | None = None,
+    ) -> None:
+        """ダイアログを構築する。
+
+        Args:
+            stage: 追加先のパイプラインステージ。
+            candidates: このステージに出力を届けられる未選択モデルのリスト。
+            parent: 親 widget。
+        """
+        super().__init__(parent)
+        self.setWindowTitle(f"{stage.value.upper()} のモデルを選択")
+
+        layout = QVBoxLayout(self)
+
+        self._candidate_list = QListWidget(self)
+        self._candidate_list.setObjectName("stageModelCandidateList")
+        for info in candidates:
+            item = QListWidgetItem(self._candidate_text(info))
+            item.setFlags(item.flags() | Qt.ItemFlag.ItemIsUserCheckable)
+            item.setCheckState(Qt.CheckState.Unchecked)
+            item.setData(Qt.ItemDataRole.UserRole, info.litellm_model_id)
+            self._candidate_list.addItem(item)
+
+        if candidates:
+            layout.addWidget(self._candidate_list)
+        else:
+            self._candidate_list.hide()
+            empty_label = QLabel(_EMPTY_CANDIDATES_TEXT, self)
+            empty_label.setObjectName("emptyCandidatesLabel")
+            layout.addWidget(empty_label)
+
+        button_box = QDialogButtonBox(
+            QDialogButtonBox.StandardButton.Ok | QDialogButtonBox.StandardButton.Cancel,
+            self,
+        )
+        button_box.accepted.connect(self.accept)
+        button_box.rejected.connect(self.reject)
+        ok_button = button_box.button(QDialogButtonBox.StandardButton.Ok)
+        if ok_button is not None and not candidates:
+            ok_button.setEnabled(False)
+        layout.addWidget(button_box)
+
+    @staticmethod
+    def _candidate_text(info: StageModelInfo) -> str:
+        """候補 1 件分の表示テキストを返す。"""
+        origin = f"API: {info.provider}" if info.is_api else "ローカル"
+        text = f"{info.display_name}（{origin}）"
+        if info.is_multimodal:
+            text += f" {_MULTIMODAL_NOTE}"
+        return text
+
+    def selected_model_ids(self) -> list[str]:
+        """チェック済み候補の litellm_model_id リストを返す。"""
+        selected: list[str] = []
+        for index in range(self._candidate_list.count()):
+            item = self._candidate_list.item(index)
+            if item is not None and item.checkState() == Qt.CheckState.Checked:
+                selected.append(str(item.data(Qt.ItemDataRole.UserRole)))
+        return selected

--- a/src/lorairo/gui/window/main_window.py
+++ b/src/lorairo/gui/window/main_window.py
@@ -8,6 +8,7 @@ from typing import Any, cast
 from PySide6.QtCore import QEasingCurve, QPropertyAnimation, QSettings, Qt, QTimer, Signal
 from PySide6.QtGui import QCloseEvent, QKeySequence, QResizeEvent, QShortcut
 from PySide6.QtWidgets import (
+    QDialog,
     QFileDialog,
     QGraphicsOpacityEffect,
     QMainWindow,
@@ -22,10 +23,10 @@ from ...database.schema import ErrorRecord
 from ...gui.designer.MainWindow_ui import Ui_MainWindow
 from ...services import get_service_container
 from ...services.configuration_service import ConfigurationService
-from ...services.model_selection_service import ModelSelectionService
 from ...services.error_triage_service import ErrorFilter, ErrorRow, ErrorTriageService
+from ...services.model_selection_service import ModelSelectionService
+from ...services.pipeline_composition import PipelineCompositionService, PipelineStage, StageModelInfo
 from ...services.quality_issue_detection_service import QualityIssueDetectionService
-from ...services.pipeline_composition import PipelineCompositionService, StageModelInfo
 from ...services.selection_state_service import SelectionStateService
 from ...services.service_container import ServiceContainer
 from ...storage.file_system import FileSystemManager
@@ -43,8 +44,8 @@ from ..services.widget_setup_service import WidgetSetupService
 from ..services.worker_service import WorkerService
 from ..state.dataset_state import DatasetStateManager
 from ..widgets.dataset_export_widget import DatasetExportWidget
-from ..widgets.errors_triage_widget import ErrorsTriageWidget
 from ..widgets.error_notification_widget import ErrorNotificationWidget
+from ..widgets.errors_triage_widget import ErrorsTriageWidget
 from ..widgets.filter_search_panel import FilterSearchPanel
 from ..widgets.image_preview import ImagePreviewWidget
 from ..widgets.inference_ledger_widget import InferenceLedgerWidget
@@ -53,6 +54,7 @@ from ..widgets.provider_batch_job_widget import ProviderBatchJobWidget
 from ..widgets.quick_tag_dialog import QuickTagDialog
 from ..widgets.results_widget import ResultsWidget
 from ..widgets.selected_image_details_widget import SelectedImageDetailsWidget
+from ..widgets.stage_model_picker_dialog import StageModelPickerDialog
 from ..widgets.tag_management_dialog import TagManagementDialog
 from ..widgets.thumbnail import ThumbnailSelectorWidget
 
@@ -630,10 +632,11 @@ class MainWindow(QMainWindow, Ui_MainWindow):
     def _setup_pipeline_composition_panel(self) -> None:
         """アノテーショングループにパイプライン構成ビューを常設する。
 
-        Wireframes v11 Frame 2A · Phase 6a (表示専用)。ModelSelectionWidget の選択を
-        購読して TAGS/CAPTION/SCORE/RATING への自動仕分け・multimodal 派生チップ・
-        推論台帳 (INFERENCE LEDGER) をリアルタイム表示する。per-stage 明示割当は
-        Phase 6b で追加する。
+        Wireframes v11 Frame 2A/2B。ModelSelectionWidget の選択を購読して
+        TAGS/CAPTION/SCORE/RATING への自動仕分け・multimodal 派生チップ・
+        推論台帳 (INFERENCE LEDGER) をリアルタイム表示する (Phase 6a)。
+        各ステージ行の「+ 追加」/ primary チップの × はチェック状態の ON/OFF に
+        変換する (Phase 6b、SSoT は選択モデル集合)。
         """
         self.pipeline_composition_service = PipelineCompositionService()
         self._pipeline_staged_count = 0
@@ -653,6 +656,8 @@ class MainWindow(QMainWindow, Ui_MainWindow):
         layout.addWidget(self.inference_ledger_widget)
 
         model_widget.model_selection_changed.connect(self._on_pipeline_models_changed)
+        self.pipeline_stage_table.add_model_requested.connect(self._on_pipeline_add_model_requested)
+        self.pipeline_stage_table.remove_model_requested.connect(self._on_pipeline_remove_model_requested)
         self._refresh_pipeline_panel([])
         logger.info("✅ パイプライン構成ビュー (Frame 2A) initialized")
 
@@ -716,6 +721,61 @@ class MainWindow(QMainWindow, Ui_MainWindow):
                 )
             )
         return infos
+
+    def _on_pipeline_add_model_requested(self, stage_value: str) -> None:
+        """ステージ行の「+ 追加」でピッカーを開き、選択モデル集合へ追加する (Phase 6b)。
+
+        SSoT は ModelSelectionWidget のチェック状態。ピッカーで選んだモデルは
+        チェック ON で集合へ追加し、ステージ仕分けは compose_from_models に任せる。
+        set_selected() は checkbox シグナルを抑制するため、最後に明示再描画する。
+
+        Args:
+            stage_value: 追加先ステージの PipelineStage value。
+        """
+        model_widget = getattr(self, "batchModelSelection", None)
+        if model_widget is None:
+            return
+        stage = PipelineStage(stage_value)
+
+        service = getattr(model_widget, "model_selection_service", None)
+        all_models = service.load_models() if service is not None else []
+        all_ids = [model.litellm_model_id for model in all_models]
+        selected_ids = set(model_widget.get_selected_models())
+        candidates = [
+            info
+            for info in self._build_stage_model_infos(all_ids)
+            if stage in info.fill_stages() and info.litellm_model_id not in selected_ids
+        ]
+
+        dialog = StageModelPickerDialog(stage, candidates, parent=self)
+        if dialog.exec() != QDialog.DialogCode.Accepted:
+            return
+        for litellm_model_id in dialog.selected_model_ids():
+            checkbox_widget = model_widget.model_checkbox_widgets.get(litellm_model_id)
+            if checkbox_widget is None:
+                logger.warning(f"チェックボックス未表示のため追加をスキップ: {litellm_model_id}")
+                continue
+            checkbox_widget.set_selected(True)
+        self._refresh_pipeline_panel()
+
+    def _on_pipeline_remove_model_requested(self, stage_value: str, litellm_model_id: str) -> None:
+        """Primary チップの × でモデルを選択集合から外す (Phase 6b)。
+
+        実行粒度はモデル単位のため、チェック OFF = 全ステージから外れる。
+
+        Args:
+            stage_value: × が押されたステージの value (シグナル形状の都合で受けるが未使用)。
+            litellm_model_id: 集合から外すモデルの litellm_model_id。
+        """
+        model_widget = getattr(self, "batchModelSelection", None)
+        if model_widget is None:
+            return
+        checkbox_widget = model_widget.model_checkbox_widgets.get(litellm_model_id)
+        if checkbox_widget is None:
+            logger.warning(f"チェックボックス未表示のため除外をスキップ: {litellm_model_id}")
+            return
+        checkbox_widget.set_selected(False)
+        self._refresh_pipeline_panel()
 
     def _refresh_errors_tab(self) -> None:
         """エラータブ表示時 / フィルタ変更時にトリアージを再計算して描画する。"""

--- a/tests/unit/gui/widgets/test_pipeline_stage_table_widget.py
+++ b/tests/unit/gui/widgets/test_pipeline_stage_table_widget.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import pytest
-from PySide6.QtWidgets import QLabel, QWidget
+from PySide6.QtWidgets import QLabel, QToolButton, QWidget
 
 from lorairo.gui.widgets.pipeline_stage_table_widget import PipelineStageTableWidget
 from lorairo.services.pipeline_composition import (
@@ -128,6 +128,56 @@ class TestPipelineStageTableWidgetRatingNote:
         widget.display(_sample_rows())
         derived = widget.findChildren(QLabel, "derivedChip")
         assert all("Results" in chip.toolTip() for chip in derived)
+
+
+class TestPipelineStageTableWidgetOperations:
+    """Phase 6b: 「+ 追加」/ primary × の操作 Signal を検証する。"""
+
+    def test_add_button_click_emits_stage_value(self, widget, qtbot):
+        widget.display(_sample_rows())
+        tags_row = widget.findChildren(QWidget, "stageRow_TAGS")[0]
+        add_buttons = tags_row.findChildren(QToolButton, "stageAddModelButton")
+        assert len(add_buttons) == 1
+        with qtbot.waitSignal(widget.add_model_requested, timeout=1000) as blocker:
+            add_buttons[0].click()
+        assert blocker.args == ["tags"]
+
+    def test_every_stage_row_has_add_button(self, widget):
+        widget.display(_sample_rows())
+        for stage in ("TAGS", "CAPTION", "SCORE", "RATING"):
+            row = widget.findChildren(QWidget, f"stageRow_{stage}")[0]
+            assert len(row.findChildren(QToolButton, "stageAddModelButton")) == 1
+
+    def test_primary_chip_remove_click_emits_stage_and_model_id(self, widget, qtbot):
+        widget.display(_sample_rows())
+        tags_row = widget.findChildren(QWidget, "stageRow_TAGS")[0]
+        remove_buttons = tags_row.findChildren(QToolButton, "primaryChipRemoveButton")
+        assert len(remove_buttons) == 1
+        with qtbot.waitSignal(widget.remove_model_requested, timeout=1000) as blocker:
+            remove_buttons[0].click()
+        assert blocker.args == ["tags", "wd-v1-4-tagger"]
+
+    def test_remove_button_tooltip_warns_all_stages_removal(self, widget):
+        widget.display(_sample_rows())
+        remove_buttons = widget.findChildren(QToolButton, "primaryChipRemoveButton")
+        assert remove_buttons != []
+        assert all("全ステージ" in button.toolTip() for button in remove_buttons)
+
+    def test_derived_chip_has_no_remove_button(self, widget):
+        widget.display(_sample_rows())
+        # SCORE 行は派生チップのみ → remove ボタンは存在しない
+        score_row = widget.findChildren(QWidget, "stageRow_SCORE")[0]
+        assert score_row.findChildren(QToolButton, "primaryChipRemoveButton") == []
+        # remove ボタン総数 = primary チップ数 (派生には付かない)
+        all_removes = widget.findChildren(QToolButton, "primaryChipRemoveButton")
+        all_primaries = widget.findChildren(QLabel, "primaryChip")
+        assert len(all_removes) == len(all_primaries) == 2
+
+    def test_derived_chip_keeps_readonly_tooltip(self, widget):
+        widget.display(_sample_rows())
+        derived = widget.findChildren(QLabel, "derivedChip")
+        assert derived != []
+        assert all("外せません" in chip.toolTip() for chip in derived)
 
 
 class TestPipelineStageTableWidgetRedisplay:

--- a/tests/unit/gui/widgets/test_stage_model_picker_dialog.py
+++ b/tests/unit/gui/widgets/test_stage_model_picker_dialog.py
@@ -1,0 +1,111 @@
+"""StageModelPickerDialog 単体テスト (Phase 6b)"""
+
+from __future__ import annotations
+
+import pytest
+from PySide6.QtCore import Qt
+from PySide6.QtWidgets import QDialogButtonBox, QLabel, QListWidget
+
+from lorairo.gui.widgets.stage_model_picker_dialog import StageModelPickerDialog
+from lorairo.services.pipeline_composition import PipelineStage, StageModelInfo
+
+pytestmark = [pytest.mark.unit, pytest.mark.gui]
+
+GPT4O = StageModelInfo(
+    litellm_model_id="openai/gpt-4o",
+    display_name="gpt-4o",
+    provider="openai",
+    is_api=True,
+    capabilities=frozenset({"multimodal", "caption", "tags", "scores"}),
+)
+WD_TAGGER = StageModelInfo(
+    litellm_model_id="wd-v1-4-tagger",
+    display_name="wd-v1-4-tagger",
+    provider=None,
+    is_api=False,
+    capabilities=frozenset({"tags"}),
+)
+
+
+def _candidate_list(dialog: StageModelPickerDialog) -> QListWidget:
+    lists = dialog.findChildren(QListWidget, "stageModelCandidateList")
+    assert len(lists) == 1
+    return lists[0]
+
+
+def _ok_button(dialog: StageModelPickerDialog):
+    boxes = dialog.findChildren(QDialogButtonBox)
+    assert len(boxes) == 1
+    return boxes[0].button(QDialogButtonBox.StandardButton.Ok)
+
+
+class TestStageModelPickerDialogRendering:
+    def test_title_uses_uppercase_stage_value(self, qtbot):
+        dialog = StageModelPickerDialog(PipelineStage.TAGS, [GPT4O, WD_TAGGER])
+        qtbot.addWidget(dialog)
+        assert dialog.windowTitle() == "TAGS のモデルを選択"
+
+    def test_candidates_rendered_with_provider_origin(self, qtbot):
+        dialog = StageModelPickerDialog(PipelineStage.TAGS, [GPT4O, WD_TAGGER])
+        qtbot.addWidget(dialog)
+        candidate_list = _candidate_list(dialog)
+        assert candidate_list.count() == 2
+        texts = [candidate_list.item(i).text() for i in range(candidate_list.count())]
+        assert any("gpt-4o" in text and "API: openai" in text for text in texts)
+        assert any("wd-v1-4-tagger" in text and "ローカル" in text for text in texts)
+
+    def test_multimodal_row_shows_fanout_note(self, qtbot):
+        dialog = StageModelPickerDialog(PipelineStage.TAGS, [GPT4O, WD_TAGGER])
+        qtbot.addWidget(dialog)
+        candidate_list = _candidate_list(dialog)
+        texts = [candidate_list.item(i).text() for i in range(candidate_list.count())]
+        multimodal_texts = [text for text in texts if "gpt-4o" in text]
+        assert len(multimodal_texts) == 1
+        assert "1推論で T C S" in multimodal_texts[0]
+        assert "preflight" in multimodal_texts[0]
+        local_texts = [text for text in texts if "wd-v1-4-tagger" in text]
+        assert "1推論で" not in local_texts[0]
+
+    def test_items_are_user_checkable_and_initially_unchecked(self, qtbot):
+        dialog = StageModelPickerDialog(PipelineStage.TAGS, [GPT4O, WD_TAGGER])
+        qtbot.addWidget(dialog)
+        candidate_list = _candidate_list(dialog)
+        for i in range(candidate_list.count()):
+            item = candidate_list.item(i)
+            assert item.flags() & Qt.ItemFlag.ItemIsUserCheckable
+            assert item.checkState() == Qt.CheckState.Unchecked
+
+
+class TestStageModelPickerDialogSelection:
+    def test_no_check_returns_empty(self, qtbot):
+        dialog = StageModelPickerDialog(PipelineStage.TAGS, [GPT4O, WD_TAGGER])
+        qtbot.addWidget(dialog)
+        assert dialog.selected_model_ids() == []
+
+    def test_checked_items_return_litellm_model_ids(self, qtbot):
+        dialog = StageModelPickerDialog(PipelineStage.TAGS, [GPT4O, WD_TAGGER])
+        qtbot.addWidget(dialog)
+        candidate_list = _candidate_list(dialog)
+        candidate_list.item(0).setCheckState(Qt.CheckState.Checked)
+        candidate_list.item(1).setCheckState(Qt.CheckState.Checked)
+        assert dialog.selected_model_ids() == ["openai/gpt-4o", "wd-v1-4-tagger"]
+
+    def test_partial_check_returns_only_checked(self, qtbot):
+        dialog = StageModelPickerDialog(PipelineStage.TAGS, [GPT4O, WD_TAGGER])
+        qtbot.addWidget(dialog)
+        candidate_list = _candidate_list(dialog)
+        candidate_list.item(1).setCheckState(Qt.CheckState.Checked)
+        assert dialog.selected_model_ids() == ["wd-v1-4-tagger"]
+
+
+class TestStageModelPickerDialogEmptyCandidates:
+    def test_empty_candidates_shows_label_and_disables_ok(self, qtbot):
+        dialog = StageModelPickerDialog(PipelineStage.RATING, [])
+        qtbot.addWidget(dialog)
+        labels = dialog.findChildren(QLabel, "emptyCandidatesLabel")
+        assert len(labels) == 1
+        assert "追加できる未選択モデルがありません" in labels[0].text()
+        ok_button = _ok_button(dialog)
+        assert ok_button is not None
+        assert not ok_button.isEnabled()
+        assert dialog.selected_model_ids() == []

--- a/tests/unit/gui/window/test_main_window_pipeline_panel.py
+++ b/tests/unit/gui/window/test_main_window_pipeline_panel.py
@@ -1,13 +1,15 @@
-"""MainWindow × パイプライン構成ビュー (Phase 6a) の配線テスト。
+"""MainWindow × パイプライン構成ビュー (Phase 6a/6b) の配線テスト。
 
-Wireframes v11 Frame 2A: ModelSelectionWidget の選択購読 → ステージ自動仕分け →
-派生チップ・推論台帳のリアルタイム表示の配線を Mock ベースで検証する。
+Wireframes v11 Frame 2A/2B: ModelSelectionWidget の選択購読 → ステージ自動仕分け →
+派生チップ・推論台帳のリアルタイム表示の配線と、ステージ単位の追加/削除
+ハンドラ (Phase 6b) を Mock ベースで検証する。
 """
 
 from types import SimpleNamespace
 from unittest.mock import Mock
 
 import pytest
+from PySide6.QtWidgets import QDialog
 
 from lorairo.services.pipeline_composition import (
     PipelineCompositionService,
@@ -22,6 +24,38 @@ GPT4O_INFO = StageModelInfo(
     is_api=True,
     capabilities=frozenset({"multimodal", "caption", "tags", "scores"}),
 )
+WD_TAGGER_INFO = StageModelInfo(
+    litellm_model_id="wd-v1-4-tagger",
+    display_name="wd-v1-4-tagger",
+    provider=None,
+    is_api=False,
+    capabilities=frozenset({"tags"}),
+)
+
+
+def _make_stub_dialog(
+    exec_result: QDialog.DialogCode, picked_ids: list[str]
+) -> tuple[type, dict[str, object]]:
+    """StageModelPickerDialog 差し替え用 stub クラスと捕捉 dict を返す。
+
+    headless で exec() がブロックしないよう固定値を返す。テストごとに新しい
+    クラスを生成し、クラスレベルの状態共有 (テスト順依存) を避ける。
+    """
+    captured: dict[str, object] = {}
+
+    class _StubPickerDialog:
+        def __init__(self, stage, candidates, parent=None):
+            captured["stage"] = stage
+            captured["candidates"] = candidates
+            captured["parent"] = parent
+
+        def exec(self) -> QDialog.DialogCode:
+            return exec_result
+
+        def selected_model_ids(self) -> list[str]:
+            return picked_ids
+
+    return _StubPickerDialog, captured
 
 
 @pytest.mark.unit
@@ -143,3 +177,124 @@ class TestPipelinePanelRefresh:
 
         assert mock_window._pipeline_staged_count == 3
         mock_window._refresh_pipeline_panel.assert_called_once_with()
+
+
+@pytest.mark.unit
+class TestPipelineAddModelHandler:
+    """「+ 追加」ハンドラ: ピッカー Accepted → チェック ON 変換の検証 (Phase 6b)。"""
+
+    def _make_window(
+        self,
+        checkbox_widgets: dict[str, Mock],
+        selected_ids: list[str],
+        infos: list[StageModelInfo],
+    ) -> Mock:
+        mock_window = Mock()
+        mock_window.batchModelSelection.model_checkbox_widgets = checkbox_widgets
+        mock_window.batchModelSelection.get_selected_models.return_value = selected_ids
+        mock_window.batchModelSelection.model_selection_service.load_models.return_value = [
+            SimpleNamespace(litellm_model_id=info.litellm_model_id) for info in infos
+        ]
+        mock_window._build_stage_model_infos = lambda ids: infos
+        return mock_window
+
+    def test_accepted_dialog_sets_selected_true(self, monkeypatch):
+        from lorairo.gui.window import main_window as main_window_module
+        from lorairo.gui.window.main_window import MainWindow
+
+        checkbox = Mock()
+        mock_window = self._make_window({"openai/gpt-4o": checkbox}, [], [GPT4O_INFO])
+        stub_cls, captured = _make_stub_dialog(QDialog.DialogCode.Accepted, ["openai/gpt-4o"])
+        monkeypatch.setattr(main_window_module, "StageModelPickerDialog", stub_cls)
+
+        MainWindow._on_pipeline_add_model_requested(mock_window, "tags")
+
+        assert captured["stage"] is PipelineStage.TAGS
+        checkbox.set_selected.assert_called_once_with(True)
+        mock_window._refresh_pipeline_panel.assert_called_once_with()
+
+    def test_candidates_filtered_by_stage_and_unselected(self, monkeypatch):
+        from lorairo.gui.window import main_window as main_window_module
+        from lorairo.gui.window.main_window import MainWindow
+
+        # GPT4O は選択済み → 除外。WD_TAGGER は tags 適格 → 候補。
+        mock_window = self._make_window({}, ["openai/gpt-4o"], [GPT4O_INFO, WD_TAGGER_INFO])
+        stub_cls, captured = _make_stub_dialog(QDialog.DialogCode.Rejected, [])
+        monkeypatch.setattr(main_window_module, "StageModelPickerDialog", stub_cls)
+
+        MainWindow._on_pipeline_add_model_requested(mock_window, "tags")
+
+        candidates = captured["candidates"]
+        assert [info.litellm_model_id for info in candidates] == ["wd-v1-4-tagger"]
+
+    def test_stage_ineligible_model_not_in_candidates(self, monkeypatch):
+        from lorairo.gui.window import main_window as main_window_module
+        from lorairo.gui.window.main_window import MainWindow
+
+        # WD_TAGGER (tags のみ) は RATING 候補に出ない。multimodal も rating には届かない。
+        mock_window = self._make_window({}, [], [GPT4O_INFO, WD_TAGGER_INFO])
+        stub_cls, captured = _make_stub_dialog(QDialog.DialogCode.Rejected, [])
+        monkeypatch.setattr(main_window_module, "StageModelPickerDialog", stub_cls)
+
+        MainWindow._on_pipeline_add_model_requested(mock_window, "rating")
+
+        assert captured["candidates"] == []
+
+    def test_rejected_dialog_does_not_change_selection(self, monkeypatch):
+        from lorairo.gui.window import main_window as main_window_module
+        from lorairo.gui.window.main_window import MainWindow
+
+        checkbox = Mock()
+        mock_window = self._make_window({"openai/gpt-4o": checkbox}, [], [GPT4O_INFO])
+        stub_cls, _captured = _make_stub_dialog(QDialog.DialogCode.Rejected, ["openai/gpt-4o"])
+        monkeypatch.setattr(main_window_module, "StageModelPickerDialog", stub_cls)
+
+        MainWindow._on_pipeline_add_model_requested(mock_window, "tags")
+
+        checkbox.set_selected.assert_not_called()
+        mock_window._refresh_pipeline_panel.assert_not_called()
+
+    def test_picked_id_missing_from_checkbox_dict_is_skipped(self, monkeypatch):
+        from lorairo.gui.window import main_window as main_window_module
+        from lorairo.gui.window.main_window import MainWindow
+
+        checkbox = Mock()
+        mock_window = self._make_window({"openai/gpt-4o": checkbox}, [], [GPT4O_INFO, WD_TAGGER_INFO])
+        # wd-v1-4-tagger はフィルタで非表示 (dict に無い) → 例外なくスキップ
+        stub_cls, _captured = _make_stub_dialog(
+            QDialog.DialogCode.Accepted, ["wd-v1-4-tagger", "openai/gpt-4o"]
+        )
+        monkeypatch.setattr(main_window_module, "StageModelPickerDialog", stub_cls)
+
+        MainWindow._on_pipeline_add_model_requested(mock_window, "tags")
+
+        checkbox.set_selected.assert_called_once_with(True)
+        mock_window._refresh_pipeline_panel.assert_called_once_with()
+
+
+@pytest.mark.unit
+class TestPipelineRemoveModelHandler:
+    """Primary × ハンドラ: チェック OFF 変換の検証 (Phase 6b)。"""
+
+    def test_remove_sets_selected_false(self):
+        from lorairo.gui.window.main_window import MainWindow
+
+        checkbox = Mock()
+        mock_window = Mock()
+        mock_window.batchModelSelection.model_checkbox_widgets = {"openai/gpt-4o": checkbox}
+
+        MainWindow._on_pipeline_remove_model_requested(mock_window, "caption", "openai/gpt-4o")
+
+        checkbox.set_selected.assert_called_once_with(False)
+        mock_window._refresh_pipeline_panel.assert_called_once_with()
+
+    def test_remove_missing_id_is_noop_without_error(self):
+        from lorairo.gui.window.main_window import MainWindow
+
+        mock_window = Mock()
+        mock_window.batchModelSelection.model_checkbox_widgets = {}
+
+        # dict に無い id でも例外を出さずスキップする
+        MainWindow._on_pipeline_remove_model_requested(mock_window, "tags", "missing/model")
+
+        mock_window._refresh_pipeline_panel.assert_not_called()


### PR DESCRIPTION
## 概要

Wireframes v11 Frame 2B の Phase 6b 実装。Phase 6a のパイプライン構成ビュー（表示専用）にステージ単位の追加/削除操作を配線する。

Refs #722 / Epic #731

## アーキテクチャ判断

**SSoT は「選択モデル集合」（ModelSelectionWidget のチェック状態）のまま。** 実行粒度はモデル単位であり、派生出力は常に保存される確定仕様のためステージ割当に実行上の意味はない。ステージ操作は入力エルゴノミクスとして実装し、二重 SSoT の競合を構造的に排除:

- 「+ 追加」→ そのステージに出力を届けられるモデル（`fill_stages()` 判定）だけに絞った `StageModelPickerDialog` → チェック ON で集合へ追加
- Primary チップ「×」→ チェック OFF（**全ステージから外れる**旨を tooltip 明記）
- Derived チップは引き続き read-only
- `PipelineCompositionService.assign/remove` は不使用（compose_from_models 経路を維持）

## 変更内容

- `pipeline_stage_table_widget.py`: `add_model_requested(stage)` / `remove_model_requested(stage, id)` シグナル + 「+ 追加」ボタン + primary チップ × ボタン
- `stage_model_picker_dialog.py`（新規）: チェック式候補リスト。multimodal 行に `1推論で T C S（R は preflight 由来）` 併記、空候補時は OK 無効
- `main_window.py`: ハンドラ 2 つ。`ModelCheckboxWidget.set_selected()` は blockSignals のためシグナル連鎖が発火しない既存挙動（`select_all_models` と同じ）に合わせ、ハンドラ末尾で `_refresh_pipeline_panel()` を明示呼び出し

## 既知の制限（スコープ外、Phase 6c 候補）

- AnnotationFilter で非表示中のモデルはピッカーから選んでもチェック widget が無くスキップ（WARNING ログ）
- ピッカー経由の変更では ModelSelectionWidget 自身の選択数ラベルが更新されない（`select_all_models` と同一の既存挙動）

## テスト

新規 ~20 件含む対象 38 passed / 回帰セット 86 passed / `tests/unit/gui/` 983 passed / mypy 変更ファイル由来 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)