### PR TITLE
feat(db): SQLite busy_timeout 設定とロック競合の併用性改善 (#767)

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -22,6 +22,27 @@ lorairo-cli version
 lorairo-cli status
 ```
 
+## GUI との同時利用 (DB ロックの制約)
+
+LoRAIro の画像 DB は SQLite です。SQLite は同時読み取りは可能ですが、**同時書き込みは
+1 プロセスのみ**に制限されます (ADR 0067)。GUI を開いたまま CLI を併用する場合、次の点に
+注意してください。
+
+- **検索・一覧 (read) は併用しやすい**: WAL モードのため、GUI の書き込み中でも CLI の
+  読み取りはブロックされにくいです。
+- **書き込みの同時実行は避ける**: GUI と CLI が同時に同じプロジェクト DB へ書き込む
+  (アノテーション保存・画像登録・タグ編集など) と一時的に競合します。`PRAGMA busy_timeout`
+  (既定 30 秒、`config/lorairo.toml` の `[database] busy_timeout_ms`) により短時間の競合は
+  自動で待機・再試行されますが、長時間の書き込みを両側で同時に走らせるのは推奨しません。
+- **ロック競合時の表示**: 待機時間を超えてロックが解放されない場合、CLI は `CONFLICT`
+  エラー (`retryable=true`) と「他プロセスの書き込み完了を待って再試行」のヒントを返します。
+  GUI も同様の日本語メッセージを表示します。いずれも入力を変えずに再試行すれば成功し得ます。
+- **CLI で書き換えた後の GUI 表示**: CLI が DB を更新しても、GUI のメモリ上の検索結果・
+  件数表示は自動更新されません。CLI 併用後は GUI 側で **再検索 / 再読み込み**してください。
+
+大量アノテーションを GUI と CLI で同時実行するようなワークロードは現状の想定外です。本格的な
+複数 writer 対応が必要になった場合は PostgreSQL 等への移行を別途検討します。
+
 ## Machine-Readable Introspection
 
 ADR 0059 に従い、introspection は既存 JSONL kind の `item` / `result` / `error`

--- a/docs/decisions/0067-sqlite-concurrency-busy-timeout.md
+++ b/docs/decisions/0067-sqlite-concurrency-busy-timeout.md
@@ -1,7 +1,7 @@
 # ADR 0067: SQLite Concurrency: busy_timeout + Lock Error Classification
 
 - **日付**: 2026-06-15
-- **ステータス**: Proposed
+- **ステータス**: Accepted (2026-06-15)
 - **関連 Issue**: [NEXTAltair/LoRAIro#767](https://github.com/NEXTAltair/LoRAIro/issues/767)
 - **関連 ADR**: [ADR 0042](0042-batch-annotation-db-save-io.md) (Batch Annotation DB Save I/O),
   [ADR 0057](0057-cli-jsonl-output-and-error-contract.md) (CLI Error Contract)

--- a/docs/decisions/0067-sqlite-concurrency-busy-timeout.md
+++ b/docs/decisions/0067-sqlite-concurrency-busy-timeout.md
@@ -1,0 +1,92 @@
+# ADR 0067: SQLite Concurrency: busy_timeout + Lock Error Classification
+
+- **日付**: 2026-06-15
+- **ステータス**: Proposed
+- **関連 Issue**: [NEXTAltair/LoRAIro#767](https://github.com/NEXTAltair/LoRAIro/issues/767)
+- **関連 ADR**: [ADR 0042](0042-batch-annotation-db-save-io.md) (Batch Annotation DB Save I/O),
+  [ADR 0057](0057-cli-jsonl-output-and-error-contract.md) (CLI Error Contract)
+
+## Context
+
+LoRAIro の画像 DB は SQLite。`db_core.create_db_engine()` は接続時に
+`journal_mode=WAL` と `synchronous=NORMAL` を設定済みで、読み取りと書き込みの
+並行性はある程度確保されている。しかし SQLite は **同時書き込みを 1 プロセスに
+限定**する。
+
+GUI を開いたまま CLI を併用する運用 (検索・一覧・アノテーション保存・画像登録) では、
+両者が同じプロジェクト DB に書き込もうとすると `database is locked` が発生する。
+従来コードには `busy_timeout` の設定がなく、短時間の競合でも即時失敗していた。
+
+目標は「完全な複数 writer 対応」ではなく、SQLite/WAL 前提で実用上の併用性を上げる
+第一段階を整えること。
+
+## Decision
+
+### 1. busy_timeout を設定する
+
+`create_db_engine()` の SQLite connect リスナーで `PRAGMA busy_timeout` を設定する。
+値は `config/lorairo.toml` の `[database] busy_timeout_ms` で調整可能 (既定 30000ms)。
+DEFAULT_CONFIG にも同名キーを追加し、`db_core.BUSY_TIMEOUT_MS` を SSoT とする。
+
+短時間の書き込み競合では即時失敗せず、この時間まで SQLite 側でリトライ待機する。
+
+### 2. ロック競合エラーを分類・表示する
+
+`database is locked` / `database is busy` を示す `OperationalError` を、汎用 DB エラーとは
+区別して扱う。判定ロジックは `lorairo.database.db_errors.is_sqlite_lock_error()` に集約し
+(cause-chain を辿り型名 + メッセージで判定、重依存を import しない)、以下で共有する。
+
+- **CLI**: `_errors.classify_exception()` で SQLite ロックを再試行可能な `CONFLICT`
+  (`retryable=True`) に分類し、対処ヒントを表示する。汎用 SQLAlchemy エラーより先に
+  評価する (ロックも `OperationalError` のため)。`CONFLICT` は ADR 0057 の安定 wire
+  コード集合 (15 種) 内なので新コードは増やさない。
+- **GUI**: `LoRAIroWorkerBase` のエラー整形で、ロック時は「他プロセス (CLI 等) が
+  書き込み中。完了を待って再読み込み/再実行」という分かりやすい日本語に置換する。
+
+### 3. 長トランザクション保持フローは現状維持 (短トランザクション原則を確認)
+
+主要な書き込みフローを調査した結果、重い処理 (画像 I/O・WebAPI・モデル実行) の最中に
+DB トランザクションを保持し続ける箇所は見つからなかった。
+
+- リポジトリ層は `with self.session_factory() as session:` の短命セッションで CRUD を
+  完結させる (BaseRepository / AnnotationRepository ほか)。
+- CLI `annotate run` は chunk 単位で「画像ロード → アノテーション (セッション無し) →
+  短い保存トランザクション」に分離済み (ADR 0042 / 0053)。
+- GUI アノテーション保存・画像登録ワーカーも Manager 経由の短命セッションを使う。
+
+よって本 ADR では既存フローを変更しない。将来 per-image commit の集約が必要になった
+場合は ADR 0042 の batch save API を踏襲する。
+
+### 4. GUI の外部更新検知は手動リロードに留める (非目標を明確化)
+
+CLI が DB を書き換えても GUI のメモリ上の検索結果・件数表示は自動更新されない。
+本段階では **手動の再検索/再読み込み**で対応する方針とし、DB ファイル更新時刻の監視や
+更新イベントのポーリングは将来課題 (後続 Issue) とする。
+
+### 非目標
+
+- SQLite で完全な複数同時 writer を保証すること
+- 大量アノテーション保存を GUI と CLI で同時実行しても衝突しないこと
+- PostgreSQL 等への移行
+
+## Rationale
+
+WAL + busy_timeout + 短トランザクションは SQLite 併用性を上げる現実的な第一段階。
+busy_timeout は 1 行の PRAGMA で大半の短時間競合を吸収でき、アプリ側のリトライループ
+より単純。ロック競合を `CONFLICT` (retryable) に分類することで、エージェント/人間とも
+「待って再試行すればよい一時的競合」と「恒久的な DB エラー」を区別できる。
+
+別案として「アプリ層で `OperationalError` を捕捉して指数バックオフ再試行」も検討したが、
+busy_timeout が SQLite ネイティブに同等を提供するため YAGNI として見送った。複数 writer の
+本格対応 (PostgreSQL 移行) は需要が出た時点で別途検討する。
+
+## Consequences
+
+- 既定 30 秒まで書き込み競合を待機するため、GUI/CLI 併用時の `database is locked` 即時
+  失敗が大幅に減る。
+- 競合が 30 秒を超えた場合はロックとして分類され、ユーザーに再試行を促すメッセージが出る
+  (CLI は `CONFLICT` + ヒント、GUI は専用文言)。
+- busy_timeout は「待つ」挙動なので、デッドロック級の長時間ロック時は応答が最大 30 秒
+  ブロックし得る。値は設定で短縮可能。
+- GUI の外部更新自動反映は未対応。CLI 併用後は手動で再検索/再読み込みが必要 (ドキュメント
+  に明記)。

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -70,7 +70,7 @@ LoRAIro の重要な設計判断を記録するドキュメント群。
 | [0064](0064-cli-original-image-annotation-guard.md) | CLI Original Image Annotation Guard | 2026-06-07 | Accepted |
 | [0065](0065-tag-caption-soft-reject.md) | Tag/Caption Soft-Reject And Export Resolution | 2026-06-11 | Accepted |
 | [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
-| [0067](0067-sqlite-concurrency-busy-timeout.md) | SQLite Concurrency: busy_timeout + Lock Error Classification | 2026-06-15 | Proposed |
+| [0067](0067-sqlite-concurrency-busy-timeout.md) | SQLite Concurrency: busy_timeout + Lock Error Classification | 2026-06-15 | Accepted |
 
 ## ADR テンプレート
 

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -1,188 +1,98 @@
 # Architecture Decision Records
-| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 
-| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 LoRAIro の重要な設計判断を記録するドキュメント群。
-| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 
-| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 | ADR | タイトル | 日付 | ステータス |
-| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 |-----|---------|------|-----------|
-| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 | [0001](0001-two-tier-service-architecture.md) | Two-Tier Service Architecture | 2025-08-16 | Accepted |
-| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 | [0002](0002-database-schema-decisions.md) | Database Schema Decisions | 2025-10-01 | Accepted |
-| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 | [0003](0003-annotator-config-management.md) | Annotator Config Management | 2025-11-15 | Superseded by 0021 (partial) |
-| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 | [0004](0004-annotator-lib-architecture.md) | Annotator-Lib Architecture | 2025-11-15 | Accepted |
-| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 | [0005](0005-annotation-layer-reorganization.md) | Annotation Layer Reorganization | 2025-11-15 | Accepted |
-| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 | [0006](0006-pagination-approach.md) | Pagination Approach | 2026-02-05 | Accepted |
-| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 | [0007](0007-batch-tag-annotation-ux.md) | Batch Tag Annotation UX | 2026-02-09 | Accepted |
-| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 | [0008](0008-claude-md-resilience-architecture.md) | CLAUDE.md Resilience Architecture | 2026-01-01 | Accepted |
-| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 | [0009](0009-qt-decoupling-design.md) | Qt Decoupling Design | 2026-02-16 | Accepted |
-| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 | [0010](0010-torch-import-design.md) | Torch Import Design | 2025-10-28 | Accepted |
-| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 | [0011](0011-mainwindow-ui-redesign.md) | MainWindow UI Redesign | 2026-01-04 | Accepted |
-| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 | [0012](0012-batch-tag-atomic-transaction.md) | Batch Tag Atomic Transaction Fix | 2026-01-06 | Accepted |
-| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 | [0013](0013-legacy-tag-db-cleanup.md) | Legacy Tag DB Cleanup | 2026-01-02 | Accepted |
-| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 | [0014](0014-agent-teams-integration.md) | Agent Teams Integration | 2026-04-09 | Accepted |
-| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 | [0015](0015-manual-rating-storage-unification.md) | Manual Rating Storage Unification | 2026-04-18 | Accepted |
-| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 | [0016](0016-coverage-threshold-policy.md) | Coverage Threshold Policy | 2026-04-20 | Accepted (amended) |
-| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 | [0017](0017-project-db-normalization.md) | Project DB Normalization | 2026-04-22 | Implemented |
-| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 | [0018](0018-project-storage-unification.md) | Project Storage Unification | 2026-04-22 | Implemented |
-| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 | [0019](0019-export-filter-required-design.md) | Export Filter Required Design | 2026-04-22 | Implemented |
-| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 | [0020](0020-cli-message-language-policy.md) | CLI Message Language Policy | 2026-04-27 | Accepted |
-| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 | [0021](0021-litellm-driven-model-registry.md) | LiteLLM-Driven WebAPI Model Registry | 2026-04-28 | Superseded by 0023 (partial) |
-| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 | [0022](0022-aesthetic-score-predictor-survey.md) | Aesthetic Score Predictor Model Survey | 2025-02-06 | Accepted |
-| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 | [0023](0023-pydanticai-litellm-webapi-inference-boundary.md) | PydanticAI / LiteLLM WebAPI Inference Boundary | 2026-05-07 | Accepted |
-| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 | [0024](0024-pytest-test-responsibility-separation.md) | pytest Test Responsibility Separation by Package | 2026-05-13 | Accepted |
-| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 | [0025](0025-uv-lock-version-control-policy.md) | uv.lock Version Control Policy | 2026-05-14 | Accepted |
-| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 | [0026](0026-on-demand-runtime-validation-strategy.md) | On-Demand Runtime Validation Strategy | 2026-05-17 | Accepted |
-| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 | [0027](0027-score-labels-db-storage.md) | Score Labels DB Storage | 2026-05-17 | Accepted |
-| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 | [0028](0028-score-labels-usage-and-display.md) | Score Labels Usage and Display Strategy | 2026-05-18 | Accepted |
-| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 | [0029](0029-unified-dataset-quality-tier.md) | Unified Dataset Quality Tier | 2026-05-19 | Accepted |
-| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 | [0030](0030-batch-annotation-model-selection-ui.md) | Batch Annotation Model Selection UI | 2026-05-20 | Accepted |
-| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 | [0031](0031-ai-rating-mapping.md) | AI Rating Mapping to Canonical Rating | 2026-05-21 | Accepted (amended) |
-| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 | [0032](0032-copyable-readonly-text-display.md) | Copyable Read-Only Text Display Policy | 2026-05-23 | Accepted |
-| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 | [0033](0033-annotation-worker-batch-execution-contract.md) | AnnotationWorker Batch Execution Contract | 2026-05-23 | Accepted |
-| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 | [0034](0034-worker-operation-pipeline-lifecycle.md) | Worker / Operation / Pipeline Lifecycle Boundary | 2026-05-24 | Accepted |
-| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 | [0035](0035-repository-aggregate-split-policy.md) | Repository Aggregate分割方針 | 2026-05-25 | Accepted |
-| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 | [0036](0036-gui-compound-widget-split-policy.md) | GUI Compound Widget 分割方針 | 2026-05-25 | Accepted |
-| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 | [0037](0037-api-facade-wiring-policy.md) | api/ Public Facade Wiring Policy | 2026-05-25 | Accepted |
-| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 | [0038](0038-provider-batch-api-integration-strategy.md) | Provider Batch API Integration Strategy | 2026-05-25 | Accepted |
-| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 | [0039](0039-agent-pr-maintenance-automation.md) | Agent PR Maintenance Automation | 2026-05-25 | Accepted |
-| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 | [0040](0040-local-ml-model-config-ownership.md) | Local ML Model Config Ownership | 2026-05-24 | Accepted |
-| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 | [0041](0041-provider-batch-execution-ui-unification.md) | Provider Batch 実行 UI の個別実行フロー統一 | 2026-05-29 | Accepted |
-| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 | [0042](0042-batch-annotation-db-save-io.md) | Batch Annotation DB Save I/O | 2026-05-30 | Accepted |
-| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 | [0043](0043-db-core-logging-loguru-unification.md) | db_core Logging Loguru Unification | 2026-05-31 | Accepted |
-| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 | [0044](0044-provider-batch-submit-threading.md) | Provider Batch Submit Threading | 2026-05-31 | Accepted |
-| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 | [0045](0045-large-search-result-log-level.md) | Large Search Result Log Level | 2026-05-31 | Accepted |
-| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 | [0046](0046-loguru-placeholder-format.md) | Loguru Placeholder Format | 2026-05-31 | Accepted |
-| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 | [0047](0047-trace-level-for-per-item-diagnostics.md) | TRACE Level for Per-Item Diagnostics | 2026-05-31 | Accepted |
-| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 | [0048](0048-webapi-annotation-candidate-filtering.md) | WebAPI Annotation Candidate Filtering (Endpoint / Capability / Suitability) | 2026-05-31 | Accepted |
-| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 | [0049](0049-cli-images-list-db-limit.md) | Apply CLI Image List Limit in the Repository Query | 2026-06-01 | Accepted |
-| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 | [0050](0050-cli-tag-db-lazy-initialization.md) | CLI Tag DB Lazy Initialization | 2026-06-01 | Accepted |
-| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 | [0051](0051-codex-worktree-shared-uv-environment.md) | Codex Worktree Shared uv Environment | 2026-06-01 | Accepted |
-| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 | [0052](0052-model-selection-auto-reconcile.md) | ModelSelectionWidget 初回表示時の model reconcile | 2026-06-01 | Accepted |
-| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 | [0053](0053-cli-streaming-annotation-memory-bounded-contract.md) | CLI Streaming Annotation Memory-Bounded Execution Contract | 2026-05-29 | Accepted (amended by 0057) |
-| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 | [0054](0054-gui-tag-language-reader-initialization.md) | GUI tag language reader initialization | 2026-06-03 | Accepted |
-| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 | [0055](0055-workspace-export-target-staging-unification.md) | Workspace Export Target = Staging Set / Selection-Source Unification | 2026-06-04 | Accepted |
-| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 | [0056](0056-exact-set-selector-id-count-guard.md) | exact-set selector の大量ID集合ガード / count-only 軽量化方針 | 2026-06-05 | Accepted |
-| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 | [0057](0057-cli-jsonl-output-and-error-contract.md) | CLI Machine-Readable (JSONL) Output and Error Contract | 2026-06-05 | Accepted (amended by 0060) |
-| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 | [0058](0058-cli-output-mode-trigger-and-entrypoint-policy.md) | CLI Output Mode Trigger and Entry-Point Policy | 2026-06-05 | Accepted |
-| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 | [0059](0059-cli-command-introspection.md) | CLI Command Introspection Contract | 2026-06-06 | Accepted |
-| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 | [0060](0060-cli-bounded-pagination-contract.md) | CLI Bounded Pagination and Count-First Contract | 2026-06-06 | Accepted |
-| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 | [0061](0061-phash-duplicate-variant-classification.md) | 登録パイプライン再設計 — pHash 候補の重複/別版分類 | 2026-06-05 | Accepted |
-| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 | [0062](0062-batch-custom-id-phash-long-edge.md) | Provider Batch custom_id を pHash + 長辺解像度基準へ統一 | 2026-06-05 | Accepted |
-| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 | [0063](0063-cli-batch-submit-image-ids-csv.md) | CLI Batch Submit Image IDs CSV Contract | 2026-06-07 | Accepted |
+| [0064](0064-cli-original-image-annotation-guard.md) | CLI Original Image Annotation Guard | 2026-06-07 | Accepted |
+| [0065](0065-tag-caption-soft-reject.md) | Tag/Caption Soft-Reject And Export Resolution | 2026-06-11 | Accepted |
 | [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
+| [0067](0067-sqlite-concurrency-busy-timeout.md) | SQLite Concurrency: busy_timeout + Lock Error Classification | 2026-06-15 | Proposed |
 
-| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 ## ADR テンプレート
-| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 
-| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 ```markdown
-| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 # ADR XXXX: タイトル
-| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 
-| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 - **日付**: YYYY-MM-DD
-| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 - **ステータス**: Proposed | Accepted | Deprecated | Superseded by [XXXX]
-| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 
-| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 ## Context
-| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 
-| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 なぜこの決定が必要だったか。問題の背景と制約。
-| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 
-| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 ## Decision
-| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 
-| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 何を決定したか。
-| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 
-| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 ## Rationale
-| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 
-| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 なぜこの選択をしたか。他の選択肢との比較。
-| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 
-| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 ## Consequences
-| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 
-| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 この決定による影響。良い点・悪い点・トレードオフ。
-| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 ```
-| [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |

--- a/src/lorairo/cli/_errors.py
+++ b/src/lorairo/cli/_errors.py
@@ -64,6 +64,10 @@ _HINTS: dict[ErrorCode, str] = {
     ErrorCode.RESOURCE_EXHAUSTED: "batch_size を下げてから再実行してください (同一条件の再試行は再失敗します)。",
     ErrorCode.RATE_LIMITED: "しばらく待ってから再試行してください。",
     ErrorCode.RESULT_SET_TOO_LARGE: "検索条件を追加して 500 件以下に絞ってください。",
+    ErrorCode.CONFLICT: (
+        "DB が他プロセス (GUI 等) の書き込みでロックされています。"
+        "完了を待ってから再試行してください (SQLite は同時書き込みを 1 つに制限します)。"
+    ),
 }
 
 
@@ -149,6 +153,17 @@ def _is_db_error(exc: BaseException) -> bool:
     return any(_module_chain_matches(item, ("sqlalchemy",)) for item in _iter_cause_chain(exc))
 
 
+def _is_sqlite_lock(exc: BaseException) -> bool:
+    """SQLite の書き込みロック競合 (``database is locked``) かを判定する。
+
+    判定ロジックは GUI ワーカーと共有するため :mod:`lorairo.database.db_errors`
+    に集約している (遅延 import で軽量に保つ)。
+    """
+    from lorairo.database.db_errors import is_sqlite_lock_error
+
+    return is_sqlite_lock_error(exc)
+
+
 def _is_auth_error(exc: BaseException) -> bool:
     for item in _iter_cause_chain(exc):
         # LoRAIro 独自の APIKeyNotConfiguredError (SDK 到達前にキー未設定で送出)
@@ -213,6 +228,8 @@ def _classify_lorairo_exception(exc: BaseException) -> ErrorInfo | None:
 
 # cause-chain で真因を優先判定する分類器テーブル (順序が結果優先順位、上が勝つ)。
 # wrap された OOM / 認証 / ネットワークを真因として拾うため LoRAIro 独自例外より先に評価する。
+# SQLite ロックは SQLAlchemy ``OperationalError`` でもあるため、汎用 DB エラーより先に
+# 評価して再試行可能な CONFLICT に分類する (Issue #767)。
 _CHAIN_CLASSIFIERS: tuple[tuple[Callable[[BaseException], bool], ErrorInfo], ...] = (
     (
         _is_resource_exhausted,
@@ -221,6 +238,7 @@ _CHAIN_CLASSIFIERS: tuple[tuple[Callable[[BaseException], bool], ErrorInfo], ...
     (_is_auth_error, ErrorInfo(ErrorCode.AUTH_ERROR, retryable=False, user_action_required=True)),
     (_is_rate_limited, ErrorInfo(ErrorCode.RATE_LIMITED, retryable=True, user_action_required=False)),
     (_is_network_error, ErrorInfo(ErrorCode.NETWORK_ERROR, retryable=True, user_action_required=False)),
+    (_is_sqlite_lock, ErrorInfo(ErrorCode.CONFLICT, retryable=True, user_action_required=False)),
     (_is_db_error, ErrorInfo(ErrorCode.DB_ERROR, retryable=False, user_action_required=False)),
 )
 

--- a/src/lorairo/cli/main.py
+++ b/src/lorairo/cli/main.py
@@ -73,6 +73,12 @@ app = typer.Typer(
         "              lorairo-cli batch submit --project <name> --task-type rating_preflight "
         "--model openai/omni-moderation-latest --image-ids <id,id,...>"
     ),
+    epilog=(
+        "GUI/CLI concurrent use: the image DB is SQLite (single concurrent writer). "
+        "Reads are safe alongside the GUI; avoid concurrent writes. Lock contention "
+        "waits up to busy_timeout (default 30s) then returns CONFLICT (retryable). "
+        "After CLI writes, reload/re-search in the GUI to see changes. See docs/cli.md."
+    ),
     add_completion=True,
     no_args_is_help=True,
 )

--- a/src/lorairo/database/db_core.py
+++ b/src/lorairo/database/db_core.py
@@ -25,6 +25,10 @@ config = get_config()
 db_config = config.get("database", {})
 dir_config = config.get("directories", {})
 
+# SQLite 書き込みロック競合時の待機時間 (ミリ秒)。GUI/CLI 併用時の一時的な
+# `database is locked` を即時失敗させず、この時間まで再試行待機する (Issue #767)。
+BUSY_TIMEOUT_MS: int = int(db_config.get("busy_timeout_ms", 30000))
+
 
 def get_project_dir(base_dir_name: str, project_name: str) -> Path:
     """プロジェクトディレクトリを生成（任意名前_日付_連番形式）
@@ -340,6 +344,9 @@ def create_db_engine(database_url: str | None = None) -> Engine:
             logger.debug(f"PRAGMA journal_mode=WAL executed: {journal_mode}")
             cursor.execute("PRAGMA synchronous=NORMAL")
             logger.debug("PRAGMA synchronous=NORMAL executed.")
+            # GUI/CLI 併用時の一時的な書き込みロックを即時失敗させず待機させる (Issue #767)。
+            cursor.execute(f"PRAGMA busy_timeout={BUSY_TIMEOUT_MS}")
+            logger.debug(f"PRAGMA busy_timeout={BUSY_TIMEOUT_MS} executed.")
         except Exception:
             logger.opt(exception=True).warning("Failed to configure SQLite PRAGMA settings")
         finally:

--- a/src/lorairo/database/db_errors.py
+++ b/src/lorairo/database/db_errors.py
@@ -1,0 +1,53 @@
+"""DB エラー判定ユーティリティ (Qt-free / 重依存なし)。
+
+SQLite の書き込みロック競合 (``database is locked`` / ``database is busy``) を、
+SQLAlchemy / sqlite3 のどちらの層から送出されても検出する。CLI のエラー分類
+(:mod:`lorairo.cli._errors`) と GUI ワーカー (:mod:`lorairo.gui.workers.base`) の
+両方から共有するため、ここでは ``sqlalchemy`` 等を import せず例外の型名・メッセージ
+だけで判定する (Issue #767)。
+
+SQLite は WAL + ``busy_timeout`` を設定しても、待機時間内に他プロセスが書き込み
+ロックを解放しなければ ``database is locked`` を送出する。GUI を開いたまま CLI で
+書き込むといった同時利用ではこの一時的競合が起こり得るため、内部 DB エラーとは
+区別して「再試行可能な競合」として扱えるようにする。
+"""
+
+from __future__ import annotations
+
+# SQLite ロック競合を示すメッセージ断片 (sqlite3 / SQLAlchemy 共通)。
+_LOCK_MESSAGE_FRAGMENTS = ("database is locked", "database is busy")
+
+
+def _iter_exception_chain(exc: BaseException) -> list[BaseException]:
+    """``__cause__`` / ``__context__`` を遡って例外チェーンを列挙する。
+
+    SQLAlchemy は sqlite3 の ``OperationalError`` を ``raise ... from orig`` で
+    包むため、真因を辿らないと wrap された層でロックを見逃す。
+    """
+    chain: list[BaseException] = []
+    seen: set[int] = set()
+    current: BaseException | None = exc
+    while current is not None and id(current) not in seen:
+        seen.add(id(current))
+        chain.append(current)
+        current = current.__cause__ or current.__context__
+    return chain
+
+
+def is_sqlite_lock_error(exc: BaseException) -> bool:
+    """例外 (または cause chain) が SQLite の書き込みロック競合かを判定する。
+
+    Args:
+        exc: 判定対象の例外。
+
+    Returns:
+        ``database is locked`` / ``database is busy`` を示す ``OperationalError`` が
+        チェーン上に存在すれば ``True``。
+    """
+    for item in _iter_exception_chain(exc):
+        if type(item).__name__ != "OperationalError":
+            continue
+        message = str(item).lower()
+        if any(fragment in message for fragment in _LOCK_MESSAGE_FRAGMENTS):
+            return True
+    return False

--- a/src/lorairo/gui/workers/base.py
+++ b/src/lorairo/gui/workers/base.py
@@ -168,10 +168,27 @@ class LoRAIroWorkerBase[T](QObject):
 
         except Exception as e:
             self._set_status(WorkerStatus.FAILED)
-            error_msg = f"ワーカー実行エラー: {e!s}"
+            error_msg = self._format_worker_error(e)
             logger.error(error_msg, exc_info=True)
             self._record_unhandled_error(e)
             self.error_occurred.emit(error_msg)
+
+    @staticmethod
+    def _format_worker_error(e: Exception) -> str:
+        """ワーカー例外をユーザー向けメッセージに整形する。
+
+        SQLite の書き込みロック競合 (``database is locked``) は CLI 等の他プロセスが
+        同じ DB に書き込み中であることを示すため、専用の分かりやすい文言にする
+        (Issue #767)。それ以外は従来どおり例外文字列を提示する。
+        """
+        from ...database.db_errors import is_sqlite_lock_error
+
+        if is_sqlite_lock_error(e):
+            return (
+                "DB が他プロセス (CLI 等) の書き込みでロックされています。"
+                "完了を待ってから再読み込み/再実行してください。"
+            )
+        return f"ワーカー実行エラー: {e!s}"
 
     def _record_unhandled_error(self, e: Exception) -> None:
         """ハンドルされなかった例外をDBエラーログに記録する。

--- a/src/lorairo/utils/config.py
+++ b/src/lorairo/utils/config.py
@@ -103,6 +103,10 @@ DEFAULT_CONFIG = {
     ],
     "database": {
         "image_db_filename": "image_database.db",  # 画像データベースのファイル名
+        # SQLite 書き込みロック競合時の最大待機時間 (ミリ秒)。GUI/CLI を同じプロジェクト
+        # DB に併用すると一時的な書き込み競合が起こり得るため、即時失敗せず一定時間
+        # リトライ待機する (PRAGMA busy_timeout / Issue #767)。
+        "busy_timeout_ms": 30000,
         # Note: tag_db_package and tag_db_filename were removed (2026-01-02)
         # Tag databases are now managed via genai-tag-db-tools public API (initialize_databases)
     },

--- a/tests/unit/cli/test_errors.py
+++ b/tests/unit/cli/test_errors.py
@@ -123,6 +123,29 @@ def test_classify_sqlalchemy_by_module() -> None:
 
 @pytest.mark.unit
 @pytest.mark.cli
+def test_classify_sqlite_lock_as_conflict() -> None:
+    """SQLite の database is locked は再試行可能な CONFLICT に分類する (Issue #767)。"""
+    locked = type("OperationalError", (Exception,), {"__module__": "sqlalchemy.exc"})(
+        "(sqlite3.OperationalError) database is locked"
+    )
+    info = classify_exception(locked)
+    assert info.code == ErrorCode.CONFLICT
+    assert info.retryable is True
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+def test_classify_sqlite_lock_wrapped_in_cause_chain() -> None:
+    """cause chain 下層の database is locked も CONFLICT として拾う (Issue #767)。"""
+    orig = type("OperationalError", (Exception,), {"__module__": "sqlite3"})("database is locked")
+    try:
+        raise RuntimeError("save failed") from orig
+    except RuntimeError as exc:
+        assert classify_exception(exc).code == ErrorCode.CONFLICT
+
+
+@pytest.mark.unit
+@pytest.mark.cli
 def test_classify_pydantic_validation_before_value_error() -> None:
     """Pydantic ValidationError は ValueError subclass だが VALIDATION_FAILED にする。"""
     pyd = type("ValidationError", (ValueError,), {"__module__": "pydantic"})("invalid")
@@ -135,4 +158,5 @@ def test_hint_for_known_codes() -> None:
     """対処ヒントが定義済みコードに返り、未定義には None。"""
     assert hint_for(ErrorCode.RESULT_SET_TOO_LARGE) is not None
     assert hint_for(ErrorCode.AUTH_ERROR) is not None
+    assert hint_for(ErrorCode.CONFLICT) is not None
     assert hint_for(ErrorCode.INTERNAL_ERROR) is None

--- a/tests/unit/database/test_db_core_sqlite_pragmas.py
+++ b/tests/unit/database/test_db_core_sqlite_pragmas.py
@@ -19,6 +19,20 @@ def test_create_db_engine_sets_file_sqlite_wal_and_normal(tmp_path) -> None:
     assert foreign_keys == 1
 
 
+def test_create_db_engine_sets_busy_timeout(tmp_path) -> None:
+    """GUI/CLI 併用時のロック待機のため busy_timeout が設定される (Issue #767)。"""
+    from lorairo.database.db_core import BUSY_TIMEOUT_MS
+
+    db_path = tmp_path / "busy-timeout.sqlite"
+    engine = create_db_engine(f"sqlite:///{db_path}?check_same_thread=False")
+
+    with engine.connect() as connection:
+        busy_timeout = connection.execute(text("PRAGMA busy_timeout")).scalar_one()
+
+    assert busy_timeout == BUSY_TIMEOUT_MS
+    assert BUSY_TIMEOUT_MS > 0
+
+
 def test_create_db_engine_keeps_memory_sqlite_usable() -> None:
     engine = create_db_engine("sqlite:///:memory:")
 

--- a/tests/unit/database/test_db_errors.py
+++ b/tests/unit/database/test_db_errors.py
@@ -1,0 +1,45 @@
+"""SQLite ロック競合判定 (lorairo.database.db_errors) のテスト (Issue #767)。"""
+
+import pytest
+
+from lorairo.database.db_errors import is_sqlite_lock_error
+
+
+def _operational_error(message: str, module: str = "sqlite3") -> Exception:
+    """型名 OperationalError を持つ軽量例外を生成する (sqlite3/SQLAlchemy 模擬)。"""
+    return type("OperationalError", (Exception,), {"__module__": module})(message)
+
+
+@pytest.mark.unit
+def test_detects_database_is_locked() -> None:
+    assert is_sqlite_lock_error(_operational_error("database is locked")) is True
+
+
+@pytest.mark.unit
+def test_detects_database_is_busy() -> None:
+    assert is_sqlite_lock_error(_operational_error("database is busy")) is True
+
+
+@pytest.mark.unit
+def test_detects_sqlalchemy_wrapped_message() -> None:
+    wrapped = _operational_error("(sqlite3.OperationalError) database is locked", module="sqlalchemy.exc")
+    assert is_sqlite_lock_error(wrapped) is True
+
+
+@pytest.mark.unit
+def test_detects_lock_in_cause_chain() -> None:
+    orig = _operational_error("database is locked")
+    try:
+        raise RuntimeError("save failed") from orig
+    except RuntimeError as exc:
+        assert is_sqlite_lock_error(exc) is True
+
+
+@pytest.mark.unit
+def test_other_operational_error_is_not_lock() -> None:
+    assert is_sqlite_lock_error(_operational_error("no such table: images")) is False
+
+
+@pytest.mark.unit
+def test_non_operational_error_is_not_lock() -> None:
+    assert is_sqlite_lock_error(ValueError("database is locked")) is False

--- a/tests/unit/gui/workers/test_base_worker.py
+++ b/tests/unit/gui/workers/test_base_worker.py
@@ -250,6 +250,27 @@ class TestLoRAIroWorkerBase:
         status_calls = [call[0][0] for call in status_mock.call_args_list]
         assert WorkerStatus.FAILED in status_calls
 
+    def test_execution_with_sqlite_lock_error_emits_friendly_message(self):
+        """SQLite ロック競合は GUI 向けの分かりやすい文言に整形される (Issue #767)。"""
+
+        class LockWorker(LoRAIroWorkerBase[str]):
+            def execute(self) -> str:
+                lock_error = type("OperationalError", (Exception,), {"__module__": "sqlalchemy.exc"})(
+                    "(sqlite3.OperationalError) database is locked"
+                )
+                raise lock_error
+
+        worker = LockWorker()
+        error_mock = Mock()
+        worker.error_occurred.connect(error_mock)
+
+        worker.run()
+
+        error_mock.assert_called_once()
+        error_message = error_mock.call_args[0][0]
+        assert "ロック" in error_message
+        assert "他プロセス" in error_message
+
     def test_cancellation(self, worker):
         """キャンセルテスト"""
         # キャンセルシグナル接続


### PR DESCRIPTION
## 概要

Issue #767: GUI/CLI を同じプロジェクト DB に併用しやすくする第一段階。SQLite/WAL 前提で `busy_timeout` + ロック競合エラーの分類・表示を追加する (ADR 0067)。

## 受け入れ条件への対応

- [x] **busy_timeout 設定**: `create_db_engine()` の SQLite connect リスナーに `PRAGMA busy_timeout` を追加 (既定 30000ms、`config/lorairo.toml` の `[database] busy_timeout_ms` で調整可、`DEFAULT_CONFIG` / `db_core.BUSY_TIMEOUT_MS` が SSoT)。
- [x] **WAL + busy_timeout の単体テスト**: `test_db_core_sqlite_pragmas.py` に busy_timeout アサートを追加。
- [x] **CLI/GUI 同時利用制約のドキュメント/ヘルプ記載**: `docs/cli.md` に「GUI との同時利用 (DB ロックの制約)」セクション、CLI app help に epilog 注記。
- [x] **長トランザクション保持フロー調査**: 主要書き込みフロー (CLI `annotate run` / GUI アノテーション保存・画像登録 / リポジトリ CRUD) を調査。いずれも「読込→重処理 (セッション無し)→短い保存トランザクション」の短トランザクション原則 (ADR 0042/0053 + Repository パターン) に従っており、重い処理中に DB トランザクションを保持する箇所は無し → 修正不要。ADR 0067 に記録。
- [x] **ロック競合エラーの分類・表示**:
  - 共有ヘルパー `lorairo.database.db_errors.is_sqlite_lock_error()` (cause-chain を辿り型名+メッセージで判定、重依存非 import)。
  - CLI: `database is locked` を再試行可能な `CONFLICT` (`retryable=true`) に分類しヒント表示 (ADR 0057 の 15 種 wire コード内、新コード追加なし)。
  - GUI: `LoRAIroWorkerBase` のエラー整形で専用日本語メッセージに置換。

## 非目標 (ADR 0067)

完全な複数同時 writer 保証 / GUI・CLI 同時大量保存の無衝突化 / PostgreSQL 移行は対象外。GUI の外部更新自動反映も未対応 (手動再読み込み、後続課題)。

## テスト

新規/変更テスト 69 件 pass (`test_db_errors.py` 新規、`test_db_core_sqlite_pragmas.py` / `test_errors.py` / `test_base_worker.py` 追加)。ruff format / check、mypy (6 files) クリーン。

> 注: `tests/unit/database/test_db_manager_thumbnail.py` の 3 件は本 PR と無関係な既存の test-isolation 脆弱性 (`@patch("lorairo.editor.image_processor")` が `lorairo.editor` の事前 import に依存)。main checkout の isolation 実行でも同一に再現、フルスイートでは pass。

## 補足

- ADR 0067 は **Proposed**。Accepted 判断まで merge は保留してください。
- `docs/decisions/README.md` は #743 由来の重複破損 (94 行の `0066` 重複 + `0064`/`0065` 行欠落) を修復し、欠落行と新規 0067 を補完しました。
- submodule (`local_packages/*`) 非変更。

🤖 Generated with [Claude Code](https://claude.com/claude-code)