### PR TITLE
feat(gui): Phase 8 Map tab — TagMapWidget + TagClusterService (Issue #720)

### DIFF
--- a/src/lorairo/gui/widgets/tag_map_widget.py
+++ b/src/lorairo/gui/widgets/tag_map_widget.py
@@ -1,0 +1,556 @@
+"""タグベースクラスタ散布図ウィジェット（Wireframes v11 · Map フレーム）。
+
+左サイドバー: クラスタリスト・色分け・表示オプション
+右メインエリア: 2D 散布図（QPainter）+ ラッソ選択
+"""
+
+from __future__ import annotations
+
+import math
+from typing import TYPE_CHECKING
+
+from loguru import logger
+from PySide6.QtCore import QPoint, QPointF, QRectF, Qt, QThread, QTimer, Signal
+from PySide6.QtGui import (
+    QBrush,
+    QColor,
+    QFont,
+    QMouseEvent,
+    QPainter,
+    QPen,
+    QPolygonF,
+    QResizeEvent,
+)
+from PySide6.QtWidgets import (
+    QHBoxLayout,
+    QLabel,
+    QPushButton,
+    QScrollArea,
+    QSizePolicy,
+    QVBoxLayout,
+    QWidget,
+)
+
+from lorairo.services.tag_cluster_service import (
+    OUTLIER_CLUSTER_ID,
+    ClusterInfo,
+    ClusterResult,
+    DotInfo,
+    TagClusterService,
+)
+
+if TYPE_CHECKING:
+    from lorairo.database.db_manager import ImageDatabaseManager
+
+_DOT_RADIUS = 5
+_HOVER_RADIUS = 8
+_LASSO_COLOR = QColor("#c44a2f")
+_SELECTION_COLOR = QColor("#c44a2f")
+_GRID_COLOR = QColor(0, 0, 0, 13)
+
+
+class _PlotWorker(QThread):
+    """バックグラウンドでクラスタ計算を実行するスレッド。"""
+
+    finished = Signal(object)  # ClusterResult
+    error = Signal(str)
+
+    def __init__(self, service: TagClusterService, n_clusters: int) -> None:
+        super().__init__()
+        self._service = service
+        self._n_clusters = n_clusters
+
+    def run(self) -> None:
+        try:
+            result = self._service.build_cluster_result(self._n_clusters)
+            self.finished.emit(result)
+        except Exception as exc:
+            self.error.emit(str(exc))
+
+
+class _ScatterPlot(QWidget):
+    """散布図描画 + ラッソ選択ウィジェット。"""
+
+    selection_changed = Signal(list)  # list[int] image_ids
+
+    def __init__(self, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        self.setMouseTracking(True)
+        self.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Expanding)
+
+        self._dots: list[DotInfo] = []
+        self._clusters: dict[int, ClusterInfo] = {}
+        self._color_by = "cluster"  # "cluster" | "tier"
+        self._show_labels = True
+        self._show_hulls = True
+
+        self._lasso_points: list[QPointF] = []
+        self._is_lassoing = False
+        self._selected_ids: set[int] = set()
+        self._hover_id: int | None = None
+
+    def set_result(self, result: ClusterResult) -> None:
+        """クラスタ結果をセットして再描画。"""
+        self._dots = result.dots
+        self._clusters = {c.id: c for c in result.clusters}
+        self._selected_ids.clear()
+        self._lasso_points.clear()
+        self.update()
+
+    def set_color_by(self, mode: str) -> None:
+        self._color_by = mode
+        self.update()
+
+    def set_show_labels(self, show: bool) -> None:
+        self._show_labels = show
+        self.update()
+
+    def set_show_hulls(self, show: bool) -> None:
+        self._show_hulls = show
+        self.update()
+
+    def clear_selection(self) -> None:
+        self._selected_ids.clear()
+        self.selection_changed.emit([])
+        self.update()
+
+    def select_cluster(self, cluster_id: int) -> None:
+        """クラスタ全選択。"""
+        cl = self._clusters.get(cluster_id)
+        if cl is None:
+            return
+        self._selected_ids = set(cl.image_ids)
+        self.selection_changed.emit(list(self._selected_ids))
+        self.update()
+
+    # ------------------------------------------------------------------
+    # Qt events
+    # ------------------------------------------------------------------
+
+    def mousePressEvent(self, event: QMouseEvent) -> None:
+        if event.button() == Qt.MouseButton.LeftButton:
+            self._is_lassoing = True
+            self._lasso_points = [QPointF(event.position())]
+            self._selected_ids.clear()
+            self.update()
+
+    def mouseMoveEvent(self, event: QMouseEvent) -> None:
+        pos = event.position()
+        if self._is_lassoing:
+            self._lasso_points.append(QPointF(pos))
+            self.update()
+        else:
+            # ホバー検出
+            hit = self._hit_test(pos)
+            if hit != self._hover_id:
+                self._hover_id = hit
+                self.update()
+
+    def mouseReleaseEvent(self, event: QMouseEvent) -> None:
+        if event.button() == Qt.MouseButton.LeftButton and self._is_lassoing:
+            self._is_lassoing = False
+            if len(self._lasso_points) > 2:
+                self._compute_lasso_selection()
+            self._lasso_points.clear()
+            self.update()
+
+    def paintEvent(self, _event: object) -> None:
+        painter = QPainter(self)
+        painter.setRenderHint(QPainter.RenderHint.Antialiasing)
+        w, h = self.width(), self.height()
+
+        # 背景
+        painter.fillRect(0, 0, w, h, QColor("#f9f7f2"))
+        self._draw_grid(painter, w, h)
+
+        if not self._dots:
+            self._draw_empty(painter, w, h)
+            painter.end()
+            return
+
+        # 凸包（hull）
+        if self._show_hulls:
+            self._draw_hulls(painter, w, h)
+
+        # クラスタラベル
+        if self._show_labels:
+            self._draw_labels(painter, w, h)
+
+        # 点
+        for dot in self._dots:
+            self._draw_dot(painter, dot, w, h)
+
+        # ラッソ
+        if self._is_lassoing and len(self._lasso_points) > 1:
+            pen = QPen(_LASSO_COLOR, 1.5, Qt.PenStyle.DashLine)
+            painter.setPen(pen)
+            painter.setBrush(QBrush(QColor(196, 74, 47, 25)))
+            poly = QPolygonF(self._lasso_points)
+            painter.drawPolygon(poly)
+
+        painter.end()
+
+    def resizeEvent(self, _event: QResizeEvent) -> None:
+        self.update()
+
+    # ------------------------------------------------------------------
+    # Drawing helpers
+    # ------------------------------------------------------------------
+
+    def _draw_grid(self, painter: QPainter, w: int, h: int) -> None:
+        pen = QPen(_GRID_COLOR, 1)
+        painter.setPen(pen)
+        step_x = w / 10
+        step_y = h / 10
+        for i in range(1, 10):
+            x = int(i * step_x)
+            painter.drawLine(x, 0, x, h)
+        for i in range(1, 10):
+            y = int(i * step_y)
+            painter.drawLine(0, y, w, y)
+
+    def _draw_empty(self, painter: QPainter, w: int, h: int) -> None:
+        painter.setPen(QColor("#aaaaaa"))
+        painter.setFont(QFont("monospace", 11))
+        painter.drawText(
+            QRectF(0, 0, w, h), Qt.AlignmentFlag.AlignCenter, "タグなし画像のみ\nクラスタ計算不可"
+        )
+
+    def _dot_pos(self, dot: DotInfo, w: int, h: int) -> QPointF:
+        return QPointF(dot.x * w, dot.y * h)
+
+    def _dot_color(self, dot: DotInfo) -> QColor:
+        cl = self._clusters.get(dot.cluster_id)
+        if cl is None:
+            return QColor("#aaaaaa")
+        return QColor(cl.color)
+
+    def _draw_dot(self, painter: QPainter, dot: DotInfo, w: int, h: int) -> None:
+        pos = self._dot_pos(dot, w, h)
+        color = self._dot_color(dot)
+        r = _HOVER_RADIUS if dot.image_id == self._hover_id else _DOT_RADIUS
+        selected = dot.image_id in self._selected_ids
+        if selected:
+            painter.setPen(QPen(_SELECTION_COLOR, 2))
+            painter.setBrush(QBrush(color.lighter(130)))
+        else:
+            painter.setPen(QPen(color.darker(140), 1))
+            painter.setBrush(QBrush(color))
+        painter.drawEllipse(pos, r, r)
+
+    def _draw_labels(self, painter: QPainter, w: int, h: int) -> None:
+        font = QFont("monospace", 8)
+        painter.setFont(font)
+        for cl in self._clusters.values():
+            if not cl.image_ids:
+                continue
+            # クラスタ重心
+            xs = [d.x for d in self._dots if d.cluster_id == cl.id]
+            ys = [d.y for d in self._dots if d.cluster_id == cl.id]
+            if not xs:
+                continue
+            cx = sum(xs) / len(xs) * w
+            cy = sum(ys) / len(ys) * h
+            color = QColor(cl.color)
+            painter.setPen(QPen(color.darker(160), 1))
+            painter.drawText(QPointF(cx + 6, cy - 4), cl.label)
+
+    def _draw_hulls(self, painter: QPainter, w: int, h: int) -> None:
+        for cl in self._clusters.values():
+            pts = [self._dot_pos(d, w, h) for d in self._dots if d.cluster_id == cl.id]
+            if len(pts) < 3:
+                continue
+            hull_pts = self._convex_hull(pts)
+            if len(hull_pts) < 3:
+                continue
+            color = QColor(cl.color)
+            color.setAlpha(30)
+            border = QColor(cl.color)
+            border.setAlpha(80)
+            painter.setPen(QPen(border, 1, Qt.PenStyle.DashLine))
+            painter.setBrush(QBrush(color))
+            painter.drawPolygon(QPolygonF(hull_pts))
+
+    # ------------------------------------------------------------------
+    # Geometry helpers
+    # ------------------------------------------------------------------
+
+    def _hit_test(self, pos: QPointF) -> int | None:
+        w, h = self.width(), self.height()
+        best: int | None = None
+        best_dist = _HOVER_RADIUS * _HOVER_RADIUS * 2.0
+        for dot in self._dots:
+            dp = self._dot_pos(dot, w, h)
+            dist = (dp.x() - pos.x()) ** 2 + (dp.y() - pos.y()) ** 2
+            if dist < best_dist:
+                best_dist = dist
+                best = dot.image_id
+        return best
+
+    def _compute_lasso_selection(self) -> None:
+        w, h = self.width(), self.height()
+        poly = QPolygonF(self._lasso_points)
+        for dot in self._dots:
+            dp = self._dot_pos(dot, w, h)
+            if poly.containsPoint(dp, Qt.FillRule.OddEvenFill):
+                self._selected_ids.add(dot.image_id)
+        self.selection_changed.emit(list(self._selected_ids))
+
+    @staticmethod
+    def _convex_hull(points: list[QPointF]) -> list[QPointF]:
+        """Graham scan による凸包。"""
+        pts = [(p.x(), p.y()) for p in points]
+        pts.sort()
+        if len(pts) <= 2:
+            return [QPointF(x, y) for x, y in pts]
+
+        def cross(o: tuple[float, float], a: tuple[float, float], b: tuple[float, float]) -> float:
+            return float((a[0] - o[0]) * (b[1] - o[1]) - (a[1] - o[1]) * (b[0] - o[0]))
+
+        lower: list[tuple[float, float]] = []
+        for p in pts:
+            while len(lower) >= 2 and cross(lower[-2], lower[-1], p) <= 0:
+                lower.pop()
+            lower.append(p)
+        upper: list[tuple[float, float]] = []
+        for p in reversed(pts):
+            while len(upper) >= 2 and cross(upper[-2], upper[-1], p) <= 0:
+                upper.pop()
+            upper.append(p)
+        hull = lower[:-1] + upper[:-1]
+        # 膨らます（余白）
+        cx = sum(x for x, _ in hull) / len(hull)
+        cy = sum(y for _, y in hull) / len(hull)
+        expanded = []
+        for x, y in hull:
+            dx, dy = x - cx, y - cy
+            dist = math.sqrt(dx * dx + dy * dy) or 1
+            expanded.append(QPointF(x + dx / dist * 12, y + dy / dist * 12))
+        return expanded
+
+
+class _SidebarClusterRow(QWidget):
+    """サイドバーのクラスタ1行。"""
+
+    clicked = Signal(int)  # cluster_id
+
+    def __init__(self, cluster: ClusterInfo, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        self._cluster_id = cluster.id
+        layout = QHBoxLayout(self)
+        layout.setContentsMargins(2, 2, 2, 2)
+        layout.setSpacing(6)
+
+        # カラードット
+        dot_label = QLabel()
+        dot_label.setFixedSize(10, 10)
+        dot_label.setStyleSheet(
+            f"background:{cluster.color};border-radius:5px;border:1px solid {QColor(cluster.color).darker(150).name()};"
+        )
+        layout.addWidget(dot_label)
+
+        # ラベル
+        text = f"{cluster.label} ({len(cluster.image_ids)})"
+        name_label = QLabel(text)
+        name_label.setFont(QFont("monospace", 9))
+        name_label.setStyleSheet("color:#333333;")
+        name_label.setWordWrap(False)
+        layout.addWidget(name_label, stretch=1)
+
+        self.setFixedHeight(24)
+        self.setCursor(Qt.CursorShape.PointingHandCursor)
+        self.setToolTip(f"クリックでクラスタ {cluster.label} を全選択")
+
+    def mousePressEvent(self, _event: QMouseEvent) -> None:
+        self.clicked.emit(self._cluster_id)
+
+
+class TagMapWidget(QWidget):
+    """マップタブのルートウィジェット。
+
+    Signals:
+        images_staged: ステージングに追加する画像 ID リスト。
+    """
+
+    images_staged = Signal(list)  # list[int]
+
+    def __init__(self, db_manager: ImageDatabaseManager, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        self._db = db_manager
+        self._service = TagClusterService(db_manager)
+        self._worker: _PlotWorker | None = None
+        self._result: ClusterResult | None = None
+        self._n_clusters = 7
+
+        self._build_ui()
+        # 初回はタブアクティブ時に遅延ロード
+        QTimer.singleShot(0, self._load_clusters)
+
+    # ------------------------------------------------------------------
+    # UI construction
+    # ------------------------------------------------------------------
+
+    def _build_ui(self) -> None:
+        root = QHBoxLayout(self)
+        root.setContentsMargins(0, 0, 0, 0)
+        root.setSpacing(0)
+
+        # 散布図はサイドバーのボタン接続より先に生成する
+        self._plot = _ScatterPlot()
+
+        # 左サイドバー
+        sidebar = self._build_sidebar()
+        root.addWidget(sidebar, 0)
+
+        # 右: 散布図
+        self._plot.selection_changed.connect(self._on_selection_changed)
+        root.addWidget(self._plot, 1)
+
+    def _build_sidebar(self) -> QWidget:
+        panel = QWidget()
+        panel.setFixedWidth(260)
+        panel.setStyleSheet("background:#f0ede6;border-right:1px solid #d0ccc4;")
+        layout = QVBoxLayout(panel)
+        layout.setContentsMargins(10, 10, 10, 10)
+        layout.setSpacing(8)
+
+        # ヘッダー
+        title = QLabel("MAP · タグクラスタ")
+        title.setFont(QFont("monospace", 10, QFont.Weight.Bold))
+        title.setStyleSheet("color:#333;letter-spacing:1px;")
+        layout.addWidget(title)
+
+        # 状態ラベル
+        self._status_label = QLabel("クラスタ計算中...")
+        self._status_label.setFont(QFont("monospace", 9))
+        self._status_label.setStyleSheet("color:#888;")
+        layout.addWidget(self._status_label)
+
+        # クラスタリスト (スクロール可)
+        cluster_section_label = QLabel("クラスタ")
+        cluster_section_label.setFont(QFont("monospace", 8))
+        cluster_section_label.setStyleSheet(
+            "color:#888;text-transform:uppercase;letter-spacing:2px;margin-top:6px;"
+        )
+        layout.addWidget(cluster_section_label)
+
+        scroll = QScrollArea()
+        scroll.setWidgetResizable(True)
+        scroll.setFrameShape(QScrollArea.Shape.NoFrame)
+        scroll.setStyleSheet("background:transparent;")
+        self._cluster_list_widget = QWidget()
+        self._cluster_list_layout = QVBoxLayout(self._cluster_list_widget)
+        self._cluster_list_layout.setContentsMargins(0, 0, 0, 0)
+        self._cluster_list_layout.setSpacing(1)
+        self._cluster_list_layout.addStretch()
+        scroll.setWidget(self._cluster_list_widget)
+        scroll.setMinimumHeight(140)
+        scroll.setMaximumHeight(260)
+        layout.addWidget(scroll)
+
+        # 選択情報
+        sel_label = QLabel("選択")
+        sel_label.setFont(QFont("monospace", 8))
+        sel_label.setStyleSheet("color:#888;text-transform:uppercase;letter-spacing:2px;margin-top:6px;")
+        layout.addWidget(sel_label)
+
+        self._sel_count_label = QLabel("0 枚選択中")
+        self._sel_count_label.setFont(QFont("monospace", 10))
+        self._sel_count_label.setStyleSheet("color:#333;font-weight:bold;")
+        layout.addWidget(self._sel_count_label)
+
+        # 選択クリアボタン
+        clear_btn = QPushButton("選択解除")
+        clear_btn.setFont(QFont("monospace", 9))
+        clear_btn.setStyleSheet(
+            "QPushButton{background:#e8e4dc;border:1px solid #c0bbb2;border-radius:3px;padding:3px 8px;}"
+            "QPushButton:hover{background:#d8d4cc;}"
+        )
+        clear_btn.clicked.connect(self._plot.clear_selection)
+        layout.addWidget(clear_btn)
+
+        # Stage ボタン
+        self._stage_btn = QPushButton("▶ Annotate へ")
+        self._stage_btn.setFont(QFont("monospace", 10, QFont.Weight.Bold))
+        self._stage_btn.setEnabled(False)
+        self._stage_btn.setStyleSheet(
+            "QPushButton{background:#c44a2f;color:white;border:none;border-radius:3px;padding:5px 10px;}"
+            "QPushButton:hover{background:#a83a20;}"
+            "QPushButton:disabled{background:#d0ccc4;color:#aaa;}"
+        )
+        self._stage_btn.clicked.connect(self._on_stage_clicked)
+        layout.addWidget(self._stage_btn)
+
+        # 再計算ボタン
+        reload_btn = QPushButton("↺ 再計算")
+        reload_btn.setFont(QFont("monospace", 9))
+        reload_btn.setStyleSheet(
+            "QPushButton{background:#e8e4dc;border:1px solid #c0bbb2;border-radius:3px;padding:3px 8px;}"
+            "QPushButton:hover{background:#d8d4cc;}"
+        )
+        reload_btn.clicked.connect(self._load_clusters)
+        layout.addWidget(reload_btn)
+
+        layout.addStretch()
+        return panel
+
+    # ------------------------------------------------------------------
+    # Data loading
+    # ------------------------------------------------------------------
+
+    def _load_clusters(self) -> None:
+        if self._worker is not None and self._worker.isRunning():
+            return
+        self._status_label.setText("クラスタ計算中...")
+        self._worker = _PlotWorker(self._service, self._n_clusters)
+        self._worker.finished.connect(self._on_cluster_ready)
+        self._worker.error.connect(self._on_cluster_error)
+        self._worker.start()
+
+    def _on_cluster_ready(self, result: ClusterResult) -> None:
+        self._result = result
+        self._plot.set_result(result)
+        self._refresh_cluster_list(result)
+        n_cl = len([c for c in result.clusters if c.id != OUTLIER_CLUSTER_ID])
+        self._status_label.setText(
+            f"{result.total_images}枚 · {result.tagged_images}枚タグあり · {n_cl}クラスタ"
+        )
+        logger.debug(f"Map: クラスタ結果受信 total={result.total_images}")
+
+    def _on_cluster_error(self, msg: str) -> None:
+        self._status_label.setText(f"エラー: {msg}")
+        logger.error(f"Map クラスタ計算エラー: {msg}")
+
+    # ------------------------------------------------------------------
+    # UI updates
+    # ------------------------------------------------------------------
+
+    def _refresh_cluster_list(self, result: ClusterResult) -> None:
+        # 既存ウィジェットを削除
+        while self._cluster_list_layout.count() > 1:
+            item = self._cluster_list_layout.takeAt(0)
+            if item:
+                w = item.widget()
+                if w is not None:
+                    w.deleteLater()
+
+        for cl in result.clusters:
+            row = _SidebarClusterRow(cl)
+            row.clicked.connect(self._plot.select_cluster)
+            self._cluster_list_layout.insertWidget(self._cluster_list_layout.count() - 1, row)
+
+    def _on_selection_changed(self, image_ids: list[int]) -> None:
+        n = len(image_ids)
+        self._sel_count_label.setText(f"{n} 枚選択中")
+        self._stage_btn.setEnabled(n > 0)
+        self._stage_btn.setText(f"▶ {n}枚を Annotate へ" if n > 0 else "▶ Annotate へ")
+
+    def _on_stage_clicked(self) -> None:
+        if self._result is None:
+            return
+        # ScatterPlot の選択 ID をシグナルで通知
+        plot = self._plot
+        ids = list(plot._selected_ids)
+        if ids:
+            self.images_staged.emit(ids)
+            logger.debug(f"Map: {len(ids)}枚をステージングへ送信")

--- a/src/lorairo/gui/window/main_window.py
+++ b/src/lorairo/gui/window/main_window.py
@@ -56,6 +56,7 @@ from ..widgets.results_widget import ResultsWidget
 from ..widgets.selected_image_details_widget import SelectedImageDetailsWidget
 from ..widgets.stage_model_picker_dialog import StageModelPickerDialog
 from ..widgets.tag_management_dialog import TagManagementDialog
+from ..widgets.tag_map_widget import TagMapWidget
 from ..widgets.thumbnail import ThumbnailSelectorWidget
 
 
@@ -114,6 +115,9 @@ class MainWindow(QMainWindow, Ui_MainWindow):
     error_triage_service: ErrorTriageService
     results_widget: ResultsWidget | None
     quality_issue_detection_service: QualityIssueDetectionService
+
+    # Map tab
+    map_widget: TagMapWidget | None
 
     # Tag management UI components
     tag_management_dialog: TagManagementDialog | None
@@ -391,11 +395,51 @@ class MainWindow(QMainWindow, Ui_MainWindow):
 
         # QTabWidget初期化（タブ切り替え用）
         self._setup_tab_widget()
+        self._setup_map_tab()
         self._setup_provider_batch_tab()
         self._setup_results_tab()
         self._setup_errors_tab()
         self._setup_export_tab()
         self._setup_tab_shortcuts()
+
+    def _setup_map_tab(self) -> None:
+        """マップタブ (TagMapWidget) を初期化する。"""
+        container = getattr(self, "tabMap", None)
+        if container is None:
+            logger.warning("tabMap not found - マップタブ skipped")
+            self.map_widget = None
+            return
+        if self.db_manager is None:
+            logger.warning("db_manager 未初期化 - マップタブ skipped")
+            self.map_widget = None
+            return
+        try:
+            layout = container.layout()
+            if layout is not None:
+                while layout.count():
+                    item = layout.takeAt(0)
+                    w = item.widget() if item else None
+                    if w is not None:
+                        w.deleteLater()
+            else:
+                from PySide6.QtWidgets import QVBoxLayout
+
+                layout = QVBoxLayout(container)
+            widget = TagMapWidget(db_manager=self.db_manager, parent=container)
+            widget.images_staged.connect(self._on_map_images_staged)
+            layout.addWidget(widget)
+            self.map_widget = widget
+            logger.info("マップタブ (TagMapWidget) initialized")
+        except Exception as e:
+            self.map_widget = None
+            logger.error(f"マップタブ initialization failed: {e}", exc_info=True)
+
+    def _on_map_images_staged(self, image_ids: list[int]) -> None:
+        """マップタブからのステージング要求を処理する。"""
+        logger.debug(f"マップタブから {len(image_ids)} 件のステージング要求")
+        batch_widget = getattr(self, "batchTagAddWidget", None)
+        if batch_widget is not None:
+            batch_widget.add_image_ids_to_staging(image_ids)
 
     def _setup_provider_batch_tab(self) -> None:
         """ジョブタブ (Provider Batch job management) を追加する。

--- a/src/lorairo/services/tag_cluster_service.py
+++ b/src/lorairo/services/tag_cluster_service.py
@@ -1,0 +1,328 @@
+"""タグ共起ベースのクラスタリングと2D配置サービス。
+
+numpy + scipy のみを使用。GPU・重量MLモデル不要。
+既存 Tag テーブルのデータからクラスタを導出する。
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, cast
+
+import numpy as np
+from loguru import logger
+
+if TYPE_CHECKING:
+    from lorairo.database.db_manager import ImageDatabaseManager
+
+# 語彙サイズ上限（タグ頻度上位）
+_VOCAB_SIZE = 300
+# クラスタ表示名に使う上位タグ数
+_LABEL_TOP_K = 3
+# 未タグ画像のクラスタID
+OUTLIER_CLUSTER_ID = -1
+
+_CLUSTER_COLORS = [
+    "#c44a2f",
+    "#2f7fa0",
+    "#1f8a5b",
+    "#7a4bc4",
+    "#c08a2c",
+    "#3a6ea5",
+    "#c0392b",
+    "#5a8a3f",
+    "#a04060",
+    "#3a8a8a",
+]
+
+
+@dataclass
+class DotInfo:
+    """散布図上の1点（1画像）の情報。"""
+
+    image_id: int
+    x: float  # 0..1 正規化済み
+    y: float  # 0..1 正規化済み
+    cluster_id: int
+    top_tags: list[str]  # ツールチップ用上位タグ
+
+
+@dataclass
+class ClusterInfo:
+    """クラスタメタデータ。"""
+
+    id: int
+    label: str  # タグ頻度から自動生成
+    image_ids: list[int] = field(default_factory=list)
+    color: str = "#8a8a8a"
+
+
+@dataclass
+class ClusterResult:
+    """`TagClusterService.build_cluster_result` の返り値。"""
+
+    dots: list[DotInfo]
+    clusters: list[ClusterInfo]
+    total_images: int
+    tagged_images: int
+
+
+class TagClusterService:
+    """タグ共起行列から2Dクラスタ散布図を構築する。
+
+    - ステップ1: DB から未 reject タグを全ロード
+    - ステップ2: 頻出上位タグを語彙に選定、二値ベクトル化
+    - ステップ3: PCA で2次元に圧縮
+    - ステップ4: k-means でクラスタリング
+    - ステップ5: クラスタをタグ頻度から命名
+    """
+
+    def __init__(self, db_manager: ImageDatabaseManager) -> None:
+        self._db = db_manager
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def build_cluster_result(self, n_clusters: int = 7) -> ClusterResult:
+        """全画像のタグを読み込みクラスタ結果を返す。
+
+        Args:
+            n_clusters: 目標クラスタ数（実際のクラスタ数はデータ量で変動可）。
+
+        Returns:
+            ClusterResult — 点座標・クラスタ情報を含む。
+        """
+        image_tags = self._load_tags()
+        tagged_ids = [iid for iid, tags in image_tags.items() if tags]
+        untagged_ids = [iid for iid, tags in image_tags.items() if not tags]
+        total = len(image_tags)
+        logger.debug(f"タグ読込: 全{total}件 (タグあり={len(tagged_ids)}, なし={len(untagged_ids)})")
+
+        if not tagged_ids:
+            # タグあり画像が0件 → 全画像をアウトライアクラスタへ
+            return self._all_untagged_result(image_tags)
+
+        if len(tagged_ids) < max(n_clusters, 2):
+            return self._fallback_result(image_tags)
+
+        X, ids_in_order, vocab = self._build_vectors(image_tags, tagged_ids)
+        coords_2d = self._pca_2d(X)
+        labels = self._kmeans(coords_2d, min(n_clusters, len(tagged_ids)))
+        coords_norm = self._normalize_coords(coords_2d)
+
+        clusters = self._build_cluster_infos(labels, ids_in_order, image_tags, vocab, n_clusters)
+        dots = self._build_dots(ids_in_order, coords_norm, labels, image_tags)
+
+        # 未タグ画像はアウトライアクラスタへ
+        if untagged_ids:
+            outlier = ClusterInfo(id=OUTLIER_CLUSTER_ID, label="未タグ", color="#aaaaaa")
+            outlier.image_ids = untagged_ids
+            clusters.append(outlier)
+            # 外縁に均等配置
+            for i, iid in enumerate(untagged_ids):
+                angle = 2 * math.pi * i / max(len(untagged_ids), 1)
+                dots.append(
+                    DotInfo(
+                        image_id=iid,
+                        x=0.5 + 0.48 * math.cos(angle),
+                        y=0.5 + 0.48 * math.sin(angle),
+                        cluster_id=OUTLIER_CLUSTER_ID,
+                        top_tags=[],
+                    )
+                )
+
+        return ClusterResult(
+            dots=dots,
+            clusters=clusters,
+            total_images=total,
+            tagged_images=len(tagged_ids),
+        )
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _load_tags(self) -> dict[int, list[str]]:
+        """未 reject タグを全ロードして {image_id: [tag, ...]} を返す。"""
+        from sqlalchemy import select
+
+        from lorairo.database.schema import Image, Tag
+
+        result: dict[int, list[str]] = {}
+        try:
+            session = self._db.image_repo.get_session()
+            with session:
+                # 全画像IDを取得
+                image_ids = [row[0] for row in session.execute(select(Image.id)).all()]
+                for iid in image_ids:
+                    result[iid] = []
+                # タグ取得（rejected_at IS NULL）
+                rows = session.execute(select(Tag.image_id, Tag.tag).where(Tag.rejected_at.is_(None))).all()
+                for image_id, tag in rows:
+                    if image_id in result:
+                        result[image_id].append(tag.lower())
+        except Exception as exc:
+            logger.error(f"タグ読込エラー: {exc}", exc_info=True)
+            raise
+        return result
+
+    def _build_vectors(
+        self,
+        image_tags: dict[int, list[str]],
+        tagged_ids: list[int],
+    ) -> tuple[np.ndarray, list[int], list[str]]:
+        """タグ頻度上位 _VOCAB_SIZE の二値ベクトル行列を構築する。"""
+        from collections import Counter
+
+        # 語彙選定
+        all_tags: list[str] = []
+        for iid in tagged_ids:
+            all_tags.extend(image_tags[iid])
+        freq = Counter(all_tags)
+        vocab = [tag for tag, _ in freq.most_common(_VOCAB_SIZE)]
+        vocab_idx = {t: i for i, t in enumerate(vocab)}
+
+        # 二値行列
+        n = len(tagged_ids)
+        m = len(vocab)
+        X = np.zeros((n, m), dtype=np.float32)
+        for row_i, iid in enumerate(tagged_ids):
+            for tag in image_tags[iid]:
+                if tag in vocab_idx:
+                    X[row_i, vocab_idx[tag]] = 1.0
+
+        return X, tagged_ids, vocab
+
+    def _pca_2d(self, X: np.ndarray) -> np.ndarray:
+        """numpy SVD による PCA で2次元射影を返す。"""
+        X_centered = X - X.mean(axis=0)
+        # 分散がゼロの列を除去
+        std = X_centered.std(axis=0)
+        mask = std > 0
+        if mask.sum() < 2:
+            # タグが全く分散しない場合はランダム配置
+            rng = np.random.default_rng(42)
+            return rng.random((len(X), 2)).astype(np.float32)
+        X_scaled = X_centered[:, mask]
+        # 特異値分解（大規模行列では truncated SVD が有利だが scipy なし → 全量）
+        try:
+            _, _, Vt = np.linalg.svd(X_scaled, full_matrices=False)
+            coords = X_scaled @ Vt[:2].T
+        except np.linalg.LinAlgError:
+            rng = np.random.default_rng(42)
+            coords = rng.random((len(X), 2)).astype(np.float32)
+        return cast(np.ndarray, coords.astype(np.float32))
+
+    def _kmeans(self, coords: np.ndarray, k: int, max_iter: int = 50) -> np.ndarray:
+        """簡易 k-means（scipy.cluster.vq を使用）。"""
+        from scipy.cluster.vq import kmeans2
+
+        try:
+            _, labels = kmeans2(coords, k, iter=max_iter, minit="points", seed=42)
+        except Exception as exc:
+            logger.warning(f"k-means 失敗、均等分割にフォールバック: {exc}")
+            labels = np.arange(len(coords)) % k
+        return cast(np.ndarray, labels.astype(np.int32))
+
+    def _normalize_coords(self, coords: np.ndarray) -> np.ndarray:
+        """座標を [0.05, 0.95] に正規化する（端に余白）。"""
+        mn = coords.min(axis=0)
+        mx = coords.max(axis=0)
+        rng = mx - mn
+        rng[rng == 0] = 1.0
+        normalized = (coords - mn) / rng * 0.90 + 0.05
+        return cast(np.ndarray, normalized.astype(np.float32))
+
+    def _build_cluster_infos(
+        self,
+        labels: np.ndarray,
+        ids_in_order: list[int],
+        image_tags: dict[int, list[str]],
+        vocab: list[str],
+        n_clusters: int,
+    ) -> list[ClusterInfo]:
+        """クラスタごとの上位タグからラベルを生成する。"""
+        from collections import Counter
+
+        clusters: dict[int, ClusterInfo] = {}
+        for cid in range(n_clusters):
+            color = _CLUSTER_COLORS[cid % len(_CLUSTER_COLORS)]
+            clusters[cid] = ClusterInfo(id=cid, label="", color=color)
+
+        # 各クラスタの画像IDとタグ収集
+        cluster_tags: dict[int, Counter[str]] = {cid: Counter() for cid in range(n_clusters)}
+        for _row_i, (iid, cid) in enumerate(zip(ids_in_order, labels, strict=False)):
+            cid_int = int(cid)
+            if cid_int not in clusters:
+                continue
+            clusters[cid_int].image_ids.append(iid)
+            cluster_tags[cid_int].update(image_tags.get(iid, []))
+
+        # タグ上位3つからクラスタ名を生成
+        for cid, counter in cluster_tags.items():
+            top = [t for t, _ in counter.most_common(_LABEL_TOP_K)]
+            clusters[cid].label = " · ".join(top) if top else f"Cluster {cid}"
+
+        return list(clusters.values())
+
+    def _build_dots(
+        self,
+        ids_in_order: list[int],
+        coords_norm: np.ndarray,
+        labels: np.ndarray,
+        image_tags: dict[int, list[str]],
+    ) -> list[DotInfo]:
+        """DotInfo リストを構築する。"""
+        dots = []
+        for row_i, iid in enumerate(ids_in_order):
+            tags = image_tags.get(iid, [])
+            dots.append(
+                DotInfo(
+                    image_id=iid,
+                    x=float(coords_norm[row_i, 0]),
+                    y=float(coords_norm[row_i, 1]),
+                    cluster_id=int(labels[row_i]),
+                    top_tags=tags[:5],
+                )
+            )
+        return dots
+
+    def _all_untagged_result(self, image_tags: dict[int, list[str]]) -> ClusterResult:
+        """タグあり画像が0件のケース。全画像をアウトライアクラスタへ配置。"""
+        ids = list(image_tags.keys())
+        outlier = ClusterInfo(id=OUTLIER_CLUSTER_ID, label="未タグ", color="#aaaaaa", image_ids=ids)
+        dots = [
+            DotInfo(
+                image_id=iid,
+                x=0.5 + 0.48 * math.cos(2 * math.pi * i / max(len(ids), 1)),
+                y=0.5 + 0.48 * math.sin(2 * math.pi * i / max(len(ids), 1)),
+                cluster_id=OUTLIER_CLUSTER_ID,
+                top_tags=[],
+            )
+            for i, iid in enumerate(ids)
+        ]
+        return ClusterResult(dots=dots, clusters=[outlier], total_images=len(ids), tagged_images=0)
+
+    def _fallback_result(self, image_tags: dict[int, list[str]]) -> ClusterResult:
+        """タグが少なすぎる場合のフォールバック。"""
+        rng = np.random.default_rng(42)
+        ids = list(image_tags.keys())
+        dots = [
+            DotInfo(
+                image_id=iid,
+                x=float(rng.random()),
+                y=float(rng.random()),
+                cluster_id=0,
+                top_tags=image_tags.get(iid, [])[:5],
+            )
+            for iid in ids
+        ]
+        cluster = ClusterInfo(id=0, label="全画像", color=_CLUSTER_COLORS[0], image_ids=ids)
+        return ClusterResult(
+            dots=dots,
+            clusters=[cluster],
+            total_images=len(ids),
+            tagged_images=sum(1 for t in image_tags.values() if t),
+        )

--- a/tests/unit/services/test_tag_cluster_service.py
+++ b/tests/unit/services/test_tag_cluster_service.py
@@ -1,0 +1,138 @@
+"""TagClusterService のユニットテスト。"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+
+from lorairo.services.tag_cluster_service import (
+    OUTLIER_CLUSTER_ID,
+    ClusterResult,
+    TagClusterService,
+)
+
+
+def _make_service(image_tags: dict[int, list[str]]) -> TagClusterService:
+    """TagClusterService をモック DB でインスタンス化。"""
+    db_manager = MagicMock()
+    svc = TagClusterService(db_manager)
+    svc._load_tags = MagicMock(return_value=image_tags)
+    return svc
+
+
+@pytest.mark.unit
+class TestTagClusterServiceBasic:
+    def test_empty_db_returns_fallback(self) -> None:
+        svc = _make_service({})
+        result = svc.build_cluster_result(n_clusters=3)
+        assert isinstance(result, ClusterResult)
+        assert result.total_images == 0
+        assert result.tagged_images == 0
+
+    def test_all_untagged_goes_to_outlier_cluster(self) -> None:
+        image_tags = {1: [], 2: [], 3: []}
+        svc = _make_service(image_tags)
+        result = svc.build_cluster_result(n_clusters=2)
+        outlier_clusters = [c for c in result.clusters if c.id == OUTLIER_CLUSTER_ID]
+        assert len(outlier_clusters) == 1
+        assert set(outlier_clusters[0].image_ids) == {1, 2, 3}
+        assert result.tagged_images == 0
+
+    def test_tagged_images_get_dot_positions(self) -> None:
+        image_tags = {i: [f"tag_{i % 5}", "common_tag"] for i in range(20)}
+        svc = _make_service(image_tags)
+        result = svc.build_cluster_result(n_clusters=3)
+        assert len(result.dots) == 20
+        for dot in result.dots:
+            assert 0.0 <= dot.x <= 1.0
+            assert 0.0 <= dot.y <= 1.0
+
+    def test_cluster_labels_from_top_tags(self) -> None:
+        # 桜タグを持つグループとバラタグを持つグループ
+        image_tags: dict[int, list[str]] = {}
+        for i in range(15):
+            image_tags[i] = ["sakura", "outdoor", f"style_{i % 3}"]
+        for i in range(15, 30):
+            image_tags[i] = ["rose", "indoor", f"tone_{i % 3}"]
+        svc = _make_service(image_tags)
+        result = svc.build_cluster_result(n_clusters=2)
+        labels = [c.label for c in result.clusters if c.id != OUTLIER_CLUSTER_ID]
+        assert all(label != "" for label in labels)
+
+    def test_total_and_tagged_counts(self) -> None:
+        image_tags = {1: ["a", "b"], 2: [], 3: ["c"], 4: []}
+        svc = _make_service(image_tags)
+        result = svc.build_cluster_result(n_clusters=2)
+        assert result.total_images == 4
+        assert result.tagged_images == 2
+
+    def test_dot_top_tags_capped_at_5(self) -> None:
+        image_tags = {1: [f"tag{i}" for i in range(20)]}
+        svc = _make_service(image_tags)
+        result = svc.build_cluster_result(n_clusters=1)
+        for dot in result.dots:
+            assert len(dot.top_tags) <= 5
+
+    def test_n_clusters_respected_approximately(self) -> None:
+        image_tags = {i: [f"tag_{i % 10}", f"sub_{i % 5}"] for i in range(50)}
+        svc = _make_service(image_tags)
+        result = svc.build_cluster_result(n_clusters=4)
+        real_clusters = [c for c in result.clusters if c.id != OUTLIER_CLUSTER_ID]
+        # k-means は指定数を返す（空クラスタは除外されない可能性あり）
+        assert len(real_clusters) <= 4
+
+    def test_fallback_on_too_few_tagged_images(self) -> None:
+        # タグあり画像が n_clusters より少ない場合
+        image_tags = {1: ["a"], 2: ["b"]}
+        svc = _make_service(image_tags)
+        result = svc.build_cluster_result(n_clusters=7)
+        assert result.total_images == 2
+
+
+@pytest.mark.unit
+class TestBuildVectors:
+    def test_returns_binary_matrix(self) -> None:
+        svc = _make_service({})
+        image_tags = {1: ["a", "b"], 2: ["b", "c"]}
+        tagged_ids = [1, 2]
+        X, _ids, vocab = svc._build_vectors(image_tags, tagged_ids)
+        assert X.shape == (2, len(vocab))
+        assert X.dtype == np.float32
+        # 各行の値は 0 か 1
+        assert set(X.flatten().tolist()).issubset({0.0, 1.0})
+
+    def test_vocab_size_capped(self) -> None:
+        svc = _make_service({})
+        # 500 以上のユニークタグを持つ画像
+        many_tags = [f"tag_{i}" for i in range(600)]
+        image_tags = {1: many_tags}
+        tagged_ids = [1]
+        _X, _, vocab = svc._build_vectors(image_tags, tagged_ids)
+        assert len(vocab) <= 300  # _VOCAB_SIZE
+
+
+@pytest.mark.unit
+class TestPCA2D:
+    def test_returns_2d_array(self) -> None:
+        svc = _make_service({})
+        X = np.random.default_rng(0).random((30, 50)).astype(np.float32)
+        coords = svc._pca_2d(X)
+        assert coords.shape == (30, 2)
+
+    def test_handles_zero_variance_columns(self) -> None:
+        svc = _make_service({})
+        X = np.ones((10, 5), dtype=np.float32)  # 全列が定数 → 分散 0
+        coords = svc._pca_2d(X)
+        assert coords.shape == (10, 2)
+
+
+@pytest.mark.unit
+class TestNormalizeCoords:
+    def test_output_in_range(self) -> None:
+        svc = _make_service({})
+        coords = np.array([[0, 0], [1, 1], [0.5, 0.5]], dtype=np.float32)
+        norm = svc._normalize_coords(coords)
+        assert norm.min() >= 0.04
+        assert norm.max() <= 0.96


### PR DESCRIPTION
## Summary

- `TagClusterService`: tag共起行列 → SVD PCA 2D座標 + k-means クラスタリング (Qt-free)
- `TagMapWidget`: QPainter散布図 + ラッソ選択 + クラスターサイドバー。背景計算は `_PlotWorker(QThread)` で非同期
- `MainWindow._setup_map_tab()`: try-exceptラップで孤立障害を防止。選択画像は `batchTagAddWidget.add_image_ids_to_staging()` 経由でステージングへ送出

## Background

PR #752 (epic/gui-wireframes-v11 → main) は squash-merge 履歴の乖離でコンフリクト不可。
origin/main から `feat/phase8-direct` ブランチを新規作成し、Phase 8 変更のみを移植。

## Test plan

- [ ] `pytest tests/unit/services/test_tag_cluster_service.py` — TagClusterService ユニットテスト
- [ ] CI all checks pass
- [ ] マップタブ (`tabMap`) に `TagMapWidget` が表示される
- [ ] ラッソ選択 → 「ステージに追加」でアノテーションタブに反映

Closes #720

🤖 Generated with [Claude Code](https://claude.com/claude-code)