### PR TITLE
feat(gui): Map タブに共起タグ・ネットワーク図を追加

### DIFF
--- a/src/lorairo/gui/widgets/tag_cloud_widget.py
+++ b/src/lorairo/gui/widgets/tag_cloud_widget.py
@@ -1,17 +1,22 @@
-"""キーワード連動の共起タグクラウドウィジェット（Map フレーム）。
+"""キーワード連動の共起タグ探索ウィジェット（Map フレーム）。
 
-任意のキーワード（部分一致）でマッチした画像群の共起タグを、頻度に応じた
-フォントサイズで雲状に表示する。タグクリックで AND 絞り込み（ドリルダウン）し、
-関連タグを辿って探索する。探索専用でステージング導線は持たない。
+任意のキーワード（部分一致）でマッチした画像群の共起タグを、力学配置の
+ネットワーク図、またはフォントサイズ可変のタグクラウドで可視化する。
+タグ（ノード）クリックで AND 絞り込み（ドリルダウン）し、関連タグを辿って
+探索する。探索専用でステージング導線は持たない。
+
+Map Tab.html (Claude Design) の見た目を PySide6 + QPainter で再現する。
 """
 
 from __future__ import annotations
 
+import math
+from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from loguru import logger
-from PySide6.QtCore import QObject, QRect, QSize, Qt, QThread, QTimer, Signal
-from PySide6.QtGui import QFont, QMouseEvent
+from PySide6.QtCore import QObject, QPointF, QRect, QRectF, QSize, Qt, QThread, QTimer, Signal
+from PySide6.QtGui import QBrush, QColor, QFont, QMouseEvent, QPainter, QPen
 from PySide6.QtWidgets import (
     QHBoxLayout,
     QLabel,
@@ -21,21 +26,36 @@ from PySide6.QtWidgets import (
     QPushButton,
     QScrollArea,
     QSizePolicy,
+    QStackedWidget,
     QVBoxLayout,
     QWidget,
 )
 
 from lorairo.gui import theme
-from lorairo.services.tag_cloud_service import CloudResult, TagCloudService
+from lorairo.services.tag_cloud_service import GraphResult, TagCloudService
 
 if TYPE_CHECKING:
     from lorairo.database.db_manager import ImageDatabaseManager
 
-# フォントサイズ範囲（weight 0..1 をこの px 範囲へマッピング）
-_FONT_SIZE_MIN = 10
-_FONT_SIZE_MAX = 30
 # キーワード入力のデバウンス（ms）
 _DEBOUNCE_MS = 250
+# 力学シミュレーションの更新間隔（ms）
+_SIM_INTERVAL_MS = 16
+# alpha がこの値を下回ったらシミュレーションを停止（収束）
+_SIM_SETTLE = 0.05
+
+# 頻度カラーランプの両端（暖色グレー → アクセント）
+_RAMP_LOW = (154, 148, 136)
+_RAMP_HIGH = (194, 94, 63)
+
+
+def _ramp_color(t: float) -> QColor:
+    """頻度 weight (0..1) を暖色グレー→アクセントのランプ色へ変換する。"""
+    e = math.pow(max(0.0, min(1.0, t)), 0.85)
+    r = round(_RAMP_LOW[0] + (_RAMP_HIGH[0] - _RAMP_LOW[0]) * e)
+    g = round(_RAMP_LOW[1] + (_RAMP_HIGH[1] - _RAMP_LOW[1]) * e)
+    b = round(_RAMP_LOW[2] + (_RAMP_HIGH[2] - _RAMP_LOW[2]) * e)
+    return QColor(r, g, b)
 
 
 class FlowLayout(QLayout):
@@ -107,24 +127,21 @@ class FlowLayout(QLayout):
 
 
 class _TagCloudLabel(QLabel):
-    """クリック可能なタグクラウド用ラベル。"""
+    """クリック可能なタグクラウド用ラベル（頻度でフォントサイズ可変）。"""
 
     clicked = Signal(str)
 
     def __init__(self, tag: str, count: int, weight: float, parent: QWidget | None = None) -> None:
-        super().__init__(tag, parent)
+        super().__init__(f"{tag}", parent)
         self._tag = tag
-        font_px = int(_FONT_SIZE_MIN + weight * (_FONT_SIZE_MAX - _FONT_SIZE_MIN))
-        font = QFont("sans-serif", -1)
+        font_px = 13 + round(34 * math.pow(weight, 0.8))
+        font = QFont("monospace", -1)
         font.setPixelSize(font_px)
-        # ウェイトが高いほど太字寄りに
-        font.setWeight(QFont.Weight.DemiBold if weight >= 0.5 else QFont.Weight.Normal)
+        font.setWeight(QFont.Weight.DemiBold if weight > 0.55 else QFont.Weight.Normal)
         self.setFont(font)
-        # 頻度ティアで色付け
-        color = theme.ACCENT if weight >= 0.66 else (theme.INK if weight >= 0.33 else theme.INK_SOFT)
-        self.setStyleSheet(f"color:{color};padding:1px 3px;")
+        self.setStyleSheet(f"color:{_ramp_color(weight).name()};padding:1px 2px;")
         self.setCursor(Qt.CursorShape.PointingHandCursor)
-        self.setToolTip(f"{tag} ({count}件) — クリックで絞り込み")
+        self.setToolTip(f"{tag} · {count}枚 — クリックで絞り込み")
 
     def mousePressEvent(self, event: QMouseEvent) -> None:
         if event.button() == Qt.MouseButton.LeftButton:
@@ -161,10 +178,351 @@ class _DrillChip(QWidget):
         layout.addWidget(close_btn)
 
 
-class _CloudWorker(QThread):
-    """バックグラウンドで初回タグロード+集計を実行するスレッド。"""
+@dataclass
+class _Particle:
+    """力学シミュレーションの粒子（1ノードの物理状態）。"""
 
-    finished = Signal(object)  # CloudResult
+    x: float
+    y: float
+    vx: float
+    vy: float
+    r: float
+
+
+class NetworkGraphView(QWidget):
+    """共起タグの力学配置ネットワーク図（QPainter 描画）。
+
+    Signals:
+        node_clicked: ノード（タグ）クリック時にタグ名を通知。
+    """
+
+    node_clicked = Signal(str)
+
+    def __init__(self, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        self.setMouseTracking(True)
+        self.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Expanding)
+        self._result: GraphResult | None = None
+        self._particles: list[_Particle] = []
+        self._hover = -1
+        self._alpha = 1.0
+        self._timer = QTimer(self)
+        self._timer.setInterval(_SIM_INTERVAL_MS)
+        self._timer.timeout.connect(self._tick)
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def set_graph(self, result: GraphResult) -> None:
+        """グラフ結果をセットして力学配置を初期化・再開する。"""
+        self._result = result
+        self._hover = -1
+        self._init_particles()
+        self._alpha = 1.0
+        if self._particles:
+            self._timer.start()
+        else:
+            self._timer.stop()
+        self.update()
+
+    def stop(self) -> None:
+        """シミュレーションを停止する。"""
+        self._timer.stop()
+
+    # ------------------------------------------------------------------
+    # Simulation
+    # ------------------------------------------------------------------
+
+    def _init_particles(self) -> None:
+        if self._result is None:
+            self._particles = []
+            return
+        nodes = self._result.nodes
+        n = len(nodes)
+        w = max(self.width(), 200)
+        h = max(self.height(), 200)
+        cx, cy = w / 2, h / 2
+        self._particles = []
+        for i, node in enumerate(nodes):
+            r = 8 + 19 * math.sqrt(node.weight)
+            ang = i / max(n, 1) * math.tau
+            x = cx + math.cos(ang) * (120 + 30 * (i % 3))
+            y = cy + math.sin(ang) * (90 + 25 * (i % 3))
+            self._particles.append(_Particle(x=x, y=y, vx=0.0, vy=0.0, r=r))
+
+    def _tick(self) -> None:
+        self._step()
+        self.update()
+        if self._alpha <= _SIM_SETTLE:
+            self._timer.stop()
+
+    def _step(self) -> None:
+        if self._result is None or not self._particles:
+            return
+        ps = self._particles
+        edges = self._result.edges
+        w = max(self.width(), 200)
+        h = max(self.height(), 200)
+        cx, cy = w / 2, h / 2
+        alpha = self._alpha
+        n = len(ps)
+
+        # 斥力（O(n^2)、n<=34 なので許容）
+        for i in range(n):
+            a = ps[i]
+            for j in range(i + 1, n):
+                b = ps[j]
+                dx, dy = a.x - b.x, a.y - b.y
+                d2 = dx * dx + dy * dy
+                if d2 < 0.01:
+                    d2 = 0.01
+                    dx, dy = 0.1, 0.1
+                d = math.sqrt(d2)
+                min_d = a.r + b.r + 22
+                rep = 3600 / d2
+                if d < min_d:
+                    rep += (min_d - d) * 1.1 / d
+                fx, fy = dx / d * rep, dy / d * rep
+                a.vx += fx
+                a.vy += fy
+                b.vx -= fx
+                b.vy -= fy
+
+        # バネ（共起が強いほど近く・強く引く）
+        for e in edges:
+            a, b = ps[e.a], ps[e.b]
+            dx, dy = b.x - a.x, b.y - a.y
+            d = math.sqrt(dx * dx + dy * dy) or 0.01
+            target = 175 - 80 * e.norm
+            k = 0.010 + 0.045 * e.norm
+            f = (d - target) * k
+            fx, fy = dx / d * f, dy / d * f
+            a.vx += fx
+            a.vy += fy
+            b.vx -= fx
+            b.vy -= fy
+
+        # 中心への重力
+        for a in ps:
+            a.vx += (cx - a.x) * 0.0045
+            a.vy += (cy - a.y) * 0.0045
+
+        # 積分
+        damp = 0.86
+        max_sp = 18 * alpha + 2
+        for a in ps:
+            a.vx *= damp
+            a.vy *= damp
+            sp = math.hypot(a.vx, a.vy)
+            if sp > max_sp:
+                a.vx *= max_sp / sp
+                a.vy *= max_sp / sp
+            a.x += a.vx * alpha
+            a.y += a.vy * alpha
+            a.x = max(a.r + 6, min(w - a.r - 6, a.x))
+            a.y = max(a.r + 6, min(h - a.r - 6, a.y))
+
+        self._alpha *= 0.992
+
+    # ------------------------------------------------------------------
+    # Hit testing
+    # ------------------------------------------------------------------
+
+    def _node_at(self, x: float, y: float) -> int:
+        for i in range(len(self._particles) - 1, -1, -1):
+            p = self._particles[i]
+            if math.hypot(x - p.x, y - p.y) <= p.r + 2:
+                return i
+        return -1
+
+    # ------------------------------------------------------------------
+    # Qt events
+    # ------------------------------------------------------------------
+
+    def resizeEvent(self, _event: object) -> None:
+        # 収束後にリサイズされたら軽く揺らして再配置
+        if self._particles and self._alpha <= _SIM_SETTLE:
+            self._alpha = 0.5
+            self._timer.start()
+        self.update()
+
+    def mouseMoveEvent(self, event: QMouseEvent) -> None:
+        pos = event.position()
+        idx = self._node_at(pos.x(), pos.y())
+        if idx != self._hover:
+            self._hover = idx
+            self.setCursor(Qt.CursorShape.PointingHandCursor if idx >= 0 else Qt.CursorShape.ArrowCursor)
+            self.update()
+
+    def mousePressEvent(self, event: QMouseEvent) -> None:
+        if event.button() != Qt.MouseButton.LeftButton:
+            return
+        pos = event.position()
+        self._click_at(pos.x(), pos.y())
+
+    def _click_at(self, x: float, y: float) -> None:
+        """指定座標にノードがあれば node_clicked を発火する。"""
+        if self._result is None:
+            return
+        idx = self._node_at(x, y)
+        if idx >= 0:
+            self.node_clicked.emit(self._result.nodes[idx].tag)
+
+    def leaveEvent(self, _event: object) -> None:
+        if self._hover != -1:
+            self._hover = -1
+            self.update()
+
+    # ------------------------------------------------------------------
+    # Painting
+    # ------------------------------------------------------------------
+
+    def paintEvent(self, _event: object) -> None:
+        painter = QPainter(self)
+        painter.setRenderHint(QPainter.RenderHint.Antialiasing)
+        w, h = self.width(), self.height()
+        painter.fillRect(0, 0, w, h, QColor(theme.CARD))
+        if self._result is None or not self._particles:
+            painter.end()
+            return
+        self._draw_edges(painter)
+        self._draw_nodes(painter)
+        self._draw_labels(painter)
+        self._draw_legend(painter, h)
+        self._draw_hint(painter, w)
+        if self._hover >= 0:
+            self._draw_tooltip(painter)
+        painter.end()
+
+    def _draw_edges(self, painter: QPainter) -> None:
+        assert self._result is not None
+        ps = self._particles
+        hov = self._hover
+        painter.setBrush(Qt.BrushStyle.NoBrush)
+        for e in self._result.edges:
+            a, b = ps[e.a], ps[e.b]
+            lit = hov < 0 or hov == e.a or hov == e.b
+            if hov >= 0 and not lit:
+                pen = QPen(QColor(185, 180, 165, 20), max(0.6, 0.6 + e.norm * 2))
+            elif hov >= 0:
+                pen = QPen(QColor(194, 94, 63, 140), 1.2 + e.norm * 4)
+            else:
+                alpha = int((0.16 + e.norm * 0.42) * 255)
+                pen = QPen(QColor(155, 148, 136, alpha), 0.6 + e.norm * 3.4)
+            pen.setCapStyle(Qt.PenCapStyle.RoundCap)
+            painter.setPen(pen)
+            painter.drawLine(QPointF(a.x, a.y), QPointF(b.x, b.y))
+
+    def _draw_nodes(self, painter: QPainter) -> None:
+        assert self._result is not None
+        ps = self._particles
+        hov = self._hover
+        neighbors = self._result.adjacency[hov] if hov >= 0 else None
+        for i, p in enumerate(ps):
+            node = self._result.nodes[i]
+            dim = hov >= 0 and hov != i and not (neighbors is not None and i in neighbors)
+            color = _ramp_color(node.weight)
+            painter.setOpacity(0.28 if dim else 1.0)
+            painter.setBrush(QBrush(color))
+            if hov == i:
+                painter.setPen(QPen(QColor(38, 36, 31), 2.5))
+            else:
+                painter.setPen(QPen(QColor(255, 255, 255, 191), 1))
+            painter.drawEllipse(QPointF(p.x, p.y), p.r, p.r)
+        painter.setOpacity(1.0)
+
+    def _draw_labels(self, painter: QPainter) -> None:
+        assert self._result is not None
+        ps = self._particles
+        hov = self._hover
+        neighbors = self._result.adjacency[hov] if hov >= 0 else None
+        for i, p in enumerate(ps):
+            node = self._result.nodes[i]
+            dim = hov >= 0 and hov != i and not (neighbors is not None and i in neighbors)
+            if dim:
+                continue
+            fs = round(10 + 9 * node.weight + (1.5 if hov == i else 0))
+            font = QFont("monospace", -1)
+            font.setPixelSize(fs)
+            if hov == i or node.weight > 0.55:
+                font.setWeight(QFont.Weight.DemiBold)
+            painter.setFont(font)
+            ly = p.y + p.r + fs * 0.85 + 3
+            rect = QRectF(p.x - 120, ly - fs, 240, fs * 1.6)
+            # 白ハロー（縁取り）
+            painter.setPen(QPen(QColor(255, 255, 255, 235), 3))
+            for ox, oy in ((-1, 0), (1, 0), (0, -1), (0, 1)):
+                painter.drawText(rect.translated(ox, oy), Qt.AlignmentFlag.AlignHCenter, node.tag)
+            painter.setPen(
+                QColor(38, 36, 31) if hov == i else QColor(58, 52, 46 if node.weight > 0.55 else 76)
+            )
+            painter.drawText(rect, Qt.AlignmentFlag.AlignHCenter, node.tag)
+
+    def _draw_legend(self, painter: QPainter, h: int) -> None:
+        x, y = 12, h - 64
+        painter.setBrush(QBrush(QColor(255, 255, 255, 235)))
+        painter.setPen(QPen(QColor(theme.LINE), 1))
+        painter.drawRoundedRect(QRectF(x, y, 156, 52), 6, 6)
+        font = QFont("monospace", -1)
+        font.setPixelSize(9)
+        painter.setFont(font)
+        painter.setPen(QColor(theme.INK_FAINT))
+        painter.drawText(QPointF(x + 10, y + 14), "出現頻度  低 → 高")
+        # ランプ
+        for i in range(5):
+            painter.setPen(Qt.PenStyle.NoPen)
+            painter.setBrush(QBrush(_ramp_color(i / 4)))
+            painter.drawRect(QRectF(x + 10 + i * 26, y + 20, 26, 9))
+        painter.setPen(QColor(theme.INK_SOFT))
+        painter.drawText(QPointF(x + 10, y + 46), "線の太さ = 共起の強さ")
+
+    def _draw_hint(self, painter: QPainter, w: int) -> None:
+        text = "ノードをクリックで絞り込み・ホバーで近傍を強調"
+        font = QFont("monospace", -1)
+        font.setPixelSize(10)
+        painter.setFont(font)
+        tw = painter.fontMetrics().horizontalAdvance(text) + 22
+        x = w - tw - 12
+        painter.setBrush(QBrush(QColor(255, 255, 255, 230)))
+        painter.setPen(QPen(QColor(theme.LINE), 1))
+        painter.drawRoundedRect(QRectF(x, 12, tw, 22), 11, 11)
+        painter.setPen(QColor(theme.INK_FAINT))
+        painter.drawText(QRectF(x, 12, tw, 22), Qt.AlignmentFlag.AlignCenter, text)
+
+    def _draw_tooltip(self, painter: QPainter) -> None:
+        assert self._result is not None
+        idx = self._hover
+        p = self._particles[idx]
+        node = self._result.nodes[idx]
+        deg = len(self._result.adjacency[idx])
+        title = node.tag
+        line = f"出現 {node.count:,} 枚 · 共起 {deg} タグ"
+        hint = "クリックで AND 絞り込みに追加"
+        font = QFont("monospace", -1)
+        font.setPixelSize(11)
+        painter.setFont(font)
+        fm = painter.fontMetrics()
+        tw = max(fm.horizontalAdvance(title), fm.horizontalAdvance(line), fm.horizontalAdvance(hint))
+        bw = tw + 18
+        bh = 56
+        tx = min(p.x + 14, self.width() - bw - 4)
+        ty = min(p.y + 14, self.height() - bh - 4)
+        painter.setBrush(QBrush(QColor(38, 36, 31)))
+        painter.setPen(Qt.PenStyle.NoPen)
+        painter.drawRoundedRect(QRectF(tx, ty, bw, bh), 5, 5)
+        painter.setPen(QColor(255, 255, 255))
+        painter.drawText(QPointF(tx + 9, ty + 17), title)
+        painter.setPen(QColor(217, 211, 196))
+        painter.drawText(QPointF(tx + 9, ty + 34), line)
+        painter.setPen(QColor(154, 149, 138))
+        painter.drawText(QPointF(tx + 9, ty + 50), hint)
+
+
+class _GraphWorker(QThread):
+    """バックグラウンドで初回タグロード+グラフ集計を実行するスレッド。"""
+
+    finished = Signal(object)  # GraphResult
     error = Signal(str)
 
     def __init__(
@@ -181,14 +539,19 @@ class _CloudWorker(QThread):
 
     def run(self) -> None:
         try:
-            result = self._service.build_cloud(self._keyword, self._selected_tags)
+            result = self._service.build_graph(self._keyword, self._selected_tags)
             self.finished.emit(result)
         except Exception as exc:
             self.error.emit(str(exc))
 
 
 class TagCloudWidget(QWidget):
-    """マップタブのルートウィジェット（キーワード連動共起タグクラウド）。"""
+    """マップタブのルートウィジェット（キーワード連動の共起タグ探索）。"""
+
+    # スタックページ
+    _PAGE_MESSAGE = 0
+    _PAGE_NETWORK = 1
+    _PAGE_CLOUD = 2
 
     def __init__(self, db_manager: ImageDatabaseManager, parent: QWidget | None = None) -> None:
         super().__init__(parent)
@@ -196,7 +559,9 @@ class TagCloudWidget(QWidget):
         self._service = TagCloudService(db_manager)
         self._keyword = ""
         self._selected_tags: list[str] = []
-        self._worker: _CloudWorker | None = None
+        self._view = "network"  # "network" | "cloud"
+        self._result: GraphResult | None = None
+        self._worker: _GraphWorker | None = None
         self._loaded_once = False
 
         self._debounce = QTimer(self)
@@ -205,6 +570,7 @@ class TagCloudWidget(QWidget):
         self._debounce.timeout.connect(self._recompute)
 
         self._build_ui()
+        self._show_placeholder()
 
     # ------------------------------------------------------------------
     # UI construction
@@ -215,7 +581,7 @@ class TagCloudWidget(QWidget):
         root.setContentsMargins(12, 12, 12, 12)
         root.setSpacing(8)
 
-        # 上部: キーワード入力 + リセット/再読込
+        # 上部: キーワード入力 + 表示トグル + リセット/再読込
         top = QHBoxLayout()
         top.setSpacing(6)
         self._keyword_edit = QLineEdit()
@@ -224,14 +590,20 @@ class TagCloudWidget(QWidget):
         self._keyword_edit.textChanged.connect(self._on_keyword_changed)
         top.addWidget(self._keyword_edit, 1)
 
+        self._network_btn = self._make_toggle_btn("ネットワーク", "network", checked=True)
+        self._cloud_btn = self._make_toggle_btn("クラウド", "cloud", checked=False)
+        top.addWidget(self._network_btn)
+        top.addWidget(self._cloud_btn)
+
         self._reset_btn = QPushButton("リセット")
         self._reset_btn.setCursor(Qt.CursorShape.PointingHandCursor)
+        self._reset_btn.setToolTip("キーワードと絞り込みを解除")
         self._reset_btn.clicked.connect(self._on_reset)
         top.addWidget(self._reset_btn)
 
         self._reload_btn = QPushButton("↺ 再読込")
         self._reload_btn.setCursor(Qt.CursorShape.PointingHandCursor)
-        self._reload_btn.setToolTip("DB を読み直してクラウドを更新")
+        self._reload_btn.setToolTip("DB を読み直して再集計")
         self._reload_btn.clicked.connect(self._on_reload)
         top.addWidget(self._reload_btn)
         root.addLayout(top)
@@ -244,20 +616,51 @@ class TagCloudWidget(QWidget):
         # ステータス
         self._status_label = QLabel("")
         self._status_label.setFont(QFont("monospace", 9))
-        self._status_label.setStyleSheet(f"color:{theme.INK_FAINT};")
+        self._status_label.setStyleSheet(f"color:{theme.INK_SOFT};")
         root.addWidget(self._status_label)
 
-        # クラウド本体（スクロール可）
-        self._scroll = QScrollArea()
-        self._scroll.setWidgetResizable(True)
-        self._scroll.setFrameShape(QScrollArea.Shape.NoFrame)
+        # ステージ（メッセージ / ネットワーク / クラウド の3ページ）
+        self._stack = QStackedWidget()
+        self._stack.setStyleSheet(
+            f"background:{theme.CARD};border:1px solid {theme.LINE};border-radius:{theme.RADIUS}px;"
+        )
+
+        self._message_label = QLabel()
+        self._message_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        self._message_label.setWordWrap(True)
+        self._message_label.setStyleSheet(f"color:{theme.INK_FAINT};")
+        self._message_label.setFont(QFont("monospace", 11))
+        self._stack.addWidget(self._message_label)  # PAGE_MESSAGE
+
+        self._network_view = NetworkGraphView()
+        self._network_view.node_clicked.connect(self._on_tag_clicked)
+        self._stack.addWidget(self._network_view)  # PAGE_NETWORK
+
+        self._cloud_scroll = QScrollArea()
+        self._cloud_scroll.setWidgetResizable(True)
+        self._cloud_scroll.setFrameShape(QScrollArea.Shape.NoFrame)
         self._cloud_container = QWidget()
         self._cloud_container.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Expanding)
-        self._cloud_layout = FlowLayout(self._cloud_container, spacing=8)
-        self._scroll.setWidget(self._cloud_container)
-        root.addWidget(self._scroll, 1)
+        self._cloud_layout = FlowLayout(self._cloud_container, spacing=14)
+        self._cloud_scroll.setWidget(self._cloud_container)
+        self._stack.addWidget(self._cloud_scroll)  # PAGE_CLOUD
 
-        self._show_placeholder()
+        root.addWidget(self._stack, 1)
+
+    def _make_toggle_btn(self, text: str, view: str, checked: bool) -> QPushButton:
+        btn = QPushButton(text)
+        btn.setCheckable(True)
+        btn.setChecked(checked)
+        btn.setCursor(Qt.CursorShape.PointingHandCursor)
+        btn.setFont(QFont("monospace", 9))
+        btn.setStyleSheet(
+            f"QPushButton{{background:{theme.PAPER_SHADE};color:{theme.INK_SOFT};"
+            f"border:1px solid {theme.LINE_STRONG};border-radius:4px;padding:5px 12px;}}"
+            f"QPushButton:checked{{background:{theme.CARD};color:{theme.INK};"
+            f"border-color:{theme.ACCENT};font-weight:bold;}}"
+        )
+        btn.clicked.connect(lambda: self._on_view_changed(view))
+        return btn
 
     # ------------------------------------------------------------------
     # Event handlers
@@ -269,11 +672,20 @@ class TagCloudWidget(QWidget):
         self._selected_tags = []
         self._debounce.start()
 
+    def _on_view_changed(self, view: str) -> None:
+        self._view = view
+        self._network_btn.setChecked(view == "network")
+        self._cloud_btn.setChecked(view == "cloud")
+        if self._result is not None and self._result.nodes:
+            self._render_active_view()
+
     def _on_reset(self) -> None:
         self._keyword_edit.clear()
         self._keyword = ""
         self._selected_tags = []
+        self._result = None
         self._debounce.stop()
+        self._network_view.stop()
         self._show_placeholder()
 
     def _on_reload(self) -> None:
@@ -302,65 +714,95 @@ class TagCloudWidget(QWidget):
             return
         self._status_label.setText("集計中...")
         if not self._loaded_once:
-            # 初回はタグ全ロードが走るためバックグラウンドで
             self._start_worker()
         else:
-            # キャッシュ済みなら同期で十分軽い
-            result = self._service.build_cloud(self._keyword, self._selected_tags)
+            result = self._service.build_graph(self._keyword, self._selected_tags)
             self._apply_result(result)
 
     def _start_worker(self) -> None:
         if self._worker is not None and self._worker.isRunning():
             return
-        worker = _CloudWorker(self._service, self._keyword, list(self._selected_tags), parent=self)
+        worker = _GraphWorker(self._service, self._keyword, list(self._selected_tags), parent=self)
         worker.finished.connect(self._on_worker_finished)
         worker.error.connect(self._on_worker_error)
         self._worker = worker
         worker.start()
 
-    def _on_worker_finished(self, result: CloudResult) -> None:
+    def _on_worker_finished(self, result: GraphResult) -> None:
         self._loaded_once = True
         self._apply_result(result)
 
     def _on_worker_error(self, msg: str) -> None:
         self._status_label.setText(f"エラー: {msg}")
-        logger.error(f"TagCloud 計算エラー: {msg}")
+        logger.error(f"TagGraph 計算エラー: {msg}")
 
     # ------------------------------------------------------------------
     # Rendering
     # ------------------------------------------------------------------
 
-    def _apply_result(self, result: CloudResult) -> None:
+    def _apply_result(self, result: GraphResult) -> None:
+        self._result = result
         self._refresh_chips()
+        if not result.nodes:
+            self._network_view.stop()
+            kw = f"「{self._keyword}」" if self._keyword else "（条件）"
+            self._message_label.setText(
+                f"該当する画像がありません\n{kw} を含むタグが見つかりませんでした。"
+            )
+            self._stack.setCurrentIndex(self._PAGE_MESSAGE)
+            self._status_label.setText(f"該当 0枚 / 全 {result.total_images:,}枚")
+            return
+        filtered = "絞り込み中" if (self._keyword or self._selected_tags) else "全件"
+        self._status_label.setText(
+            f"該当 {result.matched_images:,}枚 / 全 {result.total_images:,}枚 · "
+            f"{result.tag_count}タグ · 表示 {len(result.nodes)}ノード / "
+            f"{len(result.edges)}共起 · {filtered}"
+        )
+        self._render_active_view()
+
+    def _render_active_view(self) -> None:
+        if self._result is None:
+            return
+        if self._view == "network":
+            self._stack.setCurrentIndex(self._PAGE_NETWORK)
+            self._network_view.set_graph(self._result)
+        else:
+            self._network_view.stop()
+            self._render_cloud(self._result)
+            self._stack.setCurrentIndex(self._PAGE_CLOUD)
+
+    def _render_cloud(self, result: GraphResult) -> None:
         self._clear_layout(self._cloud_layout)
-        for entry in result.entries:
-            label = _TagCloudLabel(entry.tag, entry.count, entry.weight)
+        for node in result.nodes:
+            label = _TagCloudLabel(node.tag, node.count, node.weight)
             label.clicked.connect(self._on_tag_clicked)
             self._cloud_layout.addWidget(label)
-        if result.entries:
-            self._status_label.setText(
-                f"該当 {result.matched_images}枚 / 全 {result.total_images}枚 · {len(result.entries)}タグ"
-            )
-        else:
-            self._status_label.setText(
-                f"該当なし（全 {result.total_images}枚） — 別のキーワードを試してください"
-            )
 
     def _refresh_chips(self) -> None:
         self._clear_layout(self._chip_layout)
+        lead = QLabel("ドリルダウン:")
+        lead.setFont(QFont("monospace", 9))
+        lead.setStyleSheet(f"color:{theme.INK_FAINT};")
+        self._chip_layout.addWidget(lead)
+        if not self._selected_tags:
+            hint = QLabel("なし — ノードをクリックして絞り込み")
+            hint.setFont(QFont("monospace", 9))
+            hint.setStyleSheet(
+                f"color:{theme.INK_FAINT};border:1px dashed {theme.LINE_STRONG};"
+                f"border-radius:{theme.RADIUS_CHIP}px;padding:2px 8px;"
+            )
+            self._chip_layout.addWidget(hint)
+            return
         for tag in self._selected_tags:
             chip = _DrillChip(tag)
             chip.removed.connect(self._on_chip_removed)
             self._chip_layout.addWidget(chip)
 
     def _show_placeholder(self) -> None:
-        self._clear_layout(self._cloud_layout)
         self._clear_layout(self._chip_layout)
-        placeholder = QLabel("キーワードを入力すると、共起タグがクラウド表示されます")
-        placeholder.setAlignment(Qt.AlignmentFlag.AlignCenter)
-        placeholder.setStyleSheet(f"color:{theme.INK_FAINT};")
-        placeholder.setFont(QFont("monospace", 11))
-        self._cloud_layout.addWidget(placeholder)
+        self._refresh_chips()
+        self._message_label.setText("キーワードを入力すると、共起タグの関係がネットワーク図で表示されます")
+        self._stack.setCurrentIndex(self._PAGE_MESSAGE)
         self._status_label.setText("")
 
     @staticmethod

--- a/src/lorairo/services/tag_cloud_service.py
+++ b/src/lorairo/services/tag_cloud_service.py
@@ -1,15 +1,15 @@
-"""キーワード連動の共起タグクラウドサービス。
+"""キーワード連動の共起タグ探索サービス。
 
-任意のキーワード（部分一致）でマッチした画像群の共起タグを頻度集計し、
-タグクラウド表示用のウェイト付きエントリを返す。クリックによる AND ドリル
-ダウン絞り込みに対応する。重量 ML 依存なし（標準ライブラリのみ）。
+任意のキーワード（部分一致）でマッチした画像群から、タグの出現頻度と
+タグ同士の共起関係を集計し、ネットワーク図・タグクラウド双方の描画に使える
+グラフモデルを返す。クリックによる AND ドリルダウン絞り込みに対応する。
+重量 ML 依存なし（標準ライブラリのみ）。
 """
 
 from __future__ import annotations
 
-import math
 from collections import Counter
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
 from loguru import logger
@@ -17,30 +17,48 @@ from loguru import logger
 if TYPE_CHECKING:
     from lorairo.database.db_manager import ImageDatabaseManager
 
-# クラウドに表示するタグ数の既定上限
-_DEFAULT_TOP_N = 80
+# ネットワーク図に表示するノード数の上限（読みやすさ優先）
+_DEFAULT_MAX_NODES = 34
+# 1ノードあたりのエッジ数上限（hairball 抑制）
+_DEFAULT_MAX_EDGES_PER_NODE = 5
+# エッジとして採用する最小共起回数
+_MIN_EDGE_WEIGHT = 2
 
 
 @dataclass
-class TagWeight:
-    """タグクラウドの1エントリ。"""
+class GraphNode:
+    """共起グラフの1ノード（1タグ）。"""
 
     tag: str
     count: int  # 該当画像群での出現数
-    weight: float  # 0.0..1.0 正規化済み（フォントサイズ用）
+    weight: float  # 0.0..1.0 正規化済み頻度（min-max、サイズ/色用）
 
 
 @dataclass
-class CloudResult:
-    """`TagCloudService.build_cloud` の返り値。"""
+class GraphEdge:
+    """共起グラフの1エッジ（2タグの共起）。"""
 
-    entries: list[TagWeight]
+    a: int  # ノードインデックス
+    b: int  # ノードインデックス
+    weight: int  # 共起回数
+    norm: float  # 0.0..1.0 正規化済み共起強度（線の太さ用）
+
+
+@dataclass
+class GraphResult:
+    """`TagCloudService.build_graph` の返り値。"""
+
+    nodes: list[GraphNode]
+    edges: list[GraphEdge]
+    adjacency: list[set[int]]  # nodes と同じ並び。各ノードの隣接ノード集合
     matched_images: int
     total_images: int
+    tag_count: int = 0  # 該当画像群に出現したユニークタグ総数
+    excluded_tags: list[str] = field(default_factory=list)  # 絞り込みに使用中のタグ
 
 
 class TagCloudService:
-    """共起タグクラウドを構築する。
+    """共起タグのグラフモデルを構築する。
 
     起動時に `{image_id: [tag, ...]}` を1度ロードしてキャッシュし、
     ドリルダウン時はキャッシュの再フィルタのみで高速に再計算する。
@@ -55,25 +73,31 @@ class TagCloudService:
     # Public API
     # ------------------------------------------------------------------
 
-    def build_cloud(
+    def build_graph(
         self,
         keyword: str,
         selected_tags: list[str] | None = None,
-        top_n: int = _DEFAULT_TOP_N,
-    ) -> CloudResult:
-        """キーワードと絞り込みタグから共起タグクラウドを構築する。
+        max_nodes: int = _DEFAULT_MAX_NODES,
+        max_edges_per_node: int = _DEFAULT_MAX_EDGES_PER_NODE,
+    ) -> GraphResult:
+        """キーワードと絞り込みタグから共起グラフを構築する。
 
         画像が対象となる条件:
             - `keyword` を部分文字列に含むタグを1つ以上持つ
             - `selected_tags` のタグを全て持つ（AND 絞り込み）
 
+        ノードは該当画像群の頻度上位 `max_nodes` 個（絞り込み中タグを除く）。
+        エッジは採用ノード間の共起のうち共起回数 >= 2 のものを、ノードあたり
+        `max_edges_per_node` 本まで（共起の強い順に）採用する。
+
         Args:
-            keyword: 部分一致検索キーワード。空文字なら空クラウドを返す。
+            keyword: 部分一致検索キーワード。空文字なら空グラフを返す。
             selected_tags: ドリルダウンで追加された完全一致タグのリスト。
-            top_n: クラウドに含めるタグ数の上限。
+            max_nodes: ノード数の上限。
+            max_edges_per_node: 1ノードあたりのエッジ採用数上限。
 
         Returns:
-            CloudResult — ウェイト付きタグエントリと該当件数。
+            GraphResult — ノード・エッジ・隣接情報と該当件数。
         """
         image_tags = self._get_image_tags()
         total = len(image_tags)
@@ -83,30 +107,46 @@ class TagCloudService:
         selected_set = set(selected)
 
         if not keyword_norm:
-            return CloudResult(entries=[], matched_images=0, total_images=total)
+            return GraphResult(
+                nodes=[],
+                edges=[],
+                adjacency=[],
+                matched_images=0,
+                total_images=total,
+                tag_count=0,
+                excluded_tags=selected,
+            )
 
-        # 条件を満たす画像のタグを集計
-        counter: Counter[str] = Counter()
-        matched = 0
-        for tags in image_tags.values():
-            tag_set = set(tags)
-            if selected_set and not selected_set.issubset(tag_set):
-                continue
-            if not any(keyword_norm in tag for tag in tags):
-                continue
-            matched += 1
-            counter.update(tags)
+        matched = self._filter_matched(image_tags, keyword_norm, selected_set)
 
-        # 絞り込みに使ったタグはクラウドから除外
-        for sel in selected_set:
-            counter.pop(sel, None)
+        # 該当画像群のタグ頻度
+        freq: Counter[str] = Counter()
+        for tags in matched:
+            freq.update(tags)
 
-        entries = self._build_entries(counter, top_n)
+        # ノード選定: 絞り込み中タグを除いた頻度上位
+        entries = [(t, c) for t, c in freq.items() if t not in selected_set]
+        entries.sort(key=lambda e: e[1], reverse=True)
+        top = entries[:max_nodes]
+        keep = {t for t, _ in top}
+
+        nodes = self._build_nodes(top)
+        node_index = {n.tag: i for i, n in enumerate(nodes)}
+        edges, adjacency = self._build_edges(matched, keep, node_index, len(nodes), max_edges_per_node)
+
         logger.debug(
-            f"TagCloud: keyword='{keyword_norm}' selected={selected} "
-            f"matched={matched}/{total} entries={len(entries)}"
+            f"TagGraph: keyword='{keyword_norm}' selected={selected} "
+            f"matched={len(matched)}/{total} nodes={len(nodes)} edges={len(edges)}"
         )
-        return CloudResult(entries=entries, matched_images=matched, total_images=total)
+        return GraphResult(
+            nodes=nodes,
+            edges=edges,
+            adjacency=adjacency,
+            matched_images=len(matched),
+            total_images=total,
+            tag_count=len(freq),
+            excluded_tags=selected,
+        )
 
     def refresh(self) -> None:
         """タグキャッシュを破棄し、次回 build 時に DB から再ロードする。"""
@@ -122,22 +162,76 @@ class TagCloudService:
             self._image_tags = self._load_tags()
         return self._image_tags
 
-    def _build_entries(self, counter: Counter[str], top_n: int) -> list[TagWeight]:
-        """頻度 Counter を sqrt 正規化したウェイト付きエントリへ変換する。"""
-        if not counter:
+    @staticmethod
+    def _filter_matched(
+        image_tags: dict[int, list[str]],
+        keyword_norm: str,
+        selected_set: set[str],
+    ) -> list[list[str]]:
+        """条件を満たす画像のタグリスト一覧を返す。"""
+        matched: list[list[str]] = []
+        for tags in image_tags.values():
+            if selected_set and not selected_set.issubset(tags):
+                continue
+            if not any(keyword_norm in tag for tag in tags):
+                continue
+            matched.append(tags)
+        return matched
+
+    @staticmethod
+    def _build_nodes(top: list[tuple[str, int]]) -> list[GraphNode]:
+        """頻度上位タグを min-max 正規化したノードへ変換する。"""
+        if not top:
             return []
-        top = counter.most_common(top_n)
         counts = [c for _, c in top]
-        # sqrt スケールで歪みを抑えた min-max 正規化
-        sqrt_counts = [math.sqrt(c) for c in counts]
-        s_min = min(sqrt_counts)
-        s_max = max(sqrt_counts)
-        span = s_max - s_min
-        entries: list[TagWeight] = []
-        for (tag, count), s in zip(top, sqrt_counts, strict=True):
-            weight = 1.0 if span == 0 else (s - s_min) / span
-            entries.append(TagWeight(tag=tag, count=count, weight=weight))
-        return entries
+        max_freq = max(counts)
+        min_freq = min(counts)
+        span = max_freq - min_freq
+        return [
+            GraphNode(tag=tag, count=count, weight=1.0 if span == 0 else (count - min_freq) / span)
+            for tag, count in top
+        ]
+
+    @staticmethod
+    def _build_edges(
+        matched: list[list[str]],
+        keep: set[str],
+        node_index: dict[str, int],
+        node_count: int,
+        max_edges_per_node: int,
+    ) -> tuple[list[GraphEdge], list[set[int]]]:
+        """採用ノード間の共起ペアを集計し、エッジと隣接情報を返す。"""
+        # ペア共起回数
+        pair: Counter[tuple[str, str]] = Counter()
+        for tags in matched:
+            present = sorted({t for t in tags if t in keep})
+            for i in range(len(present)):
+                for j in range(i + 1, len(present)):
+                    pair[(present[i], present[j])] += 1
+
+        # 共起の強い順に、ノードあたり上限まで採用
+        candidates = sorted(pair.items(), key=lambda kv: kv[1], reverse=True)
+        per_node: dict[int, int] = {}
+        kept: list[GraphEdge] = []
+        for (a_tag, b_tag), w in candidates:
+            if w < _MIN_EDGE_WEIGHT:
+                continue
+            a, b = node_index[a_tag], node_index[b_tag]
+            if per_node.get(a, 0) >= max_edges_per_node and per_node.get(b, 0) >= max_edges_per_node:
+                continue
+            per_node[a] = per_node.get(a, 0) + 1
+            per_node[b] = per_node.get(b, 0) + 1
+            kept.append(GraphEdge(a=a, b=b, weight=w, norm=0.0))
+
+        max_w = max((e.weight for e in kept), default=1)
+        for e in kept:
+            e.norm = e.weight / max_w
+
+        adjacency: list[set[int]] = [set() for _ in range(node_count)]
+        for e in kept:
+            adjacency[e.a].add(e.b)
+            adjacency[e.b].add(e.a)
+        return kept, adjacency
 
     def _load_tags(self) -> dict[int, list[str]]:
         """未 reject タグを全ロードして {image_id: [tag, ...]} を返す。"""

--- a/tests/unit/gui/widgets/test_tag_cloud_widget.py
+++ b/tests/unit/gui/widgets/test_tag_cloud_widget.py
@@ -1,56 +1,112 @@
-"""TagCloudWidget の GUI テスト。"""
+"""TagCloudWidget / NetworkGraphView の GUI テスト。"""
 
 from __future__ import annotations
 
 from unittest.mock import MagicMock
 
 import pytest
+from PySide6.QtGui import QColor
 from PySide6.QtWidgets import QLabel, QWidget
 
 from lorairo.gui.widgets.tag_cloud_widget import (
     FlowLayout,
+    NetworkGraphView,
     TagCloudWidget,
+    _ramp_color,
     _TagCloudLabel,
 )
-from lorairo.services.tag_cloud_service import CloudResult, TagWeight
+from lorairo.services.tag_cloud_service import GraphEdge, GraphNode, GraphResult
 
 
-def _make_widget(qtbot: pytest.FixtureRequest, result: CloudResult) -> TagCloudWidget:
-    """build_cloud をスタブした TagCloudWidget を生成（同期パス）。"""
+def _sample_graph() -> GraphResult:
+    return GraphResult(
+        nodes=[
+            GraphNode(tag="long_hair", count=10, weight=1.0),
+            GraphNode(tag="smile", count=5, weight=0.5),
+            GraphNode(tag="blush", count=2, weight=0.0),
+        ],
+        edges=[GraphEdge(a=0, b=1, weight=3, norm=1.0)],
+        adjacency=[{1}, {0}, set()],
+        matched_images=8,
+        total_images=20,
+        tag_count=5,
+        excluded_tags=[],
+    )
+
+
+def _empty_graph() -> GraphResult:
+    return GraphResult(nodes=[], edges=[], adjacency=[], matched_images=0, total_images=20, tag_count=0)
+
+
+def _make_widget(qtbot: pytest.FixtureRequest, result: GraphResult) -> TagCloudWidget:
+    """build_graph をスタブした TagCloudWidget を生成（同期パス）。"""
     widget = TagCloudWidget(db_manager=MagicMock())
     qtbot.addWidget(widget)
     widget._service = MagicMock()
-    widget._service.build_cloud = MagicMock(return_value=result)
-    widget._loaded_once = True  # ワーカーを介さず同期で recompute
+    widget._service.build_graph = MagicMock(return_value=result)
+    widget._loaded_once = True
     return widget
-
-
-def _sample_result() -> CloudResult:
-    return CloudResult(
-        entries=[
-            TagWeight(tag="long_hair", count=10, weight=1.0),
-            TagWeight(tag="smile", count=5, weight=0.5),
-            TagWeight(tag="blush", count=2, weight=0.0),
-        ],
-        matched_images=8,
-        total_images=20,
-    )
 
 
 @pytest.mark.unit
 @pytest.mark.gui
-class TestFlowLayout:
-    def test_add_count_take(self, qtbot: pytest.FixtureRequest) -> None:
+class TestHelpers:
+    def test_ramp_color_returns_qcolor(self) -> None:
+        assert isinstance(_ramp_color(0.0), QColor)
+
+    def test_ramp_low_and_high_differ(self) -> None:
+        assert _ramp_color(0.0).name() != _ramp_color(1.0).name()
+
+    def test_flowlayout_add_count_take(self, qtbot: pytest.FixtureRequest) -> None:
         container = QWidget()
         qtbot.addWidget(container)
         layout = FlowLayout(container)
         layout.addWidget(QLabel("a"))
         layout.addWidget(QLabel("b"))
         assert layout.count() == 2
-        item = layout.takeAt(0)
-        assert item is not None
+        assert layout.takeAt(0) is not None
         assert layout.count() == 1
         assert layout.takeAt(5) is None
+
+
+@pytest.mark.unit
+@pytest.mark.gui
+class TestNetworkGraphView:
+    def test_set_graph_populates_particles(self, qtbot: pytest.FixtureRequest) -> None:
+        view = NetworkGraphView()
+        qtbot.addWidget(view)
+        view.set_graph(_sample_graph())
+        assert len(view._particles) == 3
+
+    def test_empty_graph_has_no_particles(self, qtbot: pytest.FixtureRequest) -> None:
+        view = NetworkGraphView()
+        qtbot.addWidget(view)
+        view.set_graph(_empty_graph())
+        assert view._particles == []
+
+    def test_node_click_emits_tag(self, qtbot: pytest.FixtureRequest) -> None:
+        view = NetworkGraphView()
+        qtbot.addWidget(view)
+        view.resize(400, 400)
+        view.set_graph(_sample_graph())
+        # 1つ目の粒子を既知座標へ移動してクリック
+        view._particles[0].x = 100.0
+        view._particles[0].y = 100.0
+        view._particles[0].r = 20.0
+        with qtbot.waitSignal(view.node_clicked, timeout=1000) as blocker:
+            view._click_at(100.0, 100.0)
+        assert blocker.args == ["long_hair"]
+
+    def test_node_at_detects_node(self, qtbot: pytest.FixtureRequest) -> None:
+        view = NetworkGraphView()
+        qtbot.addWidget(view)
+        view.resize(400, 400)
+        view.set_graph(_sample_graph())
+        view._particles[1].x = 200.0
+        view._particles[1].y = 200.0
+        view._particles[1].r = 15.0
+        assert view._node_at(200.0, 200.0) == 1
+        assert view._node_at(5.0, 5.0) == -1
 
 
 @pytest.mark.unit
@@ -59,71 +115,83 @@ class TestTagCloudWidget:
     def test_initial_state_shows_placeholder(self, qtbot: pytest.FixtureRequest) -> None:
         widget = TagCloudWidget(db_manager=MagicMock())
         qtbot.addWidget(widget)
-        # キーワード未入力 → クラウドはプレースホルダーラベル1つのみ
-        assert widget._cloud_layout.count() == 1
+        assert widget._stack.currentIndex() == TagCloudWidget._PAGE_MESSAGE
         assert widget._status_label.text() == ""
         assert widget._selected_tags == []
 
-    def test_keyword_builds_cloud(self, qtbot: pytest.FixtureRequest) -> None:
-        widget = _make_widget(qtbot, _sample_result())
+    def test_keyword_builds_network(self, qtbot: pytest.FixtureRequest) -> None:
+        widget = _make_widget(qtbot, _sample_graph())
         widget._keyword = "hair"
         widget._recompute()
-        # 3 エントリ分の _TagCloudLabel が並ぶ
+        assert widget._stack.currentIndex() == TagCloudWidget._PAGE_NETWORK
+        assert len(widget._network_view._particles) == 3
+        assert "該当 8枚" in widget._status_label.text()
+        assert "3ノード" in widget._status_label.text()
+
+    def test_empty_result_shows_message(self, qtbot: pytest.FixtureRequest) -> None:
+        widget = _make_widget(qtbot, _empty_graph())
+        widget._keyword = "zzz"
+        widget._recompute()
+        assert widget._stack.currentIndex() == TagCloudWidget._PAGE_MESSAGE
+        assert "該当する画像がありません" in widget._message_label.text()
+
+    def test_empty_keyword_recompute_shows_placeholder(self, qtbot: pytest.FixtureRequest) -> None:
+        widget = _make_widget(qtbot, _sample_graph())
+        widget._keyword = "   "
+        widget._recompute()
+        assert widget._stack.currentIndex() == TagCloudWidget._PAGE_MESSAGE
+        widget._service.build_graph.assert_not_called()
+
+    def test_toggle_to_cloud_shows_cloud_page(self, qtbot: pytest.FixtureRequest) -> None:
+        widget = _make_widget(qtbot, _sample_graph())
+        widget._keyword = "hair"
+        widget._recompute()
+        widget._on_view_changed("cloud")
+        assert widget._stack.currentIndex() == TagCloudWidget._PAGE_CLOUD
         labels = [widget._cloud_layout.itemAt(i).widget() for i in range(widget._cloud_layout.count())]
         assert all(isinstance(label, _TagCloudLabel) for label in labels)
         assert len(labels) == 3
-        assert "該当 8枚" in widget._status_label.text()
 
-    def test_empty_keyword_recompute_shows_placeholder(self, qtbot: pytest.FixtureRequest) -> None:
-        widget = _make_widget(qtbot, _sample_result())
-        widget._keyword = "   "
-        widget._recompute()
-        assert widget._cloud_layout.count() == 1
-        widget._service.build_cloud.assert_not_called()
-
-    def test_tag_click_adds_drill_chip_and_recomputes(self, qtbot: pytest.FixtureRequest) -> None:
-        widget = _make_widget(qtbot, _sample_result())
+    def test_tag_click_adds_chip_and_recomputes(self, qtbot: pytest.FixtureRequest) -> None:
+        widget = _make_widget(qtbot, _sample_graph())
         widget._keyword = "hair"
         widget._recompute()
         widget._on_tag_clicked("smile")
         assert widget._selected_tags == ["smile"]
-        # チップが1つ生成される
-        assert widget._chip_layout.count() == 1
-        # build_cloud が selected_tags 付きで再呼び出し
-        widget._service.build_cloud.assert_called_with("hair", ["smile"])
+        widget._service.build_graph.assert_called_with("hair", ["smile"])
 
     def test_duplicate_tag_click_ignored(self, qtbot: pytest.FixtureRequest) -> None:
-        widget = _make_widget(qtbot, _sample_result())
+        widget = _make_widget(qtbot, _sample_graph())
         widget._keyword = "hair"
         widget._on_tag_clicked("smile")
         widget._on_tag_clicked("smile")
         assert widget._selected_tags == ["smile"]
 
     def test_chip_removed_recomputes(self, qtbot: pytest.FixtureRequest) -> None:
-        widget = _make_widget(qtbot, _sample_result())
+        widget = _make_widget(qtbot, _sample_graph())
         widget._keyword = "hair"
         widget._selected_tags = ["smile", "blush"]
         widget._on_chip_removed("smile")
         assert widget._selected_tags == ["blush"]
 
     def test_reset_clears_state(self, qtbot: pytest.FixtureRequest) -> None:
-        widget = _make_widget(qtbot, _sample_result())
+        widget = _make_widget(qtbot, _sample_graph())
         widget._keyword_edit.setText("hair")
         widget._selected_tags = ["smile"]
         widget._on_reset()
         assert widget._keyword == ""
         assert widget._selected_tags == []
         assert widget._keyword_edit.text() == ""
-        assert widget._cloud_layout.count() == 1  # placeholder
+        assert widget._stack.currentIndex() == TagCloudWidget._PAGE_MESSAGE
 
     def test_reload_refreshes_service(self, qtbot: pytest.FixtureRequest) -> None:
-        widget = _make_widget(qtbot, _sample_result())
+        widget = _make_widget(qtbot, _sample_graph())
         widget._keyword = "hair"
         widget._on_reload()
         widget._service.refresh.assert_called_once()
 
     def test_keyword_change_resets_drilldown(self, qtbot: pytest.FixtureRequest) -> None:
-        widget = _make_widget(qtbot, _sample_result())
+        widget = _make_widget(qtbot, _sample_graph())
         widget._selected_tags = ["smile"]
         widget._on_keyword_changed("eyes")
         assert widget._keyword == "eyes"

--- a/tests/unit/services/test_tag_cloud_service.py
+++ b/tests/unit/services/test_tag_cloud_service.py
@@ -1,4 +1,4 @@
-"""TagCloudService のユニットテスト。"""
+"""TagCloudService のユニットテスト（共起グラフモデル）。"""
 
 from __future__ import annotations
 
@@ -7,9 +7,8 @@ from unittest.mock import MagicMock
 import pytest
 
 from lorairo.services.tag_cloud_service import (
-    CloudResult,
+    GraphResult,
     TagCloudService,
-    TagWeight,
 )
 
 
@@ -22,16 +21,17 @@ def _make_service(image_tags: dict[int, list[str]]) -> TagCloudService:
 
 
 @pytest.mark.unit
-class TestBuildCloud:
-    def test_empty_keyword_returns_empty_cloud(self) -> None:
+class TestBuildGraph:
+    def test_empty_keyword_returns_empty_graph(self) -> None:
         svc = _make_service({1: ["a", "b"], 2: ["c"]})
-        result = svc.build_cloud("", [])
-        assert isinstance(result, CloudResult)
-        assert result.entries == []
+        result = svc.build_graph("", [])
+        assert isinstance(result, GraphResult)
+        assert result.nodes == []
+        assert result.edges == []
         assert result.matched_images == 0
         assert result.total_images == 2
 
-    def test_substring_match_aggregates_cooccurring_tags(self) -> None:
+    def test_substring_match_builds_nodes(self) -> None:
         image_tags = {
             1: ["long_hair", "blonde_hair", "smile"],
             2: ["long_hair", "blue_eyes"],
@@ -39,15 +39,11 @@ class TestBuildCloud:
             4: ["tree", "outdoor"],  # hair を含まない → 除外
         }
         svc = _make_service(image_tags)
-        result = svc.build_cloud("hair", [])
-        tags = {e.tag for e in result.entries}
-        # hair を含む画像 (1,2,3) の全タグが対象
+        result = svc.build_graph("hair", [])
+        tags = {n.tag for n in result.nodes}
         assert "smile" in tags
         assert "blue_eyes" in tags
-        assert "long_hair" in tags
-        # hair を含まない画像のタグは出ない
         assert "tree" not in tags
-        assert "outdoor" not in tags
         assert result.matched_images == 3
 
     def test_drilldown_and_filter_narrows_results(self) -> None:
@@ -57,78 +53,102 @@ class TestBuildCloud:
             3: ["short_hair", "smile"],
         }
         svc = _make_service(image_tags)
-        # keyword=hair + selected=smile → 画像1,3 のみ (long/short_hair 両方含む)
-        result = svc.build_cloud("hair", ["smile"])
+        result = svc.build_graph("hair", ["smile"])
         assert result.matched_images == 2
-        tags = {e.tag for e in result.entries}
-        assert "serious" not in tags  # 画像2は smile を持たないので除外
+        tags = {n.tag for n in result.nodes}
+        assert "serious" not in tags
         assert "long_hair" in tags
         assert "short_hair" in tags
 
-    def test_selected_tags_excluded_from_cloud(self) -> None:
+    def test_selected_tags_excluded_from_nodes(self) -> None:
         image_tags = {1: ["long_hair", "smile"], 2: ["long_hair", "smile", "blush"]}
         svc = _make_service(image_tags)
-        result = svc.build_cloud("hair", ["smile"])
-        tags = {e.tag for e in result.entries}
-        # 絞り込みに使った smile はクラウドに出さない
+        result = svc.build_graph("hair", ["smile"])
+        tags = {n.tag for n in result.nodes}
         assert "smile" not in tags
         assert "long_hair" in tags
-        assert "blush" in tags
+        assert result.excluded_tags == ["smile"]
 
-    def test_top_n_limits_entries(self) -> None:
-        image_tags = {1: ["kw_tag"] + [f"tag_{i}" for i in range(100)]}
+    def test_max_nodes_limits_nodes(self) -> None:
+        image_tags = {1: ["kw_tag", *[f"tag_{i}" for i in range(100)]]}
         svc = _make_service(image_tags)
-        result = svc.build_cloud("kw", [], top_n=10)
-        assert len(result.entries) <= 10
+        result = svc.build_graph("kw", [], max_nodes=10)
+        assert len(result.nodes) <= 10
 
-    def test_no_match_returns_empty_entries(self) -> None:
+    def test_no_match_returns_empty_nodes(self) -> None:
         svc = _make_service({1: ["cat"], 2: ["dog"]})
-        result = svc.build_cloud("xyz", [])
-        assert result.entries == []
+        result = svc.build_graph("xyz", [])
+        assert result.nodes == []
         assert result.matched_images == 0
         assert result.total_images == 2
 
-    def test_weights_normalized_in_range(self) -> None:
+    def test_node_weights_normalized_in_range(self) -> None:
         image_tags = {
             1: ["kw", "common", "rare"],
             2: ["kw", "common"],
             3: ["kw", "common"],
         }
         svc = _make_service(image_tags)
-        result = svc.build_cloud("kw", [])
-        assert all(isinstance(e, TagWeight) for e in result.entries)
-        for e in result.entries:
-            assert 0.0 <= e.weight <= 1.0
-        # 最頻タグの weight が最大 (1.0)
-        top = max(result.entries, key=lambda e: e.count)
+        result = svc.build_graph("kw", [])
+        for n in result.nodes:
+            assert 0.0 <= n.weight <= 1.0
+        top = max(result.nodes, key=lambda n: n.count)
         assert top.weight == pytest.approx(1.0)
 
-    def test_entries_sorted_by_count_desc(self) -> None:
+    def test_edges_built_from_cooccurrence(self) -> None:
         image_tags = {
-            1: ["kw", "common", "mid"],
-            2: ["kw", "common", "mid"],
-            3: ["kw", "common"],
+            1: ["kw_a", "long_hair", "smile"],
+            2: ["kw_a", "long_hair", "smile"],
+            3: ["kw_a", "long_hair", "smile"],
         }
         svc = _make_service(image_tags)
-        result = svc.build_cloud("kw", [])
-        counts = [e.count for e in result.entries]
-        assert counts == sorted(counts, reverse=True)
+        result = svc.build_graph("kw", [])
+        assert len(result.edges) > 0
+        for e in result.edges:
+            assert 0 <= e.a < len(result.nodes)
+            assert 0 <= e.b < len(result.nodes)
+            assert 0.0 <= e.norm <= 1.0
+
+    def test_edge_below_min_weight_excluded(self) -> None:
+        # 各ペアの共起が1回のみ → エッジ採用されない（min=2）
+        image_tags = {
+            1: ["kw_a", "x1", "y1"],
+            2: ["kw_b", "x2", "y2"],
+        }
+        svc = _make_service(image_tags)
+        result = svc.build_graph("kw", [])
+        assert result.edges == []
+
+    def test_adjacency_is_symmetric(self) -> None:
+        image_tags = {
+            1: ["kw_a", "p", "q"],
+            2: ["kw_a", "p", "q"],
+        }
+        svc = _make_service(image_tags)
+        result = svc.build_graph("kw", [])
+        assert len(result.adjacency) == len(result.nodes)
+        for e in result.edges:
+            assert e.b in result.adjacency[e.a]
+            assert e.a in result.adjacency[e.b]
+
+    def test_tag_count_reflects_unique_tags(self) -> None:
+        image_tags = {1: ["kw", "a", "b"], 2: ["kw", "b", "c"]}
+        svc = _make_service(image_tags)
+        result = svc.build_graph("kw", [])
+        assert result.tag_count == 4
 
     def test_case_insensitive_match(self) -> None:
-        # _load_tags は小文字化済みを返す前提
         svc = _make_service({1: ["long_hair", "smile"]})
-        result = svc.build_cloud("HAIR", [])
+        result = svc.build_graph("HAIR", [])
         assert result.matched_images == 1
 
     def test_refresh_reloads_tags(self) -> None:
         svc = _make_service({1: ["kw_a"]})
-        first = svc.build_cloud("kw", [])
+        first = svc.build_graph("kw", [])
         assert first.total_images == 1
-        # DB が更新されたと仮定して別データを返すようにする
         svc._load_tags = MagicMock(return_value={1: ["kw_a"], 2: ["kw_b"]})  # type: ignore[method-assign]
-        # refresh 前はキャッシュのまま
-        cached = svc.build_cloud("kw", [])
+        cached = svc.build_graph("kw", [])
         assert cached.total_images == 1
         svc.refresh()
-        after = svc.build_cloud("kw", [])
+        after = svc.build_graph("kw", [])
         assert after.total_images == 2


### PR DESCRIPTION
## 概要

「テキストだけじゃ分かりづらい、図にタグの繋がりが出ると分かりやすい」という要望を受け、Map タブに **共起タグの力学配置ネットワーク図** を追加する。

Claude Design (claude.ai/design) で作成された `Map Tab.html` を、README の指示どおり PySide6 + QPainter で**視覚を合わせて再現**した（プロトタイプの内部構造ではなく見た目を移植）。タグ同士の共起関係をノード・リンク図で示し、既存のテキストタグクラウドとはトグルで切り替えられる。

## 実装内容

**サービス (`TagCloudService`)**
- `build_cloud` を `build_graph()` に置き換え、共起グラフモデル (`GraphResult`) を返す
- ノード = 該当画像群の頻度上位34タグ（絞り込み中タグを除く）、`weight` は min-max 正規化
- エッジ = 採用ノード間の共起（共起回数 >= 2）、ノードあたり5本まで共起の強い順に採用、`norm` で線の太さを表現
- `adjacency`（隣接集合）でホバー時の近傍強調をサポート
- クラウド/ネットワーク双方が**同一モデルを共有**（モックと同じ設計）

**ネットワーク図 (`NetworkGraphView`, QPainter)**
- force-directed レイアウト（斥力 + バネ + 中心重力、alpha 減衰で収束したらタイマー停止）
- ノードサイズ = 出現頻度、色 = 頻度ランプ（暖色グレー→アクセント）、線の太さ = 共起の強さ
- ホバー: 近傍ノード/エッジを強調し他を減光 + ダークツールチップ（出現枚数・共起タグ数）
- クリック: AND 絞り込みに追加（ドリルダウン）
- 凡例（出現頻度ランプ・線=共起の強さ）とヒントピルを canvas にオーバーレイ描画

**ルートウィジェット (`TagCloudWidget`)**
- 「ネットワーク / クラウド」表示トグルを追加（`QStackedWidget` でメッセージ/ネットワーク/クラウドの3ページ）
- ステータス行に「表示 N ノード / M 共起」「絞り込み中/全件」を追加
- 該当0件時の専用メッセージページ
- 配色は LoRAIro テーマ（`#fbfaf6` ペーパー + `#c25e3f` テラコッタアクセント）に整合

## テスト

- `test_tag_cloud_service.py`（13件）: 部分一致 / AND ドリルダウン / ノード選定・除外 / max_nodes / 共起エッジ生成・最小重み除外 / 隣接対称性 / weight 正規化 / tag_count / refresh
- `test_tag_cloud_widget.py`（18件）: ramp 色 / FlowLayout / NetworkGraphView（set_graph・node_at・node_clicked・空グラフ）/ プレースホルダー / ネットワーク生成 / 該当0件メッセージ / トグル / ドリルダウン / リセット / 再読込

新規/更新テスト 31件すべて pass。新規ファイルの mypy / ruff クリーン。

> 注: 本 worktree 環境は `libcudnn.so.9` 欠落で torch 依存テスト（model_sync / annotator_adapter / image_processor 系）が collection 汚染で fail するが、これは PR #764 と同じ環境固有のベースライン（本変更とは無関係）。CI が SSoT。

🤖 Generated with [Claude Code](https://claude.com/claude-code)