### PR TITLE
docs(adr): ADR 0066 Unified Jobs Lifecycle View (Proposed)

### DIFF
--- a/docs/decisions/0066-unified-jobs-lifecycle-view.md
+++ b/docs/decisions/0066-unified-jobs-lifecycle-view.md
@@ -1,7 +1,7 @@
 # ADR 0066: Unified Jobs Lifecycle View (Wireframes v11 Phase 7)
 
 - **日付**: 2026-06-12
-- **ステータス**: Proposed
+- **ステータス**: Accepted (2026-06-12)
 - **関連**: ADR 0034 (Worker / Operation / Pipeline Lifecycle Boundary), ADR 0038 (Provider Batch API Integration), ADR 0041 (Provider Batch 実行 UI 統一), ADR 0044 (Provider Batch Submit Threading)
 
 ## Context

--- a/docs/decisions/0066-unified-jobs-lifecycle-view.md
+++ b/docs/decisions/0066-unified-jobs-lifecycle-view.md
@@ -1,0 +1,62 @@
+# ADR 0066: Unified Jobs Lifecycle View (Wireframes v11 Phase 7)
+
+- **日付**: 2026-06-12
+- **ステータス**: Proposed
+- **関連**: ADR 0034 (Worker / Operation / Pipeline Lifecycle Boundary), ADR 0038 (Provider Batch API Integration), ADR 0041 (Provider Batch 実行 UI 統一), ADR 0044 (Provider Batch Submit Threading)
+
+## Context
+
+実行状況の表示が分断されている: 同期実行 (AnnotationWorker 等) は進捗ポップアップ（廃止予定の暫定実装）、Provider Batch はジョブタブ (`ProviderBatchJobWidget`)。Wireframes v11 Frame 3 と Epic #731 で「B 案: 独立 Jobs タブ」が確定済みであり、本 ADR は統一 Jobs lifecycle ビューの設計を形式化する。
+
+## Decision
+
+### 1. Jobs タブを統一 lifecycle ビューにする
+
+「実行中 / キュー / 履歴」の 3 状態で同期ジョブと Provider Batch を 1 つのビューに統合する。空状態でも履歴テーブルの枠は消さない（Jobs の半分は台帳 — Frame 3）。
+
+### 2. 同期ジョブの履歴はセッションスコープ (in-memory) — DB 永続化しない
+
+同期ジョブの履歴に新規テーブルは作らない。永続化は重いだけで利点がなく、元来「個別実行をログに残さない」運用である（2026-06-12 ユーザー判断）。診断には loguru ログが既に存在する。
+
+- 同期ジョブ: in-memory 台帳（アプリ再起動で消える）
+- Provider Batch: 既存 `provider_batch_jobs` テーブルのまま。**非同期で再起動を跨ぐ必然がある**ため永続が正当化される非対称を意図的に許容する
+
+### 3. ジョブ粒度 = Pipeline / Operation レベル (ADR 0034)
+
+Jobs に載せるのは: アノテーションパイプライン実行・Provider Batch（rating preflight 含む。preflight は親 Operation の子として表示）・DB 登録バッチ・model install（枠のみ、§5）。
+**載せない**: 検索 / サムネイル等の UI 応答系 Worker（ジョブではなく操作の一部。載せると firehose 化する）。
+
+### 4. 進捗ポップアップは Phase 7 で廃止
+
+- 並存期間は置かない（暫定実装の役目を終える）
+- 実行開始時に Jobs タブへの自動遷移は**しない**（statusbar 通知のみ。完了時は既存の Results 自動着地 — Frame 5）
+- キャンセル操作は Jobs 行のアクションへ移設する
+
+### 5. Model installer は job_type の枠のみ定義
+
+「暗黙 HuggingFace DL の明示 install ジョブ化」(Epic 確定済み判断) は iam-lib 側のバックエンド新規を伴うため、本 ADR では Jobs ビューに installer 用 job_type を予約するに留め、DL の job 化実装は別 Phase に分離する。
+
+### 6. キューは実セマンティクスを持つ
+
+表示上の状態だけでなく実行制御を導入する:
+
+- **ローカル GPU 推論ジョブ: 同時 1 件**（直列キュー。VRAM 競合を構造的に防ぐ）
+- API 系ジョブ: 並列許容（プロバイダ rate limit は lib 側 retry で吸収、ADR 0023 Phase 1.8）
+
+## Consequences
+
+### 良い点
+
+- 実行状況の確認場所が 1 箇所になり、ポップアップの暫定実装を返却できる
+- スキーマ変更ゼロ（同期履歴 in-memory + 既存 provider_batch_jobs）で導入が軽い
+- GPU 直列化で VRAM 競合由来の失敗が構造的に消える
+
+### トレードオフ
+
+- 同期ジョブ履歴は再起動で消える（意図的。台帳の永続性が必要なのは Provider Batch のみ）
+- 「直近の実行サマリ」表示はセッション内に限定される
+
+## 実装メモ (Phase 7)
+
+- 既存 `ProviderBatchJobWidget` を拡張するか統一ビューへ置換するかは実装時に判断
+- in-memory 台帳は Qt-free サービス（`JobLedgerService` 等）として実装し、WorkerService のライフサイクルイベント (ADR 0034) を購読する

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -1,94 +1,188 @@
 # Architecture Decision Records
+| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 
+| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 LoRAIro の重要な設計判断を記録するドキュメント群。
+| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 
+| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 | ADR | タイトル | 日付 | ステータス |
+| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 |-----|---------|------|-----------|
+| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 | [0001](0001-two-tier-service-architecture.md) | Two-Tier Service Architecture | 2025-08-16 | Accepted |
+| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 | [0002](0002-database-schema-decisions.md) | Database Schema Decisions | 2025-10-01 | Accepted |
+| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 | [0003](0003-annotator-config-management.md) | Annotator Config Management | 2025-11-15 | Superseded by 0021 (partial) |
+| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 | [0004](0004-annotator-lib-architecture.md) | Annotator-Lib Architecture | 2025-11-15 | Accepted |
+| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 | [0005](0005-annotation-layer-reorganization.md) | Annotation Layer Reorganization | 2025-11-15 | Accepted |
+| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 | [0006](0006-pagination-approach.md) | Pagination Approach | 2026-02-05 | Accepted |
+| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 | [0007](0007-batch-tag-annotation-ux.md) | Batch Tag Annotation UX | 2026-02-09 | Accepted |
+| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 | [0008](0008-claude-md-resilience-architecture.md) | CLAUDE.md Resilience Architecture | 2026-01-01 | Accepted |
+| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 | [0009](0009-qt-decoupling-design.md) | Qt Decoupling Design | 2026-02-16 | Accepted |
+| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 | [0010](0010-torch-import-design.md) | Torch Import Design | 2025-10-28 | Accepted |
+| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 | [0011](0011-mainwindow-ui-redesign.md) | MainWindow UI Redesign | 2026-01-04 | Accepted |
+| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 | [0012](0012-batch-tag-atomic-transaction.md) | Batch Tag Atomic Transaction Fix | 2026-01-06 | Accepted |
+| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 | [0013](0013-legacy-tag-db-cleanup.md) | Legacy Tag DB Cleanup | 2026-01-02 | Accepted |
+| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 | [0014](0014-agent-teams-integration.md) | Agent Teams Integration | 2026-04-09 | Accepted |
+| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 | [0015](0015-manual-rating-storage-unification.md) | Manual Rating Storage Unification | 2026-04-18 | Accepted |
+| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 | [0016](0016-coverage-threshold-policy.md) | Coverage Threshold Policy | 2026-04-20 | Accepted (amended) |
+| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 | [0017](0017-project-db-normalization.md) | Project DB Normalization | 2026-04-22 | Implemented |
+| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 | [0018](0018-project-storage-unification.md) | Project Storage Unification | 2026-04-22 | Implemented |
+| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 | [0019](0019-export-filter-required-design.md) | Export Filter Required Design | 2026-04-22 | Implemented |
+| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 | [0020](0020-cli-message-language-policy.md) | CLI Message Language Policy | 2026-04-27 | Accepted |
+| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 | [0021](0021-litellm-driven-model-registry.md) | LiteLLM-Driven WebAPI Model Registry | 2026-04-28 | Superseded by 0023 (partial) |
+| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 | [0022](0022-aesthetic-score-predictor-survey.md) | Aesthetic Score Predictor Model Survey | 2025-02-06 | Accepted |
+| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 | [0023](0023-pydanticai-litellm-webapi-inference-boundary.md) | PydanticAI / LiteLLM WebAPI Inference Boundary | 2026-05-07 | Accepted |
+| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 | [0024](0024-pytest-test-responsibility-separation.md) | pytest Test Responsibility Separation by Package | 2026-05-13 | Accepted |
+| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 | [0025](0025-uv-lock-version-control-policy.md) | uv.lock Version Control Policy | 2026-05-14 | Accepted |
+| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 | [0026](0026-on-demand-runtime-validation-strategy.md) | On-Demand Runtime Validation Strategy | 2026-05-17 | Accepted |
+| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 | [0027](0027-score-labels-db-storage.md) | Score Labels DB Storage | 2026-05-17 | Accepted |
+| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 | [0028](0028-score-labels-usage-and-display.md) | Score Labels Usage and Display Strategy | 2026-05-18 | Accepted |
+| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 | [0029](0029-unified-dataset-quality-tier.md) | Unified Dataset Quality Tier | 2026-05-19 | Accepted |
+| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 | [0030](0030-batch-annotation-model-selection-ui.md) | Batch Annotation Model Selection UI | 2026-05-20 | Accepted |
+| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 | [0031](0031-ai-rating-mapping.md) | AI Rating Mapping to Canonical Rating | 2026-05-21 | Accepted (amended) |
+| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 | [0032](0032-copyable-readonly-text-display.md) | Copyable Read-Only Text Display Policy | 2026-05-23 | Accepted |
+| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 | [0033](0033-annotation-worker-batch-execution-contract.md) | AnnotationWorker Batch Execution Contract | 2026-05-23 | Accepted |
+| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 | [0034](0034-worker-operation-pipeline-lifecycle.md) | Worker / Operation / Pipeline Lifecycle Boundary | 2026-05-24 | Accepted |
+| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 | [0035](0035-repository-aggregate-split-policy.md) | Repository Aggregate分割方針 | 2026-05-25 | Accepted |
+| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 | [0036](0036-gui-compound-widget-split-policy.md) | GUI Compound Widget 分割方針 | 2026-05-25 | Accepted |
+| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 | [0037](0037-api-facade-wiring-policy.md) | api/ Public Facade Wiring Policy | 2026-05-25 | Accepted |
+| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 | [0038](0038-provider-batch-api-integration-strategy.md) | Provider Batch API Integration Strategy | 2026-05-25 | Accepted |
+| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 | [0039](0039-agent-pr-maintenance-automation.md) | Agent PR Maintenance Automation | 2026-05-25 | Accepted |
+| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 | [0040](0040-local-ml-model-config-ownership.md) | Local ML Model Config Ownership | 2026-05-24 | Accepted |
+| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 | [0041](0041-provider-batch-execution-ui-unification.md) | Provider Batch 実行 UI の個別実行フロー統一 | 2026-05-29 | Accepted |
+| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 | [0042](0042-batch-annotation-db-save-io.md) | Batch Annotation DB Save I/O | 2026-05-30 | Accepted |
+| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 | [0043](0043-db-core-logging-loguru-unification.md) | db_core Logging Loguru Unification | 2026-05-31 | Accepted |
+| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 | [0044](0044-provider-batch-submit-threading.md) | Provider Batch Submit Threading | 2026-05-31 | Accepted |
+| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 | [0045](0045-large-search-result-log-level.md) | Large Search Result Log Level | 2026-05-31 | Accepted |
+| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 | [0046](0046-loguru-placeholder-format.md) | Loguru Placeholder Format | 2026-05-31 | Accepted |
+| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 | [0047](0047-trace-level-for-per-item-diagnostics.md) | TRACE Level for Per-Item Diagnostics | 2026-05-31 | Accepted |
+| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 | [0048](0048-webapi-annotation-candidate-filtering.md) | WebAPI Annotation Candidate Filtering (Endpoint / Capability / Suitability) | 2026-05-31 | Accepted |
+| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 | [0049](0049-cli-images-list-db-limit.md) | Apply CLI Image List Limit in the Repository Query | 2026-06-01 | Accepted |
+| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 | [0050](0050-cli-tag-db-lazy-initialization.md) | CLI Tag DB Lazy Initialization | 2026-06-01 | Accepted |
+| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 | [0051](0051-codex-worktree-shared-uv-environment.md) | Codex Worktree Shared uv Environment | 2026-06-01 | Accepted |
+| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 | [0052](0052-model-selection-auto-reconcile.md) | ModelSelectionWidget 初回表示時の model reconcile | 2026-06-01 | Accepted |
+| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 | [0053](0053-cli-streaming-annotation-memory-bounded-contract.md) | CLI Streaming Annotation Memory-Bounded Execution Contract | 2026-05-29 | Accepted (amended by 0057) |
+| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 | [0054](0054-gui-tag-language-reader-initialization.md) | GUI tag language reader initialization | 2026-06-03 | Accepted |
+| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 | [0055](0055-workspace-export-target-staging-unification.md) | Workspace Export Target = Staging Set / Selection-Source Unification | 2026-06-04 | Accepted |
+| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 | [0056](0056-exact-set-selector-id-count-guard.md) | exact-set selector の大量ID集合ガード / count-only 軽量化方針 | 2026-06-05 | Accepted |
+| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 | [0057](0057-cli-jsonl-output-and-error-contract.md) | CLI Machine-Readable (JSONL) Output and Error Contract | 2026-06-05 | Accepted (amended by 0060) |
+| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 | [0058](0058-cli-output-mode-trigger-and-entrypoint-policy.md) | CLI Output Mode Trigger and Entry-Point Policy | 2026-06-05 | Accepted |
+| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 | [0059](0059-cli-command-introspection.md) | CLI Command Introspection Contract | 2026-06-06 | Accepted |
+| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 | [0060](0060-cli-bounded-pagination-contract.md) | CLI Bounded Pagination and Count-First Contract | 2026-06-06 | Accepted |
+| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 | [0061](0061-phash-duplicate-variant-classification.md) | 登録パイプライン再設計 — pHash 候補の重複/別版分類 | 2026-06-05 | Accepted |
+| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 | [0062](0062-batch-custom-id-phash-long-edge.md) | Provider Batch custom_id を pHash + 長辺解像度基準へ統一 | 2026-06-05 | Accepted |
+| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 | [0063](0063-cli-batch-submit-image-ids-csv.md) | CLI Batch Submit Image IDs CSV Contract | 2026-06-07 | Accepted |
+| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 
+| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 ## ADR テンプレート
+| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 
+| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 ```markdown
+| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 # ADR XXXX: タイトル
+| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 
+| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 - **日付**: YYYY-MM-DD
+| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 - **ステータス**: Proposed | Accepted | Deprecated | Superseded by [XXXX]
+| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 
+| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 ## Context
+| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 
+| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 なぜこの決定が必要だったか。問題の背景と制約。
+| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 
+| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 ## Decision
+| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 
+| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 何を決定したか。
+| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 
+| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 ## Rationale
+| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 
+| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 なぜこの選択をしたか。他の選択肢との比較。
+| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 
+| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 ## Consequences
+| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 
+| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 この決定による影響。良い点・悪い点・トレードオフ。
+| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 ```
+| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |


### PR DESCRIPTION
## 概要

Wireframes v11 Phase 7 (Jobs 統合、#721) の前提 ADR。Status=**Proposed** — レビュー・承認をお願いします。

## 決定事項（セッションでの議論を形式化）

1. Jobs タブを統一 lifecycle ビューに（実行中/キュー/履歴、B 案は Epic #731 で確定済み）
2. **同期ジョブ履歴は in-memory（DB 永続化しない）** — 永続化は重いだけで利点なし、元来ログに残さない運用（ユーザー判断）。Provider Batch のみ既存テーブルで永続（再起動を跨ぐ必然）
3. ジョブ粒度 = Pipeline/Operation レベル（ADR 0034）。検索/サムネ等の UI 応答系は載せない
4. 進捗ポップアップは Phase 7 で即廃止（自動遷移なし、キャンセルは Jobs 行へ）
5. Model installer は job_type 枠のみ予約（DL の job 化は別 Phase）
6. キューは実セマンティクス: ローカル GPU 推論は同時 1 件直列、API 系は並列

## 運用ノート

Proposed ADR のため **Accepted 確定まで merge 保留**（autoloop の merge 対象外）。承認後に Status を Accepted に更新してマージ → Phase 7 実装着手。

README インデックスへの追記は merge 時に行います。

🤖 Generated with [Claude Code](https://claude.com/claude-code)