### PR TITLE
fix(errors): Errors タブの naive/aware datetime 比較クラッシュを修正 (#748)

### DIFF
--- a/src/lorairo/services/error_triage_service.py
+++ b/src/lorairo/services/error_triage_service.py
@@ -13,6 +13,24 @@ from datetime import UTC, datetime, timedelta
 from enum import Enum
 
 
+def _to_aware_utc(dt: datetime) -> datetime:
+    """naive datetime を UTC とみなして aware に揃える。
+
+    SQLite は TIMESTAMP の timezone を保持しないため、DB から読み戻した
+    datetime は naive で返る。aware な閾値との比較で TypeError になるのを防ぐ。
+    既に aware の場合はそのまま返す。
+
+    Args:
+        dt: 正規化対象の datetime (naive または aware)。
+
+    Returns:
+        UTC tzinfo を持つ aware datetime。
+    """
+    if dt.tzinfo is None:
+        return dt.replace(tzinfo=UTC)
+    return dt
+
+
 class ErrorStatusFilter(Enum):
     """status クロスフィルタの 3 値。"""
 
@@ -162,8 +180,12 @@ class ErrorTriageService:
         resolved = total - unresolved
 
         # last_24h: created_at >= now(UTC)-24h (created_at None は除外)
+        # SQLite は TIMESTAMP の tz を保持しないため DB 由来の created_at は naive で返る。
+        # func.now() (= CURRENT_TIMESTAMP) は UTC なので naive を UTC とみなして aware に揃える。
         threshold = datetime.now(UTC) - timedelta(hours=24)
-        last_24h = sum(1 for r in rows if r.created_at is not None and r.created_at >= threshold)
+        last_24h = sum(
+            1 for r in rows if r.created_at is not None and _to_aware_utc(r.created_at) >= threshold
+        )
 
         # by_error_type: 未解決行の error_type ごと件数
         by_error_type: dict[str, int] = {}

--- a/tests/unit/services/test_error_triage_service.py
+++ b/tests/unit/services/test_error_triage_service.py
@@ -236,6 +236,33 @@ class TestSummarize:
         summary = service.summarize(rows)
         assert summary.last_24h == 2
 
+    def test_last_24h_with_naive_created_at(self, service: ErrorTriageService) -> None:
+        """naive な created_at (SQLite 由来) でも TypeError にならず正しく集計する。
+
+        リグレッション (Issue #748): SQLite は TIMESTAMP の tz を保持しないため
+        DB から読み戻した created_at は naive。aware な閾値との比較で
+        ``can't compare offset-naive and offset-aware datetimes`` が出ていた。
+        """
+        now_naive = datetime.now(UTC).replace(tzinfo=None)
+        rows = [
+            _row(1, created_at=now_naive),  # 含む (naive)
+            _row(2, created_at=now_naive - timedelta(hours=23)),  # 含む (naive)
+            _row(3, created_at=now_naive - timedelta(hours=25)),  # 除外 (naive)
+        ]
+        summary = service.summarize(rows)
+        assert summary.last_24h == 2
+
+    def test_last_24h_mixed_naive_and_aware(self, service: ErrorTriageService) -> None:
+        """naive と aware が混在しても比較できる。"""
+        now = datetime.now(UTC)
+        rows = [
+            _row(1, created_at=now),  # aware, 含む
+            _row(2, created_at=now.replace(tzinfo=None) - timedelta(hours=1)),  # naive, 含む
+            _row(3, created_at=now.replace(tzinfo=None) - timedelta(hours=30)),  # naive, 除外
+        ]
+        summary = service.summarize(rows)
+        assert summary.last_24h == 2
+
     def test_empty_input(self, service: ErrorTriageService) -> None:
         summary = service.summarize([])
         assert summary.total == 0


### PR DESCRIPTION
## 概要

Windows ネイティブ起動で Errors タブに切り替えると `ErrorTriageService.summarize` が `TypeError: can't compare offset-naive and offset-aware datetimes` でクラッシュする問題を修正。Phase 3 (Wireframes v11 #725) のリグレッション。

Closes #748

## 原因

- `threshold = datetime.now(UTC) - timedelta(hours=24)` は **aware**
- スキーマは `TIMESTAMP(timezone=True)` だが **SQLite は timezone を保持しない**ため DB から読み戻した `created_at` は **naive**
- naive vs aware の比較で TypeError

## Linux CI で検出されなかった理由

`test_error_triage_service.py` のヘルパー `_row` が `created_at=datetime.now(UTC)`（aware）を直接構築し ErrorRow を渡すため、**実 DB の naive 挙動を再現していなかった**。

## 修正

- `_to_aware_utc()` で created_at を比較前に aware UTC へ正規化（naive は UTC とみなす。SQLite の `func.now()` = CURRENT_TIMESTAMP は UTC）
- リグレッションテスト 2 件追加（naive のみ / naive+aware 混在）

同種の「DB naive vs コード生成 aware」比較が他の services に無いことを grep で確認済み（DATE ヒストグラム等は DB naive 同士の比較で問題なし）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)