### PR TITLE
feat(db): タグ保存境界を clean_format 整形に統一 (#769, ADR 0068 Phase 1)

### DIFF
--- a/docs/decisions/0067-tag-normalization-tagdb-delegation.md
+++ b/docs/decisions/0067-tag-normalization-tagdb-delegation.md
@@ -1,0 +1,91 @@
+# 0067. タグ正規化責任の genai-tag-db-tools への集約
+
+- Status: Proposed
+- Date: 2026-06-16
+- Deciders: NEXTAltair
+
+## Context
+
+LoRAIro GUI の詳細表示に未整形タグが出るケースが報告された (Issue #769, image ID `14443`)。
+例: `_touhou`, `blue_hair_`, `alternate_costume`, `Grey hair`, `Pov hands`, `bad_id`,
+`bad_pixiv_id`, `__commentary_request`, `_highres` など。
+
+調査の結果、原因は単一バグではなく **タグ canonical 化の境界がアーキテクチャ上存在しない**
+ことだった。
+
+1. **表示は `Tag.tag` を verbatim 出力** — `ImageRepository._format_tags()` は
+   `", ".join(tag.tag for ...)` で tagdb 変換を一切かけない。DB の値がそのまま画面に出る。
+2. **保存経路ごとに正規化レベルがバラバラ**:
+   - `.txt` 取込 (`ExistingFileReader._read_annotations`): `clean_format()` のみ (`_`→空白、
+     小文字化なし・tagdb 解決なし)
+   - `_persist_existing_annotations` (`db_manager.py`): `tag` は raw 保存、clean_format は
+     `tag_id` キャッシュキーにしか使わない
+   - OpenAI Batch JSONL 取込 (`batch_import_service`): `tag.strip()` のみ
+   - AI annotation 保存 (`_save_tags`): 正規化なし (`tag=tag_string` verbatim)
+   - GUI 手動追加 (`batch_tag_add_widget`): `clean_format()` + `.lower()` + `.strip()`
+3. **alias→preferred (推奨タグ) 関係は format (サイト) ごとに異なる**。あるタグが
+   danbooru では別タグの alias でも e621 では preferred 扱い、というように「どの canonical に
+   解決するか」自体が format 依存。よって**取込時に 1 format の preferred を焼き込むのは不可**
+   (後で別 format 学習時に食い違う)。
+4. tagdb には既に `convert_tags(repo, tags, format_name)` という canonical 化一括 API がある
+   (`clean_format` + `resolve_preferred=True`) が、LoRAIro は未使用。さらに既存の
+   `search_tags` 呼び出しは全て `resolve_preferred=False`。
+5. `convert_tags` の完全一致 lookup は **case-sensitive** (`normalize_search_keyword` は
+   lower しない) ため、`Grey hair` が danbooru の `grey hair` にマッチせず変換漏れする。
+
+## Decision
+
+正規化 (整形・語の同定・preferred 解決) の責任を **genai-tag-db-tools に集約**する。
+LoRAIro は「保存は整形のみ」「表示/export は target format を指定して都度解決」を tagdb API
+経由で行う。LoRAIro 側に正規化ロジックを散らさない。
+
+### データの扱い
+
+| 局面 | `Tag.tag` / 出力値 | 処理 |
+|---|---|---|
+| **保存** | `clean_format` 整形文字列のみ (preferred 未解決) | 全取込経路で統一。tag_id は同定できれば保存 |
+| **GUI 詳細表示** | 基準 format (danbooru) の canonical | 表示時に `convert_tags` で preferred 解決 (キャッシュ付き) |
+| **学習 export** | target format の canonical | `convert_tags(target)` + `type=meta` 除外 |
+| **管理メタタグ** | DB / 表示には残す | export 時のみ `type=meta` を除外 |
+
+### 原則
+
+- **alias→preferred 解決は保存時に確定させない** (format 依存のため出力時に回す)。
+- **変換失敗タグ (tagdb 未登録) は整形 raw のまま保持** — 勝手に削除しない (Issue の要件)。
+- **format は固定しない** — 使う時 (表示/export) に指定。表示は基準 format (danbooru) 1 つで可。
+
+## 実装 (フェーズ分割)
+
+### Phase 1 (#769 中核)
+- **genai-tag-db-tools**: `convert_tags` の lookup を case-insensitive 化
+  (`Grey hair`→`grey hair` 同定)。`type=meta` 除外サポート。
+- **LoRAIro**: 全保存経路で `Tag.tag = clean_format` 済みに統一
+  (`_save_tags` / `batch_import_service` / `_persist_existing_annotations` / `register_prompt_tags`)。
+- **LoRAIro**: 既存 DB の `Tag.tag` を `clean_format` で一括整形する修復スクリプト
+  (preferred は焼かない)。
+
+### Phase 2
+- **LoRAIro**: GUI 詳細表示 (`SelectedImageDetailsWidget` / `AnnotationDataDisplayWidget`) で
+  表示時に `convert_tags(danbooru)` を適用 (キャッシュ付き)。
+
+### Phase 3
+- **LoRAIro**: 学習 export の target format 出し分け + `type=meta` 除外。
+
+## Consequences
+
+### Positive
+- `Tag.tag` の意味が「整形済み文字列 (preferred 未解決)」に一本化され明文化される。
+- 正規化ロジックが genai-tag-db-tools に集約され、LoRAIro 側の散発呼び出しが消える。
+- format 依存の alias/preferred 解決を出力時に回すことで、複数 format 学習に対応できる。
+- 管理メタタグを削除せず export からのみ除外でき、追跡性と学習品質を両立。
+
+### Negative / リスク
+- 2 リポジトリ (LoRAIro + genai-tag-db-tools) にまたがる。submodule pin 更新が必要。
+- GUI 表示時の `convert_tags` がコスト増 → キャッシュで緩和。
+- 既存 DB の修復スクリプトは破壊的更新なので backup / dry-run を要する。
+
+## Related
+
+- Issue: NEXTAltair/LoRAIro#769
+- 関連 Issue: NEXTAltair/genai-tag-db-tools#2 (refinement recommendation 仕様)
+- ADR 0065 (Tag/Caption soft reject) — `rejected_at` による採否境界

--- a/docs/decisions/0068-tag-normalization-tagdb-delegation.md
+++ b/docs/decisions/0068-tag-normalization-tagdb-delegation.md
@@ -1,6 +1,6 @@
-# 0067. タグ正規化責任の genai-tag-db-tools への集約
+# 0068. タグ正規化責任の genai-tag-db-tools への集約
 
-- Status: Proposed
+- Status: Accepted
 - Date: 2026-06-16
 - Deciders: NEXTAltair
 

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -71,6 +71,7 @@ LoRAIro の重要な設計判断を記録するドキュメント群。
 | [0065](0065-tag-caption-soft-reject.md) | Tag/Caption Soft-Reject And Export Resolution | 2026-06-11 | Accepted |
 | [0066](0066-unified-jobs-lifecycle-view.md) | Unified Jobs Lifecycle View | 2026-06-12 | Accepted |
 | [0067](0067-sqlite-concurrency-busy-timeout.md) | SQLite Concurrency: busy_timeout + Lock Error Classification | 2026-06-15 | Accepted |
+| [0068](0068-tag-normalization-tagdb-delegation.md) | タグ正規化責任の genai-tag-db-tools への集約 | 2026-06-16 | Accepted |
 
 ## ADR テンプレート
 

--- a/src/lorairo/database/repository/annotation_record.py
+++ b/src/lorairo/database/repository/annotation_record.py
@@ -865,7 +865,7 @@ class AnnotationRepository(BaseRepository):
         }
 
         for tag_info in tags_data:
-            # 保存境界の SSoT (ADR 0067): 全取込経路の tag をここで clean_format 整形に統一する。
+            # 保存境界の SSoT (ADR 0068): 全取込経路の tag をここで clean_format 整形に統一する。
             # preferred 解決はしない (format 依存のため出力時に回す)。lower 化もしない。
             tag_string = TagCleaner.clean_format(tag_info["tag"]).strip()
             if not tag_string:

--- a/src/lorairo/database/repository/annotation_record.py
+++ b/src/lorairo/database/repository/annotation_record.py
@@ -858,41 +858,47 @@ class AnnotationRepository(BaseRepository):
         # 既存のタグを image_id と tag 文字列で取得 (効率化のため)
         existing_tags_stmt = select(Tag).where(Tag.image_id == image_id)
         existing_tags_result = session.execute(existing_tags_stmt).scalars().all()
-        # (tag_string, model_id) をキーとする辞書を作成
-        existing_tags_map = {(t.tag, t.model_id): t for t in existing_tags_result}
+        # (整形済み tag_string, model_id) をキーとする辞書を作成。
+        # 旧 raw 行 (clean_format 前) も整形後キーに揃え、整形後の入力と突合できるようにする。
+        existing_tags_map = {
+            (TagCleaner.clean_format(t.tag).strip(), t.model_id): t for t in existing_tags_result
+        }
 
         for tag_info in tags_data:
-            tag_string = tag_info["tag"]
+            # 保存境界の SSoT (ADR 0067): 全取込経路の tag をここで clean_format 整形に統一する。
+            # preferred 解決はしない (format 依存のため出力時に回す)。lower 化もしない。
+            tag_string = TagCleaner.clean_format(tag_info["tag"]).strip()
+            if not tag_string:
+                # 整形後に空文字になったタグはスキップ
+                continue
             model_id = tag_info.get("model_id")  # Optional
             confidence = tag_info.get("confidence_score")  # Optional
             is_existing_tag = tag_info.get("existing", False)  # 元ファイル由来か
 
             # 外部DBから tag_id を取得/作成
-            # 呼び出し元が設定済みの tag_id を優先し、未設定時はキャッシュ→個別照会の順
+            # 呼び出し元が設定済みの tag_id を優先し、未設定時はキャッシュ→個別照会の順。
+            # tag_string は整形済みなので tag_id_cache (整形後キー) と直接突合できる。
             external_tag_id: int | None = tag_info.get("tag_id")
             if external_tag_id is None:
-                if tag_id_cache is not None:
-                    normalized_key = TagCleaner.clean_format(tag_string).strip()
-                    if normalized_key in tag_id_cache:
-                        external_tag_id = tag_id_cache[normalized_key]
-                    else:
-                        # キャッシュミス: 従来の個別照会にフォールバック
-                        external_tag_id = self._get_or_create_tag_id_external(session, tag_string)
+                if tag_id_cache is not None and tag_string in tag_id_cache:
+                    external_tag_id = tag_id_cache[tag_string]
                 else:
+                    # キャッシュミス / キャッシュ無し: 従来の個別照会にフォールバック
                     external_tag_id = self._get_or_create_tag_id_external(session, tag_string)
 
-            if external_tag_id is None and tag_string:
+            if external_tag_id is None:
                 logger.warning(
                     f"Tag '{tag_string}' could not be linked to external tag_db. "
                     "Saving with tag_id=None (limited taxonomy features).",
                 )
 
-            # 既存レコードを検索
+            # 既存レコードを整形後キーで検索
             existing_record = existing_tags_map.get((tag_string, model_id))
 
             if existing_record:
-                # 更新
+                # 更新 (旧 raw 行は整形後の値へ揃える)
                 logger.debug(f"Updating existing tag: id={existing_record.id}, tag='{tag_string}'")
+                existing_record.tag = tag_string
                 existing_record.tag_id = external_tag_id
                 existing_record.confidence_score = confidence
                 existing_record.existing = is_existing_tag

--- a/tests/unit/database/repository/test_annotation_record_repository.py
+++ b/tests/unit/database/repository/test_annotation_record_repository.py
@@ -389,7 +389,7 @@ class TestSaveTagsAndCaptions:
         image_id: int,
         memory_session_factory,
     ) -> None:
-        """raw なタグを保存しても DB には clean_format 整形済みが入る (ADR 0067)。"""
+        """raw なタグを保存しても DB には clean_format 整形済みが入る (ADR 0068)。"""
         annotation_repository.save_annotations(
             image_id=image_id,
             annotations={

--- a/tests/unit/database/repository/test_annotation_record_repository.py
+++ b/tests/unit/database/repository/test_annotation_record_repository.py
@@ -383,6 +383,95 @@ class TestSaveTagsAndCaptions:
             assert len(rows) == 1
             assert rows[0].rejected_at is not None
 
+    def test_save_tags_normalizes_raw_tag_to_clean_format(
+        self,
+        annotation_repository: AnnotationRepository,
+        image_id: int,
+        memory_session_factory,
+    ) -> None:
+        """raw なタグを保存しても DB には clean_format 整形済みが入る (ADR 0067)。"""
+        annotation_repository.save_annotations(
+            image_id=image_id,
+            annotations={
+                "tags": [
+                    {"tag": "_touhou", "model_id": None, "tag_id": None},
+                    {"tag": "blue_hair_", "model_id": None, "tag_id": None},
+                    {"tag": "alternate_costume", "model_id": None, "tag_id": None},
+                ]
+            },
+        )
+
+        with memory_session_factory() as session:
+            rows = session.execute(select(Tag).where(Tag.image_id == image_id)).scalars().all()
+            saved = {row.tag for row in rows}
+        # clean_format は `_`→空白・先頭末尾記号整理 (preferred 解決・lower 化はしない)
+        assert saved == {"touhou", "blue hair", "alternate costume"}
+
+    def test_save_tags_skips_tag_empty_after_clean_format(
+        self,
+        annotation_repository: AnnotationRepository,
+        image_id: int,
+        memory_session_factory,
+    ) -> None:
+        """整形後に空文字になるタグはスキップする。"""
+        annotation_repository.save_annotations(
+            image_id=image_id,
+            annotations={
+                "tags": [
+                    {"tag": "___", "model_id": None, "tag_id": None},
+                    {"tag": "valid_tag", "model_id": None, "tag_id": None},
+                ]
+            },
+        )
+
+        with memory_session_factory() as session:
+            rows = session.execute(select(Tag).where(Tag.image_id == image_id)).scalars().all()
+            saved = {row.tag for row in rows}
+        assert saved == {"valid tag"}
+
+    def test_save_tags_dedupes_tags_colliding_after_clean_format(
+        self,
+        annotation_repository: AnnotationRepository,
+        image_id: int,
+        memory_session_factory,
+    ) -> None:
+        """整形で同一になるタグ (`blue_hair` と `blue hair`) は Upsert で 1 行に吸収する。"""
+        annotation_repository.save_annotations(
+            image_id=image_id,
+            annotations={
+                "tags": [
+                    {"tag": "blue_hair", "model_id": None, "tag_id": None},
+                    {"tag": "blue hair", "model_id": None, "tag_id": None},
+                ]
+            },
+        )
+
+        with memory_session_factory() as session:
+            rows = session.execute(select(Tag).where(Tag.image_id == image_id)).scalars().all()
+        assert len(rows) == 1
+        assert rows[0].tag == "blue hair"
+
+    def test_save_tags_matches_existing_raw_row_by_normalized_key(
+        self,
+        annotation_repository: AnnotationRepository,
+        image_id: int,
+        memory_session_factory,
+    ) -> None:
+        """既存 raw 行 (`blue_hair`) は整形後キーで突合し、整形済み値へ揃える。"""
+        with memory_session_factory() as session:
+            session.add(Tag(image_id=image_id, model_id=None, tag="blue_hair", existing=False))
+            session.commit()
+
+        annotation_repository.save_annotations(
+            image_id=image_id,
+            annotations={"tags": [{"tag": "blue hair", "model_id": None, "tag_id": None}]},
+        )
+
+        with memory_session_factory() as session:
+            rows = session.execute(select(Tag).where(Tag.image_id == image_id)).scalars().all()
+        assert len(rows) == 1
+        assert rows[0].tag == "blue hair"
+
     def test_save_captions_does_not_revive_rejected_row(
         self,
         annotation_repository: AnnotationRepository,


### PR DESCRIPTION
## 概要

Issue #769 / ADR 0067 Phase 1。タグ canonical 化の境界が存在せず、保存経路ごとに正規化レベルがバラバラで GUI に未整形タグ (`_touhou`, `blue_hair_`, `alternate_costume` 等) が表示される問題に対し、**保存は整形 (`clean_format`) のみに統一**する。

全タグ保存経路 (AI annotation / OpenAI Batch JSONL 取込 / 既存ファイル取込 / プロンプトタグ) は `AnnotationRepository._save_tags` を経由するため、ここを**保存境界の SSoT** とし `TagCleaner.clean_format().strip()` を一律適用する。

## 変更点

- `_save_tags` で `Tag.tag = clean_format().strip()` に統一 (保存境界の SSoT)
  - **preferred 解決はしない** (format 依存のため出力時に回す、ADR 0067)
  - **lower 化もしない** (`Grey hair` はそのまま保持)
  - 整形後に空文字になるタグはスキップ
  - `existing_tags_map` のキーも整形後の値で揃え、旧 raw 行を整形後値へ移行
  - 整形で衝突するタグ (`blue_hair` と `blue hair`) は Upsert で 1 行に吸収
  - `tag_id_cache` は整形済み tag_string を直接 lookup
- 正規化ロジックを `_save_tags` の 1 箇所に集約 (ADR 0067 の「LoRAIro 側に正規化を散らさない」方針)。`batch_import_service` / `_persist_existing_annotations` / `register_prompt_tags` は全て `_save_tags` を経由するため、これら経由の `Tag.tag` も自動的に整形済みになる
- リグレッションテスト 4 件追加 (raw→整形、空文字スキップ、整形衝突の dedup、既存 raw 行の突合)

## テスト

`CI-EQUIV-TESTED`: worktree で CI-equivalent filter (`-m "not gui_show and not calls_real_webapi and not downloads_and_runs_model and not slow"`) を実行。

- タグ正規化の surface (annotation_record / model_sync / annotator_adapter / search_criteria 含む **4344 tests pass**、新規 4 テスト含む)
- 残る torch/libcudnn 由来の collection error + thumbnail/BDD 失敗は **GPU 環境問題**で、`origin/main` でも同一に再現する既存事象 (本変更とは無関係であることを baseline 比較で確認済み)
- `ruff format` / `ruff check` / `mypy` 全 pass

## 関連

- Issue: #769
- ADR: `docs/decisions/0067-tag-normalization-tagdb-delegation.md` (Status: Proposed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)