### PR TITLE
feat(cli): errors get コマンドで単一エラーレコード詳細を取得

### DIFF
--- a/src/lorairo/api/exceptions.py
+++ b/src/lorairo/api/exceptions.py
@@ -224,6 +224,25 @@ class TagRegistrationError(TagError):
         super().__init__(f"タグ '{tag_name}' の登録に失敗しました: {reason}")
 
 
+# エラーレコード関連例外
+class ErrorRecordError(LoRAIroException):
+    """エラーレコード操作エラーの基底クラス。"""
+
+    pass
+
+
+class ErrorRecordNotFoundError(ErrorRecordError):
+    """指定されたエラーレコードが見つからない場合に発生。
+
+    Args:
+        error_id: 見つからないエラーレコードID。
+    """
+
+    def __init__(self, error_id: int) -> None:
+        self.error_id = error_id
+        super().__init__(f"エラーレコード ID={error_id} が見つかりません")
+
+
 # データベース関連例外
 class DatabaseError(LoRAIroException):
     """データベース操作エラーの基底クラス。"""

--- a/src/lorairo/cli/_errors.py
+++ b/src/lorairo/cli/_errors.py
@@ -185,7 +185,13 @@ def _classify_lorairo_exception(exc: BaseException) -> ErrorInfo | None:
     from lorairo.api import exceptions as app_exc
 
     if isinstance(
-        exc, (app_exc.ProjectNotFoundError, app_exc.ImageNotFoundError, app_exc.TagNotFoundError)
+        exc,
+        (
+            app_exc.ProjectNotFoundError,
+            app_exc.ImageNotFoundError,
+            app_exc.TagNotFoundError,
+            app_exc.ErrorRecordNotFoundError,
+        ),
     ):
         return ErrorInfo(ErrorCode.NOT_FOUND, retryable=False, user_action_required=True)
     if isinstance(exc, (app_exc.ProjectAlreadyExistsError, app_exc.DuplicateImageError)):

--- a/src/lorairo/cli/commands/errors.py
+++ b/src/lorairo/cli/commands/errors.py
@@ -12,6 +12,7 @@ import click
 import typer
 from rich.table import Table
 
+from lorairo.api.exceptions import ErrorRecordNotFoundError
 from lorairo.api.project import get_project as api_get_project
 from lorairo.cli._boundary import command_boundary
 from lorairo.cli._console import make_console
@@ -123,6 +124,56 @@ def list_errors(
             )
         console.print(table)
         console.print(f"[dim]{len(records)} record(s) shown[/dim]")
+
+
+@app.command("get")
+def get_error(
+    error_id: int = typer.Argument(..., help="Error record ID to retrieve"),
+    project: str = typer.Option(..., "--project", "-p", help="Project name"),
+) -> None:
+    """Get a single error record by ID (full detail).
+
+    `list` は error_message を切り詰め stack_trace / file_path / image_id を省くため、
+    1 件の全容を確認するには本コマンドを使う。
+
+    Example:
+        lorairo-cli errors get 42 --project proj
+    """
+    with command_boundary():
+        api_get_project(project)
+
+        container = get_service_container()
+        container.set_active_project(project)
+        repo = container.db_manager.error_record_repo
+
+        record = repo.get_error_record(error_id)
+        if record is None:
+            raise ErrorRecordNotFoundError(error_id)
+
+        fields = {
+            "id": record.id,
+            "image_id": record.image_id,
+            "operation_type": record.operation_type,
+            "error_type": record.error_type,
+            "error_message": record.error_message,
+            "stack_trace": record.stack_trace,
+            "file_path": record.file_path,
+            "model_name": record.model_name,
+            "resolved_at": record.resolved_at.isoformat() if record.resolved_at else None,
+            "created_at": record.created_at.isoformat() if record.created_at else None,
+        }
+
+        if is_json_mode():
+            emit_item(fields)
+            emit_result("1 error record", count=1)
+            return
+
+        table = Table(title=f"Error Record #{record.id} ({project})", show_header=False)
+        table.add_column("Field", style="cyan", no_wrap=True)
+        table.add_column("Value", style="white")
+        for key, value in fields.items():
+            table.add_row(key, "" if value is None else str(value))
+        console.print(table)
 
 
 @app.command("resolve")

--- a/src/lorairo/database/repository/error_record.py
+++ b/src/lorairo/database/repository/error_record.py
@@ -213,6 +213,33 @@ class ErrorRecordRepository(BaseRepository):
                 logger.error(f"エラーレコードの取得中にエラーが発生しました: {e}", exc_info=True)
                 raise
 
+    def get_error_record(self, error_id: int) -> ErrorRecord | None:
+        """ID 指定で単一のエラーレコードを取得する。
+
+        Args:
+            error_id: エラーレコードID。
+
+        Returns:
+            ErrorRecord | None: 該当レコード。存在しなければ None。
+
+        Raises:
+            SQLAlchemyError: データベース操作でエラーが発生した場合。
+        """
+        with self.session_factory() as session:
+            try:
+                record = session.get(ErrorRecord, error_id)
+                if record is None:
+                    logger.debug(f"エラーレコードが見つかりません: ID={error_id}")
+                    return None
+                # session クローズ後も全属性へアクセスできるよう detach 前に展開しておく
+                session.expunge(record)
+                return record
+            except SQLAlchemyError as e:
+                logger.error(
+                    f"エラーレコードの取得中にエラーが発生しました (ID={error_id}): {e}", exc_info=True
+                )
+                raise
+
     def mark_error_resolved(self, error_id: int) -> None:
         """エラーを解決済みにマークする (resolved_at = 現在時刻)。
 

--- a/tests/unit/cli/test_commands_errors.py
+++ b/tests/unit/cli/test_commands_errors.py
@@ -24,6 +24,9 @@ def _make_error_record(
     model_name: str | None = None,
     resolved_at: datetime | None = None,
     created_at: datetime = _NOW,
+    image_id: int | None = None,
+    stack_trace: str | None = None,
+    file_path: str | None = None,
 ) -> MagicMock:
     r = MagicMock()
     r.id = id
@@ -33,6 +36,9 @@ def _make_error_record(
     r.model_name = model_name
     r.resolved_at = resolved_at
     r.created_at = created_at
+    r.image_id = image_id
+    r.stack_trace = stack_trace
+    r.file_path = file_path
     return r
 
 
@@ -115,6 +121,80 @@ class TestErrorsList:
         runner.invoke(app, ["--json", "errors", "list", "--project", "proj", "--all"])
         kwargs = mock_project_and_container.db_manager.error_record_repo.get_error_records.call_args.kwargs
         assert kwargs.get("resolved") is None
+
+
+@pytest.mark.unit
+class TestErrorsGet:
+    @pytest.fixture
+    def mock_get(self, monkeypatch):
+        record = _make_error_record(
+            id=7,
+            op="annotation",
+            et="APIError",
+            msg="long error message " * 20,
+            model_name="gpt-4",
+            image_id=42,
+            stack_trace="Traceback (most recent call last):\n  ...",
+            file_path="/path/to/file.jpg",
+        )
+        container = MagicMock()
+        container.db_manager.error_record_repo.get_error_record.return_value = record
+        monkeypatch.setattr(
+            "lorairo.cli.commands.errors.api_get_project", MagicMock(return_value=MagicMock())
+        )
+        monkeypatch.setattr(
+            "lorairo.cli.commands.errors.get_service_container", MagicMock(return_value=container)
+        )
+        return container, record
+
+    def test_get_calls_repo_with_id(self, mock_get):
+        container, _ = mock_get
+        result = runner.invoke(app, ["--json", "errors", "get", "7", "--project", "proj"])
+        assert result.exit_code == 0, result.output
+        container.db_manager.error_record_repo.get_error_record.assert_called_once_with(7)
+
+    def test_get_json_emits_full_fields(self, mock_get):
+        _, record = mock_get
+        result = runner.invoke(app, ["--json", "errors", "get", "7", "--project", "proj"])
+        assert result.exit_code == 0, result.output
+        lines = [json.loads(line) for line in result.stdout.strip().splitlines() if line.strip()]
+        item = next(r for r in lines if r.get("kind") == "item")
+        for field in (
+            "id",
+            "image_id",
+            "operation_type",
+            "error_type",
+            "error_message",
+            "stack_trace",
+            "file_path",
+            "model_name",
+            "resolved_at",
+            "created_at",
+        ):
+            assert field in item, f"Missing field: {field}"
+        # error_message は truncate されず全文が出る
+        assert item["error_message"] == record.error_message
+        assert item["stack_trace"] == record.stack_trace
+
+    def test_get_not_found_returns_error_exit(self, monkeypatch):
+        container = MagicMock()
+        container.db_manager.error_record_repo.get_error_record.return_value = None
+        monkeypatch.setattr(
+            "lorairo.cli.commands.errors.api_get_project", MagicMock(return_value=MagicMock())
+        )
+        monkeypatch.setattr(
+            "lorairo.cli.commands.errors.get_service_container", MagicMock(return_value=container)
+        )
+        result = runner.invoke(app, ["--json", "errors", "get", "999", "--project", "proj"])
+        assert result.exit_code != 0
+        lines = [json.loads(line) for line in result.stdout.strip().splitlines() if line.strip()]
+        error_row = next(r for r in lines if r.get("kind") == "error")
+        assert error_row["code"] == "NOT_FOUND"
+
+    def test_get_rich_output(self, mock_get):
+        result = runner.invoke(app, ["errors", "get", "7", "--project", "proj"])
+        assert result.exit_code == 0, result.output
+        assert "7" in result.stdout
 
 
 @pytest.mark.unit

--- a/tests/unit/database/repository/test_error_record_repository.py
+++ b/tests/unit/database/repository/test_error_record_repository.py
@@ -249,6 +249,39 @@ class TestGetErrorRecords:
 
 
 @pytest.mark.unit
+class TestGetErrorRecord:
+    """`get_error_record` の単件取得動作。"""
+
+    def test_returns_record_by_id(self, error_record_repository: ErrorRecordRepository) -> None:
+        """ID 指定で該当する 1 件を返す。"""
+        eid = error_record_repository.save_error_record(
+            operation_type="annotation",
+            error_type="APIError",
+            error_message="timeout",
+            image_id=42,
+            stack_trace="trace lines",
+            file_path="/path/to/file.jpg",
+            model_name="gpt-4",
+        )
+
+        record = error_record_repository.get_error_record(eid)
+
+        assert record is not None
+        assert record.id == eid
+        assert record.operation_type == "annotation"
+        assert record.error_type == "APIError"
+        assert record.error_message == "timeout"
+        assert record.image_id == 42
+        assert record.stack_trace == "trace lines"
+        assert record.file_path == "/path/to/file.jpg"
+        assert record.model_name == "gpt-4"
+
+    def test_returns_none_for_unknown_id(self, error_record_repository: ErrorRecordRepository) -> None:
+        """存在しない ID では None を返す (正常系)。"""
+        assert error_record_repository.get_error_record(99999) is None
+
+
+@pytest.mark.unit
 class TestMarkErrorResolved:
     """`mark_error_resolved` の単件解決動作。"""
 


### PR DESCRIPTION
## 概要

`lorairo-cli errors get <ID> --project <name>` を追加。ID 指定で 1 件のエラーレコードを**全フィールド**で取得する。

既存の `errors list` は `error_message` を 80 文字に切り詰め、`stack_trace` / `file_path` / `image_id` を出さないため、1 件の全容をデバッグするには不十分だった。本コマンドはその詳細確認用。

## 変更内容

- **Repository**: `ErrorRecordRepository.get_error_record(error_id) -> ErrorRecord | None` を追加。`session.get` で 1 件取得し、未存在は `None`。`SQLAlchemyError` は既存メソッド同様に伝播。
- **Exception**: `ErrorRecordNotFoundError` を追加し、`classify_exception` の NOT_FOUND タプルへ登録。未存在 ID は `NOT_FOUND` の exit code / 構造化エラーで返る(既存の not-found 流儀と一致)。
- **Command**: `errors get` を追加。
  - JSON モード: `emit_item` で全フィールド(`id, image_id, operation_type, error_type, error_message`(全文)`, stack_trace, file_path, model_name, resolved_at, created_at`)→ `emit_result(count=1)`
  - rich モード: key-value テーブル(`stack_trace` も truncate せず全文)

## テスト

- Repository unit: 取得成功 / 未存在 None
- CLI(CliRunner): ID で repo 呼び出し / JSON 全フィールド / 未存在→`NOT_FOUND` exit / rich 出力
- 隣接領域(`tests/unit/cli`, `tests/unit/database/repository`, error_records)577 passed
- 注: 全体 CI-equivalent 実行で model_sync/thumbnail 系 37 件が落ちるが、これは当環境の torch/libcudnn 欠落由来の既存失敗(clean main checkout でも再現)で本変更とは無関係。submodule 変更なし。

🤖 Generated with [Claude Code](https://claude.com/claude-code)