### PR TITLE
feat(gui): Settings 往復導線 — needs key チップから API キー設定へ誘導し ● API ready に解消

### DIFF
--- a/src/lorairo/gui/controllers/settings_controller.py
+++ b/src/lorairo/gui/controllers/settings_controller.py
@@ -53,10 +53,15 @@ class SettingsController:
 
         return True
 
-    def open_settings_dialog(self) -> bool:
+    def open_settings_dialog(self, highlight_provider: str | None = None) -> bool:
         """設定ダイアログを開く
 
         ConfigurationServiceを使用して設定ダイアログを表示します。
+
+        Args:
+            highlight_provider: 指定すると該当 provider の API キー欄を
+                ハイライト・フォーカスした状態で開く (Issue #755: モデルピッカーの
+                ``○ needs key`` チップからの往復導線)。
 
         Returns:
             bool: ユーザーが OK で確定し設定が保存された場合 True、
@@ -77,6 +82,8 @@ class SettingsController:
             assert self.config_service is not None  # _validate_services()で検証済み
             dialog = ConfigurationWindow(config_service=self.config_service, parent=self.parent)
             dialog.setModal(True)
+            if highlight_provider:
+                dialog.focus_api_key_field(highlight_provider)
             result = dialog.exec()
 
             if result == QDialog.DialogCode.Accepted:

--- a/src/lorairo/gui/widgets/date_histogram_widget.py
+++ b/src/lorairo/gui/widgets/date_histogram_widget.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import datetime
 
 from PySide6.QtCore import QSize, Signal
-from PySide6.QtGui import QColor, QMouseEvent, QPaintEvent, QPainter
+from PySide6.QtGui import QColor, QMouseEvent, QPainter, QPaintEvent
 from PySide6.QtWidgets import QWidget
 
 

--- a/src/lorairo/gui/widgets/model_checkbox_widget.py
+++ b/src/lorairo/gui/widgets/model_checkbox_widget.py
@@ -188,14 +188,19 @@ class ModelCheckboxWidget(QWidget, Ui_ModelCheckboxWidget):
             self.labelStatus.setText(STATUS_INSTALLED)
             self.labelStatus.setStyleSheet(_STATUS_READY_STYLE)
             self.labelStatus.setToolTip("")
+            self.checkboxModel.setEnabled(True)
         elif self.model_info.available:
             self.labelStatus.setText(STATUS_API_READY)
             self.labelStatus.setStyleSheet(_STATUS_READY_STYLE)
             self.labelStatus.setToolTip("")
+            self.checkboxModel.setEnabled(True)
         else:
             self.labelStatus.setText(STATUS_NEEDS_KEY)
             self.labelStatus.setStyleSheet(_STATUS_NEEDS_KEY_STYLE)
             self.labelStatus.setToolTip(_NEEDS_KEY_TOOLTIP)
+            # Codex review (PR #757): 実行不能モデルの選択を入口で防ぐ
+            # (選択後の _validate_api_keys_for_models での実行時失敗より UX が良い)
+            self.checkboxModel.setEnabled(False)
 
     @staticmethod
     def _format_route_tooltip(route: str) -> str:
@@ -256,6 +261,10 @@ class ModelCheckboxWidget(QWidget, Ui_ModelCheckboxWidget):
     def is_selected(self) -> bool:
         """チェックボックスの選択状態を取得"""
         return self.checkboxModel.isChecked()
+
+    def is_selectable(self) -> bool:
+        """ユーザーが選択可能か (Issue #755: needs key 行は選択不可)。"""
+        return self.model_info.is_local or self.model_info.available
 
     def get_model_name(self) -> str:
         """モデルの表示名を取得 (Issue #245: 内部キーは get_model_litellm_id() を使用)"""

--- a/src/lorairo/gui/widgets/model_checkbox_widget.py
+++ b/src/lorairo/gui/widgets/model_checkbox_widget.py
@@ -14,7 +14,7 @@ ModelSelectionWidgetから分離された機能を提供
 from dataclasses import dataclass, field
 
 from PySide6.QtCore import Qt, Signal, Slot
-from PySide6.QtWidgets import QWidget
+from PySide6.QtWidgets import QLabel, QWidget
 
 from ...gui.designer.ModelCheckboxWidget_ui import Ui_ModelCheckboxWidget
 from ...utils.log import logger
@@ -34,6 +34,10 @@ class ModelInfo:
     の経路 ("direct" / "openrouter")、``alternatives`` は同一 canonical key の
     代替 route の litellm_model_id 群。OpenRouter は実行経路なので primary label
     には出さず、tooltip に raw ID と route 情報を載せる。
+
+    Issue #755: ``available`` は API キー設定状況による実行可否
+    (``DisplayModelOption.available`` 由来)。False の WebAPI モデルは
+    ``○ needs key`` ステータスで可視化する (非表示にしない)。
     """
 
     name: str
@@ -44,6 +48,7 @@ class ModelInfo:
     requires_api_key: bool = True
     route: str = "direct"
     alternatives: tuple[str, ...] = field(default_factory=tuple)
+    available: bool = True
 
 
 # プロバイダー別スタイル定義（PySide6パレット機能でダークモード自動対応）
@@ -91,6 +96,14 @@ PROVIDER_STYLES = {
     }""",
 }
 
+# Issue #755: Wireframes v11 のモデルステータス表現 (● installed / ● API ready / ○ needs key)
+STATUS_INSTALLED = "● installed"
+STATUS_API_READY = "● API ready"
+STATUS_NEEDS_KEY = "○ needs key"
+_STATUS_READY_STYLE = "QLabel { color: #2E7D32; }"
+_STATUS_NEEDS_KEY_STYLE = "QLabel { color: #E65100; }"
+_NEEDS_KEY_TOOLTIP = "API キー未設定のため実行できません。⚙ 設定の該当プロバイダ欄でキーを保存すると ● API ready になります。"
+
 
 class ModelCheckboxWidget(QWidget, Ui_ModelCheckboxWidget):
     """
@@ -112,6 +125,11 @@ class ModelCheckboxWidget(QWidget, Ui_ModelCheckboxWidget):
 
         # モデル情報保存
         self.model_info = model_info
+
+        # Issue #755: ステータスラベル (.ui には無いためプログラム的に追加)
+        self.labelStatus = QLabel(self)
+        self.labelStatus.setObjectName("labelStatus")
+        self.mainLayout.addWidget(self.labelStatus)
 
         # UI初期化
         self._setup_model_display()
@@ -154,8 +172,30 @@ class ModelCheckboxWidget(QWidget, Ui_ModelCheckboxWidget):
                 capabilities_text += "..."
             self.labelCapabilities.setText(capabilities_text)
 
+            # Issue #755: ステータス表示 (● installed / ● API ready / ○ needs key)
+            self._update_status_display()
+
         except Exception as e:
             logger.error(f"Error setting up model display for {self.model_info.name}: {e}", exc_info=True)
+
+    def _update_status_display(self) -> None:
+        """API キー設定状況に応じたモデルステータスを表示する (Issue #755)。
+
+        Wireframes v11: キー未設定の WebAPI モデルは非表示にせず ``○ needs key``
+        で可視化し、⚙ 設定での解消を tooltip で案内する。
+        """
+        if self.model_info.is_local:
+            self.labelStatus.setText(STATUS_INSTALLED)
+            self.labelStatus.setStyleSheet(_STATUS_READY_STYLE)
+            self.labelStatus.setToolTip("")
+        elif self.model_info.available:
+            self.labelStatus.setText(STATUS_API_READY)
+            self.labelStatus.setStyleSheet(_STATUS_READY_STYLE)
+            self.labelStatus.setToolTip("")
+        else:
+            self.labelStatus.setText(STATUS_NEEDS_KEY)
+            self.labelStatus.setStyleSheet(_STATUS_NEEDS_KEY_STYLE)
+            self.labelStatus.setToolTip(_NEEDS_KEY_TOOLTIP)
 
     @staticmethod
     def _format_route_tooltip(route: str) -> str:

--- a/src/lorairo/gui/widgets/model_selection_widget.py
+++ b/src/lorairo/gui/widgets/model_selection_widget.py
@@ -415,6 +415,10 @@ if not __name__ == "__main__":
                 logger.trace("モデル表示は前回と同一のため再構築をスキップ")
                 return
 
+            # Issue #755 (Codex review): 再構築前の選択状態を保持し、API キー保存等による
+            # availability 変化の rebuild でチェック済みモデルが silent に消えるのを防ぐ
+            previously_selected = self.get_selected_models()
+
             # 現在の表示をクリアして再構築
             self._clear_model_display()
             self.filtered_options = options
@@ -440,6 +444,18 @@ if not __name__ == "__main__":
             for provider, group_options in provider_groups.items():
                 if group_options:
                     self._add_provider_group(provider, group_options)
+
+            # 再構築後も表示中のモデルはチェック状態を復元する (単一選択モードの
+            # 不変条件は set_selected_models 側で強制される)。needs key 化した行は
+            # 選択不可のため復元対象から外す。
+            restorable = [
+                litellm_model_id
+                for litellm_model_id in previously_selected
+                if (widget := self.model_checkbox_widgets.get(litellm_model_id)) is not None
+                and widget.is_selectable()
+            ]
+            if restorable:
+                self.set_selected_models(restorable)
 
             self._update_selection_count()
             self._last_render_signature = signature
@@ -850,6 +866,9 @@ if not __name__ == "__main__":
             """
             seen: set[str] = set()
             batch_options: list[tuple[str, str, ModelInfo]] = []
+            # Issue #755 (Codex review): batch 行にも API key 設定状況を反映し、
+            # キー未設定 provider のモデルが ● API ready と誤表示されるのを防ぐ
+            available_providers = self._build_available_providers()
 
             for raw in raw_models:
                 litellm_id = litellm_id_from_batch_model(raw)
@@ -879,6 +898,7 @@ if not __name__ == "__main__":
                     is_local=not getattr(model, "requires_api_key", True),
                     requires_api_key=getattr(model, "requires_api_key", True),
                     route="direct",
+                    available=provider in available_providers,
                 )
                 batch_options.append((provider, direct_id, model_info))
 

--- a/src/lorairo/gui/widgets/model_selection_widget.py
+++ b/src/lorairo/gui/widgets/model_selection_widget.py
@@ -137,7 +137,10 @@ if not __name__ == "__main__":
             self.filtered_options: list[DisplayModelOption] = []
             self.model_checkbox_widgets: dict[str, ModelCheckboxWidget] = {}
             # Issue #584: 直近の描画シグネチャ。同一フィルタ結果での冗長な全消し全再生成を抑制する
-            self._last_render_signature: tuple[str, bool, tuple[tuple[str, str, str], ...]] | None = None
+            # (Issue #755: available を含む。型は _compute_render_signature の戻り値と同期)
+            self._last_render_signature: tuple[str, bool, tuple[tuple[str, str, str, bool], ...]] | None = (
+                None
+            )
             self._refresh_thread: QThread | None = None
             self._refresh_worker: _ModelRefreshWorker | None = None
             self._refresh_is_automatic = False
@@ -403,7 +406,9 @@ if not __name__ == "__main__":
             else:
                 options = self._apply_advanced_filters(available_providers, route_preference)
 
-            options = self._filter_unavailable_web_api_options(options)
+            # Issue #755: API key 未設定の WebAPI モデルも除外しない (可視 + その場で解消)。
+            # 旧実装は「APIモデルのみ」表示で available=False を非表示にしていたが、
+            # Wireframes v11 では ○ needs key ステータスで表示する設計に統一。
             signature = self._compute_render_signature(options, False)
             if signature == self._last_render_signature and self.model_checkbox_widgets:
                 # 同一フィルタ結果。既存ウィジェット (選択状態含む) をそのまま温存する
@@ -441,17 +446,19 @@ if not __name__ == "__main__":
 
         def _compute_render_signature(
             self, options: list[DisplayModelOption], web_api_placeholder: bool
-        ) -> tuple[str, bool, tuple[tuple[str, str, str], ...]]:
+        ) -> tuple[str, bool, tuple[tuple[str, str, str, bool], ...]]:
             """描画結果の同一性判定用シグネチャ (Issue #584)。
 
-            mode・placeholder 種別・各 option の (litellm_model_id, route, display_name) を
-            含め、フィルタ結果が視覚的に同一かを判定する。
+            mode・placeholder 種別・各 option の (litellm_model_id, route, display_name,
+            available) を含め、フィルタ結果が視覚的に同一かを判定する。available は
+            Issue #755 のステータス表示 (● API ready / ○ needs key) に影響するため、
+            API キー保存直後の再描画がスキップされないようシグネチャへ含める。
             """
             return (
                 self.mode,
                 web_api_placeholder,
                 tuple(
-                    (opt.preferred.litellm_model_id, opt.preferred.route, opt.display_name)
+                    (opt.preferred.litellm_model_id, opt.preferred.route, opt.display_name, opt.available)
                     for opt in options
                 ),
             )
@@ -551,14 +558,6 @@ if not __name__ == "__main__":
 
             return filtered
 
-        def _filter_unavailable_web_api_options(
-            self, options: list[DisplayModelOption]
-        ) -> list[DisplayModelOption]:
-            """Web API only 表示では API key 未設定などで実行不能な候補を除外する。"""
-            if self.current_execution_env != "APIモデルのみ":
-                return options
-            return [option for option in options if option.available]
-
         def _group_options_by_provider(
             self, options: list[DisplayModelOption]
         ) -> dict[str, list[DisplayModelOption]]:
@@ -619,6 +618,7 @@ if not __name__ == "__main__":
                 requires_api_key=model.requires_api_key,
                 route=option.preferred.route,
                 alternatives=tuple(c.litellm_model_id for c in option.alternatives),
+                available=option.available,
             )
 
         def _clear_model_display(self) -> None:

--- a/src/lorairo/gui/widgets/stage_model_picker_dialog.py
+++ b/src/lorairo/gui/widgets/stage_model_picker_dialog.py
@@ -4,11 +4,16 @@
 チェック可能リストで提示する。OK 後の `selected_model_ids()` を呼び出し元
 (MainWindow) が ModelSelectionWidget のチェック ON に変換する — SSoT は
 あくまで「選択モデル集合」であり、本ダイアログは候補提示と選択結果の返却のみ。
+
+Issue #755: API キー未設定の WebAPI モデルも非表示にせず ``○ needs key``
+ステータスで可視化する。needs key 行のクリックは ``configure_key_requested``
+シグナルで呼び出し元へ通知し、ConfigurationWindow の該当プロバイダ欄へ誘導
+する。キー保存後は ``refresh_key_status()`` で ``● API ready`` に解消される。
 """
 
 from __future__ import annotations
 
-from PySide6.QtCore import Qt
+from PySide6.QtCore import Qt, Signal
 from PySide6.QtWidgets import (
     QDialog,
     QDialogButtonBox,
@@ -23,21 +28,36 @@ from lorairo.services.cost_estimation_service import (
     CostEstimationService,
     format_per_image_cost,
 )
+from lorairo.services.model_route_service import required_provider_for
 from lorairo.services.pipeline_composition import PipelineStage, StageModelInfo
 
 _EMPTY_CANDIDATES_TEXT = "このステージに追加できる未選択モデルがありません"
 _MULTIMODAL_NOTE = "· 1推論で T C S（R は preflight 由来）"
 
+# Issue #755: Wireframes v11 Frame 2B のモデルステータス表現
+_STATUS_INSTALLED = "● installed"
+_STATUS_API_READY = "● API ready"
+_STATUS_NEEDS_KEY = "○ needs key"
+_NEEDS_KEY_TOOLTIP = "API キー未設定です。クリックすると設定画面の該当プロバイダ欄を開きます。"
+
 _cost_service = CostEstimationService()
 
 
 class StageModelPickerDialog(QDialog):
-    """ステージに追加可能なモデル候補を列挙するチェックリストダイアログ。"""
+    """ステージに追加可能なモデル候補を列挙するチェックリストダイアログ。
+
+    Signals:
+        configure_key_requested (str): ``○ needs key`` 行クリック時に、API キーが
+            必要な provider 名 (例 ``"anthropic"``) を通知する (Issue #755)。
+    """
+
+    configure_key_requested = Signal(str)
 
     def __init__(
         self,
         stage: PipelineStage,
         candidates: list[StageModelInfo],
+        available_providers: set[str] | None = None,
         parent: QWidget | None = None,
     ) -> None:
         """ダイアログを構築する。
@@ -45,21 +65,28 @@ class StageModelPickerDialog(QDialog):
         Args:
             stage: 追加先のパイプラインステージ。
             candidates: このステージに出力を届けられる未選択モデルのリスト。
+            available_providers: API キー設定済み provider 集合。None の場合は
+                全 provider をキー設定済み扱いにする (後方互換)。
             parent: 親 widget。
         """
         super().__init__(parent)
         self.setWindowTitle(f"{stage.value.upper()} のモデルを選択")
 
+        self._candidates = list(candidates)
+        self._available_providers: set[str] | None = (
+            set(available_providers) if available_providers is not None else None
+        )
+
         layout = QVBoxLayout(self)
 
         self._candidate_list = QListWidget(self)
         self._candidate_list.setObjectName("stageModelCandidateList")
-        for info in candidates:
-            item = QListWidgetItem(self._candidate_text(info))
-            item.setFlags(item.flags() | Qt.ItemFlag.ItemIsUserCheckable)
-            item.setCheckState(Qt.CheckState.Unchecked)
+        for info in self._candidates:
+            item = QListWidgetItem()
             item.setData(Qt.ItemDataRole.UserRole, info.litellm_model_id)
+            self._apply_item_state(item, info)
             self._candidate_list.addItem(item)
+        self._candidate_list.itemClicked.connect(self._on_item_clicked)
 
         if candidates:
             layout.addWidget(self._candidate_list)
@@ -89,6 +116,65 @@ class StageModelPickerDialog(QDialog):
         if info.is_multimodal:
             text += f" {_MULTIMODAL_NOTE}"
         return text
+
+    def _needs_key(self, info: StageModelInfo) -> bool:
+        """API キー未設定で実行できない WebAPI モデルか判定する (Issue #755)。"""
+        if not info.is_api:
+            return False
+        if self._available_providers is None:
+            return False
+        return required_provider_for(info.litellm_model_id, info.provider) not in self._available_providers
+
+    def _status_text(self, info: StageModelInfo) -> str:
+        """Wireframes v11 のステータス表現を返す。"""
+        if not info.is_api:
+            return _STATUS_INSTALLED
+        return _STATUS_NEEDS_KEY if self._needs_key(info) else _STATUS_API_READY
+
+    def _apply_item_state(self, item: QListWidgetItem, info: StageModelInfo) -> None:
+        """候補行のテキスト・チェック可否・tooltip を現在のキー状況で更新する。
+
+        needs key 行はチェック不可 (実行不能モデルの追加を防ぐ) とし、クリックで
+        設定導線を開けることを tooltip で案内する。キー設定済みになった行は
+        チェック可能へ戻す。
+        """
+        item.setText(f"{self._candidate_text(info)} · {self._status_text(info)}")
+        if self._needs_key(info):
+            item.setFlags(Qt.ItemFlag.ItemIsEnabled | Qt.ItemFlag.ItemIsSelectable)
+            item.setData(Qt.ItemDataRole.CheckStateRole, None)
+            item.setToolTip(_NEEDS_KEY_TOOLTIP)
+        else:
+            item.setFlags(
+                Qt.ItemFlag.ItemIsEnabled | Qt.ItemFlag.ItemIsSelectable | Qt.ItemFlag.ItemIsUserCheckable
+            )
+            if item.data(Qt.ItemDataRole.CheckStateRole) is None:
+                item.setCheckState(Qt.CheckState.Unchecked)
+            item.setToolTip("")
+
+    def refresh_key_status(self, available_providers: set[str]) -> None:
+        """API キー設定状況を再評価して全行のステータス表示を更新する (Issue #755)。
+
+        キー保存後に呼び出すと ``○ needs key`` 行が ``● API ready`` に変わり、
+        チェック可能になる (アプリ再起動不要)。
+
+        Args:
+            available_providers: 最新の API キー設定済み provider 集合。
+        """
+        self._available_providers = set(available_providers)
+        for row, info in enumerate(self._candidates):
+            item = self._candidate_list.item(row)
+            if item is not None:
+                self._apply_item_state(item, info)
+
+    def _on_item_clicked(self, item: QListWidgetItem) -> None:
+        """needs key 行のクリックで設定導線シグナルを emit する (Issue #755)。"""
+        row = self._candidate_list.row(item)
+        if not (0 <= row < len(self._candidates)):
+            return
+        info = self._candidates[row]
+        if self._needs_key(info):
+            provider = required_provider_for(info.litellm_model_id, info.provider)
+            self.configure_key_requested.emit(provider)
 
     def selected_model_ids(self) -> list[str]:
         """チェック済み候補の litellm_model_id リストを返す。"""

--- a/src/lorairo/gui/window/configuration_window.py
+++ b/src/lorairo/gui/window/configuration_window.py
@@ -12,6 +12,7 @@ from PySide6.QtWidgets import (
     QDialogButtonBox,
     QFormLayout,
     QGroupBox,
+    QHBoxLayout,
     QLabel,
     QLineEdit,
     QMessageBox,
@@ -34,6 +35,21 @@ _LOG_LEVELS = ["DEBUG", "INFO", "WARNING", "ERROR"]
 # CLI 経路 (--route all) と config 手動編集 ("all") の値は parse_route_preference で
 # 受理し続けるが、GUI から保存できる値は auto / direct / openrouter のみ。
 _ROUTE_PREFERENCES = ["auto", "direct", "openrouter"]
+
+# Issue #755: API キー欄の定義。provider 名 (model_route_service の
+# required_provider_for が返す canonical key) → (表示ラベル, config キー, objectName)。
+_API_KEY_ROWS: tuple[tuple[str, str, str, str], ...] = (
+    ("openai", "OpenAI API Key:", "openai_key", "lineEditOpenAiKey"),
+    ("google", "Google API Key:", "google_key", "lineEditGoogleKey"),
+    ("anthropic", "Claude API Key:", "claude_key", "lineEditClaudeKey"),
+    ("openrouter", "OpenRouter API Key:", "openrouter_key", "lineEditOpenRouterKey"),
+)
+_API_KEY_SAVED_TEXT = "保存済"
+_API_KEY_UNSET_TEXT = "未設定"
+_API_KEY_SAVED_PLACEHOLDER = "保存済（変更する場合のみ入力）"
+_API_KEY_HIGHLIGHT_STYLE = "QLineEdit { border: 2px solid #FF9800; }"
+_API_KEY_SAVED_STATUS_STYLE = "QLabel { color: #2E7D32; font-weight: 600; }"
+_API_KEY_UNSET_STATUS_STYLE = "QLabel { color: palette(mid); }"
 
 
 class ConfigurationWindow(QDialog):
@@ -90,24 +106,33 @@ class ConfigurationWindow(QDialog):
         tab = QWidget()
         tab_layout = QVBoxLayout(tab)
 
-        # API設定
+        # API設定 (Issue #755: マスク入力 + 保存済/未設定ステータスのみ表示。
+        # 保存済キーは UI に echo back しない。クリアは config/lorairo.toml 直接編集で行う)
         api_group = QGroupBox("API設定")
         api_layout = QFormLayout(api_group)
 
-        self._line_edit_openai_key = QLineEdit()
-        self._line_edit_openai_key.setObjectName("lineEditOpenAiKey")
-        self._line_edit_openai_key.setEchoMode(QLineEdit.EchoMode.Password)
-        api_layout.addRow("OpenAI API Key:", self._line_edit_openai_key)
+        self._api_key_edits: dict[str, QLineEdit] = {}
+        self._api_key_status_labels: dict[str, QLabel] = {}
+        self._saved_api_keys: dict[str, str] = {}
 
-        self._line_edit_google_key = QLineEdit()
-        self._line_edit_google_key.setObjectName("lineEditGoogleKey")
-        self._line_edit_google_key.setEchoMode(QLineEdit.EchoMode.Password)
-        api_layout.addRow("Google API Key:", self._line_edit_google_key)
+        for provider, label_text, _config_key, object_name in _API_KEY_ROWS:
+            key_edit = QLineEdit()
+            key_edit.setObjectName(object_name)
+            key_edit.setEchoMode(QLineEdit.EchoMode.Password)
 
-        self._line_edit_claude_key = QLineEdit()
-        self._line_edit_claude_key.setObjectName("lineEditClaudeKey")
-        self._line_edit_claude_key.setEchoMode(QLineEdit.EchoMode.Password)
-        api_layout.addRow("Claude API Key:", self._line_edit_claude_key)
+            status_label = QLabel(_API_KEY_UNSET_TEXT)
+            status_label.setObjectName(f"{object_name}Status")
+            status_label.setStyleSheet(_API_KEY_UNSET_STATUS_STYLE)
+
+            row_widget = QWidget()
+            row_layout = QHBoxLayout(row_widget)
+            row_layout.setContentsMargins(0, 0, 0, 0)
+            row_layout.addWidget(key_edit, stretch=1)
+            row_layout.addWidget(status_label)
+            api_layout.addRow(label_text, row_widget)
+
+            self._api_key_edits[provider] = key_edit
+            self._api_key_status_labels[provider] = status_label
 
         tab_layout.addWidget(api_group)
 
@@ -213,11 +238,22 @@ class ConfigurationWindow(QDialog):
         """ConfigurationService から現在の設定値を読み込み、UIに反映する。"""
         config = self._config_service.get_all_settings()
 
-        # API設定
+        # API設定 (Issue #755: 保存済キーは欄に echo back せず「保存済かだけ分かる」表示)
         api = config.get("api", {})
-        self._line_edit_openai_key.setText(api.get("openai_key", ""))
-        self._line_edit_google_key.setText(api.get("google_key", ""))
-        self._line_edit_claude_key.setText(api.get("claude_key", ""))
+        for provider, _label_text, config_key, _object_name in _API_KEY_ROWS:
+            saved_key = str(api.get(config_key, "") or "")
+            self._saved_api_keys[provider] = saved_key
+            key_edit = self._api_key_edits[provider]
+            status_label = self._api_key_status_labels[provider]
+            key_edit.clear()
+            if saved_key.strip():
+                key_edit.setPlaceholderText(_API_KEY_SAVED_PLACEHOLDER)
+                status_label.setText(_API_KEY_SAVED_TEXT)
+                status_label.setStyleSheet(_API_KEY_SAVED_STATUS_STYLE)
+            else:
+                key_edit.setPlaceholderText(_API_KEY_UNSET_TEXT)
+                status_label.setText(_API_KEY_UNSET_TEXT)
+                status_label.setStyleSheet(_API_KEY_UNSET_STATUS_STYLE)
 
         # ディレクトリ設定
         dirs = config.get("directories", {})
@@ -267,18 +303,42 @@ class ConfigurationWindow(QDialog):
         prompts = config.get("prompts", {})
         self._text_edit_prompt.setPlainText(prompts.get("additional", ""))
 
+    def focus_api_key_field(self, provider: str) -> bool:
+        """指定 provider の API キー欄をハイライトしてフォーカスする (Issue #755)。
+
+        モデルピッカーの ``○ needs key`` チップからの往復導線で使う。
+        基本設定タブへ切り替え、該当欄に強調枠を付けて入力を促す。
+
+        Args:
+            provider: provider 名 (``"openai"`` / ``"anthropic"`` / ``"google"`` /
+                ``"openrouter"``)。大文字小文字は区別しない。
+
+        Returns:
+            該当プロバイダ欄が存在しハイライトした場合 True、未知の provider は False。
+        """
+        key_edit = self._api_key_edits.get(provider.strip().lower())
+        if key_edit is None:
+            logger.warning(f"API キー欄が見つからない provider 指定: {provider}")
+            return False
+        self._tab_widget.setCurrentIndex(0)
+        key_edit.setStyleSheet(_API_KEY_HIGHLIGHT_STYLE)
+        key_edit.setFocus()
+        return True
+
     def _collect_settings(self) -> dict[str, dict[str, Any]]:
         """全ウィジェットから設定値を収集する。
 
         Returns:
             セクション名をキーとした設定辞書。
         """
+        # Issue #755: API キー欄が空のままなら保存済の値を維持する
+        # (欄に echo back しない UI のため、空欄 = 「変更なし」と解釈する)。
+        api_settings = {
+            config_key: (self._api_key_edits[provider].text().strip() or self._saved_api_keys[provider])
+            for provider, _label_text, config_key, _object_name in _API_KEY_ROWS
+        }
         return {
-            "api": {
-                "openai_key": self._line_edit_openai_key.text().strip(),
-                "google_key": self._line_edit_google_key.text().strip(),
-                "claude_key": self._line_edit_claude_key.text().strip(),
-            },
+            "api": api_settings,
             "directories": {
                 "database_base_dir": self._dir_picker_database_dir.get_selected_path() or "",
                 "database_project_name": self._line_edit_project_name.text().strip(),

--- a/src/lorairo/gui/window/main_window.py
+++ b/src/lorairo/gui/window/main_window.py
@@ -1990,7 +1990,16 @@ class MainWindow(QMainWindow, Ui_MainWindow):
 
         Issue #249: route_preference 等の保存値を即時反映。
         Issue #755: API キー保存による ● API ready / ○ needs key の更新もここで行う。
+        MainWindow.config_service と ServiceContainer.config_service は別インスタンス
+        (Codex review PR #757) のため、container 側を破棄して保存済みファイルから
+        再読込させてから widget を更新する (widget は container 側を参照する)。
         """
+        try:
+            container = get_service_container()
+            del container.config_service
+        except (RuntimeError, AttributeError) as e:
+            logger.warning(f"ServiceContainer の config_service 再読込に失敗 (継続可): {e}")
+
         batch_widget = getattr(self, "batchModelSelection", None)
         if batch_widget is None:
             return

--- a/src/lorairo/gui/window/main_window.py
+++ b/src/lorairo/gui/window/main_window.py
@@ -24,6 +24,7 @@ from ...gui.designer.MainWindow_ui import Ui_MainWindow
 from ...services import get_service_container
 from ...services.configuration_service import ConfigurationService
 from ...services.error_triage_service import ErrorFilter, ErrorRow, ErrorTriageService
+from ...services.model_route_service import build_available_providers
 from ...services.model_selection_service import ModelSelectionService
 from ...services.pipeline_composition import PipelineCompositionService, PipelineStage, StageModelInfo
 from ...services.quality_issue_detection_service import QualityIssueDetectionService
@@ -818,12 +819,37 @@ class MainWindow(QMainWindow, Ui_MainWindow):
             return {}
         return cost_map
 
+    def _available_api_providers(self) -> set[str]:
+        """config の API キー設定状況から実行可能な WebAPI provider 集合を返す (Issue #755)。
+
+        Returns:
+            非空キーが保存されている provider 名集合。config 未初期化・取得失敗時は
+            空集合 (= 全 WebAPI モデルが needs key 扱い)。
+        """
+        config_service = getattr(self, "config_service", None)
+        if config_service is None:
+            return set()
+        try:
+            api_keys = {
+                "openai": config_service.get_setting("api", "openai_key", ""),
+                "anthropic": config_service.get_setting("api", "claude_key", ""),
+                "google": config_service.get_setting("api", "google_key", ""),
+                "openrouter": config_service.get_setting("api", "openrouter_key", ""),
+            }
+        except (AttributeError, KeyError, TypeError):
+            logger.warning("API キー設定の取得に失敗 (全 provider を needs key 扱い)", exc_info=True)
+            return set()
+        return build_available_providers(api_keys)
+
     def _on_pipeline_add_model_requested(self, stage_value: str) -> None:
         """ステージ行の「+ 追加」でピッカーを開き、選択モデル集合へ追加する (Phase 6b)。
 
         SSoT は ModelSelectionWidget のチェック状態。ピッカーで選んだモデルは
         チェック ON で集合へ追加し、ステージ仕分けは compose_from_models に任せる。
         set_selected() は checkbox シグナルを抑制するため、最後に明示再描画する。
+
+        Issue #755: キー未設定 WebAPI モデルも候補に含め ``○ needs key`` で可視化。
+        チップクリック → 設定 → キー保存 → ``● API ready`` の往復導線を配線する。
 
         Args:
             stage_value: 追加先ステージの PipelineStage value。
@@ -843,7 +869,15 @@ class MainWindow(QMainWindow, Ui_MainWindow):
             if stage in info.fill_stages() and info.litellm_model_id not in selected_ids
         ]
 
-        dialog = StageModelPickerDialog(stage, candidates, parent=self)
+        dialog = StageModelPickerDialog(
+            stage,
+            candidates,
+            available_providers=self._available_api_providers(),
+            parent=self,
+        )
+        dialog.configure_key_requested.connect(
+            lambda provider, dialog=dialog: self._on_picker_configure_key_requested(provider, dialog)
+        )
         if dialog.exec() != QDialog.DialogCode.Accepted:
             return
         for litellm_model_id in dialog.selected_model_ids():
@@ -872,6 +906,25 @@ class MainWindow(QMainWindow, Ui_MainWindow):
             return
         checkbox_widget.set_selected(False)
         self._refresh_pipeline_panel()
+
+    def _on_picker_configure_key_requested(self, provider: str, dialog: StageModelPickerDialog) -> None:
+        """ピッカーの ``○ needs key`` チップから設定の該当プロバイダ欄へ誘導する (Issue #755)。
+
+        キー保存 (OK) 後はモデル一覧と開いたままのピッカーを再評価し、
+        アプリ再起動なしで ``● API ready`` に解消する。
+
+        Args:
+            provider: API キーが必要な provider 名 (例 ``"anthropic"``)。
+            dialog: シグナル発火元のピッカーダイアログ (開いたまま更新する)。
+        """
+        if not self.settings_controller:
+            logger.warning("SettingsController 未初期化のため API キー設定導線をスキップします")
+            return
+        settings_applied = self.settings_controller.open_settings_dialog(highlight_provider=provider)
+        if not settings_applied:
+            return
+        self._reload_model_widget_after_settings()
+        dialog.refresh_key_status(self._available_api_providers())
 
     def _refresh_errors_tab(self) -> None:
         """エラータブ表示時 / フィルタ変更時にトリアージを再計算して描画する。"""
@@ -1932,19 +1985,27 @@ class MainWindow(QMainWindow, Ui_MainWindow):
             self.pipeline_control_service = None
             self.progress_state_service = None
 
+    def _reload_model_widget_after_settings(self) -> None:
+        """設定保存後にモデル選択ウィジェットへ最新のキー状況を反映する。
+
+        Issue #249: route_preference 等の保存値を即時反映。
+        Issue #755: API キー保存による ● API ready / ○ needs key の更新もここで行う。
+        """
+        batch_widget = getattr(self, "batchModelSelection", None)
+        if batch_widget is None:
+            return
+        try:
+            batch_widget.update_model_display()
+            logger.debug("設定変更を反映してモデル選択ウィジェットを更新しました")
+        except Exception as e:
+            logger.warning(f"モデル選択ウィジェットの更新に失敗 (継続可): {e}")
+
     def open_settings(self) -> None:
         """設定ウィンドウを開く（SettingsControllerに委譲）"""
         if self.settings_controller:
             settings_applied = self.settings_controller.open_settings_dialog()
-            # Issue #249: route_preference 等の保存値を ModelSelectionWidget に即時反映
             if settings_applied:
-                batch_widget = getattr(self, "batchModelSelection", None)
-                if batch_widget is not None:
-                    try:
-                        batch_widget.update_model_display()
-                        logger.debug("設定変更を反映してモデル選択ウィジェットを更新しました")
-                    except Exception as e:
-                        logger.warning(f"モデル選択ウィジェットの更新に失敗 (継続可): {e}")
+                self._reload_model_widget_after_settings()
         else:
             logger.error("SettingsControllerが初期化されていません")
             QMessageBox.warning(

--- a/tests/unit/gui/controllers/test_settings_controller.py
+++ b/tests/unit/gui/controllers/test_settings_controller.py
@@ -138,6 +138,45 @@ class TestSettingsControllerDialog:
 
         assert result is False
 
+    def test_open_settings_dialog_highlights_provider_field(self, qtbot):
+        """Issue #755: highlight_provider 指定で該当 API キー欄をフォーカスする。"""
+        parent = QWidget()
+        qtbot.addWidget(parent)
+
+        mock_config = Mock()
+        controller = SettingsController(config_service=mock_config, parent=parent)
+
+        mock_dialog = Mock()
+        mock_dialog.exec.return_value = QDialog.DialogCode.Accepted
+
+        with patch(
+            "lorairo.gui.window.configuration_window.ConfigurationWindow",
+            return_value=mock_dialog,
+        ):
+            result = controller.open_settings_dialog(highlight_provider="anthropic")
+
+        assert result is True
+        mock_dialog.focus_api_key_field.assert_called_once_with("anthropic")
+
+    def test_open_settings_dialog_without_highlight_skips_focus(self, qtbot):
+        """highlight_provider 未指定では focus_api_key_field を呼ばない。"""
+        parent = QWidget()
+        qtbot.addWidget(parent)
+
+        mock_config = Mock()
+        controller = SettingsController(config_service=mock_config, parent=parent)
+
+        mock_dialog = Mock()
+        mock_dialog.exec.return_value = QDialog.DialogCode.Rejected
+
+        with patch(
+            "lorairo.gui.window.configuration_window.ConfigurationWindow",
+            return_value=mock_dialog,
+        ):
+            controller.open_settings_dialog()
+
+        mock_dialog.focus_api_key_field.assert_not_called()
+
     def test_open_settings_dialog_import_error_uses_fallback(self, qtbot, monkeypatch):
         """ConfigurationWindow の ImportError 時はフォールバックダイアログを表示して False を返す。
 

--- a/tests/unit/gui/widgets/test_model_checkbox_widget.py
+++ b/tests/unit/gui/widgets/test_model_checkbox_widget.py
@@ -78,6 +78,31 @@ class TestModelCheckboxWidget:
         assert hasattr(widget_openai, "labelModelName")
         assert hasattr(widget_openai, "labelProvider")
         assert hasattr(widget_openai, "labelCapabilities")
+        assert hasattr(widget_openai, "labelStatus")
+
+    def test_api_model_available_shows_api_ready_status(self, widget_openai):
+        """Issue #755: available な API モデルは ● API ready を表示する。"""
+        assert widget_openai.labelStatus.text() == "● API ready"
+
+    def test_local_model_shows_installed_status(self, widget_local):
+        """Issue #755: ローカルモデルは ● installed を表示する。"""
+        assert widget_local.labelStatus.text() == "● installed"
+
+    def test_api_model_unavailable_shows_needs_key_status(self, qtbot):
+        """Issue #755: API key 未設定の API モデルは ○ needs key を表示する。"""
+        info = ModelInfo(
+            name="claude-3-sonnet",
+            provider="anthropic",
+            capabilities=["caption"],
+            litellm_model_id="anthropic/claude-3-sonnet",
+            is_local=False,
+            requires_api_key=True,
+            available=False,
+        )
+        widget = ModelCheckboxWidget(info)
+        qtbot.addWidget(widget)
+        assert widget.labelStatus.text() == "○ needs key"
+        assert "API キー未設定" in widget.labelStatus.toolTip()
 
     def test_model_name_display(self, widget_openai):
         """モデル名表示テスト (Issue #245: ラベルは "{name} ({provider})" 形式)"""

--- a/tests/unit/gui/widgets/test_model_checkbox_widget.py
+++ b/tests/unit/gui/widgets/test_model_checkbox_widget.py
@@ -83,13 +83,17 @@ class TestModelCheckboxWidget:
     def test_api_model_available_shows_api_ready_status(self, widget_openai):
         """Issue #755: available な API モデルは ● API ready を表示する。"""
         assert widget_openai.labelStatus.text() == "● API ready"
+        assert widget_openai.checkboxModel.isEnabled()
+        assert widget_openai.is_selectable() is True
 
     def test_local_model_shows_installed_status(self, widget_local):
         """Issue #755: ローカルモデルは ● installed を表示する。"""
         assert widget_local.labelStatus.text() == "● installed"
+        assert widget_local.checkboxModel.isEnabled()
+        assert widget_local.is_selectable() is True
 
     def test_api_model_unavailable_shows_needs_key_status(self, qtbot):
-        """Issue #755: API key 未設定の API モデルは ○ needs key を表示する。"""
+        """Issue #755: API key 未設定の API モデルは ○ needs key を表示し選択不可。"""
         info = ModelInfo(
             name="claude-3-sonnet",
             provider="anthropic",
@@ -103,6 +107,9 @@ class TestModelCheckboxWidget:
         qtbot.addWidget(widget)
         assert widget.labelStatus.text() == "○ needs key"
         assert "API キー未設定" in widget.labelStatus.toolTip()
+        # Codex review (PR #757): 実行不能モデルはチェック不可
+        assert not widget.checkboxModel.isEnabled()
+        assert widget.is_selectable() is False
 
     def test_model_name_display(self, widget_openai):
         """モデル名表示テスト (Issue #245: ラベルは "{name} ({provider})" 形式)"""

--- a/tests/unit/gui/widgets/test_model_selection_widget.py
+++ b/tests/unit/gui/widgets/test_model_selection_widget.py
@@ -125,10 +125,10 @@ class TestModelSelectionWidgetFilters:
         assert w.placeholderLabel.isHidden()
         assert list(w.model_checkbox_widgets) == ["openai/gpt-4o"]
 
-    def test_batch_web_api_only_hides_unavailable_options_and_shows_placeholder(
+    def test_batch_web_api_only_shows_unavailable_options_with_needs_key_status(
         self, qtbot, mock_model_service
     ):
-        """Web API only で API key 未設定などにより実行不能な候補だけなら placeholder を表示する"""
+        """Issue #755: API key 未設定の候補も非表示にせず ○ needs key で可視化する。"""
         model = _fake_db_model(
             name="gpt-4o",
             provider="openai",
@@ -142,9 +142,30 @@ class TestModelSelectionWidgetFilters:
 
         w.apply_filters(execution_env="APIモデルのみ", annotation_only=True)
 
-        assert not w.placeholderLabel.isHidden()
-        assert w.placeholderLabel.text() == ModelSelectionWidget.WEB_API_UNAVAILABLE_PLACEHOLDER
-        assert w.model_checkbox_widgets == {}
+        assert w.placeholderLabel.isHidden()
+        assert list(w.model_checkbox_widgets) == ["openai/gpt-4o"]
+        checkbox_widget = w.model_checkbox_widgets["openai/gpt-4o"]
+        assert checkbox_widget.model_info.available is False
+        assert checkbox_widget.labelStatus.text() == "○ needs key"
+
+    def test_render_signature_includes_availability(self, qtbot, mock_model_service):
+        """Issue #755: キー保存で available だけ変わっても再描画される (signature に含む)。"""
+        model = _fake_db_model(
+            name="gpt-4o",
+            provider="openai",
+            litellm_model_id="openai/gpt-4o",
+            requires_api_key=True,
+            capabilities=["caption"],
+        )
+        needs_key_options = build_display_options([model], set(), "auto")
+        ready_options = build_display_options([model], {"openai"}, "auto")
+        sig_needs_key = ModelSelectionWidget._compute_render_signature(
+            Mock(mode="advanced"), needs_key_options, False
+        )
+        sig_ready = ModelSelectionWidget._compute_render_signature(
+            Mock(mode="advanced"), ready_options, False
+        )
+        assert sig_needs_key != sig_ready
 
     def test_non_batch_web_api_only_uses_normal_filtering(self, qtbot, mock_model_service):
         """通常利用時の Web API only は batch placeholder 分岐に入らない"""

--- a/tests/unit/gui/widgets/test_model_selection_widget.py
+++ b/tests/unit/gui/widgets/test_model_selection_widget.py
@@ -147,6 +147,78 @@ class TestModelSelectionWidgetFilters:
         checkbox_widget = w.model_checkbox_widgets["openai/gpt-4o"]
         assert checkbox_widget.model_info.available is False
         assert checkbox_widget.labelStatus.text() == "○ needs key"
+        # Codex review (PR #757): needs key 行は選択不可 (実行時失敗を入口で防ぐ)
+        assert not checkbox_widget.checkboxModel.isEnabled()
+        assert checkbox_widget.is_selectable() is False
+
+    def test_rebuild_preserves_selection_when_availability_changes(self, qtbot, mock_model_service):
+        """Codex review (PR #757): キー保存による rebuild で選択済みモデルを維持する。"""
+        model_a = _fake_db_model(
+            name="gpt-4o",
+            provider="openai",
+            litellm_model_id="openai/gpt-4o",
+            requires_api_key=True,
+            capabilities=["caption"],
+        )
+        model_b = _fake_db_model(
+            name="claude-x",
+            provider="anthropic",
+            litellm_model_id="anthropic/claude-x",
+            requires_api_key=True,
+            capabilities=["caption"],
+        )
+        mock_model_service.load_grouped_models.return_value = build_display_options(
+            [model_a, model_b], {"openai"}, "auto"
+        )
+        w = ModelSelectionWidget(model_selection_service=mock_model_service, mode="advanced")
+        qtbot.addWidget(w)
+        w.apply_filters(execution_env="APIモデルのみ")
+        w.model_checkbox_widgets["openai/gpt-4o"].set_selected(True)
+        assert w.get_selected_models() == ["openai/gpt-4o"]
+
+        # anthropic キー保存 → availability 変化で signature が変わり rebuild される
+        mock_model_service.load_grouped_models.return_value = build_display_options(
+            [model_a, model_b], {"openai", "anthropic"}, "auto"
+        )
+        w.update_model_display()
+
+        assert w.get_selected_models() == ["openai/gpt-4o"]
+        assert w.model_checkbox_widgets["anthropic/claude-x"].labelStatus.text() == "● API ready"
+
+    def test_batch_capable_rows_reflect_api_key_availability(self, qtbot, mock_model_service, monkeypatch):
+        """Codex review (PR #757): batch-capable 行もキー未設定なら ○ needs key になる。"""
+        from types import SimpleNamespace
+
+        db_model = SimpleNamespace(
+            provider="openai",
+            litellm_model_id="openai/gpt-4.1-mini",
+            name="gpt-4.1-mini",
+            requires_api_key=True,
+            capabilities=["caption"],
+            model_types=(),
+            available=True,
+        )
+        mock_repo = Mock()
+        mock_repo.get_model_by_litellm_id.return_value = db_model
+        mock_container = Mock()
+        mock_container.db_manager.model_repo = mock_repo
+        # 全 provider のキー未設定
+        mock_container.config_service.get_setting.side_effect = lambda section, key, default="": ""
+        monkeypatch.setattr(
+            "lorairo.gui.widgets.model_selection_widget.get_service_container",
+            lambda: mock_container,
+        )
+
+        model_source = Mock()
+        model_source.list_batch_capable_models.return_value = ("openai/gpt-4.1-mini",)
+        w = ModelSelectionWidget(model_selection_service=mock_model_service)
+        qtbot.addWidget(w)
+
+        w.set_batch_capable_filtering(True, "annotation", model_source)
+
+        checkbox_widget = w.model_checkbox_widgets["openai/gpt-4.1-mini"]
+        assert checkbox_widget.model_info.available is False
+        assert checkbox_widget.labelStatus.text() == "○ needs key"
 
     def test_render_signature_includes_availability(self, qtbot, mock_model_service):
         """Issue #755: キー保存で available だけ変わっても再描画される (signature に含む)。"""

--- a/tests/unit/gui/widgets/test_stage_model_picker_dialog.py
+++ b/tests/unit/gui/widgets/test_stage_model_picker_dialog.py
@@ -130,3 +130,95 @@ class TestStageModelPickerDialogEmptyCandidates:
         assert ok_button is not None
         assert not ok_button.isEnabled()
         assert dialog.selected_model_ids() == []
+
+
+class TestStageModelPickerDialogKeyStatus:
+    """Issue #755: ● installed / ● API ready / ○ needs key ステータス表示。"""
+
+    def _texts(self, dialog: StageModelPickerDialog) -> list[str]:
+        candidate_list = _candidate_list(dialog)
+        return [candidate_list.item(i).text() for i in range(candidate_list.count())]
+
+    def test_local_model_shows_installed_status(self, qtbot):
+        dialog = StageModelPickerDialog(PipelineStage.TAGS, [WD_TAGGER], available_providers=set())
+        qtbot.addWidget(dialog)
+        texts = self._texts(dialog)
+        assert any("wd-v1-4-tagger" in t and "● installed" in t for t in texts)
+
+    def test_api_model_with_key_shows_api_ready(self, qtbot):
+        dialog = StageModelPickerDialog(PipelineStage.TAGS, [GPT4O], available_providers={"openai"})
+        qtbot.addWidget(dialog)
+        texts = self._texts(dialog)
+        assert any("gpt-4o" in t and "● API ready" in t for t in texts)
+
+    def test_api_model_without_key_shows_needs_key_and_not_checkable(self, qtbot):
+        dialog = StageModelPickerDialog(
+            PipelineStage.TAGS, [GPT4O, NO_PRICE_API], available_providers={"openai"}
+        )
+        qtbot.addWidget(dialog)
+        candidate_list = _candidate_list(dialog)
+        texts = self._texts(dialog)
+        assert any("claude-x" in t and "○ needs key" in t for t in texts)
+        # needs key 行 (anthropic) はチェック不可、API ready 行 (openai) はチェック可
+        for i in range(candidate_list.count()):
+            item = candidate_list.item(i)
+            if "claude-x" in item.text():
+                assert not (item.flags() & Qt.ItemFlag.ItemIsUserCheckable)
+            else:
+                assert item.flags() & Qt.ItemFlag.ItemIsUserCheckable
+
+    def test_default_none_available_providers_treats_all_api_ready(self, qtbot):
+        """後方互換: available_providers 未指定では needs key を出さない。"""
+        dialog = StageModelPickerDialog(PipelineStage.TAGS, [GPT4O, NO_PRICE_API])
+        qtbot.addWidget(dialog)
+        texts = self._texts(dialog)
+        assert all("○ needs key" not in t for t in texts)
+
+    def test_needs_key_item_click_emits_configure_key_requested(self, qtbot):
+        dialog = StageModelPickerDialog(PipelineStage.TAGS, [NO_PRICE_API], available_providers=set())
+        qtbot.addWidget(dialog)
+        candidate_list = _candidate_list(dialog)
+        item = candidate_list.item(0)
+        with qtbot.waitSignal(dialog.configure_key_requested, timeout=1000) as blocker:
+            candidate_list.itemClicked.emit(item)
+        assert blocker.args == ["anthropic"]
+
+    def test_ready_item_click_does_not_emit_signal(self, qtbot):
+        dialog = StageModelPickerDialog(PipelineStage.TAGS, [GPT4O], available_providers={"openai"})
+        qtbot.addWidget(dialog)
+        candidate_list = _candidate_list(dialog)
+        emitted: list[str] = []
+        dialog.configure_key_requested.connect(emitted.append)
+        candidate_list.itemClicked.emit(candidate_list.item(0))
+        assert emitted == []
+
+    def test_refresh_key_status_resolves_needs_key_to_api_ready(self, qtbot):
+        """キー保存後の refresh で ○ needs key → ● API ready に解消され、選択可能になる。"""
+        dialog = StageModelPickerDialog(PipelineStage.TAGS, [NO_PRICE_API], available_providers=set())
+        qtbot.addWidget(dialog)
+        candidate_list = _candidate_list(dialog)
+        item = candidate_list.item(0)
+        assert "○ needs key" in item.text()
+
+        dialog.refresh_key_status({"anthropic"})
+
+        assert "● API ready" in item.text()
+        assert "○ needs key" not in item.text()
+        assert item.flags() & Qt.ItemFlag.ItemIsUserCheckable
+        item.setCheckState(Qt.CheckState.Checked)
+        assert dialog.selected_model_ids() == ["anthropic/claude-x"]
+
+    def test_refresh_key_status_preserves_checked_state(self, qtbot):
+        """refresh はチェック済み行の選択状態を維持する。"""
+        dialog = StageModelPickerDialog(
+            PipelineStage.TAGS, [GPT4O, NO_PRICE_API], available_providers={"openai"}
+        )
+        qtbot.addWidget(dialog)
+        candidate_list = _candidate_list(dialog)
+        for i in range(candidate_list.count()):
+            if "gpt-4o" in candidate_list.item(i).text():
+                candidate_list.item(i).setCheckState(Qt.CheckState.Checked)
+
+        dialog.refresh_key_status({"openai", "anthropic"})
+
+        assert dialog.selected_model_ids() == ["openai/gpt-4o"]

--- a/tests/unit/gui/window/test_configuration_window.py
+++ b/tests/unit/gui/window/test_configuration_window.py
@@ -8,7 +8,7 @@ from io import StringIO
 from unittest.mock import MagicMock, patch
 
 import pytest
-from PySide6.QtWidgets import QComboBox, QLineEdit, QMessageBox, QTabWidget
+from PySide6.QtWidgets import QComboBox, QLabel, QLineEdit, QMessageBox, QTabWidget
 
 from lorairo.gui.window.configuration_window import ConfigurationWindow
 from lorairo.services.configuration_service import ConfigurationService
@@ -74,17 +74,38 @@ class TestConfigurationWindow:
         assert tab_widget.tabText(0) == "基本設定"
         assert tab_widget.tabText(1) == "詳細設定"
 
-    def test_populate_sets_api_keys(self, dialog: ConfigurationWindow) -> None:
-        """APIキーがUIに反映される。"""
-        openai = dialog.findChild(QLineEdit, "lineEditOpenAiKey")
-        google = dialog.findChild(QLineEdit, "lineEditGoogleKey")
-        claude = dialog.findChild(QLineEdit, "lineEditClaudeKey")
-        assert openai is not None
-        assert openai.text() == "sk-test-openai"
-        assert google is not None
-        assert google.text() == "google-test-key"
-        assert claude is not None
-        assert claude.text() == "claude-test-key"
+    def test_populate_does_not_echo_saved_api_keys(self, dialog: ConfigurationWindow) -> None:
+        """Issue #755: 保存済キーは欄に echo back せず「保存済」ステータスのみ表示する。"""
+        for object_name in ("lineEditOpenAiKey", "lineEditGoogleKey", "lineEditClaudeKey"):
+            key_edit = dialog.findChild(QLineEdit, object_name)
+            assert key_edit is not None
+            assert key_edit.text() == ""
+            assert key_edit.placeholderText() == "保存済（変更する場合のみ入力）"
+            status = dialog.findChild(QLabel, f"{object_name}Status")
+            assert status is not None
+            assert status.text() == "保存済"
+
+    def test_unset_api_key_shows_unset_status(self, dialog: ConfigurationWindow) -> None:
+        """Issue #755: 未設定キー (openrouter) は「未設定」ステータスを表示する。"""
+        key_edit = dialog.findChild(QLineEdit, "lineEditOpenRouterKey")
+        assert key_edit is not None
+        assert key_edit.text() == ""
+        assert key_edit.placeholderText() == "未設定"
+        status = dialog.findChild(QLabel, "lineEditOpenRouterKeyStatus")
+        assert status is not None
+        assert status.text() == "未設定"
+
+    def test_api_keys_masked_with_password_echo(self, dialog: ConfigurationWindow) -> None:
+        """Issue #755: 全 API キー欄はマスク入力 (表示切替なし)。"""
+        for object_name in (
+            "lineEditOpenAiKey",
+            "lineEditGoogleKey",
+            "lineEditClaudeKey",
+            "lineEditOpenRouterKey",
+        ):
+            key_edit = dialog.findChild(QLineEdit, object_name)
+            assert key_edit is not None
+            assert key_edit.echoMode() == QLineEdit.EchoMode.Password
 
     def test_populate_sets_log_level(self, dialog: ConfigurationWindow) -> None:
         """ログレベルが選択される。"""
@@ -112,13 +133,41 @@ class TestConfigurationWindow:
         assert set(settings.keys()) == expected_sections
 
     def test_populate_and_collect_roundtrip(self, dialog: ConfigurationWindow) -> None:
-        """populate→collectで値が保持される。"""
+        """populate→collectで値が保持される (Issue #755: 空欄 = 保存済キー維持)。"""
         settings = dialog._collect_settings()
         assert settings["api"]["openai_key"] == "sk-test-openai"
         assert settings["api"]["google_key"] == "google-test-key"
         assert settings["api"]["claude_key"] == "claude-test-key"
         assert settings["log"]["level"] == "WARNING"
         assert settings["prompts"]["additional"] == "test prompt text"
+
+    def test_collect_uses_typed_api_key_when_entered(self, dialog: ConfigurationWindow) -> None:
+        """Issue #755: 入力した新キーは保存済の値を上書きする。"""
+        key_edit = dialog.findChild(QLineEdit, "lineEditClaudeKey")
+        assert key_edit is not None
+        key_edit.setText("  sk-new-claude-key  ")
+        settings = dialog._collect_settings()
+        assert settings["api"]["claude_key"] == "sk-new-claude-key"
+        # 触っていない欄は保存済の値を維持
+        assert settings["api"]["openai_key"] == "sk-test-openai"
+
+    def test_focus_api_key_field_highlights_provider_row(self, dialog: ConfigurationWindow) -> None:
+        """Issue #755: needs key 導線で該当プロバイダ欄をハイライトする。"""
+        # 詳細設定タブへ移しておき、基本設定タブへ戻ることを検証
+        tab_widget = dialog.findChild(QTabWidget)
+        assert tab_widget is not None
+        tab_widget.setCurrentIndex(1)
+
+        assert dialog.focus_api_key_field("anthropic") is True
+
+        assert tab_widget.currentIndex() == 0
+        key_edit = dialog.findChild(QLineEdit, "lineEditClaudeKey")
+        assert key_edit is not None
+        assert "#FF9800" in key_edit.styleSheet()
+
+    def test_focus_api_key_field_unknown_provider_returns_false(self, dialog: ConfigurationWindow) -> None:
+        """未知 provider は False を返し例外を出さない。"""
+        assert dialog.focus_api_key_field("xai") is False
 
     def test_ok_saves_and_accepts(
         self, dialog: ConfigurationWindow, config_service: MagicMock, qtbot

--- a/tests/unit/gui/window/test_main_window_pipeline_panel.py
+++ b/tests/unit/gui/window/test_main_window_pipeline_panel.py
@@ -337,6 +337,36 @@ class TestPickerConfigureKeyRoundTrip:
 
         dialog.refresh_key_status.assert_not_called()
 
+    def test_reload_after_settings_resets_container_config_service(self, monkeypatch):
+        """Codex review (PR #757): container 側 config_service を破棄して保存値を再読込させる。
+
+        MainWindow.config_service と ServiceContainer.config_service は別インスタンス
+        のため、保存後に container 側を破棄しないと widget が stale なキー状況を見る。
+        """
+        from lorairo.gui.window import main_window as main_window_module
+        from lorairo.gui.window.main_window import MainWindow
+
+        class _StubContainer:
+            def __init__(self) -> None:
+                self.config_deleted = False
+
+            @property
+            def config_service(self) -> Mock:
+                return Mock()
+
+            @config_service.deleter
+            def config_service(self) -> None:
+                self.config_deleted = True
+
+        container = _StubContainer()
+        monkeypatch.setattr(main_window_module, "get_service_container", lambda: container)
+        mock_window = Mock()
+
+        MainWindow._reload_model_widget_after_settings(mock_window)
+
+        assert container.config_deleted is True
+        mock_window.batchModelSelection.update_model_display.assert_called_once_with()
+
 
 @pytest.mark.unit
 class TestAvailableApiProviders:

--- a/tests/unit/gui/window/test_main_window_pipeline_panel.py
+++ b/tests/unit/gui/window/test_main_window_pipeline_panel.py
@@ -44,10 +44,13 @@ def _make_stub_dialog(
     captured: dict[str, object] = {}
 
     class _StubPickerDialog:
-        def __init__(self, stage, candidates, parent=None):
+        def __init__(self, stage, candidates, available_providers=None, parent=None):
             captured["stage"] = stage
             captured["candidates"] = candidates
+            captured["available_providers"] = available_providers
             captured["parent"] = parent
+            # Issue #755: MainWindow が connect する設定導線シグナルの差し替え
+            self.configure_key_requested = Mock()
 
         def exec(self) -> QDialog.DialogCode:
             return exec_result
@@ -272,6 +275,100 @@ class TestPipelineAddModelHandler:
 
         checkbox.set_selected.assert_called_once_with(True)
         mock_window._refresh_pipeline_panel.assert_called_once_with()
+
+
+@pytest.mark.unit
+class TestPickerConfigureKeyRoundTrip:
+    """Issue #755: needs key チップ → 設定 → ● API ready 解消の往復導線。"""
+
+    def test_picker_receives_available_providers(self, monkeypatch):
+        from lorairo.gui.window import main_window as main_window_module
+        from lorairo.gui.window.main_window import MainWindow
+
+        mock_window = Mock()
+        mock_window.batchModelSelection.model_checkbox_widgets = {}
+        mock_window.batchModelSelection.get_selected_models.return_value = []
+        mock_window.batchModelSelection.model_selection_service.load_models.return_value = []
+        mock_window._build_stage_model_infos = lambda ids: [GPT4O_INFO]
+        mock_window._available_api_providers.return_value = {"openai"}
+        stub_cls, captured = _make_stub_dialog(QDialog.DialogCode.Rejected, [])
+        monkeypatch.setattr(main_window_module, "StageModelPickerDialog", stub_cls)
+
+        MainWindow._on_pipeline_add_model_requested(mock_window, "tags")
+
+        assert captured["available_providers"] == {"openai"}
+
+    def test_configure_key_applied_refreshes_widget_and_dialog(self):
+        from lorairo.gui.window.main_window import MainWindow
+
+        mock_window = Mock()
+        mock_window.settings_controller.open_settings_dialog.return_value = True
+        mock_window._available_api_providers.return_value = {"anthropic"}
+        dialog = Mock()
+
+        MainWindow._on_picker_configure_key_requested(mock_window, "anthropic", dialog)
+
+        mock_window.settings_controller.open_settings_dialog.assert_called_once_with(
+            highlight_provider="anthropic"
+        )
+        mock_window._reload_model_widget_after_settings.assert_called_once_with()
+        dialog.refresh_key_status.assert_called_once_with({"anthropic"})
+
+    def test_configure_key_cancelled_does_not_refresh(self):
+        from lorairo.gui.window.main_window import MainWindow
+
+        mock_window = Mock()
+        mock_window.settings_controller.open_settings_dialog.return_value = False
+        dialog = Mock()
+
+        MainWindow._on_picker_configure_key_requested(mock_window, "anthropic", dialog)
+
+        mock_window._reload_model_widget_after_settings.assert_not_called()
+        dialog.refresh_key_status.assert_not_called()
+
+    def test_configure_key_without_settings_controller_is_noop(self):
+        from lorairo.gui.window.main_window import MainWindow
+
+        mock_window = Mock()
+        mock_window.settings_controller = None
+        dialog = Mock()
+
+        MainWindow._on_picker_configure_key_requested(mock_window, "anthropic", dialog)
+
+        dialog.refresh_key_status.assert_not_called()
+
+
+@pytest.mark.unit
+class TestAvailableApiProviders:
+    """Issue #755: config からの API キー設定済み provider 集合の導出。"""
+
+    def _make_window_with_keys(self, keys: dict[tuple[str, str], str]) -> Mock:
+        mock_window = Mock()
+        mock_window.config_service.get_setting.side_effect = lambda section, key, default="": keys.get(
+            (section, key), default
+        )
+        return mock_window
+
+    def test_only_providers_with_nonempty_keys(self):
+        from lorairo.gui.window.main_window import MainWindow
+
+        mock_window = self._make_window_with_keys(
+            {
+                ("api", "openai_key"): "sk-test",
+                ("api", "claude_key"): "   ",
+                ("api", "google_key"): "",
+                ("api", "openrouter_key"): "or-key",
+            }
+        )
+        providers = MainWindow._available_api_providers(mock_window)
+        assert providers == {"openai", "openrouter"}
+
+    def test_missing_config_service_returns_empty(self):
+        from lorairo.gui.window.main_window import MainWindow
+
+        mock_window = Mock()
+        mock_window.config_service = None
+        assert MainWindow._available_api_providers(mock_window) == set()
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## 概要

Issue #755 の実装。Wireframes v11 (docs/design/wireframes-v11/HANDOFF.md §137-138) で確定した「API キー未設定モデルは非表示にせず、可視 + その場で解消」設計に統一する。

## 実装内容

### モデルピッカー (Frame 2B / StageModelPickerDialog)
- 全候補行に Wireframes v11 のステータス表現を表示: `● installed` (ローカル) / `● API ready` (キー設定済 WebAPI) / `○ needs key` (キー未設定 WebAPI)
- `○ needs key` 行はチェック不可 (実行不能モデルの追加を防止)、行クリックで `configure_key_requested(provider)` を emit
- `refresh_key_status(available_providers)` でキー保存後にダイアログを開いたまま `● API ready` へ解消 (アプリ再起動不要)

### 往復導線 (MainWindow)
- ピッカー生成時に config の API キー状況 (`_available_api_providers()`) を注入
- needs key チップクリック → `SettingsController.open_settings_dialog(highlight_provider=...)` → キー保存 → モデル一覧 (`update_model_display`) と開いたままのピッカーを再評価

### ConfigurationWindow
- API キー欄はマスク入力 (Password echo・表示切替なし) のまま、保存値を欄に echo back しない。「保存済 / 未設定」ステータスラベルで保存状態だけ分かる UI に変更
- 空欄のまま OK した場合は保存済キーを維持 (空欄 = 変更なし)。キーのクリアは config/lorairo.toml の直接編集で行う
- OpenRouter API キー欄を追加 (route_preference=openrouter / openrouter 経路モデルの needs key 解消用)
- `focus_api_key_field(provider)` 新設: 基本設定タブへ切替 + 該当欄をハイライト・フォーカス

### ModelSelectionWidget / ModelCheckboxWidget
- 「APIモデルのみ」表示でキー未設定モデルを非表示にしていた `_filter_unavailable_web_api_options` を廃止し、`labelStatus` で `○ needs key` を可視化
- 描画シグネチャ (Issue #584) に `available` を含め、キー保存直後の再描画スキップ (stale 表示) を防止

### ⚙ 導線
- 既存の `actionSettings` / `pushButtonSettings` → `open_settings` 導線を確認 (変更不要)。設定保存後のモデル一覧反映を `_reload_model_widget_after_settings()` に共通化

## 検証

- `ruff format` / `ruff check` pass
- `mypy --follow-imports=silent` で変更 6 ファイル error なし (worktree からの `mypy -p lorairo` は editable install 経由で main checkout を解決する既知の制約があるため、最終確認は CI を SSoT とする)
- CI-equivalent filter (`-m "not gui_show and not calls_real_webapi and not downloads_and_runs_model and not slow" --timeout=60`): **4222 passed**。失敗 20 件 + collection error 2 ファイルは libcudnn 欠落 (devcontainer の torch import 失敗) による既存の環境問題で、main checkout でも同一に失敗することを確認済み (本変更とは無関係)

Closes #755

🤖 Generated with [Claude Code](https://claude.com/claude-code)