### PR TITLE
fix(scripts): repair_tag_normalization で reader 取得前に tag_db を初期化 (#769)

### DIFF
--- a/scripts/repair_tag_normalization.py
+++ b/scripts/repair_tag_normalization.py
@@ -32,6 +32,7 @@ from loguru import logger
 from sqlalchemy import create_engine, select
 from sqlalchemy.orm import Session, sessionmaker
 
+from lorairo.database.db_core import ensure_tag_db_initialized
 from lorairo.database.schema import Tag
 from lorairo.utils.config import get_config
 
@@ -403,6 +404,9 @@ def _get_canonical_reader() -> MergedTagReader | None:
         初期化済み MergedTagReader。取得失敗時は None。
     """
     try:
+        # get_default_reader() は base DB パス設定済みが前提のため、先に初期化する
+        # (annotation_record._initialize_merged_reader と同じ順序)。
+        ensure_tag_db_initialized()
         return get_default_reader()
     except Exception as e:
         # 外部 tag_db は任意依存: 取得失敗時は clean_format のみへ縮退する。

--- a/tests/unit/scripts/test_repair_tag_normalization.py
+++ b/tests/unit/scripts/test_repair_tag_normalization.py
@@ -22,6 +22,9 @@ repair_script = importlib.util.module_from_spec(_SPEC)
 sys.modules["repair_tag_normalization"] = repair_script
 _SPEC.loader.exec_module(repair_script)
 
+# autouse フィクスチャが `_get_canonical_reader` を差し替えるため、実関数参照を捕捉しておく。
+_ORIGINAL_GET_CANONICAL_READER = repair_script._get_canonical_reader
+
 pytestmark = pytest.mark.unit
 
 
@@ -273,6 +276,39 @@ def test_build_canonical_resolver_excludes_deprecated(tmp_path: Path) -> None:
 
     result = resolver({"old tag", "gray hair"})
     assert result == {"gray hair": "grey hair"}
+
+
+def test_get_canonical_reader_initializes_tag_db_before_reader(monkeypatch: pytest.MonkeyPatch) -> None:
+    """`_get_canonical_reader` は get_default_reader 前に ensure_tag_db_initialized を呼ぶ。
+
+    base DB パス未設定だと get_default_reader が失敗するため、初期化順序が重要 (実 DB 修復時の回帰)。
+    """
+    from unittest.mock import Mock
+
+    calls: list[str] = []
+    ensure_mock = Mock(side_effect=lambda: calls.append("ensure"))
+    reader = Mock()
+    get_reader_mock = Mock(side_effect=lambda: (calls.append("get_reader"), reader)[1])
+    monkeypatch.setattr(repair_script, "ensure_tag_db_initialized", ensure_mock)
+    monkeypatch.setattr(repair_script, "get_default_reader", get_reader_mock)
+
+    result = _ORIGINAL_GET_CANONICAL_READER()
+
+    assert result is reader
+    assert calls == ["ensure", "get_reader"]
+
+
+def test_get_canonical_reader_returns_none_on_init_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    """初期化失敗時は None を返し clean_format のみへ縮退する。"""
+    from unittest.mock import Mock
+
+    monkeypatch.setattr(
+        repair_script,
+        "ensure_tag_db_initialized",
+        Mock(side_effect=RuntimeError("Tag database initialization failed")),
+    )
+
+    assert _ORIGINAL_GET_CANONICAL_READER() is None
 
 
 def test_resolve_db_path_missing_raises(tmp_path: Path) -> None:


### PR DESCRIPTION
## 背景

#774 で追加した `repair_tag_normalization.py` の `_get_canonical_reader` が、`ensure_tag_db_initialized()` を呼ばずに `get_default_reader()` を呼んでいた。実 DB の dry-run で `Base DB paths are not configured. Call ensure_db() or set_database_path() first.` が出て canonical 解決が常に clean_format へ縮退していた (876k 行が全て「変更なし」)。

## 修正

`annotation_record._initialize_merged_reader` と同じ順序で `ensure_tag_db_initialized()` → `get_default_reader()` を呼ぶ。

- 初期化順序 (ensure → get_reader) の回帰テスト
- 初期化失敗時に None へ degrade するテスト

## テスト

repair スクリプトテスト **19 passed**、mypy/ruff clean。

Refs: NEXTAltair/LoRAIro#769

🤖 Generated with [Claude Code](https://claude.com/claude-code)