### PR TITLE
feat(gui): Wireframes v11 Phase 7b — GPU 直列キュー

### DIFF
--- a/src/lorairo/gui/services/worker_service.py
+++ b/src/lorairo/gui/services/worker_service.py
@@ -1,6 +1,7 @@
 # src/lorairo/services/worker_service.py
 
 import uuid
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
@@ -12,6 +13,7 @@ from ...annotations.annotator_adapter import AnnotatorLibraryAdapter
 from ...database.db_manager import ImageDatabaseManager
 from ...services.configuration_service import ConfigurationService
 from ...services.job_ledger_service import JobLedgerService, JobStatus
+from ...services.model_registry_protocol import selection_includes_local_ml_model
 from ...services.search_models import SearchConditions
 from ...services.service_container import get_service_container
 from ...storage.file_system import FileSystemManager
@@ -31,6 +33,14 @@ _JOB_LEDGER_TITLES: dict[OperationType, str] = {
     OperationType.BATCH_IMPORT: "バッチインポート",
     OperationType.ANNOTATION: "アノテーション処理",
 }
+
+
+@dataclass(frozen=True)
+class _QueuedGpuAnnotationJob:
+    """GPU 直列キューで起動待機中のアノテーションジョブ (ADR 0066 §6)。"""
+
+    worker_id: str
+    worker: AnnotationWorker
 
 
 class WorkerService(QObject):
@@ -100,6 +110,10 @@ class WorkerService(QObject):
         self._operation_sequence = 0
         self._search_generation = 0
         self._thumbnail_generation = 0
+
+        # ADR 0066 §6: ローカル GPU 推論ジョブの直列キュー (VRAM 競合防止、同時 1 件)
+        self._gpu_active_worker_id: str | None = None
+        self._gpu_queue: list[_QueuedGpuAnnotationJob] = []
 
         # ワーカーマネージャーのシグナル接続
         self.worker_manager.worker_started.connect(self._on_worker_started)
@@ -197,6 +211,11 @@ class WorkerService(QObject):
         Issue #245 / ADR 0023 Phase 1.11: モデル指定は `Model.litellm_model_id`
         (registry key SSoT) で受け取る。
 
+        ADR 0066 §6: 選択モデルにローカル ML (provider 空/"local") が含まれる
+        ジョブは GPU 直列キューで同時 1 件に制御する。先行 GPU ジョブの実行中は
+        queued 状態で台帳に載せ、前ジョブの終端で自動起動する。API 系のみの
+        ジョブは従来通り並列実行する。
+
         Args:
             image_paths: 画像パスリスト
             litellm_model_ids: 使用モデルの `litellm_model_id` リスト
@@ -213,12 +232,13 @@ class WorkerService(QObject):
             f"バッチアノテーション準備: litellm_model_ids={litellm_model_ids}, 画像数={len(image_paths)}"
         )
 
+        model_registry = get_service_container().model_registry
         worker = AnnotationWorker(
             annotation_logic=self.annotation_logic,
             image_paths=image_paths,
             litellm_model_ids=litellm_model_ids,
             db_manager=self.db_manager,
-            model_registry=get_service_container().model_registry,
+            model_registry=model_registry,
         )
         worker_id = f"annotation_{uuid.uuid4().hex[:8]}"
         self._register_operation(worker_id, OperationType.ANNOTATION)
@@ -228,21 +248,38 @@ class WorkerService(QObject):
             lambda progress: self.worker_progress_updated.emit(worker_id, progress)
         )
 
+        # ADR 0066 §6: GPU ジョブ判定とキュー投入
+        requires_gpu = selection_includes_local_ml_model(litellm_model_ids, model_registry)
+        if requires_gpu and self._gpu_active_worker_id is not None:
+            self._enqueue_gpu_annotation(worker_id, worker, len(image_paths), len(litellm_model_ids))
+            return worker_id
+
+        if requires_gpu:
+            # start_worker 中に即終端しても terminal handler が解放できるよう先に確定する
+            self._gpu_active_worker_id = worker_id
+
         if self.worker_manager.start_worker(worker_id, worker):
             self.current_annotation_worker_id = worker_id
             logger.info(
                 f"バッチアノテーション開始: {len(image_paths)}画像 (filter 前), "
-                f"{len(litellm_model_ids)}モデル (ID: {worker_id})"
+                f"{len(litellm_model_ids)}モデル (ID: {worker_id}, GPU直列={requires_gpu})"
             )
             logger.debug("  refusal filter は Worker 内で実行 (Codex P2 対応)")
             logger.debug(f"  ワーカーID={worker_id}, litellm_model_ids=[{', '.join(litellm_model_ids)}]")
             return worker_id
         else:
             self._worker_operations.pop(worker_id, None)
+            if self._gpu_active_worker_id == worker_id:
+                self._gpu_active_worker_id = None
             raise RuntimeError(f"アノテーションワーカー開始失敗: {worker_id}")
 
     def cancel_annotation(self, worker_id: str) -> bool:
-        """アノテーションキャンセル"""
+        """アノテーションキャンセル
+
+        queued (GPU 直列キュー待機中) のジョブは実行前に即時取り消す (ADR 0066 §6)。
+        """
+        if self._cancel_queued_gpu_annotation(worker_id):
+            return True
         return self.worker_manager.cancel_worker(worker_id)
 
     # === Search ===
@@ -502,7 +539,10 @@ class WorkerService(QObject):
     # === 全般管理 ===
 
     def cancel_all_workers(self) -> None:
-        """全ワーカーキャンセル"""
+        """全ワーカーキャンセル (GPU 直列キューの待機ジョブも含めて取り消す)"""
+        # 実行中ジョブの終端で次の待機ジョブが自動起動しないよう、先にキューを空にする
+        for queued_job in list(self._gpu_queue):
+            self._cancel_queued_gpu_annotation(queued_job.worker_id, reason=CancelReason.SHUTDOWN)
         self.worker_manager.cancel_all_workers(reason=CancelReason.SHUTDOWN)
 
     def get_active_worker_count(self) -> int:
@@ -519,7 +559,8 @@ class WorkerService(QObject):
         """Jobs タブの行アクションからのジョブキャンセル (ADR 0066 §4)。
 
         進捗ポップアップ廃止に伴い、同期ジョブのキャンセル操作は
-        Jobs タブの行ボタンへ移設された。
+        Jobs タブの行ボタンへ移設された。queued (GPU 直列キュー待機中) の
+        ジョブは実行前に即時 canceled として終端する (ADR 0066 §6)。
 
         Args:
             worker_id: キャンセル対象のワーカーID (= 台帳 job_id)。
@@ -527,6 +568,8 @@ class WorkerService(QObject):
         Returns:
             キャンセル要求を発行できたかどうか。
         """
+        if self._cancel_queued_gpu_annotation(worker_id):
+            return True
         return self.worker_manager.cancel_worker(worker_id)
 
     # === プライベートメソッド ===
@@ -630,12 +673,16 @@ class WorkerService(QObject):
         elif event.outcome is WorkerOutcome.FAILED:
             if self._is_replacement_terminal(event):
                 self._clear_current_worker_id(event.worker_id)
+                self._release_gpu_slot_if_active(event)
                 return
             self._on_worker_error(event.worker_id, event.error or "")
         elif event.outcome is WorkerOutcome.CANCELED:
             self._on_worker_canceled_event(event)
         else:
             self._on_worker_abnormal_terminal(event)
+
+        # ADR 0066 §6: アクティブな GPU ジョブの終端で次の待機ジョブを自動起動
+        self._release_gpu_slot_if_active(event)
 
     def _on_worker_canceled_event(self, event: WorkerTerminalEvent) -> None:
         """ワーカーキャンセルハンドラ - エラー扱いせずプログレスを終了"""
@@ -764,8 +811,114 @@ class WorkerService(QObject):
         title = _JOB_LEDGER_TITLES.get(context.operation_type)
         if title is None:
             return
-        self.job_ledger.register(context.worker_id, context.operation_type.value, title)
+        entry = self.job_ledger.register(context.worker_id, context.operation_type.value, title)
+        if entry.status is JobStatus.QUEUED:
+            # ADR 0066 §6: GPU 直列キューからの起動 (queued -> running)
+            self.job_ledger.update(context.worker_id, status=JobStatus.RUNNING)
         self.job_ledger_changed.emit()
+
+    # === GPU 直列キュー (ADR 0066 §6) ===
+
+    def _enqueue_gpu_annotation(
+        self,
+        worker_id: str,
+        worker: AnnotationWorker,
+        image_count: int,
+        model_count: int,
+    ) -> None:
+        """先行 GPU ジョブの実行中に投入されたジョブを queued で台帳に載せて待機させる。
+
+        Args:
+            worker_id: 待機させるワーカーID。
+            worker: 構築済みの AnnotationWorker (起動は前ジョブ終端まで保留)。
+            image_count: 対象画像数 (ログ用)。
+            model_count: 選択モデル数 (ログ用)。
+        """
+        self._gpu_queue.append(_QueuedGpuAnnotationJob(worker_id=worker_id, worker=worker))
+        self.job_ledger.register(
+            worker_id,
+            OperationType.ANNOTATION.value,
+            _JOB_LEDGER_TITLES[OperationType.ANNOTATION],
+            status=JobStatus.QUEUED,
+        )
+        self.job_ledger_changed.emit()
+        logger.info(
+            f"GPU直列キューで待機: {image_count}画像, {model_count}モデル (ID: {worker_id}, "
+            f"実行中: {self._gpu_active_worker_id}, 待機数: {len(self._gpu_queue)})"
+        )
+
+    def _release_gpu_slot_if_active(self, event: WorkerTerminalEvent) -> None:
+        """アクティブな GPU ジョブの終端で slot を解放し、次の待機ジョブを起動する。
+
+        UNRESPONSIVE は worker が停止確認できていない状態のため slot を保持する
+        (VRAM が解放された保証がない以上、次ジョブを起動すると競合し得る)。
+        """
+        if event.worker_id != self._gpu_active_worker_id:
+            return
+        if event.outcome is WorkerOutcome.UNRESPONSIVE:
+            logger.warning(
+                f"GPUジョブが応答不能のため直列キューを保留: {event.worker_id} "
+                f"(待機数: {len(self._gpu_queue)})"
+            )
+            return
+        self._gpu_active_worker_id = None
+        self._start_next_queued_gpu_job()
+
+    def _start_next_queued_gpu_job(self) -> None:
+        """GPU 直列キューの先頭ジョブを起動する。起動失敗時は次の待機ジョブを試す。"""
+        while self._gpu_queue:
+            queued_job = self._gpu_queue.pop(0)
+            self._gpu_active_worker_id = queued_job.worker_id
+            if self.worker_manager.start_worker(queued_job.worker_id, queued_job.worker):
+                self.current_annotation_worker_id = queued_job.worker_id
+                logger.info(
+                    f"GPU直列キューからジョブ起動: {queued_job.worker_id} "
+                    f"(残り待機数: {len(self._gpu_queue)})"
+                )
+                return
+            # 起動失敗: 台帳と operation を失敗で確定し、次の待機ジョブへ進む
+            logger.error(f"GPU直列キューのジョブ起動失敗: {queued_job.worker_id}")
+            if self._gpu_active_worker_id == queued_job.worker_id:
+                self._gpu_active_worker_id = None
+            self._worker_operations.pop(queued_job.worker_id, None)
+            if (
+                self.job_ledger.finish(queued_job.worker_id, JobStatus.FAILED, "ワーカー開始失敗")
+                is not None
+            ):
+                self.job_ledger_changed.emit()
+            self.enhanced_annotation_error.emit(f"アノテーションワーカー開始失敗: {queued_job.worker_id}")
+
+    def _cancel_queued_gpu_annotation(
+        self,
+        worker_id: str,
+        reason: CancelReason = CancelReason.USER_REQUESTED,
+    ) -> bool:
+        """queued (起動前) の GPU ジョブを即時 canceled として終端する (ADR 0066 §6)。
+
+        Args:
+            worker_id: 取り消す待機中ジョブのワーカーID。
+            reason: キャンセル理由。
+
+        Returns:
+            キューから取り消せた場合 True。待機中でなければ False。
+        """
+        for index, queued_job in enumerate(self._gpu_queue):
+            if queued_job.worker_id != worker_id:
+                continue
+            self._gpu_queue.pop(index)
+            queued_job.worker.deleteLater()
+            logger.info(f"GPU直列キューの待機ジョブを取り消し: {worker_id} (理由: {reason.value})")
+            # 起動前のため manager を介さず synthetic terminal で終端を確定する
+            self._on_worker_terminal(
+                WorkerTerminalEvent(
+                    worker_id=worker_id,
+                    worker_type="annotation",
+                    outcome=WorkerOutcome.CANCELED,
+                    cancel_reason=reason,
+                )
+            )
+            return True
+        return False
 
     def _record_job_ledger_terminal(
         self,

--- a/src/lorairo/services/model_registry_protocol.py
+++ b/src/lorairo/services/model_registry_protocol.py
@@ -111,3 +111,37 @@ def selection_includes_webapi_model(
     return any(
         (info := available.get(key)) is not None and info.requires_api_key for key in litellm_model_ids
     )
+
+
+def selection_includes_local_ml_model(
+    litellm_model_ids: list[str],
+    model_registry: ModelRegistryServiceProtocol,
+) -> bool:
+    """選択されたモデルにローカル ML モデル (provider 空 / "local") が含まれるか判定。
+
+    ADR 0066 §6: ローカル GPU 推論を含むアノテーションジョブは同時 1 件に
+    直列化する (VRAM 競合を構造的に防ぐ)。本関数はその GPU ジョブ判定に使う
+    Qt-free な pure helper で、`selection_includes_webapi_model` と同じく
+    registry key SSoT (`litellm_model_id` with bare-name fallback) で引く。
+
+    Args:
+        litellm_model_ids: 選択されたモデルの `litellm_model_id` リスト。
+        model_registry: モデル情報を引ける Protocol 実装。
+
+    Returns:
+        bool: 1 つでも provider が空文字または "local" のモデルがあれば True。
+            registry に未登録の litellm_model_id はローカルではないと扱う
+            (未登録モデルは実行経路に乗らないため GPU 直列化の対象外)。
+
+    Raises:
+        例外は呼び出し元で吸収しない (start 失敗として伝播させる契約)。
+    """
+    if not litellm_model_ids:
+        return False
+    available = {
+        (info.litellm_model_id or info.name): info for info in model_registry.get_available_models()
+    }
+    return any(
+        (info := available.get(key)) is not None and info.provider.strip().lower() in {"", "local"}
+        for key in litellm_model_ids
+    )

--- a/tests/unit/gui/services/test_worker_service.py
+++ b/tests/unit/gui/services/test_worker_service.py
@@ -14,7 +14,34 @@ from lorairo.gui.services.worker_service import WorkerService
 from lorairo.gui.workers.search_worker import SearchResult
 from lorairo.gui.workers.terminal import CancelReason, WorkerOutcome, WorkerTerminalEvent
 from lorairo.services.job_ledger_service import JobStatus
+from lorairo.services.model_registry_protocol import ModelInfo
 from lorairo.services.search_models import SearchConditions
+
+# GPU 直列キューテスト用の registry モデル (ADR 0066 §6)
+_LOCAL_MODEL_ID = "wd-v1-4-tagger"
+_API_MODEL_ID = "openai/gpt-4o"
+
+
+def _registry_model_infos() -> list[ModelInfo]:
+    """ローカル ML / WebAPI 混在の ModelInfo リストを返すテストヘルパー。"""
+    return [
+        ModelInfo(
+            name=_LOCAL_MODEL_ID,
+            provider="local",
+            capabilities=["tags"],
+            litellm_model_id=None,
+            requires_api_key=False,
+            estimated_size_gb=1.2,
+        ),
+        ModelInfo(
+            name=_API_MODEL_ID,
+            provider="openai",
+            capabilities=["caption", "tags"],
+            litellm_model_id=_API_MODEL_ID,
+            requires_api_key=True,
+            estimated_size_gb=None,
+        ),
+    ]
 
 
 class TestWorkerService:
@@ -949,12 +976,14 @@ class TestWorkerService:
         assert worker_service.current_thumbnail_worker_id is None
         assert worker_service.current_batch_import_worker_id is None
 
+    @patch("lorairo.gui.services.worker_service.get_service_container")
     @patch("lorairo.gui.services.worker_service.AnnotationWorker")
     @patch.object(WorkerService, "annotation_logic", create=True)
     def test_start_enhanced_batch_annotation_success(
-        self, mock_annotation_logic, mock_worker_class, worker_service
+        self, mock_annotation_logic, mock_worker_class, mock_container, worker_service
     ):
         """バッチアノテーション開始成功テスト（新API）"""
+        mock_container.return_value.model_registry.get_available_models.return_value = []
         mock_worker = Mock()
         mock_worker_class.return_value = mock_worker
         worker_service.worker_manager.start_worker.return_value = True
@@ -988,12 +1017,14 @@ class TestWorkerService:
         mock_worker.progress_updated.connect.assert_called()
         assert worker_service.current_annotation_worker_id == worker_id
 
+    @patch("lorairo.gui.services.worker_service.get_service_container")
     @patch("lorairo.gui.services.worker_service.AnnotationWorker")
     @patch.object(WorkerService, "annotation_logic", create=True)
     def test_start_enhanced_batch_annotation_failure_keeps_current_worker_id(
-        self, mock_annotation_logic, mock_worker_class, worker_service
+        self, mock_annotation_logic, mock_worker_class, mock_container, worker_service
     ):
         """アノテーション開始失敗時に current_annotation_worker_id を上書きしない"""
+        mock_container.return_value.model_registry.get_available_models.return_value = []
         mock_worker_class.return_value = Mock()
         worker_service.worker_manager.start_worker.return_value = False
         worker_service.current_annotation_worker_id = "annotation_existing"
@@ -1137,3 +1168,284 @@ class TestWorkerService:
             terminal_mock.assert_called_once_with(worker_id)
 
         assert getattr(worker_service, current_attr) is None
+
+
+@patch("lorairo.gui.services.worker_service.get_service_container")
+@patch("lorairo.gui.services.worker_service.AnnotationWorker")
+@patch.object(WorkerService, "annotation_logic", create=True)
+class TestGpuSerialQueue:
+    """ローカル GPU 推論ジョブの直列キュー (ADR 0066 §6) のユニットテスト。
+
+    ローカル ML (provider 空/"local") を含むアノテーションジョブは同時 1 件。
+    実行中に投入されたジョブは queued で台帳に載り、前ジョブの終端で自動起動する。
+    """
+
+    @pytest.fixture
+    @patch("lorairo.gui.services.worker_service.WorkerManager")
+    def worker_service(self, mock_worker_manager_class):
+        """テスト用WorkerService (WorkerManagerはモック)"""
+        mock_worker_manager_class.return_value = Mock()
+        service = WorkerService(Mock(), Mock())
+        service.worker_manager = mock_worker_manager_class.return_value
+        return service
+
+    @staticmethod
+    def _setup(mock_container, mock_worker_class, worker_service):
+        """registry / worker / manager を直列キュー検証用に構成するヘルパー。
+
+        start_worker は実 WorkerManager と同様に同期で worker_started 通知
+        (= `_on_worker_started`) を発行し、起動順を `started_ids` に記録する。
+        """
+        registry = mock_container.return_value.model_registry
+        registry.get_available_models.return_value = _registry_model_infos()
+        mock_worker_class.side_effect = lambda **kwargs: Mock()
+
+        started_ids: list[str] = []
+
+        def start_and_notify(worker_id, _worker):
+            started_ids.append(worker_id)
+            worker_service._on_worker_started(worker_id)
+            return True
+
+        worker_service.worker_manager.start_worker.side_effect = start_and_notify
+        return started_ids
+
+    @staticmethod
+    def _terminal_event(worker_id: str, outcome: WorkerOutcome, **kwargs) -> WorkerTerminalEvent:
+        return WorkerTerminalEvent(
+            worker_id=worker_id,
+            worker_type="annotation",
+            outcome=outcome,
+            **kwargs,
+        )
+
+    def test_local_model_job_starts_immediately_when_gpu_idle(
+        self, mock_annotation_logic, mock_worker_class, mock_container, worker_service
+    ):
+        """GPU アイドル時のローカル ML ジョブは即起動し GPU slot を占有する"""
+        started_ids = self._setup(mock_container, mock_worker_class, worker_service)
+
+        worker_id = worker_service.start_enhanced_batch_annotation(
+            image_paths=["/img/a.jpg"], litellm_model_ids=[_LOCAL_MODEL_ID]
+        )
+
+        assert started_ids == [worker_id]
+        assert worker_service._gpu_active_worker_id == worker_id
+        assert worker_service.job_ledger.get(worker_id).status is JobStatus.RUNNING
+
+    def test_second_local_job_queued_while_gpu_active(
+        self, mock_annotation_logic, mock_worker_class, mock_container, worker_service
+    ):
+        """GPU ジョブ実行中の追加ローカル ML ジョブは queued で待機する"""
+        started_ids = self._setup(mock_container, mock_worker_class, worker_service)
+        ledger_changed_mock = Mock()
+
+        first_id = worker_service.start_enhanced_batch_annotation(
+            image_paths=["/img/a.jpg"], litellm_model_ids=[_LOCAL_MODEL_ID]
+        )
+        worker_service.job_ledger_changed.connect(ledger_changed_mock)
+        second_id = worker_service.start_enhanced_batch_annotation(
+            image_paths=["/img/b.jpg"], litellm_model_ids=[_LOCAL_MODEL_ID]
+        )
+
+        assert started_ids == [first_id]
+        assert second_id.startswith("annotation_")
+        entry = worker_service.job_ledger.get(second_id)
+        assert entry is not None
+        assert entry.status is JobStatus.QUEUED
+        ledger_changed_mock.assert_called_once()
+        assert [job.worker_id for job in worker_service._gpu_queue] == [second_id]
+
+    def test_api_only_job_runs_parallel_while_gpu_active(
+        self, mock_annotation_logic, mock_worker_class, mock_container, worker_service
+    ):
+        """API 系のみのジョブは GPU ジョブ実行中でも並列起動する (ADR 0066 §6)"""
+        started_ids = self._setup(mock_container, mock_worker_class, worker_service)
+
+        first_id = worker_service.start_enhanced_batch_annotation(
+            image_paths=["/img/a.jpg"], litellm_model_ids=[_LOCAL_MODEL_ID]
+        )
+        second_id = worker_service.start_enhanced_batch_annotation(
+            image_paths=["/img/b.jpg"], litellm_model_ids=[_API_MODEL_ID]
+        )
+
+        assert started_ids == [first_id, second_id]
+        assert worker_service._gpu_queue == []
+        assert worker_service._gpu_active_worker_id == first_id
+        assert worker_service.job_ledger.get(second_id).status is JobStatus.RUNNING
+
+    @pytest.mark.parametrize(
+        ("outcome", "cancel_reason"),
+        [
+            (WorkerOutcome.SUCCEEDED, None),
+            (WorkerOutcome.FAILED, None),
+            (WorkerOutcome.CANCELED, CancelReason.USER_REQUESTED),
+        ],
+    )
+    def test_queued_job_autostarts_after_active_terminal(
+        self,
+        mock_annotation_logic,
+        mock_worker_class,
+        mock_container,
+        worker_service,
+        outcome,
+        cancel_reason,
+    ):
+        """前 GPU ジョブの終端 (成功/失敗/キャンセル) で待機ジョブが自動起動する"""
+        started_ids = self._setup(mock_container, mock_worker_class, worker_service)
+        first_id = worker_service.start_enhanced_batch_annotation(
+            image_paths=["/img/a.jpg"], litellm_model_ids=[_LOCAL_MODEL_ID]
+        )
+        second_id = worker_service.start_enhanced_batch_annotation(
+            image_paths=["/img/b.jpg"], litellm_model_ids=[_LOCAL_MODEL_ID]
+        )
+
+        worker_service._on_worker_terminal(
+            self._terminal_event(
+                first_id,
+                outcome,
+                error="boom" if outcome is WorkerOutcome.FAILED else None,
+                cancel_reason=cancel_reason,
+            )
+        )
+
+        assert started_ids == [first_id, second_id]
+        assert worker_service._gpu_active_worker_id == second_id
+        assert worker_service.current_annotation_worker_id == second_id
+        assert worker_service._gpu_queue == []
+        assert worker_service.job_ledger.get(second_id).status is JobStatus.RUNNING
+        assert worker_service.job_ledger.get(first_id).status.is_terminal
+
+    def test_cancel_queued_job_is_immediately_canceled(
+        self, mock_annotation_logic, mock_worker_class, mock_container, worker_service
+    ):
+        """queued ジョブのキャンセルは実行前に即時 canceled で終端する"""
+        started_ids = self._setup(mock_container, mock_worker_class, worker_service)
+        canceled_mock = Mock()
+        worker_service.enhanced_annotation_canceled.connect(canceled_mock)
+        first_id = worker_service.start_enhanced_batch_annotation(
+            image_paths=["/img/a.jpg"], litellm_model_ids=[_LOCAL_MODEL_ID]
+        )
+        second_id = worker_service.start_enhanced_batch_annotation(
+            image_paths=["/img/b.jpg"], litellm_model_ids=[_LOCAL_MODEL_ID]
+        )
+
+        assert worker_service.cancel_annotation(second_id) is True
+
+        worker_service.worker_manager.cancel_worker.assert_not_called()
+        canceled_mock.assert_called_once_with(second_id)
+        entry = worker_service.job_ledger.get(second_id)
+        assert entry.status is JobStatus.CANCELED
+        assert entry.finished_at is not None
+        assert worker_service._gpu_queue == []
+
+        # 前ジョブ終端後もキャンセル済みジョブは起動しない
+        worker_service._on_worker_terminal(self._terminal_event(first_id, WorkerOutcome.SUCCEEDED))
+        assert started_ids == [first_id]
+        assert worker_service._gpu_active_worker_id is None
+
+    def test_cancel_job_cancels_queued_entry(
+        self, mock_annotation_logic, mock_worker_class, mock_container, worker_service
+    ):
+        """Jobs タブ行アクションの cancel_job でも queued ジョブを即時取り消せる"""
+        self._setup(mock_container, mock_worker_class, worker_service)
+        worker_service.start_enhanced_batch_annotation(
+            image_paths=["/img/a.jpg"], litellm_model_ids=[_LOCAL_MODEL_ID]
+        )
+        second_id = worker_service.start_enhanced_batch_annotation(
+            image_paths=["/img/b.jpg"], litellm_model_ids=[_LOCAL_MODEL_ID]
+        )
+
+        assert worker_service.cancel_job(second_id) is True
+        assert worker_service.job_ledger.get(second_id).status is JobStatus.CANCELED
+        worker_service.worker_manager.cancel_worker.assert_not_called()
+
+    def test_cancel_all_workers_flushes_gpu_queue(
+        self, mock_annotation_logic, mock_worker_class, mock_container, worker_service
+    ):
+        """cancel_all_workers は待機ジョブも SHUTDOWN 理由で取り消す"""
+        self._setup(mock_container, mock_worker_class, worker_service)
+        worker_service.start_enhanced_batch_annotation(
+            image_paths=["/img/a.jpg"], litellm_model_ids=[_LOCAL_MODEL_ID]
+        )
+        second_id = worker_service.start_enhanced_batch_annotation(
+            image_paths=["/img/b.jpg"], litellm_model_ids=[_LOCAL_MODEL_ID]
+        )
+
+        worker_service.cancel_all_workers()
+
+        assert worker_service._gpu_queue == []
+        assert worker_service.job_ledger.get(second_id).status is JobStatus.CANCELED
+        worker_service.worker_manager.cancel_all_workers.assert_called_once_with(
+            reason=CancelReason.SHUTDOWN
+        )
+
+    def test_gpu_slot_cleared_when_start_fails(
+        self, mock_annotation_logic, mock_worker_class, mock_container, worker_service
+    ):
+        """GPU ジョブの起動失敗時は slot を解放して例外を伝播する"""
+        self._setup(mock_container, mock_worker_class, worker_service)
+        worker_service.worker_manager.start_worker.side_effect = None
+        worker_service.worker_manager.start_worker.return_value = False
+
+        with pytest.raises(RuntimeError, match="アノテーションワーカー開始失敗"):
+            worker_service.start_enhanced_batch_annotation(
+                image_paths=["/img/a.jpg"], litellm_model_ids=[_LOCAL_MODEL_ID]
+            )
+
+        assert worker_service._gpu_active_worker_id is None
+
+    def test_queued_job_start_failure_marks_failed_and_starts_next(
+        self, mock_annotation_logic, mock_worker_class, mock_container, worker_service
+    ):
+        """待機ジョブの起動失敗は台帳 failed で確定し、次の待機ジョブを起動する"""
+        started_ids = self._setup(mock_container, mock_worker_class, worker_service)
+        error_mock = Mock()
+        worker_service.enhanced_annotation_error.connect(error_mock)
+        first_id = worker_service.start_enhanced_batch_annotation(
+            image_paths=["/img/a.jpg"], litellm_model_ids=[_LOCAL_MODEL_ID]
+        )
+        second_id = worker_service.start_enhanced_batch_annotation(
+            image_paths=["/img/b.jpg"], litellm_model_ids=[_LOCAL_MODEL_ID]
+        )
+        third_id = worker_service.start_enhanced_batch_annotation(
+            image_paths=["/img/c.jpg"], litellm_model_ids=[_LOCAL_MODEL_ID]
+        )
+
+        def start_second_fails(worker_id, _worker):
+            if worker_id == second_id:
+                return False
+            started_ids.append(worker_id)
+            worker_service._on_worker_started(worker_id)
+            return True
+
+        worker_service.worker_manager.start_worker.side_effect = start_second_fails
+        worker_service._on_worker_terminal(self._terminal_event(first_id, WorkerOutcome.SUCCEEDED))
+
+        assert started_ids == [first_id, third_id]
+        second_entry = worker_service.job_ledger.get(second_id)
+        assert second_entry.status is JobStatus.FAILED
+        assert second_entry.summary == "ワーカー開始失敗"
+        error_mock.assert_called_once()
+        assert worker_service._gpu_active_worker_id == third_id
+        assert worker_service.job_ledger.get(third_id).status is JobStatus.RUNNING
+
+    def test_unresponsive_terminal_keeps_gpu_slot(
+        self, mock_annotation_logic, mock_worker_class, mock_container, worker_service
+    ):
+        """UNRESPONSIVE 終端では VRAM 解放が未確認のため次ジョブを起動しない"""
+        started_ids = self._setup(mock_container, mock_worker_class, worker_service)
+        first_id = worker_service.start_enhanced_batch_annotation(
+            image_paths=["/img/a.jpg"], litellm_model_ids=[_LOCAL_MODEL_ID]
+        )
+        second_id = worker_service.start_enhanced_batch_annotation(
+            image_paths=["/img/b.jpg"], litellm_model_ids=[_LOCAL_MODEL_ID]
+        )
+
+        worker_service._on_worker_terminal(
+            self._terminal_event(first_id, WorkerOutcome.UNRESPONSIVE, error="unresponsive")
+        )
+
+        assert started_ids == [first_id]
+        assert worker_service._gpu_active_worker_id == first_id
+        assert [job.worker_id for job in worker_service._gpu_queue] == [second_id]

--- a/tests/unit/services/test_model_registry_protocol.py
+++ b/tests/unit/services/test_model_registry_protocol.py
@@ -12,6 +12,7 @@ import pytest
 
 from lorairo.services.model_registry_protocol import (
     NullModelRegistry,
+    selection_includes_local_ml_model,
     selection_includes_webapi_model,
 )
 
@@ -159,3 +160,78 @@ class TestSelectionIncludesWebApiModel:
         # (= info が available に居る) ことを registry mock call で間接確認
         assert selection_includes_webapi_model(["wd-v1-4-tagger"], registry) is False
         registry.get_available_models.assert_called_once()
+
+
+class TestSelectionIncludesLocalMlModel:
+    """`selection_includes_local_ml_model()` の単体テスト (ADR 0066 §6)。
+
+    ローカル GPU 推論ジョブの直列キュー判定に使う pure helper。
+    provider が空文字または "local" のモデルをローカル ML として検出する。
+    """
+
+    @staticmethod
+    def _model_info(name: str, provider: str, litellm_model_id: str | None = None):
+        """`ModelInfo` 互換 Mock (lookup キーは litellm_model_id with name fallback)。"""
+        info = Mock()
+        info.name = name
+        info.provider = provider
+        info.litellm_model_id = litellm_model_id
+        return info
+
+    def _registry(self, models):
+        registry = Mock()
+        registry.get_available_models.return_value = list(models)
+        return registry
+
+    def test_returns_true_for_local_provider(self) -> None:
+        """provider="local" のモデル選択時は True (GPU 直列化対象)。"""
+        registry = self._registry([self._model_info("wd-v1-4-tagger", provider="local")])
+        assert selection_includes_local_ml_model(["wd-v1-4-tagger"], registry) is True
+
+    def test_returns_true_for_empty_provider(self) -> None:
+        """provider が空文字のモデルもローカル ML として扱う (ADR 0066 §6)。"""
+        registry = self._registry([self._model_info("aesthetic-predictor", provider="")])
+        assert selection_includes_local_ml_model(["aesthetic-predictor"], registry) is True
+
+    def test_returns_false_for_api_only_selection(self) -> None:
+        """API 系のみの選択は False (並列許容)。"""
+        registry = self._registry(
+            [
+                self._model_info("openai/gpt-4o", provider="openai", litellm_model_id="openai/gpt-4o"),
+                self._model_info("wd-v1-4-tagger", provider="local"),
+            ]
+        )
+        assert selection_includes_local_ml_model(["openai/gpt-4o"], registry) is False
+
+    def test_returns_true_with_mixed_selection(self) -> None:
+        """ローカル + API の混在選択は True (1 つでもローカルなら直列化)。"""
+        registry = self._registry(
+            [
+                self._model_info("openai/gpt-4o", provider="openai", litellm_model_id="openai/gpt-4o"),
+                self._model_info("wd-v1-4-tagger", provider="local"),
+            ]
+        )
+        assert selection_includes_local_ml_model(["openai/gpt-4o", "wd-v1-4-tagger"], registry) is True
+
+    def test_returns_false_for_unknown_model_name(self) -> None:
+        """registry 未登録のモデルはローカル扱いしない (実行経路に乗らないため)。"""
+        registry = self._registry([self._model_info("wd-v1-4-tagger", provider="local")])
+        assert selection_includes_local_ml_model(["unknown-model"], registry) is False
+
+    def test_returns_false_for_empty_selection(self) -> None:
+        """空リストは False (early return、registry を引かない)。"""
+        registry = self._registry([self._model_info("wd-v1-4-tagger", provider="local")])
+        assert selection_includes_local_ml_model([], registry) is False
+        registry.get_available_models.assert_not_called()
+
+    def test_returns_false_for_unknown_provider(self) -> None:
+        """provider="unknown" はローカル ML ではない (API フォールバック表記)。"""
+        registry = self._registry([self._model_info("mystery-model", provider="unknown")])
+        assert selection_includes_local_ml_model(["mystery-model"], registry) is False
+
+    def test_lookup_falls_back_to_name_when_litellm_id_is_none(self) -> None:
+        """ローカル ML の `litellm_model_id is None` は bare 名 fallback で hit する。"""
+        registry = self._registry(
+            [self._model_info("wd-v1-4-tagger", provider="local", litellm_model_id=None)]
+        )
+        assert selection_includes_local_ml_model(["wd-v1-4-tagger"], registry) is True


### PR DESCRIPTION
## 概要

ADR 0066 §6 の実セマンティクスを実装: **ローカル GPU 推論ジョブは同時 1 件（直列キュー、VRAM 競合防止）、API 系は並列許容**。

Refs #721 / ADR 0066 §6 (Phase 7a #744 の JobLedgerService / queued ステータスを使用)

## 実装内容

### GPU ジョブ判定 (Qt-free helper)
- `selection_includes_local_ml_model()` を `services/model_registry_protocol.py` に追加
- 選択モデルに provider 空文字 / `"local"` の ModelInfo が含まれれば GPU ジョブ
- lookup は既存 `selection_includes_webapi_model` と同じ registry key SSoT 規約 (`litellm_model_id` with bare-name fallback)。registry 未登録 ID はローカル扱いしない

### WorkerService の直列制御
- `_gpu_active_worker_id` (GPU slot) + `_gpu_queue` を追加
- GPU ジョブ実行中に投入されたローカル ML 含みジョブは **queued** で JobLedger に登録 (`job_ledger_changed` 通知 → Jobs タブに「待機中」表示) し、起動を保留
- 前 GPU ジョブの terminal (成功/失敗/キャンセル) で次の待機ジョブを自動起動 (`queued → running` を台帳に反映)
- API のみのジョブ・他種ジョブ (登録/インポート/検索/サムネイル) は従来通り並列

### キャンセル
- queued ジョブの `cancel_annotation` / `cancel_job` は実行前に**即時 canceled**: synthetic `WorkerTerminalEvent` を既存 terminal パイプラインに流し、台帳終端・operation event・互換シグナルを一貫処理
- `cancel_all_workers` は待機ジョブを SHUTDOWN 理由で先に flush (実行中ジョブ終端での自動起動を防止)

### 設計判断
- **UNRESPONSIVE 終端では GPU slot を保持**: worker の停止が確認できない = VRAM 解放未確認のため、次ジョブを起動すると競合し得る (ADR 0066 §6 の趣旨を優先)
- **queued ジョブの起動失敗**: 台帳 failed + `enhanced_annotation_error` で確定し、次の待機ジョブを試行
- **fast-terminal 安全**: GPU slot は `start_worker` 前に確定し、start 中の即終端でも terminal handler が解放できる (既存 current id パターンと同型)

## 検証

- `tests/unit/gui` + `tests/unit/services` を CI-equivalent filter で実行: **2152 passed**
- `tests/integration/gui` (tab 統合含む): 95 passed / 2 failed は **pre-existing 環境要因** (`libcudnn.so.9` 不在で `import torch` 自体が失敗、stash 検証で変更前も同一失敗)
- `tests/unit` 全体: 失敗 20 件は stash 検証で**全て pre-existing** (test_model_sync_service 等、本変更と無関係)
- `mypy` 変更ファイル: Success (0 issues)
- 新規テスト: GPU 直列キュー 12 ケース + helper 8 ケース

🤖 Generated with [Claude Code](https://claude.com/claude-code)