### PR TITLE
feat(annotate): モデルピッカー/台帳にコスト表示 ($/img・推定時間) (#747)

### DIFF
--- a/src/lorairo/gui/widgets/inference_ledger_widget.py
+++ b/src/lorairo/gui/widgets/inference_ledger_widget.py
@@ -8,6 +8,10 @@ from __future__ import annotations
 
 from PySide6.QtWidgets import QHBoxLayout, QLabel, QVBoxLayout, QWidget
 
+from lorairo.services.cost_estimation_service import (
+    CostEstimationService,
+    format_duration,
+)
 from lorairo.services.pipeline_composition import InferenceLedger, LedgerEntry
 
 _TITLE_TEXT = "INFERENCE LEDGER — 推論回数 = ユニークモデル × ステージング枚数"
@@ -29,6 +33,8 @@ class InferenceLedgerWidget(QWidget):
     def __init__(self, parent: QWidget | None = None) -> None:
         super().__init__(parent)
 
+        self._cost_service = CostEstimationService()
+
         layout = QVBoxLayout(self)
         layout.setContentsMargins(0, 0, 0, 0)
 
@@ -46,6 +52,10 @@ class InferenceLedgerWidget(QWidget):
         self._formula_label = QLabel("", self)
         self._formula_label.setObjectName("ledgerFormulaLabel")
         layout.addWidget(self._formula_label)
+
+        self._cost_label = QLabel("", self)
+        self._cost_label.setObjectName("ledgerCostLabel")
+        layout.addWidget(self._cost_label)
 
         self._placeholder_label = QLabel(_PLACEHOLDER_TEXT, self)
         self._placeholder_label.setObjectName("ledgerPlaceholderLabel")
@@ -77,6 +87,17 @@ class InferenceLedgerWidget(QWidget):
         self._formula_label.setText(formula)
         self._formula_label.setVisible(True)
 
+        # Issue #747: コスト・推定時間の概算行 (has_unknown 時は不明含む旨を併記)
+        estimate = self._cost_service.estimate_batch(ledger)
+        amount = f"${estimate.total_usd:.2f}"
+        if estimate.has_unknown:
+            amount += "+"
+        cost_text = f"推定 {amount} · {format_duration(estimate.est_seconds)}"
+        if estimate.has_unknown:
+            cost_text += "（一部モデルは料金不明）"
+        self._cost_label.setText(cost_text)
+        self._cost_label.setVisible(True)
+
     def clear(self) -> None:
         """空表示にする。"""
         self._clear_entries()
@@ -86,6 +107,8 @@ class InferenceLedgerWidget(QWidget):
         """「モデル未選択」プレースホルダ状態に切り替える。"""
         self._formula_label.setText("")
         self._formula_label.setVisible(False)
+        self._cost_label.setText("")
+        self._cost_label.setVisible(False)
         self._placeholder_label.setText(_PLACEHOLDER_TEXT)
         self._placeholder_label.setVisible(True)
 

--- a/src/lorairo/gui/widgets/stage_model_picker_dialog.py
+++ b/src/lorairo/gui/widgets/stage_model_picker_dialog.py
@@ -19,10 +19,16 @@ from PySide6.QtWidgets import (
     QWidget,
 )
 
+from lorairo.services.cost_estimation_service import (
+    CostEstimationService,
+    format_per_image_cost,
+)
 from lorairo.services.pipeline_composition import PipelineStage, StageModelInfo
 
 _EMPTY_CANDIDATES_TEXT = "このステージに追加できる未選択モデルがありません"
 _MULTIMODAL_NOTE = "· 1推論で T C S（R は preflight 由来）"
+
+_cost_service = CostEstimationService()
 
 
 class StageModelPickerDialog(QDialog):
@@ -76,9 +82,10 @@ class StageModelPickerDialog(QDialog):
 
     @staticmethod
     def _candidate_text(info: StageModelInfo) -> str:
-        """候補 1 件分の表示テキストを返す。"""
+        """候補 1 件分の表示テキストを返す (Issue #747: コストをカード直載せ)。"""
         origin = f"API: {info.provider}" if info.is_api else "ローカル"
-        text = f"{info.display_name}（{origin}）"
+        cost = format_per_image_cost(_cost_service.per_image_usd(info), info.is_api)
+        text = f"{info.display_name}（{origin}）· {cost}"
         if info.is_multimodal:
             text += f" {_MULTIMODAL_NOTE}"
         return text

--- a/src/lorairo/gui/window/main_window.py
+++ b/src/lorairo/gui/window/main_window.py
@@ -723,6 +723,7 @@ class MainWindow(QMainWindow, Ui_MainWindow):
         service = getattr(model_widget, "model_selection_service", None)
         all_models = service.load_models() if service is not None else []
         models_by_id = {m.litellm_model_id: m for m in all_models}
+        cost_by_id = self._build_cost_map()
 
         infos: list[StageModelInfo] = []
         for litellm_id in selected_ids:
@@ -732,6 +733,7 @@ class MainWindow(QMainWindow, Ui_MainWindow):
                 continue
             provider = model.provider
             is_api = bool(provider) and provider.lower() != "local"
+            input_cost, output_cost = cost_by_id.get(litellm_id, (None, None))
             infos.append(
                 StageModelInfo(
                     litellm_model_id=litellm_id,
@@ -739,9 +741,38 @@ class MainWindow(QMainWindow, Ui_MainWindow):
                     provider=provider,
                     is_api=is_api,
                     capabilities=frozenset(str(c) for c in model.capabilities),
+                    input_cost_per_token=input_cost,
+                    output_cost_per_token=output_cost,
                 )
             )
         return infos
+
+    def _build_cost_map(self) -> dict[str, tuple[float | None, float | None]]:
+        """litellm_model_id → (input単価, output単価) のコストマップを構築する。
+
+        image-annotator-lib の ``list_annotator_info()`` から実行時に pricing を取得する
+        (Issue #747: litellm pricing は DB 保存せず on-demand)。取得失敗時は空マップを
+        返してコスト表示なしで続行する (best-effort、アノテーション機能はブロックしない)。
+
+        Returns:
+            litellm_model_id をキーとした (input_cost_per_token, output_cost_per_token)。
+        """
+        adapter = getattr(self.service_container, "annotator_library", None)
+        if adapter is None:
+            return {}
+        cost_map: dict[str, tuple[float | None, float | None]] = {}
+        try:
+            for info in adapter.list_annotator_info():
+                if info.litellm_model_id is None:
+                    continue
+                cost_map[info.litellm_model_id] = (
+                    info.input_cost_per_token,
+                    info.output_cost_per_token,
+                )
+        except (TypeError, AttributeError, RuntimeError):
+            logger.warning("コスト概算用の AnnotatorInfo 取得に失敗。コスト表示なしで続行", exc_info=True)
+            return {}
+        return cost_map
 
     def _on_pipeline_add_model_requested(self, stage_value: str) -> None:
         """ステージ行の「+ 追加」でピッカーを開き、選択モデル集合へ追加する (Phase 6b)。

--- a/src/lorairo/services/cost_estimation_service.py
+++ b/src/lorairo/services/cost_estimation_service.py
@@ -1,0 +1,126 @@
+# src/lorairo/services/cost_estimation_service.py
+"""アノテーション推論のコスト概算サービス (Wireframes v11 Frame 2B / Issue #747)。
+
+モデルピッカーのカードと INFERENCE LEDGER に「$/img・推定時間」を概算表示する
+ための Qt-free ドメインサービス。litellm の per-token 単価 (実行時取得) に粗い
+固定 token 仮定を掛けて 1 枚あたりコストを算出する。
+
+設計判断 (Issue #747):
+- ワイヤーフレームは「概算」明示なので **粗い固定 token 仮定** を使う。実際の
+  入出力トークン数は画像内容・プロンプト・出力長に依存するため厳密値は出さない。
+- litellm pricing は変動するので DB には保存せず実行時に AnnotatorInfo から取得する
+  (provider_batch_eligibility と同じ on-demand 思想)。
+- ローカル ML モデルは API 課金がないため per-image cost = 0.0 (None ではない)。
+  推定時間にはジョブ数として寄与する。
+- pricing 未取得の API モデル (litellm に単価がない) は per-image cost = None。
+  表示は "—"、バッチ合計では「一部不明」フラグを立てる。
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from lorairo.services.pipeline_composition import InferenceLedger, StageModelInfo
+
+# --- 概算用の固定仮定 (後から調整可能なよう module 定数に集約) ---------------
+
+INPUT_TOKENS_PER_IMAGE = 1500
+"""画像 high-detail エンコード + システムプロンプト相当の input トークン概算。"""
+
+OUTPUT_TOKENS_PER_IMAGE = 400
+"""構造化出力 (tags + caption + score) 相当の output トークン概算。"""
+
+SECONDS_PER_JOB = 3.0
+"""推論 1 ジョブの粗い所要秒数 (ワイヤーの `18 jobs · 推定 48s` ≈ 2.7s/job 由来)。"""
+
+_LOCAL_FREE_LABEL = "ローカル（無料）"
+_UNKNOWN_COST_LABEL = "—"
+
+
+def format_per_image_cost(per_image_usd: float | None, is_api: bool) -> str:
+    """1 枚あたりコストを表示用文字列に整形する (カード直載せ用)。
+
+    Args:
+        per_image_usd: ``CostEstimationService.per_image_usd`` の戻り値。
+        is_api: API モデルなら True。ローカル ML の 0.0 を「無料」と区別するため使う。
+
+    Returns:
+        ローカルは "ローカル（無料）"、pricing 未取得は "—"、それ以外は "$0.0050/img"。
+    """
+    if not is_api:
+        return _LOCAL_FREE_LABEL
+    if per_image_usd is None:
+        return _UNKNOWN_COST_LABEL
+    return f"${per_image_usd:.4f}/img"
+
+
+def format_duration(seconds: float) -> str:
+    """推定秒数を表示用文字列に整形する ("48s" / "2m30s")。"""
+    total = round(seconds)
+    if total < 60:
+        return f"{total}s"
+    minutes, secs = divmod(total, 60)
+    return f"{minutes}m{secs:02d}s"
+
+
+@dataclass(frozen=True)
+class BatchCostEstimate:
+    """バッチ全体のコスト・時間概算。
+
+    Attributes:
+        total_usd: per-image cost が判明したモデルの概算コスト合計 (USD)。
+        has_unknown: pricing 未取得 (per-image cost = None) のモデルを含むか。
+            True のとき total_usd は「判明分のみの下限」を意味する。
+        est_seconds: 総推論ジョブ数 × SECONDS_PER_JOB の推定所要秒数。
+    """
+
+    total_usd: float
+    has_unknown: bool
+    est_seconds: float
+
+
+class CostEstimationService:
+    """StageModelInfo / InferenceLedger からコストと時間を概算する (Qt-free)。"""
+
+    def per_image_usd(self, model: StageModelInfo) -> float | None:
+        """1 枚あたりの概算コスト (USD) を返す。
+
+        Args:
+            model: 対象モデルのスナップショット。
+
+        Returns:
+            ローカル ML モデルは 0.0。pricing 未取得の API モデルは None。
+            それ以外は固定 token 仮定による概算値。
+        """
+        if not model.is_api:
+            return 0.0
+        if model.input_cost_per_token is None or model.output_cost_per_token is None:
+            return None
+        return (
+            INPUT_TOKENS_PER_IMAGE * model.input_cost_per_token
+            + OUTPUT_TOKENS_PER_IMAGE * model.output_cost_per_token
+        )
+
+    def estimate_batch(self, ledger: InferenceLedger) -> BatchCostEstimate:
+        """推論台帳からバッチ全体のコスト・時間概算を返す。
+
+        各ユニークモデルの per-image cost × ステージング枚数を合計する。
+        per-image cost が None (pricing 未取得) のモデルは合計から除外しつつ
+        has_unknown を立てる。総時間は総ジョブ数 × SECONDS_PER_JOB。
+
+        Args:
+            ledger: PipelineCompositionService.ledger() の戻り値。
+
+        Returns:
+            BatchCostEstimate: total_usd / has_unknown / est_seconds。
+        """
+        total_usd = 0.0
+        has_unknown = False
+        for entry in ledger.entries:
+            per_image = self.per_image_usd(entry.model)
+            if per_image is None:
+                has_unknown = True
+                continue
+            total_usd += per_image * ledger.staged_count
+        est_seconds = ledger.total_jobs * SECONDS_PER_JOB
+        return BatchCostEstimate(total_usd=total_usd, has_unknown=has_unknown, est_seconds=est_seconds)

--- a/src/lorairo/services/pipeline_composition.py
+++ b/src/lorairo/services/pipeline_composition.py
@@ -54,6 +54,10 @@ class StageModelInfo:
         is_api: WebAPI モデルなら True、ローカル ML なら False。
         capabilities: model_types 由来の capability 名集合
             ({"tags", "caption", "scores", "ratings", "multimodal"} の部分集合)。
+        input_cost_per_token: LiteLLM 由来の input トークン単価 (USD/token)。
+            ローカル ML / pricing 未取得の API モデルは None (Issue #747)。
+        output_cost_per_token: LiteLLM 由来の output トークン単価 (USD/token)。
+            ローカル ML / pricing 未取得の API モデルは None (Issue #747)。
     """
 
     litellm_model_id: str
@@ -61,6 +65,8 @@ class StageModelInfo:
     provider: str | None
     is_api: bool
     capabilities: frozenset[str]
+    input_cost_per_token: float | None = None
+    output_cost_per_token: float | None = None
 
     @property
     def is_multimodal(self) -> bool:

--- a/tests/unit/gui/widgets/test_inference_ledger_widget.py
+++ b/tests/unit/gui/widgets/test_inference_ledger_widget.py
@@ -20,6 +20,8 @@ GPT4O = StageModelInfo(
     provider="openai",
     is_api=True,
     capabilities=frozenset({"multimodal", "caption", "tags", "scores"}),
+    input_cost_per_token=2.5e-06,
+    output_cost_per_token=1.0e-05,
 )
 
 
@@ -90,6 +92,41 @@ class TestInferenceLedgerWidgetChips:
         assert len(widget.findChildren(QLabel, "ledgerMultiBadge")) == 1
 
 
+class TestInferenceLedgerWidgetCost:
+    def test_cost_line_shows_estimate_and_duration(self, widget):
+        widget.display(_sample_ledger())
+        cost_text = widget._cost_label.text()
+        # GPT4O per-image = 1500*2.5e-6 + 400*1e-5 = 0.00775、×9枚 ≈ $0.07
+        assert "推定 $0.07" in cost_text
+        # 54 ジョブ × 3.0s = 162s = 2m42s
+        assert "2m42s" in cost_text
+        assert not widget._cost_label.isHidden()
+
+    def test_cost_line_flags_unknown_when_pricing_missing(self, widget):
+        no_price_api = StageModelInfo(
+            litellm_model_id="anthropic/claude-x",
+            display_name="claude-x",
+            provider="anthropic",
+            is_api=True,
+            capabilities=frozenset({"tags"}),
+        )
+        ledger = InferenceLedger(entries=(LedgerEntry(model=no_price_api, stage_count=1),), staged_count=4)
+        widget.display(ledger)
+        cost_text = widget._cost_label.text()
+        assert "$0.00+" in cost_text
+        assert "料金不明" in cost_text
+
+    def test_local_only_ledger_shows_zero_cost(self, widget):
+        ledger = InferenceLedger(
+            entries=(LedgerEntry(model=_local_model("wd-tagger", "tags"), stage_count=1),),
+            staged_count=5,
+        )
+        widget.display(ledger)
+        cost_text = widget._cost_label.text()
+        assert "推定 $0.00 ·" in cost_text
+        assert "料金不明" not in cost_text
+
+
 class TestInferenceLedgerWidgetPlaceholder:
     def test_empty_entries_shows_placeholder(self, widget):
         widget.display(InferenceLedger(entries=(), staged_count=9))
@@ -108,5 +145,6 @@ class TestInferenceLedgerWidgetPlaceholder:
         widget.clear()
         assert widget._placeholder_label.text() == "モデル未選択"
         assert widget._formula_label.text() == ""
+        assert widget._cost_label.text() == ""
         assert widget.findChildren(QLabel, "ledgerChip") == []
         assert widget.findChildren(QLabel, "ledgerMultiBadge") == []

--- a/tests/unit/gui/widgets/test_stage_model_picker_dialog.py
+++ b/tests/unit/gui/widgets/test_stage_model_picker_dialog.py
@@ -17,6 +17,15 @@ GPT4O = StageModelInfo(
     provider="openai",
     is_api=True,
     capabilities=frozenset({"multimodal", "caption", "tags", "scores"}),
+    input_cost_per_token=2.5e-06,
+    output_cost_per_token=1.0e-05,
+)
+NO_PRICE_API = StageModelInfo(
+    litellm_model_id="anthropic/claude-x",
+    display_name="claude-x",
+    provider="anthropic",
+    is_api=True,
+    capabilities=frozenset({"tags"}),
 )
 WD_TAGGER = StageModelInfo(
     litellm_model_id="wd-v1-4-tagger",
@@ -65,6 +74,18 @@ class TestStageModelPickerDialogRendering:
         assert "preflight" in multimodal_texts[0]
         local_texts = [text for text in texts if "wd-v1-4-tagger" in text]
         assert "1推論で" not in local_texts[0]
+
+    def test_candidate_cards_show_per_image_cost(self, qtbot):
+        dialog = StageModelPickerDialog(PipelineStage.TAGS, [GPT4O, WD_TAGGER, NO_PRICE_API])
+        qtbot.addWidget(dialog)
+        candidate_list = _candidate_list(dialog)
+        texts = [candidate_list.item(i).text() for i in range(candidate_list.count())]
+        # GPT4O per-image = 1500*2.5e-6 + 400*1e-5 = 0.00775 → $0.0077/img (.4f 丸め)
+        assert any("gpt-4o" in t and "$0.0077/img" in t for t in texts)
+        # ローカルは無料表記
+        assert any("wd-v1-4-tagger" in t and "ローカル（無料）" in t for t in texts)
+        # pricing 未取得の API モデルは "—"
+        assert any("claude-x" in t and "—" in t for t in texts)
 
     def test_items_are_user_checkable_and_initially_unchecked(self, qtbot):
         dialog = StageModelPickerDialog(PipelineStage.TAGS, [GPT4O, WD_TAGGER])

--- a/tests/unit/gui/window/test_main_window_pipeline_panel.py
+++ b/tests/unit/gui/window/test_main_window_pipeline_panel.py
@@ -65,6 +65,8 @@ class TestBuildStageModelInfos:
     def _make_window(self, models: list[SimpleNamespace]) -> Mock:
         mock_window = Mock()
         mock_window.batchModelSelection.model_selection_service.load_models.return_value = models
+        # Issue #747: コストマップ取得は real dict を返させ、Mock のアンパック失敗を避ける
+        mock_window._build_cost_map.return_value = {}
         return mock_window
 
     def test_converts_api_model_with_capabilities(self):

--- a/tests/unit/services/test_cost_estimation_service.py
+++ b/tests/unit/services/test_cost_estimation_service.py
@@ -1,0 +1,130 @@
+"""CostEstimationService 単体テスト (Issue #747)。"""
+
+from __future__ import annotations
+
+import pytest
+
+from lorairo.services.cost_estimation_service import (
+    INPUT_TOKENS_PER_IMAGE,
+    OUTPUT_TOKENS_PER_IMAGE,
+    SECONDS_PER_JOB,
+    CostEstimationService,
+    format_duration,
+    format_per_image_cost,
+)
+from lorairo.services.pipeline_composition import (
+    InferenceLedger,
+    LedgerEntry,
+    StageModelInfo,
+)
+
+pytestmark = [pytest.mark.unit]
+
+
+def _api_model(model_id: str, in_cost: float | None, out_cost: float | None) -> StageModelInfo:
+    return StageModelInfo(
+        litellm_model_id=model_id,
+        display_name=model_id,
+        provider="openai",
+        is_api=True,
+        capabilities=frozenset({"tags"}),
+        input_cost_per_token=in_cost,
+        output_cost_per_token=out_cost,
+    )
+
+
+def _local_model(model_id: str) -> StageModelInfo:
+    return StageModelInfo(
+        litellm_model_id=model_id,
+        display_name=model_id,
+        provider=None,
+        is_api=False,
+        capabilities=frozenset({"tags"}),
+    )
+
+
+class TestPerImageUsd:
+    def test_local_model_is_zero(self):
+        service = CostEstimationService()
+        assert service.per_image_usd(_local_model("wd-tagger")) == 0.0
+
+    def test_api_model_uses_fixed_token_assumptions(self):
+        service = CostEstimationService()
+        model = _api_model("openai/gpt-4o", 2.5e-06, 1.0e-05)
+        expected = INPUT_TOKENS_PER_IMAGE * 2.5e-06 + OUTPUT_TOKENS_PER_IMAGE * 1.0e-05
+        assert service.per_image_usd(model) == pytest.approx(expected)
+
+    def test_api_model_missing_input_cost_is_none(self):
+        service = CostEstimationService()
+        assert service.per_image_usd(_api_model("x", None, 1.0e-05)) is None
+
+    def test_api_model_missing_output_cost_is_none(self):
+        service = CostEstimationService()
+        assert service.per_image_usd(_api_model("x", 2.5e-06, None)) is None
+
+
+class TestEstimateBatch:
+    def test_empty_ledger_is_zero(self):
+        service = CostEstimationService()
+        estimate = service.estimate_batch(InferenceLedger(entries=(), staged_count=0))
+        assert estimate.total_usd == 0.0
+        assert estimate.has_unknown is False
+        assert estimate.est_seconds == 0.0
+
+    def test_api_cost_multiplied_by_staged_count(self):
+        service = CostEstimationService()
+        model = _api_model("openai/gpt-4o", 2.5e-06, 1.0e-05)
+        ledger = InferenceLedger(entries=(LedgerEntry(model=model, stage_count=1),), staged_count=9)
+        per_image = service.per_image_usd(model)
+        assert per_image is not None
+        estimate = service.estimate_batch(ledger)
+        assert estimate.total_usd == pytest.approx(per_image * 9)
+        assert estimate.has_unknown is False
+        # 1 ユニークモデル × 9 枚 = 9 ジョブ
+        assert estimate.est_seconds == pytest.approx(9 * SECONDS_PER_JOB)
+
+    def test_local_models_contribute_zero_cost_but_time(self):
+        service = CostEstimationService()
+        ledger = InferenceLedger(
+            entries=(LedgerEntry(model=_local_model("wd-tagger"), stage_count=1),),
+            staged_count=5,
+        )
+        estimate = service.estimate_batch(ledger)
+        assert estimate.total_usd == 0.0
+        assert estimate.has_unknown is False
+        assert estimate.est_seconds == pytest.approx(5 * SECONDS_PER_JOB)
+
+    def test_unknown_pricing_sets_flag_and_excludes_from_total(self):
+        service = CostEstimationService()
+        priced = _api_model("openai/gpt-4o", 2.5e-06, 1.0e-05)
+        unpriced = _api_model("anthropic/claude-x", None, None)
+        ledger = InferenceLedger(
+            entries=(
+                LedgerEntry(model=priced, stage_count=1),
+                LedgerEntry(model=unpriced, stage_count=1),
+            ),
+            staged_count=4,
+        )
+        per_image = service.per_image_usd(priced)
+        assert per_image is not None
+        estimate = service.estimate_batch(ledger)
+        assert estimate.has_unknown is True
+        # unpriced は合計から除外され priced のみ寄与
+        assert estimate.total_usd == pytest.approx(per_image * 4)
+
+
+class TestFormatHelpers:
+    def test_format_local_is_free(self):
+        assert format_per_image_cost(0.0, is_api=False) == "ローカル（無料）"
+
+    def test_format_unknown_is_dash(self):
+        assert format_per_image_cost(None, is_api=True) == "—"
+
+    def test_format_api_cost_4_decimals(self):
+        assert format_per_image_cost(0.00775, is_api=True) == "$0.0077/img"
+
+    def test_format_duration_seconds(self):
+        assert format_duration(48) == "48s"
+
+    def test_format_duration_minutes(self):
+        assert format_duration(162) == "2m42s"


### PR DESCRIPTION
## 概要

Wireframes v11 Frame 2B の確定事項「コストはカード直載せ・route は tooltip」を実装し、モデルピッカー (`StageModelPickerDialog`) と推論台帳 (`InferenceLedgerWidget`) に **per-image コスト ($/img)** と **バッチ推定時間** を概算表示する (Issue #747)。

## 変更内容

### iam-lib (submodule)
- `AnnotatorInfo` に `input_cost_per_token` / `output_cost_per_token` (float | None) を追加
- `_build_annotator_info_for_registry_model` が `_WEBAPI_MODEL_METADATA` (SSoT、discovery 由来) の cost を伝播。ローカル ML は None フォールバック
- submodule pin を該当 commit に更新

### LoRAIro
- `StageModelInfo` に cost 2 フィールドを追加 (frozen, default None で後方互換)
- `CostEstimationService` (Qt-free) を新規追加
- `_build_stage_model_infos` が `list_annotator_info()` から litellm pricing を実行時取得
- `StageModelPickerDialog`: 候補カードに per-image cost 直載せ
- `InferenceLedgerWidget`: コスト推定行を追加

## コスト概算の固定 token 仮定

ワイヤーフレームは「概算」明示のため粗い固定 token 仮定を使う (module 定数で後から調整可能):

| 定数 | 値 | 根拠 |
|---|---|---|
| `INPUT_TOKENS_PER_IMAGE` | 1500 | 画像 high-detail + システムプロンプト相当 |
| `OUTPUT_TOKENS_PER_IMAGE` | 400 | 構造化出力 (tags+caption+score) 相当 |
| `SECONDS_PER_JOB` | 3.0 | ワイヤーの `18 jobs · 推定 48s` ≈ 2.7s/job 由来 |

per-image cost = `INPUT_TOKENS_PER_IMAGE × input_cost_per_token + OUTPUT_TOKENS_PER_IMAGE × output_cost_per_token`

## 設計上の注意点

- **litellm pricing は DB に保存しない**。変動するため `list_annotator_info()` で実行時取得する (`provider_batch_eligibility` と同じ on-demand 思想)
- **ローカル ML モデルは cost = $0.0** (None ではない、API 課金なし)。推定時間にはジョブとして寄与
- **pricing 未取得の API モデルは cost = None** (表示は `—`)。バッチ合計では `has_unknown` フラグを立て `$X.XX+`（一部モデルは料金不明）と表示
- コスト取得は best-effort。取得失敗してもアノテーション機能はブロックせず None 続行

## CI-EQUIV-TESTED

submodule pin 変更を含むため CI-equivalent filter を実行:

- **iam-lib** (`-m "not downloads_and_runs_model and not calls_real_webapi"`): cost 関連 + listing テスト 91 passed。torch/libcudnn の collection 失敗は本変更と無関係の環境制約 (baseline `main` でも同様に失敗、CI runner には cudnn あり) と stash 比較で確認
- **LoRAIro** (`-m "not gui_show and not calls_real_webapi and not downloads_and_runs_model and not slow"`): `tests/unit/gui` + `tests/unit/services` 2169 passed、tab 統合テスト 38 passed、新規 cost テスト含む対象スイート 65 passed
- **mypy**: 変更ファイル由来エラー 0 (既存 29 件は全て生成 `designer/*_ui.py`、baseline でも発生)
- **ruff**: format/check pass

Closes #747

🤖 Generated with [Claude Code](https://claude.com/claude-code)
