### PR TITLE
docs(scripts): repair_tag_normalization の ADR 参照を 0068 に修正 (#769)

### DIFF
--- a/scripts/repair_tag_normalization.py
+++ b/scripts/repair_tag_normalization.py
@@ -1,6 +1,6 @@
 """既存 LoRAIro DB の `tags.tag` を `clean_format` で一括整形する修復スクリプト (Issue #769)。
 
-ADR 0067 の保存境界方針に従い、保存は整形 (`TagCleaner.clean_format().strip()`) のみを
+ADR 0068 の保存境界方針に従い、保存は整形 (`TagCleaner.clean_format().strip()`) のみを
 焼き込む。alias→preferred の解決や lower 化は format 依存のため **行わない**。
 
 整形によって同一 `(image_id, model_id)` 内で `tag` 文字列が衝突した行 (例:
@@ -40,7 +40,7 @@ _DIFF_SAMPLE_LIMIT = 30
 def normalize_tag_value(tag: str) -> str:
     """タグ文字列を保存境界の正規化規則で整形する。
 
-    ADR 0067 に従い `TagCleaner.clean_format()` + `strip()` のみを適用する。
+    ADR 0068 に従い `TagCleaner.clean_format()` + `strip()` のみを適用する。
     lower 化や alias/preferred 解決は行わない。
 
     Args:

--- a/tests/unit/scripts/test_repair_tag_normalization.py
+++ b/tests/unit/scripts/test_repair_tag_normalization.py
@@ -45,7 +45,7 @@ def test_normalize_tag_value_strips_underscores_without_lowercasing() -> None:
     assert repair_script.normalize_tag_value("blue_hair_") == "blue hair"
     assert repair_script.normalize_tag_value("_touhou") == "touhou"
     assert repair_script.normalize_tag_value("alternate_costume") == "alternate costume"
-    # lower 化はしない (ADR 0067)
+    # lower 化はしない (ADR 0068)
     assert repair_script.normalize_tag_value("Grey hair") == "Grey hair"
 
 


### PR DESCRIPTION
## 概要
`scripts/repair_tag_normalization.py` と対応テストの docstring/コメント内 ADR 参照が `0067` のまま残っていたため `0068` に修正する。

## 背景
#770 (修復スクリプト) が #771 (ADR 0068 本体) より先に merge されたため、ADR 番号衝突回避の renumber (0067→0068) がコメントに反映されていなかった。挙動変更なし、コメントのみ。

## 変更
- `scripts/repair_tag_normalization.py` の `ADR 0067` 2 箇所 → `0068`
- `tests/unit/scripts/test_repair_tag_normalization.py` の `ADR 0067` 1 箇所 → `0068`

関連: #769, ADR 0068