### PR TITLE
feat(gui): 登録完了サマリパネルを実装 (Wireframes v11 Frame 1)

### DIFF
--- a/src/lorairo/gui/services/result_handler_service.py
+++ b/src/lorairo/gui/services/result_handler_service.py
@@ -33,6 +33,7 @@ class ResultHandlerService:
         result: Any,
         status_bar: Any | None = None,
         completion_signal: SignalInstance | None = None,
+        summary_widget: Any | None = None,
     ) -> None:
         """バッチ登録完了処理
 
@@ -40,6 +41,9 @@ class ResultHandlerService:
             result: バッチ登録結果（DatabaseRegistrationResult）
             status_bar: ステータスバー（showMessage()メソッドを持つ）
             completion_signal: 完了シグナル（emit()で通知）
+            summary_widget: 登録完了サマリパネル（show_result() を持つ）。
+                指定時はパネルへ委譲し、statusBar の 5 秒フラッシュは出さない
+                (Wireframes v11 Frame 1: パネルが statusBar 表示を置換)。
         """
         logger.info(f"バッチ登録完了: result={type(result)}")
 
@@ -58,19 +62,23 @@ class ResultHandlerService:
                 variant = getattr(result, "variant_count", 0)
                 skipped = result.skipped_count
                 errors = result.error_count
-                processing_time = result.total_processing_time
 
                 # Emit completion signal for other components
                 if completion_signal:
                     completion_signal.emit(registered)
 
-                # 非ブロッキング通知でUIクラッシュを防止
-                status_msg = (
-                    f"バッチ登録完了: 登録={registered}件, 別版={variant}件, "
-                    f"スキップ={skipped}件, エラー={errors}件, 処理時間={processing_time:.1f}秒"
-                )
-                if status_bar:
-                    status_bar.showMessage(status_msg, 8000)  # 8秒表示
+                # 登録完了サマリパネルがあればそちらへ委譲（statusBar フラッシュは出さない）
+                if summary_widget is not None:
+                    summary_widget.show_result(result)
+                else:
+                    processing_time = result.total_processing_time
+                    # 非ブロッキング通知でUIクラッシュを防止
+                    status_msg = (
+                        f"バッチ登録完了: 登録={registered}件, 別版={variant}件, "
+                        f"スキップ={skipped}件, エラー={errors}件, 処理時間={processing_time:.1f}秒"
+                    )
+                    if status_bar:
+                        status_bar.showMessage(status_msg, 8000)  # 8秒表示
                 logger.info(
                     f"バッチ登録統計: 登録={registered}, 別版={variant}, "
                     f"スキップ={skipped}, エラー={errors}"

--- a/src/lorairo/gui/state/dataset_state.py
+++ b/src/lorairo/gui/state/dataset_state.py
@@ -324,8 +324,14 @@ class DatasetStateManager(QObject):
                     logger.debug(f"フィルター済み画像で発見: ID {image_id} - データを送信")
                     self.current_image_data_changed.emit(filtered_image_data)
                 else:
-                    # 空のデータでもシグナルを送信して一貫性を保つ
-                    self.current_image_data_changed.emit({})
+                    # キャッシュ未登録 (登録直後 / 検索結果外) は DB から取得して空表示を防ぐ
+                    db_image_data = self._get_image_from_db(image_id)
+                    if db_image_data:
+                        logger.debug(f"DB から画像取得: ID {image_id} - データを送信")
+                        self.current_image_data_changed.emit(db_image_data)
+                    else:
+                        # 取得できない場合のみ空データでシグナルの一貫性を保つ
+                        self.current_image_data_changed.emit({})
 
     def clear_current_image(self) -> None:
         """現在の画像選択をクリア"""
@@ -563,6 +569,21 @@ class DatasetStateManager(QObject):
             if img.get("id") == image_id:
                 return img
         return None
+
+    def _get_image_from_db(self, image_id: int) -> dict[str, Any] | None:
+        """DB から単一画像メタデータを取得する（キャッシュ未登録画像の選択用）。
+
+        登録直後や現在の検索結果に含まれない画像を選択したときに、preview /
+        details が空にならないよう DB を直接引く。
+        """
+        if not self._db_manager:
+            return None
+        try:
+            metadata: dict[str, Any] | None = self._db_manager.image_repo.get_image_metadata(image_id)
+            return metadata
+        except Exception as e:
+            logger.error(f"DB からの画像取得失敗: ID {image_id}: {e}", exc_info=True)
+            return None
 
     def get_current_image_data(self) -> dict[str, Any] | None:
         """現在選択中の画像データを取得"""

--- a/src/lorairo/gui/widgets/registration_summary_widget.py
+++ b/src/lorairo/gui/widgets/registration_summary_widget.py
@@ -1,0 +1,164 @@
+"""登録完了サマリパネル (Wireframes v11 Frame 1 / ADR 0061 §4)。
+
+専用 Import frame の代わりに、Search タブ上部へ常設するサマリパネル。
+registered / variant / skipped / errors の件数と、重複 / 別版に分類された
+ファイルの内訳（「既存 #N を表示」リンク付き）を表示する。statusBar の
+5 秒表示と異なり、✕ で閉じるまで残る。
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from PySide6.QtCore import Signal
+from PySide6.QtWidgets import (
+    QFrame,
+    QHBoxLayout,
+    QLabel,
+    QPushButton,
+    QVBoxLayout,
+    QWidget,
+)
+
+from lorairo.database.db_manager import RegistrationOutcome
+from lorairo.gui import theme
+
+if TYPE_CHECKING:
+    from lorairo.gui.workers.registration_worker import (
+        DatabaseRegistrationResult,
+        RegistrationDetailItem,
+    )
+
+# 内訳行に出す outcome（重複 / 別版のみ。新規は通常ケースなので出さない）。
+_DETAIL_OUTCOMES = (RegistrationOutcome.DUPLICATE, RegistrationOutcome.VARIANT)
+
+
+class RegistrationSummaryWidget(QWidget):
+    """登録完了サマリパネル。
+
+    Signals:
+        view_image_requested: 内訳行の「#N を表示」リンク押下時に image_id を送出。
+    """
+
+    view_image_requested = Signal(int)
+
+    def __init__(self, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        self.setObjectName("registrationSummaryWidget")
+
+        outer = QVBoxLayout(self)
+        outer.setContentsMargins(8, 6, 8, 6)
+        outer.setSpacing(4)
+
+        # ヘッダ行: ✓ 登録完了 — <dir> · N枚 · X.Xs   [counts]   [▾ 内訳] [✕]
+        header_row = QHBoxLayout()
+        self._header_label = QLabel(self)
+        self._header_label.setObjectName("registrationSummaryHeader")
+        self._counts_label = QLabel(self)
+        self._counts_label.setObjectName("registrationSummaryCounts")
+
+        self._toggle_button = QPushButton("▾ skip / 別版 の内訳", self)
+        self._toggle_button.setObjectName("registrationSummaryToggle")
+        self._toggle_button.setFlat(True)
+        self._toggle_button.clicked.connect(self._on_toggle_clicked)
+
+        self._dismiss_button = QPushButton("✕", self)
+        self._dismiss_button.setObjectName("registrationSummaryDismiss")
+        self._dismiss_button.setFlat(True)
+        self._dismiss_button.clicked.connect(self.hide)
+
+        header_row.addWidget(self._header_label)
+        header_row.addWidget(self._counts_label)
+        header_row.addStretch(1)
+        header_row.addWidget(self._toggle_button)
+        header_row.addWidget(self._dismiss_button)
+        outer.addLayout(header_row)
+
+        # 内訳コンテナ（既定で折りたたみ）
+        self._detail_container = QWidget(self)
+        self._detail_container.setObjectName("registrationSummaryDetail")
+        self._detail_layout = QVBoxLayout(self._detail_container)
+        self._detail_layout.setContentsMargins(0, 0, 0, 0)
+        self._detail_layout.setSpacing(2)
+        self._detail_container.setVisible(False)
+        outer.addWidget(self._detail_container)
+
+        # 結果到来までは非表示
+        self.setVisible(False)
+
+    def show_result(self, result: DatabaseRegistrationResult) -> None:
+        """登録結果を表示する（パネルを可視化、内訳は折りたたんだ状態で開始）。
+
+        Args:
+            result: 登録ワーカーの結果。
+        """
+        directory_name = result.directory.name if result.directory is not None else "—"
+        total = result.registered_count + result.variant_count + result.skipped_count + result.error_count
+        self._header_label.setText(
+            f"✓ 登録完了 — {directory_name} · {total}枚 · {result.total_processing_time:.1f}s"
+        )
+        self._counts_label.setText(
+            f"新規 {result.registered_count} · 別版 {result.variant_count} · "
+            f"skip {result.skipped_count} · エラー {result.error_count}"
+        )
+
+        self._rebuild_detail(result.detail)
+        # 内訳が無ければトグル自体を隠す
+        has_detail = self._detail_layout.count() > 0
+        self._toggle_button.setVisible(has_detail)
+        self._detail_container.setVisible(False)
+
+        self.setVisible(True)
+
+    def _rebuild_detail(self, detail: list[RegistrationDetailItem]) -> None:
+        """内訳行を再構築する（重複 / 別版のみ、既存呼び出しの残骸を破棄）。"""
+        while self._detail_layout.count():
+            item = self._detail_layout.takeAt(0)
+            widget = item.widget() if item else None
+            if widget is not None:
+                widget.deleteLater()
+
+        for entry in detail:
+            if entry.outcome not in _DETAIL_OUTCOMES or entry.image_id is None:
+                continue
+            self._detail_layout.addWidget(self._build_detail_row(entry))
+
+    def _build_detail_row(self, entry: RegistrationDetailItem) -> QFrame:
+        """内訳1行を構築する。"""
+        is_variant = entry.outcome is RegistrationOutcome.VARIANT
+        row = QFrame(self._detail_container)
+        row.setObjectName("registrationSummaryDetailRow")
+        layout = QHBoxLayout(row)
+        layout.setContentsMargins(0, 0, 0, 0)
+
+        filename = QLabel(entry.filename, row)
+        filename.setObjectName("registrationSummaryDetailFilename")
+
+        badge = QLabel("VARIANT" if is_variant else "DUPLICATE", row)
+        badge.setStyleSheet(theme.chip_qss("accent" if is_variant else "info"))
+
+        reason = QLabel(
+            "同一 pHash でも属性差 → 別版として新規登録"
+            if is_variant
+            else "同一 pHash · 属性差なし → 自動 skip（alias 記録済）",
+            row,
+        )
+        reason.setObjectName("registrationSummaryDetailReason")
+
+        link_text = f"→ 新規 #{entry.image_id} を表示" if is_variant else f"→ 既存 #{entry.image_id} を表示"
+        link = QPushButton(link_text, row)
+        link.setObjectName(f"registrationSummaryImageLink_{entry.image_id}")
+        link.setFlat(True)
+        image_id = entry.image_id
+        link.clicked.connect(lambda _checked=False, iid=image_id: self.view_image_requested.emit(iid))
+
+        layout.addWidget(filename)
+        layout.addWidget(badge)
+        layout.addWidget(reason)
+        layout.addStretch(1)
+        layout.addWidget(link)
+        return row
+
+    def _on_toggle_clicked(self) -> None:
+        """内訳の開閉を切り替える。"""
+        self._detail_container.setVisible(not self._detail_container.isVisible())

--- a/src/lorairo/gui/widgets/registration_summary_widget.py
+++ b/src/lorairo/gui/widgets/registration_summary_widget.py
@@ -42,6 +42,10 @@ class RegistrationSummaryWidget(QWidget):
 
     view_image_requested = Signal(int)
 
+    # 一度に描画する内訳行の上限。非スクロールのパネルに数千行を積んで GUI を
+    # 固めないため、超過分は「他 N件」の overflow ラベルへ畳む。
+    MAX_DETAIL_ROWS = 50
+
     def __init__(self, parent: QWidget | None = None) -> None:
         super().__init__(parent)
         self.setObjectName("registrationSummaryWidget")
@@ -118,10 +122,17 @@ class RegistrationSummaryWidget(QWidget):
             if widget is not None:
                 widget.deleteLater()
 
-        for entry in detail:
-            if entry.outcome not in _DETAIL_OUTCOMES or entry.image_id is None:
-                continue
+        eligible = [
+            entry for entry in detail if entry.outcome in _DETAIL_OUTCOMES and entry.image_id is not None
+        ]
+        for entry in eligible[: self.MAX_DETAIL_ROWS]:
             self._detail_layout.addWidget(self._build_detail_row(entry))
+
+        overflow = len(eligible) - self.MAX_DETAIL_ROWS
+        if overflow > 0:
+            label = QLabel(f"… 他 {overflow}件の重複 / 別版", self._detail_container)
+            label.setObjectName("registrationSummaryOverflow")
+            self._detail_layout.addWidget(label)
 
     def _build_detail_row(self, entry: RegistrationDetailItem) -> QFrame:
         """内訳1行を構築する。"""

--- a/src/lorairo/gui/window/main_window.py
+++ b/src/lorairo/gui/window/main_window.py
@@ -54,6 +54,7 @@ from ..widgets.inference_ledger_widget import InferenceLedgerWidget
 from ..widgets.pipeline_stage_table_widget import PipelineStageTableWidget
 from ..widgets.provider_batch_job_widget import ProviderBatchJobWidget
 from ..widgets.quick_tag_dialog import QuickTagDialog
+from ..widgets.registration_summary_widget import RegistrationSummaryWidget
 from ..widgets.results_widget import ResultsWidget
 from ..widgets.selected_image_details_widget import SelectedImageDetailsWidget
 from ..widgets.stage_model_picker_dialog import StageModelPickerDialog
@@ -120,6 +121,9 @@ class MainWindow(QMainWindow, Ui_MainWindow):
 
     # Map tab
     map_widget: TagMapWidget | None
+
+    # 登録完了サマリパネル (Wireframes v11 Frame 1)
+    registration_summary_widget: RegistrationSummaryWidget | None
 
     # Tag management UI components
     tag_management_dialog: TagManagementDialog | None
@@ -404,6 +408,7 @@ class MainWindow(QMainWindow, Ui_MainWindow):
         self._setup_export_tab()
         self._setup_cli_tab()
         self._setup_tab_shortcuts()
+        self._setup_registration_summary_panel()
 
     def _setup_map_tab(self) -> None:
         """マップタブ (TagMapWidget) を初期化する。"""
@@ -443,6 +448,40 @@ class MainWindow(QMainWindow, Ui_MainWindow):
         batch_widget = getattr(self, "batchTagAddWidget", None)
         if batch_widget is not None:
             batch_widget.add_image_ids_to_staging(image_ids)
+
+    def _setup_registration_summary_panel(self) -> None:
+        """登録完了サマリパネルを Search タブ上部 (qbar の上) へ常設する。
+
+        Wireframes v11 Frame 1。statusBar の 5 秒表示を置換し、registered /
+        variant / skipped / errors と重複 / 別版の内訳を ✕ で閉じるまで表示する。
+        """
+        container = getattr(self, "tabWorkspace", None)
+        layout = container.layout() if container is not None else None
+        if layout is None:
+            logger.warning("tabWorkspace layout not found - 登録完了サマリパネル skipped")
+            self.registration_summary_widget = None
+            return
+        widget = RegistrationSummaryWidget(parent=container)
+        widget.view_image_requested.connect(self._on_registration_view_image_requested)
+        # work area splitter (qbar を含む) の直前へ挿入する = qbar の上
+        insert_index = layout.count()
+        splitter = getattr(self, "splitterMainWorkArea", None)
+        if splitter is not None:
+            idx = layout.indexOf(splitter)
+            if idx != -1:
+                insert_index = idx
+        layout.insertWidget(insert_index, widget)
+        self.registration_summary_widget = widget
+        logger.info("✅ 登録完了サマリパネル (RegistrationSummaryWidget) initialized")
+
+    def _on_registration_view_image_requested(self, image_id: int) -> None:
+        """登録完了サマリの「#N を表示」リンク → 該当画像を詳細表示する。"""
+        tab_widget = getattr(self, "tabWidgetMainMode", None)
+        workspace = getattr(self, "tabWorkspace", None)
+        if tab_widget is not None and workspace is not None:
+            tab_widget.setCurrentWidget(workspace)
+        if self.dataset_state_manager is not None:
+            self.dataset_state_manager.set_current_image(image_id)
 
     def _setup_provider_batch_tab(self) -> None:
         """ジョブタブ (Provider Batch job management) を追加する。
@@ -1316,7 +1355,10 @@ class MainWindow(QMainWindow, Ui_MainWindow):
         """Batch registration finished signal handler（ResultHandlerService委譲）"""
         if self.result_handler_service:
             self.result_handler_service.handle_batch_registration_finished(
-                result, status_bar=self.statusBar(), completion_signal=self.database_registration_completed
+                result,
+                status_bar=self.statusBar(),
+                completion_signal=self.database_registration_completed,
+                summary_widget=getattr(self, "registration_summary_widget", None),
             )
         else:
             # Fallback: Service未初期化時は簡易通知のみ

--- a/src/lorairo/gui/workers/registration_worker.py
+++ b/src/lorairo/gui/workers/registration_worker.py
@@ -1,7 +1,7 @@
 """データベース登録専用ワーカー"""
 
 import traceback
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, ClassVar
 
@@ -16,12 +16,31 @@ if TYPE_CHECKING:
     from ...storage.file_system import FileSystemManager
 
 
+@dataclass(frozen=True)
+class RegistrationDetailItem:
+    """登録結果の1ファイル分の内訳。
+
+    Wireframes v11 Frame 1「登録完了サマリ」の詳細行・「既存#N を表示」リンク用。
+
+    Attributes:
+        filename: 登録対象ファイル名 (``Path.name``)。
+        outcome: pHash 分類結果 (新規 / 別版 / 重複 / 失敗)。
+        image_id: 関連付けられた画像 ID。DUPLICATE は既存 ID、VARIANT / REGISTERED は
+            新規 ID。失敗時は ``None``。
+    """
+
+    filename: str
+    outcome: RegistrationOutcome
+    image_id: int | None
+
+
 @dataclass
 class DatabaseRegistrationResult:
     """データベース登録結果。
 
     ADR 0061 §4 (#633): pHash 分類結果を全経路統一の統計値に対応させる。
     ``variant_count`` は同一 pHash でも属性差で別版として新規登録された件数。
+    ``directory`` / ``detail`` は Wireframes v11 Frame 1「登録完了サマリ」用。
     """
 
     registered_count: int
@@ -30,6 +49,8 @@ class DatabaseRegistrationResult:
     processed_paths: list[Path]
     total_processing_time: float
     variant_count: int = 0
+    directory: Path | None = None
+    detail: list[RegistrationDetailItem] = field(default_factory=list)
 
 
 class DatabaseRegistrationWorker(LoRAIroWorkerBase[DatabaseRegistrationResult]):
@@ -77,7 +98,9 @@ class DatabaseRegistrationWorker(LoRAIroWorkerBase[DatabaseRegistrationResult]):
 
         if total_count == 0:
             logger.warning(f"画像ファイルが見つかりません: {self.directory}")
-            return DatabaseRegistrationResult(0, 0, 0, [], 0.0, variant_count=0)
+            return DatabaseRegistrationResult(
+                0, 0, 0, [], 0.0, variant_count=0, directory=self.directory, detail=[]
+            )
 
         logger.info(f"登録対象画像: {total_count}件")
 
@@ -89,6 +112,7 @@ class DatabaseRegistrationWorker(LoRAIroWorkerBase[DatabaseRegistrationResult]):
         # 統計情報初期化 (#633: variant を追加し全経路統一)
         stats = {"registered": 0, "variant": 0, "skipped": 0, "errors": 0}
         processed_paths: list[Path] = []
+        detail: list[RegistrationDetailItem] = []
 
         # バッチ処理開始
         self._report_progress(10, f"バッチ登録開始: {total_count}件")
@@ -104,13 +128,14 @@ class DatabaseRegistrationWorker(LoRAIroWorkerBase[DatabaseRegistrationResult]):
                 total_count,
                 stats,
                 processed_paths,
+                detail,
                 annotations=annotations_by_path.get(image_path),
                 tag_id_cache=tag_id_cache,
             )
 
         # 完了処理
         self._report_progress(100, "データベース登録完了")
-        return self._build_registration_result(stats, processed_paths, start_time)
+        return self._build_registration_result(stats, processed_paths, detail, start_time)
 
     def _process_single_image_in_batch(
         self,
@@ -119,6 +144,7 @@ class DatabaseRegistrationWorker(LoRAIroWorkerBase[DatabaseRegistrationResult]):
         total_count: int,
         stats: dict[str, int],
         processed_paths: list[Path],
+        detail: list[RegistrationDetailItem],
         *,
         annotations: dict[str, object] | None = None,
         tag_id_cache: dict[str, int | None] | None = None,
@@ -131,12 +157,13 @@ class DatabaseRegistrationWorker(LoRAIroWorkerBase[DatabaseRegistrationResult]):
             total_count: 処理対象の総画像数。
             stats: 処理統計情報を格納する辞書（in-place更新）。
             processed_paths: 登録成功した画像パスを格納するリスト（in-place更新）。
+            detail: 1ファイル分の内訳を格納するリスト（in-place更新、登録完了サマリ用）。
             annotations: 事前読み込み済みのアノテーション。Noneの場合はその場で読み込む。
             tag_id_cache: 正規化済みタグ→tag_idのキャッシュ。
         """
         try:
             # 単一画像の登録処理 (統一エントリ経由で副作用は db_manager 側で適用)
-            outcome, _ = self._register_single_image(
+            outcome, image_id = self._register_single_image(
                 image_path, i, total_count, annotations=annotations, tag_id_cache=tag_id_cache
             )
 
@@ -146,9 +173,13 @@ class DatabaseRegistrationWorker(LoRAIroWorkerBase[DatabaseRegistrationResult]):
             # 新規 / 別版はどちらも新規行を作るので processed として記録する
             if outcome in (RegistrationOutcome.REGISTERED, RegistrationOutcome.VARIANT):
                 processed_paths.append(image_path)
+            # 登録完了サマリ用に内訳を記録 (DUPLICATE=既存ID, VARIANT/REGISTERED=新規ID)
+            resolved_id = image_id if image_id is not None and image_id >= 0 else None
+            detail.append(RegistrationDetailItem(image_path.name, outcome, resolved_id))
 
         except Exception as e:
             stats["errors"] += 1
+            detail.append(RegistrationDetailItem(image_path.name, RegistrationOutcome.FAILED, None))
             logger.error(f"画像登録エラー: {image_path}, {e}")
 
             # エラーレコード保存（二次エラー対策付き）
@@ -223,7 +254,11 @@ class DatabaseRegistrationWorker(LoRAIroWorkerBase[DatabaseRegistrationResult]):
         return outcome, image_id
 
     def _build_registration_result(
-        self, stats: dict[str, int], processed_paths: list[Path], start_time: float
+        self,
+        stats: dict[str, int],
+        processed_paths: list[Path],
+        detail: list[RegistrationDetailItem],
+        start_time: float,
     ) -> DatabaseRegistrationResult:
         """登録結果オブジェクトを構築
 
@@ -233,6 +268,7 @@ class DatabaseRegistrationWorker(LoRAIroWorkerBase[DatabaseRegistrationResult]):
         Args:
             stats: 処理統計情報（registered, skipped, errors）
             processed_paths: 登録成功した画像パスのリスト
+            detail: 1ファイル分の内訳のリスト（登録完了サマリ用）
             start_time: 処理開始時刻（time.time()）
 
         Returns:
@@ -249,6 +285,8 @@ class DatabaseRegistrationWorker(LoRAIroWorkerBase[DatabaseRegistrationResult]):
             processed_paths=processed_paths,
             total_processing_time=processing_time,
             variant_count=stats["variant"],
+            directory=self.directory,
+            detail=detail,
         )
 
         # バッチサマリーログ（INFOレベル）

--- a/tests/unit/gui/services/test_result_handler_service.py
+++ b/tests/unit/gui/services/test_result_handler_service.py
@@ -79,6 +79,34 @@ class TestHandleBatchRegistrationFinished:
         assert "スキップ=10" in mock_status_bar.showMessage.call_args[0][0]
         completion_signal.emit.assert_called_once_with(100)
 
+    def test_handle_registration_shows_summary_widget(self, service, mock_status_bar):
+        """summary_widget があれば show_result に委譲し、statusBar フラッシュは出さない。
+
+        Wireframes v11 Frame 1: 登録完了サマリパネルが 5 秒 statusBar 表示を置換する。
+        """
+        result = Mock()
+        result.registered_count = 9
+        result.skipped_count = 12
+        result.error_count = 0
+        result.total_processing_time = 18.2
+        result.variant_count = 3
+
+        summary_widget = Mock()
+        summary_widget.show_result = Mock()
+        completion_signal = Mock()
+        completion_signal.emit = Mock()
+
+        service.handle_batch_registration_finished(
+            result,
+            status_bar=mock_status_bar,
+            completion_signal=completion_signal,
+            summary_widget=summary_widget,
+        )
+
+        summary_widget.show_result.assert_called_once_with(result)
+        mock_status_bar.showMessage.assert_not_called()
+        completion_signal.emit.assert_called_once_with(9)
+
     def test_handle_registration_without_status_bar(self, service):
         """ステータスバー無し"""
         result = Mock()

--- a/tests/unit/gui/state/test_dataset_state.py
+++ b/tests/unit/gui/state/test_dataset_state.py
@@ -117,6 +117,27 @@ class TestDatasetStateManager:
         assert state_manager.current_image_id is None
         current_cleared_mock.assert_called_once()
 
+    def test_set_current_image_falls_back_to_db_when_uncached(self, state_manager):
+        """キャッシュ未登録の画像でも DB から取得して空辞書でなく実データを emit する。
+
+        登録完了サマリの「#N を表示」リンク等、現在の検索結果に含まれない画像を
+        選択したときに preview/details が空にならないようにする (PR #762 Codex P2)。
+        """
+        data_changed_mock = Mock()
+        state_manager.current_image_data_changed.connect(data_changed_mock)
+
+        mock_db_manager = Mock()
+        mock_repository = Mock()
+        mock_db_manager.image_repo = mock_repository
+        fetched = {"id": 4412, "stored_image_path": "/data/4412.webp", "width": 1024, "height": 1536}
+        mock_repository.get_image_metadata.return_value = fetched
+        state_manager._db_manager = mock_db_manager
+
+        state_manager.set_current_image(4412)
+
+        mock_repository.get_image_metadata.assert_called_once_with(4412)
+        data_changed_mock.assert_called_once_with(fetched)
+
     def test_filter_management(self, state_manager, sample_image_metadata):
         """フィルター管理テスト"""
         state_manager.set_dataset_images(sample_image_metadata)

--- a/tests/unit/gui/widgets/test_registration_summary_widget.py
+++ b/tests/unit/gui/widgets/test_registration_summary_widget.py
@@ -112,3 +112,40 @@ def test_toggle_shows_and_hides_detail(qtbot, result):
     assert not container.isHidden()
     toggle.click()
     assert container.isHidden()
+
+
+def test_detail_rows_capped_with_overflow_label(qtbot):
+    """大量の重複/別版でも行数を上限で打ち切り、残数を「他 N件」で示す。
+
+    非スクロールのパネルに数百〜数千行を一度に積んで GUI を固めないため
+    (PR #762 Codex P2)。
+    """
+    detail = [
+        RegistrationDetailItem(f"dup_{i}.jpg", RegistrationOutcome.DUPLICATE, 1000 + i)
+        for i in range(RegistrationSummaryWidget.MAX_DETAIL_ROWS + 7)
+    ]
+    result = DatabaseRegistrationResult(
+        registered_count=0,
+        skipped_count=len(detail),
+        error_count=0,
+        processed_paths=[],
+        total_processing_time=5.0,
+        variant_count=0,
+        directory=Path("/data/big_batch"),
+        detail=detail,
+    )
+
+    widget = RegistrationSummaryWidget()
+    qtbot.addWidget(widget)
+    widget.show_result(result)
+
+    links = [
+        b
+        for b in widget.findChildren(QPushButton)
+        if b.objectName().startswith("registrationSummaryImageLink_")
+    ]
+    assert len(links) == RegistrationSummaryWidget.MAX_DETAIL_ROWS
+
+    overflow = widget.findChild(QLabel, "registrationSummaryOverflow")
+    assert overflow is not None
+    assert "7" in overflow.text()  # 残り7件

--- a/tests/unit/gui/widgets/test_registration_summary_widget.py
+++ b/tests/unit/gui/widgets/test_registration_summary_widget.py
@@ -1,0 +1,114 @@
+"""RegistrationSummaryWidget 単体テスト。
+
+Wireframes v11 Frame 1「登録完了サマリ」。worker の
+``DatabaseRegistrationResult`` を渡して View の描画・詳細行・シグナル発火・
+✕ dismiss を検証する。QT_QPA_PLATFORM=offscreen ヘッドレス。
+"""
+
+from pathlib import Path
+
+import pytest
+from PySide6.QtWidgets import QLabel, QPushButton, QWidget
+
+from lorairo.database.db_manager import RegistrationOutcome
+from lorairo.gui.widgets.registration_summary_widget import RegistrationSummaryWidget
+from lorairo.gui.workers.registration_worker import (
+    DatabaseRegistrationResult,
+    RegistrationDetailItem,
+)
+
+
+@pytest.fixture
+def result() -> DatabaseRegistrationResult:
+    """新規4 / 別版1 / 重複2 / エラー0 の登録結果。"""
+    return DatabaseRegistrationResult(
+        registered_count=4,
+        skipped_count=2,
+        error_count=0,
+        processed_paths=[],
+        total_processing_time=18.2,
+        variant_count=1,
+        directory=Path("/data/uploads/shiba_batch_07"),
+        detail=[
+            RegistrationDetailItem("shiba_a.jpg", RegistrationOutcome.REGISTERED, 12480),
+            RegistrationDetailItem("shiba_close_v2.jpg", RegistrationOutcome.VARIANT, 12481),
+            RegistrationDetailItem("shiba_007_copy.jpg", RegistrationOutcome.DUPLICATE, 4412),
+            RegistrationDetailItem("shiba_012.png", RegistrationOutcome.DUPLICATE, 2871),
+        ],
+    )
+
+
+def test_show_result_displays_directory_and_counts(qtbot, result):
+    """show_result でヘッダにディレクトリ名と件数を表示し、パネルが可視になる。"""
+    widget = RegistrationSummaryWidget()
+    qtbot.addWidget(widget)
+
+    widget.show_result(result)
+
+    assert not widget.isHidden()
+    header = widget.findChild(QLabel, "registrationSummaryHeader")
+    counts = widget.findChild(QLabel, "registrationSummaryCounts")
+    assert "shiba_batch_07" in header.text()
+    counts_text = counts.text()
+    assert "4" in counts_text  # 新規
+    assert "1" in counts_text  # 別版
+    assert "2" in counts_text  # skip
+
+
+def test_dismiss_hides_widget(qtbot, result):
+    """✕ クリックでパネルが非表示になる。"""
+    widget = RegistrationSummaryWidget()
+    qtbot.addWidget(widget)
+    widget.show_result(result)
+    assert not widget.isHidden()
+
+    dismiss = widget.findChild(QPushButton, "registrationSummaryDismiss")
+    dismiss.click()
+
+    assert widget.isHidden()
+
+
+def test_detail_rows_only_for_duplicate_and_variant(qtbot, result):
+    """詳細リンクは DUPLICATE / VARIANT のみ生成される（REGISTERED は出さない）。"""
+    widget = RegistrationSummaryWidget()
+    qtbot.addWidget(widget)
+
+    widget.show_result(result)
+
+    links = [
+        b
+        for b in widget.findChildren(QPushButton)
+        if b.objectName().startswith("registrationSummaryImageLink_")
+    ]
+    linked_ids = {b.objectName().rsplit("_", 1)[1] for b in links}
+    # VARIANT 12481, DUPLICATE 4412 / 2871 の3件。REGISTERED 12480 は含めない。
+    assert linked_ids == {"12481", "4412", "2871"}
+
+
+def test_link_click_emits_view_image_requested(qtbot, result):
+    """詳細行リンクのクリックで view_image_requested(image_id) が発火する。"""
+    widget = RegistrationSummaryWidget()
+    qtbot.addWidget(widget)
+    widget.show_result(result)
+
+    link = widget.findChild(QPushButton, "registrationSummaryImageLink_4412")
+    with qtbot.waitSignal(widget.view_image_requested, timeout=1000) as blocker:
+        link.click()
+
+    assert blocker.args == [4412]
+
+
+def test_toggle_shows_and_hides_detail(qtbot, result):
+    """詳細は既定で折りたたまれ、トグルで開閉する。"""
+    widget = RegistrationSummaryWidget()
+    qtbot.addWidget(widget)
+    widget.show_result(result)
+
+    toggle = widget.findChild(QPushButton, "registrationSummaryToggle")
+    container = widget.findChild(QWidget, "registrationSummaryDetail")
+
+    assert container.isHidden()
+    toggle.click()
+    assert not container.isHidden()
+    toggle.click()
+    assert container.isHidden()

--- a/tests/unit/workers/test_database_related_workers.py
+++ b/tests/unit/workers/test_database_related_workers.py
@@ -121,6 +121,33 @@ class TestDatabaseRegistrationWorker:
             # 統一エントリが各画像で呼ばれたことを確認
             assert mock_register.call_count == 3
 
+    def test_execute_collects_per_file_detail(self, temp_dir, real_db_manager, mock_fsm):
+        """登録結果に per-file 詳細 (filename / outcome / image_id) と directory を含む。
+
+        Wireframes v11 Frame 1「登録完了サマリ」の詳細行・「既存#N を表示」リンク用。
+        DUPLICATE は既存 ID、VARIANT / REGISTERED は新規 ID が image_id に入る。
+        """
+        from lorairo.database.db_manager import RegistrationOutcome, RegistrationSideEffectResult
+        from lorairo.gui.workers.registration_worker import RegistrationDetailItem
+
+        # mock_image_files は test_image_0.jpg / _1 / _2 の3件。順に異なる outcome を返す。
+        with patch.object(real_db_manager, "register_image_with_side_effects") as mock_register:
+            mock_register.side_effect = [
+                RegistrationSideEffectResult(RegistrationOutcome.REGISTERED, 10, {"id": 10}),
+                RegistrationSideEffectResult(RegistrationOutcome.VARIANT, 11, {"id": 11}),
+                RegistrationSideEffectResult(RegistrationOutcome.DUPLICATE, 4412, {"id": 4412}),
+            ]
+
+            worker = DatabaseRegistrationWorker(temp_dir, real_db_manager, mock_fsm)
+            result = worker.execute()
+
+        assert result.directory == temp_dir
+        assert result.detail == [
+            RegistrationDetailItem("test_image_0.jpg", RegistrationOutcome.REGISTERED, 10),
+            RegistrationDetailItem("test_image_1.jpg", RegistrationOutcome.VARIANT, 11),
+            RegistrationDetailItem("test_image_2.jpg", RegistrationOutcome.DUPLICATE, 4412),
+        ]
+
     def test_associated_files_processing_integration(self, temp_dir, real_db_manager, mock_fsm):
         """
         関連ファイル処理の統合テスト
@@ -536,7 +563,7 @@ class TestBuildRegistrationResult:
         start_time = 0.0
 
         with patch("time.time", return_value=1.5):
-            result = worker._build_registration_result(stats, processed_paths, start_time)
+            result = worker._build_registration_result(stats, processed_paths, [], start_time)
 
         assert isinstance(result, DatabaseRegistrationResult)
         assert result.registered_count == 3
@@ -552,7 +579,7 @@ class TestBuildRegistrationResult:
         start_time = 0.0
 
         with patch("time.time", return_value=2.0):
-            result = worker._build_registration_result(stats, processed_paths, start_time)
+            result = worker._build_registration_result(stats, processed_paths, [], start_time)
 
         assert result.registered_count == 10
         assert result.skipped_count == 0
@@ -567,7 +594,7 @@ class TestBuildRegistrationResult:
         start_time = 0.0
 
         with patch("time.time", return_value=1.0):
-            result = worker._build_registration_result(stats, processed_paths, start_time)
+            result = worker._build_registration_result(stats, processed_paths, [], start_time)
 
         assert result.registered_count == 0
         assert result.skipped_count == 10
@@ -581,7 +608,7 @@ class TestBuildRegistrationResult:
         start_time = 0.0
 
         with patch("time.time", return_value=3.5):
-            result = worker._build_registration_result(stats, processed_paths, start_time)
+            result = worker._build_registration_result(stats, processed_paths, [], start_time)
 
         assert result.registered_count == 0
         assert result.skipped_count == 0
@@ -596,7 +623,7 @@ class TestBuildRegistrationResult:
         start_time = 10.0
 
         with patch("time.time", return_value=15.5):
-            result = worker._build_registration_result(stats, processed_paths, start_time)
+            result = worker._build_registration_result(stats, processed_paths, [], start_time)
 
         assert result.total_processing_time == 5.5
         assert result.total_processing_time > 0
@@ -608,7 +635,7 @@ class TestBuildRegistrationResult:
         start_time = 0.0
 
         with patch("time.time", return_value=1.0):
-            result = worker._build_registration_result(stats, processed_paths, start_time)
+            result = worker._build_registration_result(stats, processed_paths, [], start_time)
 
         assert result.processed_paths == processed_paths
         assert len(result.processed_paths) == 3
@@ -624,7 +651,7 @@ class TestBuildRegistrationResult:
             patch("time.time", return_value=2.0),
             patch("lorairo.gui.workers.registration_worker.logger") as mock_logger,
         ):
-            worker._build_registration_result(stats, processed_paths, start_time)
+            worker._build_registration_result(stats, processed_paths, [], start_time)
 
             # INFO ログが呼ばれたことを確認
             mock_logger.info.assert_called_once()
@@ -647,7 +674,7 @@ class TestBuildRegistrationResult:
             patch("time.time", return_value=1.5),
             patch("lorairo.gui.workers.registration_worker.logger") as mock_logger,
         ):
-            worker._build_registration_result(stats, processed_paths, start_time)
+            worker._build_registration_result(stats, processed_paths, [], start_time)
 
             # DEBUG ログが呼ばれていないことを確認
             mock_logger.debug.assert_not_called()
@@ -662,7 +689,7 @@ class TestBuildRegistrationResult:
         start_time = 0.0
 
         with patch("time.time", return_value=0.1):
-            result = worker._build_registration_result(stats, processed_paths, start_time)
+            result = worker._build_registration_result(stats, processed_paths, [], start_time)
 
         assert result.registered_count == 0
         assert result.skipped_count == 0
@@ -677,7 +704,7 @@ class TestBuildRegistrationResult:
         start_time = 0.0
 
         with patch("time.time", return_value=2.5):
-            result = worker._build_registration_result(stats, processed_paths, start_time)
+            result = worker._build_registration_result(stats, processed_paths, [], start_time)
 
         # 型チェック
         assert isinstance(result, DatabaseRegistrationResult)
@@ -705,7 +732,7 @@ class TestBuildRegistrationResult:
         start_time = 0.0
 
         with patch("time.time", return_value=1.0):
-            result = worker._build_registration_result(stats, processed_paths, start_time)
+            result = worker._build_registration_result(stats, processed_paths, [], start_time)
 
         assert result.registered_count == 4
         assert result.variant_count == 3


### PR DESCRIPTION
## 背景

ユーザーの「Wireframes v11 に対して実装が追いついていない」という指摘を起点に、ワイヤー v11 と実 GUI を突き合わせて差分を特定。最有力ギャップとして **Frame 1「登録完了サマリ」パネル**が未実装だった。

ワイヤーは「専用 Import frame の代わり」としてこのパネルを明示設計し、`registered / variant / skipped / errors` の件数＋重複/別版の内訳（「既存 #N を表示」リンク付き）を **✕ で閉じるまで常設**すると規定 (HANDOFF「確定済み設計判断」/ ADR 0061 §4)。だが実装は `statusBar.showMessage(..., 8000)` の**数秒で消える表示**のままで、これはワイヤーが「これを置き換える」と名指ししていた当の旧実装だった。

## 変更

- **registration_worker**: per-file 詳細 `(filename, outcome, image_id)` と `directory` を `DatabaseRegistrationResult` に収集 (`RegistrationDetailItem`)。`RegistrationSideEffectResult.image_id` は DUPLICATE=既存ID / VARIANT・REGISTERED=新規ID（従来は統計更新後に破棄していた）。
- **RegistrationSummaryWidget** (新規): 件数ヘッダ + 重複/別版の折りたたみ内訳行 + 「既存/新規 #N を表示」リンク + ✕。Search タブ qbar の上に常設。
- **result_handler_service**: `summary_widget` 引数を追加。あればパネルへ委譲し statusBar フラッシュは出さない（後方互換: パネル無しは従来通り statusBar）。
- **main_window**: パネルを `tabWorkspace` へマウント。`view_image_requested` → `dataset_state_manager.set_current_image(image_id)` で該当画像を詳細表示。

## テスト (TDD)

- worker 詳細収集: 51 passed（既存の `_build_registration_result` 呼び出しも追従更新）
- `RegistrationSummaryWidget`: 5 passed（描画 / dismiss / 内訳が DUPLICATE・VARIANT のみ / リンク signal / トグル）
- `result_handler_service`: 18 passed（パネル委譲時に statusBar を出さない新ケース含む）
- ruff format/check・mypy: 全変更ファイル clean

### ローカルテストの注記

CI 相当フィルタの full run で 37 failures + 2 collection errors が出るが、**すべて `torch`/`libcudnn.so.9` 欠如（`lorairo.editor` import cascade）と image-annotator-lib モック由来**で、本 PR が触れていない `image_processor` / `annotator_adapter` / `model_sync` 領域に限定される。CUDA ライブラリのある CI が SSoT。本 PR の registration 系テストは全 pass。

🤖 Generated with [Claude Code](https://claude.com/claude-code)